### PR TITLE
FINERACT-2649: batch migrate Tier 4 loan tests to feign

### DIFF
--- a/fineract-client-feign/src/main/java/org/apache/fineract/client/feign/services/RunReportsApi.java
+++ b/fineract-client-feign/src/main/java/org/apache/fineract/client/feign/services/RunReportsApi.java
@@ -22,6 +22,7 @@ import feign.Param;
 import feign.QueryMap;
 import feign.RequestLine;
 import feign.Response;
+import java.util.List;
 import java.util.Map;
 import org.apache.fineract.client.models.RunReportsResponse;
 
@@ -63,4 +64,23 @@ public interface RunReportsApi {
      */
     @RequestLine("GET /v1/runreports/{reportName}")
     Response runReportGetFile(@Param("reportName") String reportName, @QueryMap Map<String, String> parameters);
+
+    /**
+     * Run Report with {@code genericResultSet=false}, which serialises the result set as a plain array of rows instead
+     * of the {@link RunReportsResponse} "Generic Resultset" shape. One operation cannot declare both response shapes,
+     * so {@link #runReportGetData} cannot decode this variant - keep both methods rather than "simplifying" them into
+     * one.
+     *
+     * <p>
+     * The row values are inherently dynamic: the keys are whatever columns the stored SQL of the report selects, so
+     * there is no generated model to bind them to.
+     *
+     * @param reportName
+     *            reportName (required)
+     * @param parameters
+     *            Dynamic query parameters for the report, including {@code genericResultSet=false} (required)
+     * @return the report rows, one map of column name to value per row
+     */
+    @RequestLine("GET /v1/runreports/{reportName}")
+    List<Map<String, Object>> runReportGetRows(@Param("reportName") String reportName, @QueryMap Map<String, String> parameters);
 }

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoanChargesApiResourceSwagger.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoanChargesApiResourceSwagger.java
@@ -80,6 +80,8 @@ final class LoanChargesApiResourceSwagger {
         public Long id;
         @Schema(example = "1")
         public Long chargeId;
+        @Schema(example = "1")
+        public Long loanId;
         @Schema(example = "Loan Processing fee")
         public String name;
         public GetLoanChargeTimeType chargeTimeType;

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoanTransactionsApiResourceSwagger.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoanTransactionsApiResourceSwagger.java
@@ -28,7 +28,7 @@ import org.springframework.data.domain.Page;
 /**
  * Created by Chirag Gupta on 12/30/17.
  */
-final class LoanTransactionsApiResourceSwagger {
+public final class LoanTransactionsApiResourceSwagger {
 
     private LoanTransactionsApiResourceSwagger() {}
 

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/api/LoanProductsApiResourceSwagger.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/api/LoanProductsApiResourceSwagger.java
@@ -54,6 +54,10 @@ public final class LoanProductsApiResourceSwagger {
 
         public LoanProductChargeData charge;
         public GLAccountData incomeAccount;
+        @Schema(example = "1")
+        public Long chargeId;
+        @Schema(example = "1")
+        public Long incomeAccountId;
 
     }
 
@@ -236,6 +240,12 @@ public final class LoanProductsApiResourceSwagger {
         public Integer recalculationCompoundingFrequencyInterval;
         @Schema(example = "1")
         public Integer recalculationCompoundingFrequencyOnDayType;
+        @Schema(example = "1")
+        public Integer recalculationCompoundingFrequencyDayOfWeekType;
+        @Schema(example = "1")
+        public Integer recalculationRestFrequencyOnDayType;
+        @Schema(example = "1")
+        public Integer recalculationRestFrequencyDayOfWeekType;
         @Schema(example = "false")
         public Boolean isArrearsBasedOnOriginalSchedule;
         @Schema(example = "false")

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/api/LoanProductsApiResourceSwagger.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/api/LoanProductsApiResourceSwagger.java
@@ -1519,6 +1519,12 @@ public final class LoanProductsApiResourceSwagger {
         public Integer overDueDaysForRepaymentEvent;
         @Schema(example = "3")
         public Integer inArrearsTolerance;
+        @Schema(example = "1")
+        public Integer graceOnPrincipalPayment;
+        @Schema(example = "1")
+        public Integer graceOnInterestPayment;
+        @Schema(example = "1")
+        public Integer graceOnArrearsAgeing;
         @Schema(example = "false")
         public Boolean enableDownPayment;
         @Schema(example = "5.5")

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/api/ReportsApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/api/ReportsApiResourceSwagger.java
@@ -91,6 +91,8 @@ final class ReportsApiResourceSwagger {
         public String description;
         @Schema(example = "select 'very good sql' as AComment")
         public String reportSql;
+        @Schema(example = "true")
+        public Boolean useReport;
         public Collection<ReportParameterData> reportParameters;
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/interoperation/api/InteropApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/interoperation/api/InteropApiResource.java
@@ -70,6 +70,7 @@ import org.apache.fineract.interoperation.data.InteropTransferResponseData;
 import org.apache.fineract.interoperation.domain.InteropIdentifierType;
 import org.apache.fineract.interoperation.domain.InteropTransferActionType;
 import org.apache.fineract.interoperation.service.InteropService;
+import org.apache.fineract.portfolio.loanaccount.api.LoanTransactionsApiResourceSwagger;
 import org.springframework.stereotype.Component;
 
 @Path("/v1/interoperation") // api/v1/
@@ -377,7 +378,8 @@ public class InteropApiResource {
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_JSON })
     @Path("transactions/{accountId}/loanrepayment")
-    @Operation(summary = "Disburse Loan by Account Id", description = "")
+    @Operation(summary = "Loan Repayment by Account Id", description = "")
+    @RequestBody(required = true, content = @Content(schema = @Schema(implementation = LoanTransactionsApiResourceSwagger.PostLoansLoanIdTransactionsRequest.class)))
     public String loanRepayment(@PathParam("accountId") @Parameter(description = "accountId") String accountId,
             @Parameter(hidden = true) final String apiRequestBodyAsJson, @Context UriInfo uriInfo) {
         return interopService.loanRepayment(accountId, apiRequestBodyAsJson);

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/api/ClientChargesApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/api/ClientChargesApiResourceSwagger.java
@@ -125,7 +125,7 @@ final class ClientChargesApiResourceSwagger {
         private PostClientsClientIdChargesRequest() {}
 
         @Schema(example = "100")
-        public Integer amount;
+        public BigDecimal amount;
         @Schema(example = "226")
         public Long chargeId;
         @Schema(example = "dd MMMM yyyy")

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoansApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoansApiResourceSwagger.java
@@ -134,6 +134,34 @@ final class LoansApiResourceSwagger {
             public Boolean overpaid;
         }
 
+        static final class GetLoansLoanIdCollateralData {
+
+            private GetLoansLoanIdCollateralData() {}
+
+            @Schema(example = "1")
+            public Long collateralId;
+            @Schema(example = "1")
+            public Long clientCollateralId;
+            @Schema(example = "1")
+            public BigDecimal quantity;
+            @Schema(example = "10000.00")
+            public BigDecimal total;
+            @Schema(example = "10000.00")
+            public BigDecimal totalCollateral;
+        }
+
+        static final class GetLoansLoanIdSubStatus {
+
+            private GetLoansLoanIdSubStatus() {}
+
+            @Schema(example = "1")
+            public Long id;
+            @Schema(example = "loanSubStatus.foreclosed")
+            public String code;
+            @Schema(example = "Foreclosed")
+            public String value;
+        }
+
         static final class GetLoansLoanIdLoanType {
 
             private GetLoansLoanIdLoanType() {}
@@ -314,6 +342,7 @@ final class LoansApiResourceSwagger {
             @Schema(example = "0.00")
             public BigDecimal totalOutstanding;
             public List<GetLoansLoanIdRepaymentPeriod> periods;
+            public List<GetLoansLoanIdRepaymentPeriod> futurePeriods;
         }
 
         static final class GetLoansLoanIdRepaymentPeriod {
@@ -1162,6 +1191,8 @@ final class LoansApiResourceSwagger {
         @Schema(example = "000000001")
         public String accountNo;
         public GetLoansLoanIdStatus status;
+        public GetLoansLoanIdSubStatus subStatus;
+        public List<GetLoansLoanIdCollateralData> collateral;
         @Schema(example = "false")
         public boolean disallowExpectedDisbursements;
         @Schema(example = "1")
@@ -1433,6 +1464,7 @@ final class LoansApiResourceSwagger {
         public List<PostLoansDataTable> datatables;
 
         public List<PostLoansRequestChargeData> charges;
+        public List<PostLoansRequestCollateralData> collateral;
         @Schema(example = "1")
         public Long linkAccountId;
 
@@ -1460,6 +1492,20 @@ final class LoansApiResourceSwagger {
 
             @Schema(example = "1.0")
             public BigDecimal amount;
+
+            @Schema(example = "29 September 2011")
+            public String dueDate;
+        }
+
+        static final class PostLoansRequestCollateralData {
+
+            private PostLoansRequestCollateralData() {}
+
+            @Schema(example = "1")
+            public Long clientCollateralId;
+
+            @Schema(example = "1")
+            public BigDecimal quantity;
         }
 
         @Schema(description = "Originator data for loan creation request")
@@ -1815,6 +1861,8 @@ final class LoansApiResourceSwagger {
         public String externalId;
         @Schema(example = "5000.33")
         public BigDecimal transactionAmount;
+        @Schema(example = "5000.33")
+        public BigDecimal netDisbursalAmount;
         @Schema(example = "Description of disbursement details.")
         public String note;
         @Schema(example = "28 June 2022")

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoansApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoansApiResourceSwagger.java
@@ -134,6 +134,34 @@ final class LoansApiResourceSwagger {
             public Boolean overpaid;
         }
 
+        static final class GetLoansLoanIdCollateralData {
+
+            private GetLoansLoanIdCollateralData() {}
+
+            @Schema(example = "1")
+            public Long collateralId;
+            @Schema(example = "1")
+            public Long clientCollateralId;
+            @Schema(example = "1")
+            public BigDecimal quantity;
+            @Schema(example = "10000.00")
+            public BigDecimal total;
+            @Schema(example = "10000.00")
+            public BigDecimal totalCollateral;
+        }
+
+        static final class GetLoansLoanIdSubStatus {
+
+            private GetLoansLoanIdSubStatus() {}
+
+            @Schema(example = "1")
+            public Long id;
+            @Schema(example = "loanSubStatus.foreclosed")
+            public String code;
+            @Schema(example = "Foreclosed")
+            public String value;
+        }
+
         static final class GetLoansLoanIdLoanType {
 
             private GetLoansLoanIdLoanType() {}
@@ -314,6 +342,7 @@ final class LoansApiResourceSwagger {
             @Schema(example = "0.00")
             public BigDecimal totalOutstanding;
             public List<GetLoansLoanIdRepaymentPeriod> periods;
+            public List<GetLoansLoanIdRepaymentPeriod> futurePeriods;
         }
 
         static final class GetLoansLoanIdRepaymentPeriod {
@@ -1162,6 +1191,8 @@ final class LoansApiResourceSwagger {
         @Schema(example = "000000001")
         public String accountNo;
         public GetLoansLoanIdStatus status;
+        public GetLoansLoanIdSubStatus subStatus;
+        public List<GetLoansLoanIdCollateralData> collateral;
         @Schema(example = "false")
         public boolean disallowExpectedDisbursements;
         @Schema(example = "1")
@@ -1431,6 +1462,7 @@ final class LoansApiResourceSwagger {
         public List<PostLoansDataTable> datatables;
 
         public List<PostLoansRequestChargeData> charges;
+        public List<PostLoansRequestCollateralData> collateral;
         @Schema(example = "1")
         public Long linkAccountId;
 
@@ -1453,6 +1485,20 @@ final class LoansApiResourceSwagger {
 
             @Schema(example = "1.0")
             public BigDecimal amount;
+
+            @Schema(example = "29 September 2011")
+            public String dueDate;
+        }
+
+        static final class PostLoansRequestCollateralData {
+
+            private PostLoansRequestCollateralData() {}
+
+            @Schema(example = "1")
+            public Long clientCollateralId;
+
+            @Schema(example = "1")
+            public BigDecimal quantity;
         }
 
         @Schema(description = "Originator data for loan creation request")
@@ -1792,6 +1838,8 @@ final class LoansApiResourceSwagger {
         public String externalId;
         @Schema(example = "5000.33")
         public BigDecimal transactionAmount;
+        @Schema(example = "5000.33")
+        public BigDecimal netDisbursalAmount;
         @Schema(example = "Description of disbursement details.")
         public String note;
         @Schema(example = "28 June 2022")

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/api/SavingsAccountsApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/api/SavingsAccountsApiResourceSwagger.java
@@ -299,8 +299,16 @@ final class SavingsAccountsApiResourceSwagger {
 
         @Schema(example = "en")
         public String locale;
+        @Schema(example = "dd MMMM yyyy")
+        public String dateFormat;
         @Schema(example = "5.9999999999")
         public Double nominalAnnualInterestRate;
+        @Schema(example = "1")
+        public Long clientId;
+        @Schema(example = "1")
+        public Long productId;
+        @Schema(example = "01 March 2011")
+        public String submittedOnDate;
     }
 
     @Schema(description = "PutSavingsAccountsAccountIdResponse")
@@ -316,6 +324,8 @@ final class SavingsAccountsApiResourceSwagger {
             public Double nominalAnnualInterestRate;
             @Schema(example = "en")
             public String locale;
+            @Schema(example = "01 March 2011")
+            public String submittedOnDate;
         }
 
         @Schema(example = "2")

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/AdvancedPaymentAllocationLoanRepaymentScheduleTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/AdvancedPaymentAllocationLoanRepaymentScheduleTest.java
@@ -18,33 +18,28 @@
  */
 package org.apache.fineract.integrationtests;
 
-import static org.apache.fineract.integrationtests.BaseLoanIntegrationTest.InterestRateFrequencyType.MONTHS;
-import static org.apache.fineract.integrationtests.BaseLoanIntegrationTest.InterestRateFrequencyType.WHOLE_TERM;
-import static org.apache.fineract.integrationtests.BaseLoanIntegrationTest.InterestRateFrequencyType.YEARS;
-import static org.apache.fineract.integrationtests.BaseLoanIntegrationTest.RepaymentFrequencyType.DAYS;
+import static org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestRateFrequencyType.MONTHS;
+import static org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestRateFrequencyType.WHOLE_TERM;
+import static org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestRateFrequencyType.YEARS;
+import static org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.LOCALE;
+import static org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.RepaymentFrequencyType.DAYS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
 import org.apache.fineract.client.models.AdvancedPaymentData;
-import org.apache.fineract.client.models.BusinessDateUpdateRequest;
 import org.apache.fineract.client.models.CreditAllocationData;
 import org.apache.fineract.client.models.CreditAllocationOrder;
 import org.apache.fineract.client.models.GetLoanProductsProductIdResponse;
@@ -72,26 +67,27 @@ import org.apache.fineract.client.models.PostLoansResponse;
 import org.apache.fineract.client.models.PostUpdateRescheduleLoansRequest;
 import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
 import org.apache.fineract.client.models.PutLoansLoanIdRequest;
-import org.apache.fineract.client.util.CallFailedRuntimeException;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
-import org.apache.fineract.integrationtests.common.BusinessDateHelper;
-import org.apache.fineract.integrationtests.common.BusinessStepHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignBusinessStepHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignTransactionHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignUserHelper;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.DaysInMonthType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.DaysInYearType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestCalculationPeriodType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.RepaymentFrequencyType;
 import org.apache.fineract.integrationtests.common.ClientHelper;
 import org.apache.fineract.integrationtests.common.CommonConstants;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.LoanRescheduleRequestHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.common.accounting.Account;
-import org.apache.fineract.integrationtests.common.accounting.AccountHelper;
 import org.apache.fineract.integrationtests.common.accounting.PeriodicAccrualAccountingHelper;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
 import org.apache.fineract.integrationtests.common.loans.CobHelper;
 import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.apache.fineract.integrationtests.common.organisation.StaffHelper;
 import org.apache.fineract.integrationtests.common.products.DelinquencyBucketsHelper;
-import org.apache.fineract.integrationtests.common.system.CodeHelper;
-import org.apache.fineract.integrationtests.useradministration.roles.RolesHelper;
-import org.apache.fineract.integrationtests.useradministration.users.UserHelper;
 import org.apache.fineract.portfolio.loanaccount.domain.transactionprocessor.impl.AdvancedPaymentScheduleTransactionProcessor;
 import org.apache.fineract.portfolio.loanaccount.domain.transactionprocessor.impl.EarlyPaymentLoanRepaymentScheduleTransactionProcessor;
 import org.apache.fineract.portfolio.loanaccount.domain.transactionprocessor.impl.FineractStyleLoanRepaymentScheduleTransactionProcessor;
@@ -105,30 +101,15 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoanIntegrationTest {
+public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends FeignLoanTestBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(AdvancedPaymentAllocationLoanRepaymentScheduleTest.class);
-    private static final String DATETIME_PATTERN = "dd MMMM yyyy";
-    private static ResponseSpecification responseSpec;
-    private static RequestSpecification requestSpec;
-    private static BusinessDateHelper businessDateHelper;
-    private static LoanTransactionHelper loanTransactionHelper;
-    private static AccountHelper accountHelper;
-    private static Integer commonLoanProductId;
+
+    private static Long commonLoanProductId;
     private static PostClientsResponse client;
 
     @BeforeAll
     public static void setup() {
-        Utils.initializeRESTAssured();
-        requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        requestSpec.header("Fineract-Platform-TenantId", "default");
-        responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-        businessDateHelper = new BusinessDateHelper();
-        accountHelper = new AccountHelper(requestSpec, responseSpec);
-        ClientHelper clientHelper = new ClientHelper(requestSpec, responseSpec);
-
         final Account assetAccount = accountHelper.createAssetAccount();
         final Account incomeAccount = accountHelper.createIncomeAccount();
         final Account expenseAccount = accountHelper.createExpenseAccount();
@@ -138,9 +119,24 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                 LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
         client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
         // setup COB Business Steps to prevent test failing due other integration test configurations
-        new BusinessStepHelper().updateSteps("LOAN_CLOSE_OF_BUSINESS", "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION",
-                "CHECK_LOAN_REPAYMENT_DUE", "CHECK_LOAN_REPAYMENT_OVERDUE", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
+        new FeignBusinessStepHelper(FineractFeignClientHelper.getFineractFeignClient()).updateSteps("LOAN_CLOSE_OF_BUSINESS",
+                "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION", "CHECK_LOAN_REPAYMENT_DUE",
+                "CHECK_LOAN_REPAYMENT_OVERDUE", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
                 "EXTERNAL_ASSET_OWNER_TRANSFER", "CHECK_DUE_INSTALLMENTS", "ACCRUAL_ACTIVITY_POSTING", "LOAN_INTEREST_RECALCULATION");
+    }
+
+    /** Prepayment amounts as of the given date; the loan template exposes them per portion. */
+    private static GetLoansLoanIdTransactionsTemplateResponse getPrepayAmount(Long loanId, LocalDate date) {
+        return transactionHelper.getPrepaymentAmount(loanId, dateTimeFormatter.format(date), DATETIME_PATTERN);
+    }
+
+    private static Long addSpecifiedDueDateCharge(Long loanId, Long chargeId, String dueDate, double amount) {
+        return loanHelper.addSpecifiedDueDateCharge(loanId, chargeId, amount, dueDate).getResourceId();
+    }
+
+    private static void applyLoanExpectingError(PostLoansRequest request, int expectedHttpStatus) {
+        CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class, () -> loanHelper.applyForLoan(request));
+        assertEquals(expectedHttpStatus, exception.getStatus());
     }
 
     // UC1: Simple payments
@@ -156,15 +152,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -173,10 +167,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 1, 125.0, 125.0, 0.0, 375.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 250.0, 250.0, 250.0, 250.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -185,10 +179,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 2, 125.0, 125.0, 0.0, 250.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 125.0, 375.0, 125.0, 375.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -197,10 +191,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 3, 125.0, 125.0, 0.0, 125.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("15 February 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -224,15 +218,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -241,10 +233,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 1, 125.0, 125.0, 0.0, 375.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(150.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 225.0, 275.0, 225.0, 275.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -253,10 +245,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 2, 150.0, 150.0, 0.0, 225.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 100.0, 400.0, 100.0, 400.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -265,10 +257,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 3, 125.0, 125.0, 0.0, 100.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("15 February 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, 25.0);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -278,7 +270,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             assertTrue(loanDetails.getStatus().getOverpaid());
 
             // Loan Repayment (after) Overpaid
-            GetLoansLoanIdTransactionsTemplateResponse transactionAfter = loanTransactionHelper
+            GetLoansLoanIdTransactionsTemplateResponse transactionAfter = transactionHelper
                     .retrieveTransactionTemplate(loanResponse.getLoanId(), "repayment", DATETIME_PATTERN, "15 February 2023", LOCALE);
             assertNotNull(transactionAfter);
         });
@@ -296,15 +288,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -313,10 +303,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 1, 125.0, 125.0, 0.0, 375.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeGoodwillCredit(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeGoodwillCredit(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(150.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 225.0, 275.0, 225.0, 275.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -325,10 +315,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 2, 150.0, 150.0, 0.0, 225.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 100.0, 400.0, 100.0, 400.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -337,10 +327,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 3, 125.0, 125.0, 0.0, 100.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("15 February 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, 25.0);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -350,7 +340,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             assertTrue(loanDetails.getStatus().getOverpaid());
 
             // Loan Repayment (after) Overpaid
-            GetLoansLoanIdTransactionsTemplateResponse transactionAfter = loanTransactionHelper
+            GetLoansLoanIdTransactionsTemplateResponse transactionAfter = transactionHelper
                     .retrieveTransactionTemplate(loanResponse.getLoanId(), "repayment", DATETIME_PATTERN, "15 February 2023", LOCALE);
             assertNotNull(transactionAfter);
         });
@@ -369,19 +359,17 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
-            loanTransactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(1).getId(),
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
+            transactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(1).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("01 January 2023")
                             .transactionAmount(0.0).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 500.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -389,14 +377,14 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, 125.0, 0.0, 125.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(125.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
-            loanTransactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(2).getId(),
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
+            transactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(2).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023")
                             .transactionAmount(0.0).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 500.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -405,10 +393,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
 
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("20 January 2023").locale("en").transactionAmount(100.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 400.0, 100.0, 400.0, 100.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 100.0, 25.0, 0.0, 100.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -417,10 +405,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 3, 100.0, 100.0, 0.0, 400.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(40.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 360.0, 140.0, 360.0, 140.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 15.0, 110.0, 0.0, 15.0);
@@ -429,10 +417,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 4, 40.0, 40.0, 0.0, 360.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("15 February 2023").locale("en").transactionAmount(360.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 125.0);
@@ -455,16 +443,14 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
             // Verify initial state: down payment (installment 1) already paid, remaining 3 installments outstanding
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -473,10 +459,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             assertTrue(loanDetails.getStatus().getActive());
 
             // Fully pay installment 2
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 250.0, 250.0, 250.0, 250.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -487,7 +473,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             // Repayment template must point to installment 3 (next unpaid), not installment 2 (fully paid)
             // Before the fix, this would return 0.0 because the query always picked the lowest installment
             // number with outstanding balance, which after partial repayment could be a fully satisfied one
-            final GetLoansLoanIdTransactionsTemplateResponse transactionTemplate = loanTransactionHelper
+            final GetLoansLoanIdTransactionsTemplateResponse transactionTemplate = transactionHelper
                     .retrieveTransactionTemplate(loanResponse.getLoanId(), "repayment", DATETIME_PATTERN, "16 January 2023", LOCALE);
             assertNotNull(transactionTemplate);
             assertEquals(125.0, transactionTemplate.getAmount().doubleValue());
@@ -511,19 +497,17 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
-            loanTransactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(1).getId(),
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
+            transactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(1).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("01 January 2023")
                             .transactionAmount(0.0).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 500.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -531,10 +515,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, 125.0, 0.0, 125.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("8 January 2023").locale("en").transactionAmount(300.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 200.0, 300.0, 200.0, 300.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 58.33, 66.67, 58.33, 0.0);
@@ -543,10 +527,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 2, 300.0, 300.0, 0.0, 200.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(66.67));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 133.33, 366.67, 133.33, 366.67, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 58.33, 0.0);
@@ -555,10 +539,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 3, 66.67, 66.67, 0.0, 133.33);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(66.67));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 66.66, 433.34, 66.66, 433.34, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 58.33, 0.0);
@@ -567,10 +551,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 4, 66.67, 66.67, 0.0, 66.66);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("15 February 2023").locale("en").transactionAmount(66.66));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 58.33, 0.0);
@@ -595,15 +579,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
 
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -613,10 +595,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 1, 125.0, 125.0, 0.0, 375.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 250.0, 250.0, 250.0, 250.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -625,10 +607,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 2, 125.0, 125.0, 0.0, 250.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(200.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 50.0, 450.0, 50.0, 450.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -637,10 +619,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 3, 200, 200.0, 0.0, 50.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(25.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 25.0, 475.0, 25.0, 475.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -649,10 +631,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 4, 25.0, 25.0, 0.0, 25.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("15 February 2023").locale("en").transactionAmount(25.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -677,19 +659,17 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
-            loanTransactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(1).getId(),
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
+            transactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(1).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("01 January 2023")
                             .transactionAmount(0.0).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 500.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -697,14 +677,14 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, 125.0, 0.0, 125.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(125.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
-            loanTransactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(2).getId(),
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
+            transactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(2).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023")
                             .transactionAmount(0.0).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 500.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -712,10 +692,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, 125.0, 0.0, 125.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("17 January 2023").locale("en").transactionAmount(300.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 200.0, 300.0, 200.0, 300.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 125.0);
@@ -724,10 +704,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 3, 300.0, 300.0, 0.0, 200.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(100.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 100.0, 400.0, 100.0, 400.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 125.0);
@@ -736,10 +716,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 4, 100.0, 100.0, 0.0, 100.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("15 February 2023").locale("en").transactionAmount(100.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 125.0);
@@ -763,15 +743,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -780,10 +758,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 1, 125.0, 125.0, 0.0, 375.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makePayoutRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makePayoutRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("05 January 2023").locale("en").transactionAmount(200.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 175.0, 325.0, 175.0, 325.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -792,10 +770,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 2, 200.0, 200.0, 0.0, 175.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(50.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 125.0, 375.0, 125.0, 375.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -804,10 +782,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 3, 50.0, 50.0, 0.0, 125.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("15 February 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -832,15 +810,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -849,14 +825,14 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 1, 125.0, 125.0, 0.0, 375.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(125.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
-            loanTransactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(2).getId(),
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
+            transactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(2).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023")
                             .transactionAmount(0.0).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -864,10 +840,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, 125.0, 0.0, 125.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makePayoutRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makePayoutRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("17 January 2023").locale("en").transactionAmount(200.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 175.0, 325.0, 175.0, 325.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 125.0);
@@ -876,10 +852,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 3, 200.0, 200.0, 0.0, 175.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(50.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 125.0, 375.0, 125.0, 375.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 125.0);
@@ -888,10 +864,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 4, 50.0, 50.0, 0.0, 125.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("15 February 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 125.0);
@@ -915,20 +891,18 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
-            loanTransactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(1).getId(),
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
+            transactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(1).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("01 January 2023")
                             .transactionAmount(0.0).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 500.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -936,10 +910,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, 125.0, 0.0, 125.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makePayoutRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makePayoutRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("15 January 2023").locale("en").transactionAmount(400.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 100.0, 400.0, 100.0, 400.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -948,10 +922,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 2, 400.0, 400.0, 0.0, 100.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("15 February 2023").locale("en").transactionAmount(100.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -975,15 +949,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -992,10 +964,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 1, 125.0, 125.0, 0.0, 375.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeGoodwillCredit(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeGoodwillCredit(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("08 January 2023").locale("en").transactionAmount(200.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 175.0, 325.0, 175.0, 325.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1004,10 +976,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 2, 200.0, 200.0, 0.0, 175.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 50.0, 450.0, 50.0, 450.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -1016,10 +988,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 3, 125.0, 125.0, 0.0, 50.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(50.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -1044,15 +1016,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1061,13 +1031,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 1, 125.0, 125.0, 0.0, 375.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(125.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
-            loanTransactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(2).getId(),
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
+            transactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(2).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023")
                             .transactionAmount(0.0).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1075,10 +1045,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, 125.0, 0.0, 125.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeGoodwillCredit(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeGoodwillCredit(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("18 January 2023").locale("en").transactionAmount(200.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 175.0, 325.0, 175.0, 325.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 125.0);
@@ -1087,10 +1057,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 3, 200.0, 200.0, 0.0, 175.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 50.0, 450.0, 50.0, 450.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 125.0);
@@ -1099,10 +1069,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 4, 125.0, 125.0, 0.0, 50.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("15 February 2023").locale("en").transactionAmount(50.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 125.0);
@@ -1127,20 +1097,18 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
-            loanTransactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(1).getId(),
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
+            transactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(1).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("01 January 2023")
                             .transactionAmount(0.0).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 500.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1148,14 +1116,14 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, 125.0, 0.0, 125.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(125.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
-            loanTransactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(2).getId(),
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
+            transactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(2).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023")
                             .transactionAmount(0.0).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 500.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1163,9 +1131,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, 125.0, 0.0, 125.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("17 January 2023").locale("en").transactionAmount(200.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 300.0, 200.0, 300.0, 200.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 75.0, 50.0, 0.0, 75.0);
@@ -1174,9 +1142,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 3, 200.0, 200.0, 0.0, 300.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(125.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 175.0, 325.0, 175.0, 325.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 125.0);
@@ -1185,9 +1153,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 4, 125.0, 125.0, 0.0, 175.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("15 February 2023").locale("en").transactionAmount(175.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 125.0);
@@ -1212,20 +1180,18 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
-            loanTransactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(1).getId(),
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
+            transactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(1).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("01 January 2023")
                             .transactionAmount(0.0).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 500.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1233,10 +1199,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, 125.0, 0.0, 125.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeGoodwillCredit(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeGoodwillCredit(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("15 January 2023").locale("en").transactionAmount(200.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 300.0, 200.0, 300.0, 200.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1245,9 +1211,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 2, 200.0, 200.0, 0.0, 300.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(125.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 175.0, 325.0, 175.0, 325.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -1256,9 +1222,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 3, 125.0, 125.0, 0.0, 175.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(125.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 50.0, 450.0, 50.0, 450.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -1267,9 +1233,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 4, 125.0, 125.0, 0.0, 50.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("15 February 2023").locale("en").transactionAmount(50.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -1294,15 +1260,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1311,10 +1275,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 1, 125.0, 125.0, 0.0, 375.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("08 January 2023").locale("en").transactionAmount(500.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, 125.0);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -1323,9 +1287,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 2, 500.0, 375.0, 125.0, 0.0);
             assertTrue(loanDetails.getStatus().getOverpaid());
 
-            loanTransactionHelper.makeCreditBalanceRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeCreditBalanceRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("09 January 2023").locale("en").transactionAmount(125.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -1350,15 +1314,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1367,10 +1329,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 1, 125.0, 125.0, 0.0, 375.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makePayoutRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makePayoutRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("08 January 2023").locale("en").transactionAmount(500.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, 125.0);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -1379,9 +1341,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 2, 500.0, 375.0, 125.0, 0.0);
             assertTrue(loanDetails.getStatus().getOverpaid());
 
-            loanTransactionHelper.makeCreditBalanceRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeCreditBalanceRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("09 January 2023").locale("en").transactionAmount(125.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -1406,15 +1368,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1423,10 +1383,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 1, 125.0, 125.0, 0.0, 375.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeGoodwillCredit(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeGoodwillCredit(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("08 January 2023").locale("en").transactionAmount(500.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, 125.0);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -1435,9 +1395,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 2, 500.0, 375.0, 125.0, 0.0);
             assertTrue(loanDetails.getStatus().getOverpaid());
 
-            loanTransactionHelper.makeCreditBalanceRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeCreditBalanceRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("09 January 2023").locale("en").transactionAmount(125.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -1462,15 +1422,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1479,10 +1437,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 1, 125.0, 125.0, 0.0, 375.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 250.0, 250.0, 250.0, 250.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -1491,10 +1449,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 2, 125.0, 125.0, 0.0, 250.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 125.0, 375.0, 125.0, 375.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -1503,10 +1461,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 3, 125.0, 125.0, 0.0, 125.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("15 February 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -1515,9 +1473,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 4, 125.0, 125.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getClosedObligationsMet());
 
-            loanTransactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("18 February 2023").locale("en").transactionAmount(500.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, 500.0);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -1526,9 +1484,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 5, 500.0, 0.0, 500.0, 0.0);
             assertTrue(loanDetails.getStatus().getOverpaid());
 
-            loanTransactionHelper.makeCreditBalanceRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeCreditBalanceRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("20 February 2023").locale("en").transactionAmount(500.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -1555,19 +1513,17 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
-            loanTransactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(1).getId(),
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
+            transactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(1).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023")
                             .transactionAmount(0.0).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 500.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1575,10 +1531,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, 125.0, 0.0, 125.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("02 January 2023").locale("en").transactionAmount(400.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 100.0, 400.0, 100.0, 400.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 91.67, 33.33, 91.67, 0.0);
@@ -1587,9 +1543,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 2, 400.0, 400.0, 0.0, 100.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("04 January 2023").locale("en").transactionAmount(50.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 50.0, 450.0, 50.0, 450.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -1598,9 +1554,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 3, 50.0, 50.0, 0.0, 50.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(125.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, 75.0);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -1609,9 +1565,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 4, 125.0, 50.0, 75.0, 0.0);
             assertTrue(loanDetails.getStatus().getOverpaid());
 
-            loanTransactionHelper.makeCreditBalanceRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeCreditBalanceRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("18 January 2023").locale("en").transactionAmount(75.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -1620,10 +1576,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 5, 75.0, 0.0, 75.0, 0.0);
             assertTrue(loanDetails.getStatus().getClosedObligationsMet());
 
-            loanTransactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(2).getId(),
+            transactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(2).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("20 January 2023")
                             .transactionAmount(0.0).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 400.0, 175.0, 400.0, 175.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 50.0, 75.0, 0.0, 0.0);
@@ -1631,9 +1587,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, 125.0, 0.0, 125.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(275.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 125.0, 450.0, 125.0, 450.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 75.0);
@@ -1642,9 +1598,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 6, 275.0, 275.0, 0.0, 125.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("15 February 2023").locale("en").transactionAmount(125.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 575.0, 0.0, 575.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 75.0);
@@ -1669,19 +1625,17 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
-            loanTransactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(1).getId(),
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
+            transactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(1).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023")
                             .transactionAmount(0.0).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 500.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1689,9 +1643,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, 125.0, 0.0, 125.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("02 January 2023").locale("en").transactionAmount(400.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 100.0, 400.0, 100.0, 400.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 91.67, 33.33, 91.67, 0.0);
@@ -1700,9 +1654,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 2, 400.0, 400.0, 0.0, 100.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("04 January 2023").locale("en").transactionAmount(50.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 50.0, 450.0, 50.0, 450.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -1711,9 +1665,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 3, 50.0, 50.0, 0.0, 50.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("06 January 2023").locale("en").transactionAmount(40.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 10.0, 490.0, 10.0, 490.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -1737,20 +1691,18 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account incomeAccount = accountHelper.createIncomeAccount();
             final Account expenseAccount = accountHelper.createExpenseAccount();
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("500", "15", "4", true, "25", false, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("500", "15", "4", true, "25", false, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 500.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1758,9 +1710,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, 125.0, 0.0, 125.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("04 January 2023").locale("en").transactionAmount(175.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 325.0, 175.0, 325.0, 175.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 50.0, 75.0, 50.0, 0.0);
@@ -1769,10 +1721,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 1, 175.0, 175.0, 0.0, 325.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("05 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("05 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 825.0, 175.0, 825.0, 175.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1782,13 +1733,11 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             assertTrue(loanDetails.getStatus().getActive());
 
             // Add Charge Penalty
-            Integer penalty = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "100", true));
-            Integer penalty1LoanChargeId = loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "22 February 2023", "100"));
+            Long penalty = chargesHelper.createLoanSpecifiedDueDatePenalty(100.0).getResourceId();
+            Long penalty1LoanChargeId = addSpecifiedDueDateCharge(loanResponse.getLoanId(), penalty, "22 February 2023", 100.0);
             assertNotNull(penalty1LoanChargeId);
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 925.0, 175.0, 825.0, 175.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1816,20 +1765,18 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account incomeAccount = accountHelper.createIncomeAccount();
             final Account expenseAccount = accountHelper.createExpenseAccount();
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("500", "15", "4", true, "25", false, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("500", "15", "4", true, "25", false, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 500.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1845,7 +1792,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             LoanRescheduleRequestHelper.approveLoanRescheduleRequest(rescheduleLoansResponse.getResourceId(),
                     new PostUpdateRescheduleLoansRequest().approvedOnDate("16 January 2023").locale("en").dateFormat(DATETIME_PATTERN));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 500.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 31), 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1853,9 +1800,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, LocalDate.of(2023, 3, 2), 125.0, 0.0, 125.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(350.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 150.0, 350.0, 150.0, 350.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 31), 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -1863,11 +1810,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, LocalDate.of(2023, 3, 2), 125.0, 0.0, 125.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("20 February 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(250.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("20 February 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(250.0)).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 400.0, 350.0, 400.0, 350.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 31), 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -1883,7 +1829,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             LoanRescheduleRequestHelper.approveLoanRescheduleRequest(rescheduleLoansResponse.getResourceId(),
                     new PostUpdateRescheduleLoansRequest().approvedOnDate("15 February 2023").locale("en").dateFormat(DATETIME_PATTERN));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 400.0, 350.0, 400.0, 350.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 31), 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -1908,20 +1854,18 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account incomeAccount = accountHelper.createIncomeAccount();
             final Account expenseAccount = accountHelper.createExpenseAccount();
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("500", "15", "4", true, "25", false, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("500", "15", "4", true, "25", false, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 500.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1930,13 +1874,11 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             assertTrue(loanDetails.getStatus().getActive());
 
             // Add Charge Penalty
-            Integer penalty = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "100", true));
-            Integer penalty1LoanChargeId = loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "22 February 2023", "100"));
+            Long penalty = chargesHelper.createLoanSpecifiedDueDatePenalty(100.0).getResourceId();
+            Long penalty1LoanChargeId = addSpecifiedDueDateCharge(loanResponse.getLoanId(), penalty, "22 February 2023", 100.0);
             assertNotNull(penalty1LoanChargeId);
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 600.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1946,9 +1888,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("22 February 2023").locale("en").transactionAmount(600.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 600.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 125.0, 125.0, 0.0, 0.0, 125.0);
@@ -1975,20 +1917,18 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account incomeAccount = accountHelper.createIncomeAccount();
             final Account expenseAccount = accountHelper.createExpenseAccount();
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("500", "15", "4", true, "25", false, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("500", "15", "4", true, "25", false, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 500.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1997,14 +1937,11 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             assertTrue(loanDetails.getStatus().getActive());
 
             // Add Charge Penalty
-            Integer penalty = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "25", true));
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "20 January 2023", "25"));
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "10 February 2023", "25"));
+            Long penalty = chargesHelper.createLoanSpecifiedDueDatePenalty(25.0).getResourceId();
+            addSpecifiedDueDateCharge(loanResponse.getLoanId(), penalty, "20 January 2023", 25.0);
+            addSpecifiedDueDateCharge(loanResponse.getLoanId(), penalty, "10 February 2023", 25.0);
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 550.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -2014,9 +1951,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("22 February 2023").locale("en").transactionAmount(260.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 290.0, 260.0, 250.0, 250.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 125.0, 125.0, 0.0, 0.0, 125.0);
@@ -2026,9 +1963,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("22 February 2023").locale("en").transactionAmount(26.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 264.0, 286.0, 239.0, 261.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 125.0, 125.0, 0.0, 0.0, 125.0);
@@ -2054,21 +1991,19 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account incomeAccount = accountHelper.createIncomeAccount();
             final Account expenseAccount = accountHelper.createExpenseAccount();
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("500", "15", "4", true, "25", false, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("500", "15", "4", true, "25", false, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.VERTICAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023",
                     LoanScheduleProcessingType.VERTICAL);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 500.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -2077,14 +2012,11 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             assertTrue(loanDetails.getStatus().getActive());
 
             // Add Charge Penalty
-            Integer penalty = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "25", true));
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "20 January 2023", "25"));
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "10 February 2023", "25"));
+            Long penalty = chargesHelper.createLoanSpecifiedDueDatePenalty(25.0).getResourceId();
+            addSpecifiedDueDateCharge(loanResponse.getLoanId(), penalty, "20 January 2023", 25.0);
+            addSpecifiedDueDateCharge(loanResponse.getLoanId(), penalty, "10 February 2023", 25.0);
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 550.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -2094,9 +2026,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("22 February 2023").locale("en").transactionAmount(26.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 524.0, 26.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -2106,9 +2038,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     0.0, 0.0, 1.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("22 February 2023").locale("en").transactionAmount(26.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 498.0, 52.0, 498.0, 2.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 125.0, 2.0, 123.0, 0.0, 2.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -2163,13 +2095,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
             AdvancedPaymentData defaultPaymentAllocation = createDefaultPaymentAllocationWithMixedGrouping();
 
-            Integer localLoanProductId = createLoanProduct("500", "15", "4", false, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("500", "15", "4", false, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.VERTICAL, defaultPaymentAllocation, assetAccount, incomeAccount, expenseAccount,
                     overpaymentAccount);
             assertNotNull(localLoanProductId);
 
-            Integer localLoanProductId2 = createLoanProduct("500", "15", "4", false, LoanScheduleType.CUMULATIVE, assetAccount,
-                    incomeAccount, expenseAccount, overpaymentAccount);
+            Long localLoanProductId2 = createLoanProduct("500", "15", "4", false, LoanScheduleType.CUMULATIVE, assetAccount, incomeAccount,
+                    expenseAccount, overpaymentAccount);
             assertNotNull(localLoanProductId2);
 
             CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
@@ -2177,7 +2109,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                             BigDecimal.ZERO, "01 January 2023", "01 January 2023",
                             FineractStyleLoanRepaymentScheduleTransactionProcessor.STRATEGY_CODE,
                             LoanScheduleProcessingType.VERTICAL.name()));
-            assertEquals(400, exception.getResponse().code());
+            assertEquals(400, exception.getStatus());
             assertTrue(exception.getMessage().contains("supported.only.with.advanced.payment.allocation.strategy"));
 
             exception = assertThrows(CallFailedRuntimeException.class,
@@ -2185,7 +2117,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                             BigDecimal.ZERO, "01 January 2023", "01 January 2023",
                             AdvancedPaymentScheduleTransactionProcessor.ADVANCED_PAYMENT_ALLOCATION_STRATEGY,
                             LoanScheduleProcessingType.HORIZONTAL.name()));
-            assertEquals(400, exception.getResponse().code());
+            assertEquals(400, exception.getStatus());
             assertTrue(exception.getMessage()
                     .contains("mixed.due.type.allocation.rules.are.not.supported.with.horizontal.installment.processing"));
         });
@@ -2204,34 +2136,32 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account incomeAccount = accountHelper.createIncomeAccount();
             final Account expenseAccount = accountHelper.createExpenseAccount();
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("1000", "15", "3", false, null, false, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("1000", "15", "3", false, null, false, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
             assertNotNull(localLoanProductId);
 
             PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId, BigDecimal.valueOf(1000), 45,
                     15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 16), 333.33, 0.0, 333.33, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 31), 333.33, 0.0, 333.33, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 3, LocalDate.of(2023, 2, 15), 333.34, 0.0, 333.34, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getPendingApproval());
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 16), 333.33, 0.0, 333.33, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 31), 333.33, 0.0, 333.33, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 3, LocalDate.of(2023, 2, 15), 333.34, 0.0, 333.34, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getWaitingForDisbursal());
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(1000)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000)).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1000.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 16), 333.33, 0.0, 333.33, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 31), 333.33, 0.0, 333.33, 0.0, 0.0);
@@ -2241,7 +2171,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId, BigDecimal.valueOf(1000), 90, 15, 6,
                     BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 16), 166.67, 0.0, 166.67, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 31), 166.67, 0.0, 166.67, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 3, LocalDate.of(2023, 2, 15), 166.67, 0.0, 166.67, 0.0, 0.0);
@@ -2250,11 +2180,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 6, LocalDate.of(2023, 4, 1), 166.65, 0.0, 166.65, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getPendingApproval());
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 16), 166.67, 0.0, 166.67, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 31), 166.67, 0.0, 166.67, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 3, LocalDate.of(2023, 2, 15), 166.67, 0.0, 166.67, 0.0, 0.0);
@@ -2263,11 +2192,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 6, LocalDate.of(2023, 4, 1), 166.65, 0.0, 166.65, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getWaitingForDisbursal());
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(1000)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000)).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1000.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 16), 166.67, 0.0, 166.67, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 31), 166.67, 0.0, 166.67, 0.0, 0.0);
@@ -2293,34 +2221,32 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account incomeAccount = accountHelper.createIncomeAccount();
             final Account expenseAccount = accountHelper.createExpenseAccount();
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("1000", "15", "3", false, null, false, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("1000", "15", "3", false, null, false, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
             assertNotNull(localLoanProductId);
 
             PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId, BigDecimal.valueOf(1000), 45,
                     15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 16), 333.33, 0.0, 333.33, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 31), 333.33, 0.0, 333.33, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 3, LocalDate.of(2023, 2, 15), 333.34, 0.0, 333.34, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getPendingApproval());
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 16), 333.33, 0.0, 333.33, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 31), 333.33, 0.0, 333.33, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 3, LocalDate.of(2023, 2, 15), 333.34, 0.0, 333.34, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getWaitingForDisbursal());
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(1000)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000)).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1000.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 16), 333.33, 0.0, 333.33, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 31), 333.33, 0.0, 333.33, 0.0, 0.0);
@@ -2330,7 +2256,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId, BigDecimal.valueOf(1000), 90, 15, 6,
                     BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 16), 166.67, 0.0, 166.67, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 31), 166.67, 0.0, 166.67, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 3, LocalDate.of(2023, 2, 15), 166.67, 0.0, 166.67, 0.0, 0.0);
@@ -2339,11 +2265,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 6, LocalDate.of(2023, 4, 1), 166.65, 0.0, 166.65, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getPendingApproval());
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 16), 166.67, 0.0, 166.67, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 31), 166.67, 0.0, 166.67, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 3, LocalDate.of(2023, 2, 15), 166.67, 0.0, 166.67, 0.0, 0.0);
@@ -2352,11 +2277,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 6, LocalDate.of(2023, 4, 1), 166.65, 0.0, 166.65, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getWaitingForDisbursal());
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(1000)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000)).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1000.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 16), 166.67, 0.0, 166.67, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 31), 166.67, 0.0, 166.67, 0.0, 0.0);
@@ -2383,36 +2307,34 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account incomeAccount = accountHelper.createIncomeAccount();
             final Account expenseAccount = accountHelper.createExpenseAccount();
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("40.50", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("40.50", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
             assertNotNull(localLoanProductId);
 
             PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId, BigDecimal.valueOf(40.50),
                     45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 10.12, 0.0, 10.12, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 10.13, 0.0, 10.13, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 3, LocalDate.of(2023, 1, 31), 10.13, 0.0, 10.13, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 4, LocalDate.of(2023, 2, 15), 10.12, 0.0, 10.12, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getPendingApproval());
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(40.5)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(40.5))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 10.12, 0.0, 10.12, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 10.13, 0.0, 10.13, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 3, LocalDate.of(2023, 1, 31), 10.13, 0.0, 10.13, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 4, LocalDate.of(2023, 2, 15), 10.12, 0.0, 10.12, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getWaitingForDisbursal());
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(40.5)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(40.5)).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 40.5, 0.0, 40.5, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 10.12, 0.0, 10.12, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 10.13, 0.0, 10.13, 0.0, 0.0);
@@ -2436,36 +2358,34 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account incomeAccount = accountHelper.createIncomeAccount();
             final Account expenseAccount = accountHelper.createExpenseAccount();
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("40.50", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("40.50", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
             assertNotNull(localLoanProductId);
 
             PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId, BigDecimal.valueOf(40.50),
                     45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 10.12, 0.0, 10.12, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 10.13, 0.0, 10.13, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 3, LocalDate.of(2023, 1, 31), 10.13, 0.0, 10.13, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 4, LocalDate.of(2023, 2, 15), 10.12, 0.0, 10.12, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getPendingApproval());
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(40.5)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(40.5))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 10.12, 0.0, 10.12, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 10.13, 0.0, 10.13, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 3, LocalDate.of(2023, 1, 31), 10.13, 0.0, 10.13, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 4, LocalDate.of(2023, 2, 15), 10.12, 0.0, 10.12, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getWaitingForDisbursal());
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(40.5)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(40.5)).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 40.5, 0.0, 40.5, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 10.12, 0.0, 10.12, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 10.13, 0.0, 10.13, 0.0, 0.0);
@@ -2492,20 +2412,18 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account incomeAccount = accountHelper.createIncomeAccount();
             final Account expenseAccount = accountHelper.createExpenseAccount();
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId,
                     BigDecimal.valueOf(1000.0), 45, 15, 3, BigDecimal.ZERO, "01 September 2023", "01 September 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 September 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 September 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 September 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 September 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1000.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -2514,12 +2432,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             assertTrue(loanDetails.getStatus().getActive());
 
             // Add Charge Penalty
-            Integer penalty = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "20", true));
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "17 October 2023", "20"));
+            Long penalty = chargesHelper.createLoanSpecifiedDueDatePenalty(20.0).getResourceId();
+            addSpecifiedDueDateCharge(loanResponse.getLoanId(), penalty, "17 October 2023", 20.0);
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1020.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -2529,9 +2445,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("01 September 2023").locale("en").transactionAmount(250.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 770.0, 250.0, 750.0, 250.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -2541,12 +2457,11 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            businessDateHelper.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("2023.09.16").dateFormat("yyyy.MM.dd").locale("en"));
+            updateBusinessDate("2023-09-16");
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 September 2023").locale("en").transactionAmount(250.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 520.0, 500.0, 500.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 250.0, 0.0, 0.0, 0.0);
@@ -2556,14 +2471,12 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "17 September 2023", "20"));
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "16 October 2023", "20"));
+            addSpecifiedDueDateCharge(loanResponse.getLoanId(), penalty, "17 September 2023", 20.0);
+            addSpecifiedDueDateCharge(loanResponse.getLoanId(), penalty, "16 October 2023", 20.0);
 
-            loanTransactionHelper.makeGoodwillCredit(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeGoodwillCredit(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 September 2023").locale("en").transactionAmount(50.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 510.0, 550.0, 490.0, 510.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 250.0, 0.0, 0.0, 0.0);
@@ -2598,21 +2511,19 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account incomeAccount = accountHelper.createIncomeAccount();
             final Account expenseAccount = accountHelper.createExpenseAccount();
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.VERTICAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId,
                     BigDecimal.valueOf(1000.0), 45, 15, 3, BigDecimal.ZERO, "01 September 2023", "01 September 2023",
                     LoanScheduleProcessingType.VERTICAL);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 September 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 September 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 September 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 September 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1000.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -2621,12 +2532,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             assertTrue(loanDetails.getStatus().getActive());
 
             // Add Charge Penalty
-            Integer penalty = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "20", true));
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "17 October 2023", "20"));
+            Long penalty = chargesHelper.createLoanSpecifiedDueDatePenalty(20.0).getResourceId();
+            addSpecifiedDueDateCharge(loanResponse.getLoanId(), penalty, "17 October 2023", 20.0);
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1020.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -2636,9 +2545,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("01 September 2023").locale("en").transactionAmount(250.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 770.0, 250.0, 750.0, 250.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -2648,12 +2557,11 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            businessDateHelper.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("2023.09.16").dateFormat("yyyy.MM.dd").locale("en"));
+            updateBusinessDate("2023-09-16");
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 September 2023").locale("en").transactionAmount(250.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 520.0, 500.0, 500.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 250.0, 0.0, 0.0, 0.0);
@@ -2663,14 +2571,12 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "17 September 2023", "20"));
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "16 October 2023", "20"));
+            addSpecifiedDueDateCharge(loanResponse.getLoanId(), penalty, "17 September 2023", 20.0);
+            addSpecifiedDueDateCharge(loanResponse.getLoanId(), penalty, "16 October 2023", 20.0);
 
-            loanTransactionHelper.makeGoodwillCredit(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeGoodwillCredit(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 September 2023").locale("en").transactionAmount(50.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 510.0, 550.0, 500.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 250.0, 0.0, 0.0, 0.0);
@@ -2704,20 +2610,18 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account incomeAccount = accountHelper.createIncomeAccount();
             final Account expenseAccount = accountHelper.createExpenseAccount();
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId,
                     BigDecimal.valueOf(1000.0), 45, 15, 3, BigDecimal.ZERO, "01 September 2023", "01 September 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 September 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 September 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 September 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 September 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1000.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -2726,12 +2630,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             assertTrue(loanDetails.getStatus().getActive());
 
             // Add Charge Penalty
-            Integer penalty = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "20", true));
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "17 October 2023", "20"));
+            Long penalty = chargesHelper.createLoanSpecifiedDueDatePenalty(20.0).getResourceId();
+            addSpecifiedDueDateCharge(loanResponse.getLoanId(), penalty, "17 October 2023", 20.0);
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1020.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -2741,9 +2643,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("01 September 2023").locale("en").transactionAmount(250.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 770.0, 250.0, 750.0, 250.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -2753,12 +2655,11 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            businessDateHelper.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("2023.09.16").dateFormat("yyyy.MM.dd").locale("en"));
+            updateBusinessDate("2023-09-16");
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 September 2023").locale("en").transactionAmount(250.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 520.0, 500.0, 500.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 250.0, 0.0, 0.0, 0.0);
@@ -2768,14 +2669,12 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "17 September 2023", "20"));
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "16 October 2023", "20"));
+            addSpecifiedDueDateCharge(loanResponse.getLoanId(), penalty, "17 September 2023", 20.0);
+            addSpecifiedDueDateCharge(loanResponse.getLoanId(), penalty, "16 October 2023", 20.0);
 
-            loanTransactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 September 2023").locale("en").transactionAmount(30.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 530.0, 530.0, 500.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 250.0, 0.0, 0.0, 0.0);
@@ -2809,20 +2708,18 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account incomeAccount = accountHelper.createIncomeAccount();
             final Account expenseAccount = accountHelper.createExpenseAccount();
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.VERTICAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId,
                     BigDecimal.valueOf(1000.0), 45, 15, 3, BigDecimal.ZERO, "01 September 2023", "01 September 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 September 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 September 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 September 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 September 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1000.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -2831,12 +2728,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             assertTrue(loanDetails.getStatus().getActive());
 
             // Add Charge Penalty
-            Integer penalty = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "20", true));
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "17 October 2023", "20"));
+            Long penalty = chargesHelper.createLoanSpecifiedDueDatePenalty(20.0).getResourceId();
+            addSpecifiedDueDateCharge(loanResponse.getLoanId(), penalty, "17 October 2023", 20.0);
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1020.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -2846,9 +2741,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("01 September 2023").locale("en").transactionAmount(250.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 770.0, 250.0, 750.0, 250.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -2858,12 +2753,11 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            businessDateHelper.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("2023.09.16").dateFormat("yyyy.MM.dd").locale("en"));
+            updateBusinessDate("2023-09-16");
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 September 2023").locale("en").transactionAmount(250.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 520.0, 500.0, 500.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 250.0, 0.0, 0.0, 0.0);
@@ -2872,13 +2766,11 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 5, LocalDate.of(2023, 10, 17), 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 20.0, 0.0, 20.0, 0.0, 0.0,
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "17 September 2023", "20"));
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "16 October 2023", "20"));
-            loanTransactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            addSpecifiedDueDateCharge(loanResponse.getLoanId(), penalty, "17 September 2023", 20.0);
+            addSpecifiedDueDateCharge(loanResponse.getLoanId(), penalty, "16 October 2023", 20.0);
+            transactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 September 2023").locale("en").transactionAmount(30.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 530.0, 530.0, 500.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 250.0, 0.0, 0.0, 0.0);
@@ -2909,20 +2801,18 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account incomeAccount = accountHelper.createIncomeAccount();
             final Account expenseAccount = accountHelper.createExpenseAccount();
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId,
                     BigDecimal.valueOf(1000.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1000.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -2931,12 +2821,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             assertTrue(loanDetails.getStatus().getActive());
 
             // Add Charge Fee
-            Integer fee = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "50", false));
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(fee), "01 January 2023", "50"));
+            Long fee = chargesHelper.createLoanSpecifiedDueDateCharge(50.0).getResourceId();
+            addSpecifiedDueDateCharge(loanResponse.getLoanId(), fee, "01 January 2023", 50.0);
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1050.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 250.0, 0.0, 250.0, 50.0, 0.0, 50.0, 0.0, 0.0, 0.0, 0.0, 0.0,
@@ -2945,9 +2833,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, LocalDate.of(2023, 2, 15), 250.0, 0.0, 250.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("01 January 2023").locale("en").transactionAmount(250.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 800.0, 250.0, 750.0, 250.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 250.0, 0.0, 250.0, 50.0, 0.0, 50.0, 0.0, 0.0, 0.0, 0.0, 0.0,
@@ -2957,10 +2845,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             assertTrue(loanDetails.getStatus().getActive());
 
             updateBusinessDate("16 January 2023");
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("16 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(400.0)).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("16 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(400.0)).locale("en"));
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1200.0, 250.0, 1150.0, 250.0, null);
             validatePeriod(loanDetails, 0, LocalDate.of(2023, 1, 1), null, 1000.0, null, null, null, 0.0, 0.0, null, null, null, null, null,
                     null, null, null, null);
@@ -2996,20 +2883,18 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account incomeAccount = accountHelper.createIncomeAccount();
             final Account expenseAccount = accountHelper.createExpenseAccount();
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId,
                     BigDecimal.valueOf(1000.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1000.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -3018,12 +2903,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             assertTrue(loanDetails.getStatus().getActive());
 
             // Add Charge Fee
-            Integer fee = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "50", false));
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(fee), "01 January 2023", "50"));
+            Long fee = chargesHelper.createLoanSpecifiedDueDateCharge(50.0).getResourceId();
+            addSpecifiedDueDateCharge(loanResponse.getLoanId(), fee, "01 January 2023", 50.0);
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1050.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 250.0, 0.0, 250.0, 50.0, 0.0, 50.0, 0.0, 0.0, 0.0, 0.0, 0.0,
@@ -3032,9 +2915,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, LocalDate.of(2023, 2, 15), 250.0, 0.0, 250.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("01 January 2023").locale("en").transactionAmount(250.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 800.0, 250.0, 750.0, 250.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 250.0, 0.0, 250.0, 50.0, 0.0, 50.0, 0.0, 0.0, 0.0, 0.0, 0.0,
@@ -3044,13 +2927,11 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             assertTrue(loanDetails.getStatus().getActive());
 
             updateBusinessDate("16 January 2023");
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("16 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(400.0)).locale("en"));
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("16 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(80.0)).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("16 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(400.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("16 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(80.0)).locale("en"));
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1280.0, 250.0, 1230.0, 250.0, null);
             validatePeriod(loanDetails, 0, LocalDate.of(2023, 1, 1), null, 1000.0, null, null, null, 0.0, 0.0, null, null, null, null, null,
                     null, null, null, null);
@@ -3086,20 +2967,18 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account incomeAccount = accountHelper.createIncomeAccount();
             final Account expenseAccount = accountHelper.createExpenseAccount();
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId,
                     BigDecimal.valueOf(1000.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1000.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -3107,10 +2986,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, LocalDate.of(2023, 2, 15), 250.0, 0.0, 250.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(400.0)).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(400.0)).locale("en"));
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1400.0, 0.0, 1400.0, 0.0, null);
             validatePeriod(loanDetails, 0, LocalDate.of(2023, 1, 1), null, 1000.0, null, null, null, 0.0, 0.0, null, null, null, null, null,
                     null, null, null, null);
@@ -3166,20 +3044,18 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account incomeAccount = accountHelper.createIncomeAccount();
             final Account expenseAccount = accountHelper.createExpenseAccount();
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", true, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", true, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId,
                     BigDecimal.valueOf(1000.0), 45, 15, 3, BigDecimal.ZERO, "22 November 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("22 November 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("22 November 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("22 November 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("22 November 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 75.0, 25.0, 75.0, 25.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 11, 22), 25.0, 25.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 12, 7), 25.0, 0.0, 25.0, 0.0, 0.0);
@@ -3187,10 +3063,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, LocalDate.of(2024, 1, 6), 25.0, 0.0, 25.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("22 November 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(901.0)).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("22 November 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(901.0)).locale("en"));
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 750.75, 250.25, 750.75, 250.25, null);
             validatePeriod(loanDetails, 0, LocalDate.of(2023, 11, 22), null, 100.0, null, null, null, 0.0, 0.0, null, null, null, null,
                     null, null, null, null, null);
@@ -3221,10 +3096,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account incomeAccount = accountHelper.createIncomeAccount();
             final Account expenseAccount = accountHelper.createExpenseAccount();
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
 
-            loanTransactionHelper.applyLoan(new PostLoansRequest().clientId(client.getClientId()).productId(localLoanProductId.longValue())
+            loanHelper.applyForLoan(new PostLoansRequest().clientId(client.getClientId()).productId(localLoanProductId)
                     .loanType("individual").locale("en").submittedOnDate(operationDate).expectedDisbursementDate(operationDate)
                     .dateFormat(DATETIME_PATTERN).amortizationType(1).interestRatePerPeriod(BigDecimal.ZERO)
                     .interestCalculationPeriodType(1).interestType(0).repaymentFrequencyType(0).repaymentEvery(15).repaymentFrequencyType(0)
@@ -3233,12 +3108,12 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .transactionProcessingStrategyCode(AdvancedPaymentScheduleTransactionProcessor.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)
                     .loanScheduleProcessingType(LoanScheduleProcessingType.HORIZONTAL.name()));
 
-            loanTransactionHelper.applyLoanWithError(new PostLoansRequest().clientId(client.getClientId())
-                    .productId(localLoanProductId.longValue()).loanType("individual").locale("en").submittedOnDate(operationDate)
-                    .expectedDisbursementDate(operationDate).dateFormat(DATETIME_PATTERN).amortizationType(1)
-                    .interestRatePerPeriod(BigDecimal.ZERO).interestCalculationPeriodType(1).interestType(0).repaymentFrequencyType(0)
-                    .repaymentEvery(15).repaymentFrequencyType(0).numberOfRepayments(3).loanTermFrequency(45).loanTermFrequencyType(0)
-                    .principal(BigDecimal.valueOf(1000.0)).maxOutstandingLoanBalance(BigDecimal.valueOf(35000))
+            applyLoanExpectingError(new PostLoansRequest().clientId(client.getClientId()).productId(localLoanProductId)
+                    .loanType("individual").locale("en").submittedOnDate(operationDate).expectedDisbursementDate(operationDate)
+                    .dateFormat(DATETIME_PATTERN).amortizationType(1).interestRatePerPeriod(BigDecimal.ZERO)
+                    .interestCalculationPeriodType(1).interestType(0).repaymentFrequencyType(0).repaymentEvery(15).repaymentFrequencyType(0)
+                    .numberOfRepayments(3).loanTermFrequency(45).loanTermFrequencyType(0).principal(BigDecimal.valueOf(1000.0))
+                    .maxOutstandingLoanBalance(BigDecimal.valueOf(35000))
                     .transactionProcessingStrategyCode(FineractStyleLoanRepaymentScheduleTransactionProcessor.STRATEGY_CODE)
                     .loanScheduleProcessingType(LoanScheduleProcessingType.HORIZONTAL.name()), 403);
 
@@ -3259,24 +3134,22 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .numberOfRepayments(3).repaymentEvery(15).enableDownPayment(true)
                     .disbursedAmountPercentageForDownPayment(BigDecimal.valueOf(25)).enableAutoRepaymentForDownPayment(false);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), "22 November 2023",
                     1000.0, 4);
 
             applicationRequest = applicationRequest.numberOfRepayments(3).loanTermFrequency(45)
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(15);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("22 November 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("22 November 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("22 November 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("22 November 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 100.0, 0.0, 100.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 11, 22), 25.0, 0.0, 25.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 12, 7), 25.0, 0.0, 25.0, 0.0, 0.0);
@@ -3284,9 +3157,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, LocalDate.of(2024, 1, 6), 25.0, 0.0, 25.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("23 November 2023").locale("en").transactionAmount(150.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 100.0, 0.0, 100.0, 50.0);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 11, 22), 25.0, 25.0, 0.0, 0.0, 25.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 12, 7), 25.0, 25.0, 0.0, 25.0, 0.0);
@@ -3294,10 +3167,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, LocalDate.of(2024, 1, 6), 25.0, 25.0, 0.0, 25.0, 0.0);
             assertTrue(loanDetails.getStatus().getOverpaid());
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("24 November 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("24 November 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 50.0, 150.0, 50.0, 150.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 11, 22), 25.0, 25.0, 0.0, 0.0, 25.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 11, 24), 25.0, 25.0, 0.0, 0.0, 0.0);
@@ -3312,14 +3184,14 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     transaction(100, "Disbursement", "24 November 2023", 50.0, 0.0, 0.0, 0.0, 0.0, 0.0, 50.0) //
             );
             // verify journal entries
-            verifyJournalEntries(loanResponse.getLoanId(), journalEntry(100.0, loansReceivableAccount, "DEBIT"), //
-                    journalEntry(100.0, fundSource, "CREDIT"), //
-                    journalEntry(100.0, loansReceivableAccount, "CREDIT"), //
-                    journalEntry(50.0, overpaymentAccount, "CREDIT"), //
-                    journalEntry(150.0, fundSource, "DEBIT"), //
-                    journalEntry(50.0, loansReceivableAccount, "DEBIT"), //
-                    journalEntry(50.0, overpaymentAccount, "DEBIT"), //
-                    journalEntry(100.0, fundSource, "CREDIT") //
+            verifyJournalEntries(loanResponse.getLoanId(), journalEntry(100.0, loansReceivableAccount(), "DEBIT"), //
+                    journalEntry(100.0, fundSource(), "CREDIT"), //
+                    journalEntry(100.0, loansReceivableAccount(), "CREDIT"), //
+                    journalEntry(50.0, overpaymentAccount(), "CREDIT"), //
+                    journalEntry(150.0, fundSource(), "DEBIT"), //
+                    journalEntry(50.0, loansReceivableAccount(), "DEBIT"), //
+                    journalEntry(50.0, overpaymentAccount(), "DEBIT"), //
+                    journalEntry(100.0, fundSource(), "CREDIT") //
             );
         });
     }
@@ -3338,24 +3210,22 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .numberOfRepayments(3).repaymentEvery(15).enableDownPayment(true)
                     .disbursedAmountPercentageForDownPayment(BigDecimal.valueOf(25)).enableAutoRepaymentForDownPayment(false);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), "22 November 2023",
                     1000.0, 4);
 
             applicationRequest = applicationRequest.numberOfRepayments(3).loanTermFrequency(45)
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(15);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("22 November 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("22 November 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("22 November 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("22 November 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 100.0, 0.0, 100.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 11, 22), 25.0, 0.0, 25.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 12, 7), 25.0, 0.0, 25.0, 0.0, 0.0);
@@ -3363,9 +3233,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, LocalDate.of(2024, 1, 6), 25.0, 0.0, 25.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("22 November 2023").locale("en").transactionAmount(150.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 100.0, 0.0, 100.0, 50.0);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 11, 22), 25.0, 25.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 12, 7), 25.0, 25.0, 0.0, 25.0, 0.0);
@@ -3373,10 +3243,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, LocalDate.of(2024, 1, 6), 25.0, 25.0, 0.0, 25.0, 0.0);
             assertTrue(loanDetails.getStatus().getOverpaid());
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("22 November 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(28.0)).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("22 November 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(28.0)).locale("en"));
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 128.0, 0.0, 128.0, 22.0);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 11, 22), 25.0, 25.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 11, 22), 7.0, 7.0, 0.0, 0.0, 0.0);
@@ -3391,13 +3260,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     transaction(28, "Disbursement", "22 November 2023", 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 28.0) //
             );
             // verify journal entries
-            verifyJournalEntries(loanResponse.getLoanId(), journalEntry(100.0, loansReceivableAccount, "DEBIT"), //
-                    journalEntry(100.0, fundSource, "CREDIT"), //
-                    journalEntry(100.0, loansReceivableAccount, "CREDIT"), //
-                    journalEntry(50.0, overpaymentAccount, "CREDIT"), //
-                    journalEntry(150.0, fundSource, "DEBIT"), //
-                    journalEntry(28.0, overpaymentAccount, "DEBIT"), //
-                    journalEntry(28.0, fundSource, "CREDIT") //
+            verifyJournalEntries(loanResponse.getLoanId(), journalEntry(100.0, loansReceivableAccount(), "DEBIT"), //
+                    journalEntry(100.0, fundSource(), "CREDIT"), //
+                    journalEntry(100.0, loansReceivableAccount(), "CREDIT"), //
+                    journalEntry(50.0, overpaymentAccount(), "CREDIT"), //
+                    journalEntry(150.0, fundSource(), "DEBIT"), //
+                    journalEntry(28.0, overpaymentAccount(), "DEBIT"), //
+                    journalEntry(28.0, fundSource(), "CREDIT") //
             );
         });
     }
@@ -3420,84 +3289,82 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .numberOfRepayments(1).repaymentEvery(30).enableDownPayment(false);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), "25 January 2024", 1000.0,
                     4);
 
             applicationRequest = applicationRequest.numberOfRepayments(1).loanTermFrequency(30)
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(30);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("25 January 2024").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("25 January 2024").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("25 January 2024").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("25 January 2024")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 100.0, 0.0, 100.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 24), 100.0, 0.0, 100.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
             String repaymentExternalId = UUID.randomUUID().toString();
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(),
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(),
                     new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate("24 February 2024").locale("en")
                             .transactionAmount(100.0).externalId(repaymentExternalId));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 100.0, 0.0, 100.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 24), 100.0, 100.0, 0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getClosedObligationsMet());
 
             String mir1ExternalId = UUID.randomUUID().toString();
-            loanTransactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(),
+            transactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(),
                     new PostLoansLoanIdTransactionsRequest().transactionDate("28 February 2024").dateFormat(DATETIME_PATTERN)
                             .transactionAmount(36.99).locale("en").externalId(mir1ExternalId));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 100.0, 0.0, 100.0, 36.99);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 24), 100.0, 100.0, 0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getOverpaid());
 
-            loanTransactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .transactionDate("28 February 2024").dateFormat(DATETIME_PATTERN).transactionAmount(18.94).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 100.0, 0.0, 100.0, 55.93);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 24), 100.0, 100.0, 0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getOverpaid());
 
-            loanTransactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .transactionDate("28 February 2024").dateFormat(DATETIME_PATTERN).transactionAmount(36.99).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 100.0, 0.0, 100.0, 92.92);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 24), 100.0, 100.0, 0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getOverpaid());
 
-            loanTransactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .transactionDate("28 February 2024").dateFormat(DATETIME_PATTERN).transactionAmount(31.99).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 100.0, 0.0, 100.0, 124.91);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 24), 100.0, 100.0, 0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getOverpaid());
 
-            loanTransactionHelper.makeCreditBalanceRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeCreditBalanceRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .transactionDate("01 March 2024").dateFormat(DATETIME_PATTERN).transactionAmount(124.91).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 100.0, 0.0, 100.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 24), 100.0, 100.0, 0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getClosedObligationsMet());
 
-            loanTransactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .transactionDate("02 March 2024").dateFormat(DATETIME_PATTERN).transactionAmount(19.99).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 100.0, 0.0, 100.0, 19.99);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 24), 100.0, 100.0, 0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getOverpaid());
 
-            loanTransactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .transactionDate("02 March 2024").dateFormat(DATETIME_PATTERN).transactionAmount(19.99).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 100.0, 0.0, 100.0, 39.98);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 24), 100.0, 100.0, 0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getOverpaid());
@@ -3514,11 +3381,11 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     transaction(19.99, "Merchant Issued Refund", "02 March 2024", 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 19.99) //
             );
 
-            loanTransactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), mir1ExternalId,
+            transactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), mir1ExternalId,
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("02 March 2024")
                             .transactionAmount(0.0).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 224.91, 0.0, 224.91, 2.99);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 24), 100.0, 100.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2024, 3, 1), 124.91, 124.91, 0.0, 0.0, 36.99);
@@ -3536,10 +3403,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     transaction(19.99, "Merchant Issued Refund", "02 March 2024", 0.0, 17.0, 0.0, 0.0, 0.0, 0.0, 2.99) //
             );
 
-            loanTransactionHelper.chargebackLoanTransaction(loanResponse.getLoanId(), repaymentExternalId,
+            transactionHelper.chargebackLoanTransaction(loanResponse.getLoanId(), repaymentExternalId,
                     new PostLoansLoanIdTransactionsTransactionIdRequest().locale("en").transactionAmount(2.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 224.91, 0.0, 224.91, 0.99);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 24), 100.0, 100.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2024, 3, 1), 124.91, 124.91, 0.0, 0.0, 36.99);
@@ -3558,10 +3425,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     transaction(2.0, "Chargeback", "06 March 2024", 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.0) //
             );
 
-            loanTransactionHelper.chargebackLoanTransaction(loanResponse.getLoanId(), repaymentExternalId,
+            transactionHelper.chargebackLoanTransaction(loanResponse.getLoanId(), repaymentExternalId,
                     new PostLoansLoanIdTransactionsTransactionIdRequest().locale("en").transactionAmount(1.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.01, 225.90, 0.01, 225.90, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 24), 100.0, 100.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2024, 3, 6), 125.91, 125.90, 0.01, 0.0, 36.99);
@@ -3598,21 +3465,20 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .installmentAmountInMultiplesOf(null).numberOfRepayments(3).repaymentEvery(15).enableDownPayment(true)
                     .enableAutoRepaymentForDownPayment(true).disbursedAmountPercentageForDownPayment(BigDecimal.valueOf(25));
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(client.getClientId(), loanProductResponse.getResourceId(),
                     "23 March 2024", 1000.0, 4);
 
             applicationRequest = applicationRequest.numberOfRepayments(3).loanTermFrequency(45)
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(15);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()
-                    .approvedLoanAmount(BigDecimal.valueOf(10)).dateFormat(DATETIME_PATTERN).approvedOnDate("23 March 2024").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(10))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("23 March 2024").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("23 March 2024").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(10.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("23 March 2024")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(10.0)).locale("en"));
 
             // verify schedule
             verifyRepaymentSchedule(loanResponse.getLoanId(), //
@@ -3626,7 +3492,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
         });
 
         runAt("24 March 2024", () -> {
-            loanTransactionHelper.disburseLoan(createdLoanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate("24 March 2024")
+            loanHelper.disburseLoan(createdLoanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate("24 March 2024")
                     .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
 
             // verify schedule
@@ -3640,7 +3506,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     installment(27.5, 0, 0, 0, 27.5, false, "07 May 2024", 0.0) //
             );
 
-            loanTransactionHelper.disburseLoan(createdLoanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate("24 March 2024")
+            loanHelper.disburseLoan(createdLoanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate("24 March 2024")
                     .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(11.0)).locale("en"));
 
             // verify schedule
@@ -3673,24 +3539,22 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .numberOfRepayments(3).repaymentEvery(15).fixedLength(fixedLength);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), "22 November 2023",
                     1000.0, 4);
 
             applicationRequest = applicationRequest.numberOfRepayments(3).loanTermFrequency(45)
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(15);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("22 November 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("22 November 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("22 November 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("22 November 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 100.0, 0.0, 100.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 12, 7), 33.0, 0.0, 33.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 12, 22), 33.0, 0.0, 33.0, 0.0, 0.0);
@@ -3722,7 +3586,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .numberOfRepayments(3).repaymentEvery(2).repaymentFrequencyType(repaymentFrequencyType.longValue())
                     .fixedLength(fixedLength);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), "22 November 2023",
                     1000.0, 4);
 
@@ -3730,17 +3594,15 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(2)
                     .repaymentFrequencyType(repaymentFrequencyType);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("22 November 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("22 November 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("22 November 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("22 November 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 100.0, 0.0, 100.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 12, 6), 33.0, 0.0, 33.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 12, 20), 33.0, 0.0, 33.0, 0.0, 0.0);
@@ -3773,7 +3635,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .numberOfRepayments(6).repaymentEvery(2).repaymentFrequencyType(repaymentFrequencyType.longValue())
                     .fixedLength(fixedLength);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), "22 November 2023",
                     1000.0, 4);
 
@@ -3782,17 +3644,15 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(2)
                     .repaymentFrequencyType(repaymentFrequencyType);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("22 November 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("22 November 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("22 November 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("22 November 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 100.0, 0.0, 100.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 1, 22), 17.0, 0.0, 17.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2024, 3, 22), 17.0, 0.0, 17.0, 0.0, 0.0);
@@ -3825,11 +3685,11 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             // Try to create a Loan Product using Fixed Length with a wrong Loan Term setup
             LOG.info("Try to create a Loan Product using Fixed Length with a wrong Loan Term setup");
             CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                    () -> loanProductHelper
+                    () -> loanHelper
                             .createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                                     .interestRatePerPeriod(0.0).numberOfRepayments(6).repaymentEvery(1)
                                     .repaymentFrequencyType(repaymentFrequencyType.longValue()).fixedLength(fixedLength)));
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("error.msg.number.repayments.and.fixed.length.configuration.not.valid"));
         });
     }
@@ -3850,13 +3710,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
 
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .numberOfRepayments(6).repaymentEvery(1).repaymentFrequencyType(repaymentFrequencyType.longValue()).fixedLength(6);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
 
             // Try to use Fixed Length without Advanced Payment Allocation as transaction
             // processing strategy code
             LOG.info("Try to use Fixed Length without Advanced Payment Allocation as transaction processing strategy code");
             CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.applyLoan(new PostLoansRequest().clientId(client.getClientId())
+                    () -> loanHelper.applyForLoan(new PostLoansRequest().clientId(client.getClientId())
                             .productId(loanProductResponse.getResourceId()).loanType("individual").locale("en")
                             .submittedOnDate(operationDate).expectedDisbursementDate(operationDate).dateFormat(DATETIME_PATTERN)
                             .amortizationType(1).interestRatePerPeriod(BigDecimal.ZERO).interestCalculationPeriodType(1).interestType(0)
@@ -3866,7 +3726,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                             .transactionProcessingStrategyCode(FineractStyleLoanRepaymentScheduleTransactionProcessor.STRATEGY_CODE)
                             .loanScheduleProcessingType(LoanScheduleProcessingType.HORIZONTAL.name())));
 
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage()
                     .contains("error.msg.loan.repayment.strategy.can.not.be.different.than.advanced.payment.allocation"));
         });
@@ -3888,12 +3748,12 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
 
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .numberOfRepayments(6).repaymentEvery(1).repaymentFrequencyType(repaymentFrequencyType.longValue()).fixedLength(6);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
 
             // Try to use Fixed Length with an Interest Rate value higher than Zero
             LOG.info("Try to use Fixed Length with an Interest Rate value higher than Zero");
             CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.applyLoan(new PostLoansRequest().clientId(client.getClientId())
+                    () -> loanHelper.applyForLoan(new PostLoansRequest().clientId(client.getClientId())
                             .productId(loanProductResponse.getResourceId()).loanType("individual").locale("en")
                             .submittedOnDate(operationDate).expectedDisbursementDate(operationDate).dateFormat(DATETIME_PATTERN)
                             .amortizationType(1).interestRatePerPeriod(BigDecimal.ONE).interestCalculationPeriodType(1).interestType(0)
@@ -3904,7 +3764,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                                     AdvancedPaymentScheduleTransactionProcessor.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)
                             .loanScheduleProcessingType(LoanScheduleProcessingType.HORIZONTAL.name())));
 
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("error.msg.fixed.length.only.supported.for.zero.interest"));
         });
     }
@@ -3925,12 +3785,12 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
 
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .numberOfRepayments(6).repaymentEvery(1).repaymentFrequencyType(repaymentFrequencyType.longValue()).fixedLength(6);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
 
             // Try to use Fixed Length with a wrong Loan Term setup
             LOG.info("Try to use Fixed Length with a wrong Loan Term setup");
             CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.applyLoan(new PostLoansRequest().clientId(client.getClientId())
+                    () -> loanHelper.applyForLoan(new PostLoansRequest().clientId(client.getClientId())
                             .productId(loanProductResponse.getResourceId()).loanType("individual").locale("en")
                             .submittedOnDate(operationDate).expectedDisbursementDate(operationDate).dateFormat(DATETIME_PATTERN)
                             .amortizationType(1).interestRatePerPeriod(BigDecimal.ZERO).interestCalculationPeriodType(1).interestType(0)
@@ -3941,7 +3801,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                                     AdvancedPaymentScheduleTransactionProcessor.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)
                             .loanScheduleProcessingType(LoanScheduleProcessingType.HORIZONTAL.name())));
 
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("error.msg.number.repayments.and.fixed.length.configuration.not.valid"));
         });
     }
@@ -3967,23 +3827,21 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .numberOfRepayments(numberOfRepayments).repaymentEvery(15).repaymentFrequencyType(repaymentFrequencyType.longValue())
                     .fixedLength(fixedLength);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
 
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), "22 November 2023",
                     1000.0, numberOfRepayments)
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("22 November 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("22 November 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("22 November 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("22 November 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             LOG.info("Loan {} {}", loanDetails.getTimeline().getActualDisbursementDate(), loanDetails.getRepaymentSchedule().getPeriods()
                     .get(loanDetails.getRepaymentSchedule().getPeriods().size() - 1).getDueDate());
             assertEquals(
@@ -4016,22 +3874,22 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .numberOfRepayments(numberOfRepayments).repaymentEvery(30).fixedLength(fixedLength);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), operationDate, 1000.0,
                     numberOfRepayments);
 
             applicationRequest = applicationRequest.numberOfRepayments(numberOfRepayments).loanTermFrequency(120)
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(30);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()
-                    .approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
                     .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1000.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 1, 31), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2024, 3, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -4052,7 +3910,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             LoanRescheduleRequestHelper.approveLoanRescheduleRequest(rescheduleLoansResponse.getResourceId(),
                     new PostUpdateRescheduleLoansRequest().approvedOnDate("16 January 2024").locale("en").dateFormat(DATETIME_PATTERN));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1000.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 1, 31), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2024, 3, 15), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -4089,22 +3947,22 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .numberOfRepayments(numberOfRepayments).repaymentEvery(30).fixedLength(fixedLength);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), operationDate, 1000.0,
                     numberOfRepayments);
 
             applicationRequest = applicationRequest.numberOfRepayments(numberOfRepayments).loanTermFrequency(120)
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(30);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()
-                    .approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
                     .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1000.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 1, 31), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2024, 3, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -4125,7 +3983,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             LoanRescheduleRequestHelper.approveLoanRescheduleRequest(rescheduleLoansResponse.getResourceId(),
                     new PostUpdateRescheduleLoansRequest().approvedOnDate("16 January 2024").locale("en").dateFormat(DATETIME_PATTERN));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1000.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 1, 31), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2024, 3, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -4180,12 +4038,12 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             AdvancedPaymentData defaultPaymentAllocation = createDefaultPaymentAllocationWithMixedGrouping();
 
             // First scenario (Legacy): Loan product no Advanced Payment Allocation and Cumulative Loan Schedule type
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(
                     createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct().loanScheduleType(LoanScheduleType.CUMULATIVE.toString()));
             assertNotNull(loanProductResponse.getResourceId());
 
             // Second scenario: Loan product with Advanced Payment Allocation and Progressive Loan Schedule type
-            loanProductResponse = loanProductHelper
+            loanProductResponse = loanHelper
                     .createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                             .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()));
             assertNotNull(loanProductResponse.getResourceId());
@@ -4193,10 +4051,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             // Third scenario: Loan product no Advanced Payment Allocation and Progressive Loan Schedule type,
             // validation expected
             CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                    () -> loanProductHelper.createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct()
+                    () -> loanHelper.createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct()
                             .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()) //
                             .loanScheduleProcessingType(LoanScheduleProcessingType.HORIZONTAL.toString())));
-            assertEquals(400, exception.getResponse().code());
+            assertEquals(400, exception.getStatus());
             assertTrue(exception.getMessage().contains("supported.only.with.advanced.payment.allocation.strategy"));
         });
     }
@@ -4213,7 +4071,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .installmentAmountInMultiplesOf(null).numberOfRepayments(3).repaymentEvery(15).enableDownPayment(true)
                     .enableAutoRepaymentForDownPayment(true).disbursedAmountPercentageForDownPayment(BigDecimal.valueOf(25));
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(client.getClientId(), loanProductResponse.getResourceId(),
                     "23 March 2024", 1000.0, 4);
 
@@ -4221,14 +4079,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(15)
                     .enableDownPayment(false);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()
-                    .approvedLoanAmount(BigDecimal.valueOf(10)).dateFormat(DATETIME_PATTERN).approvedOnDate("23 March 2024").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(10))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("23 March 2024").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("23 March 2024").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(10.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("23 March 2024")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(10.0)).locale("en"));
 
             // verify schedule (without DownPayment)
             verifyRepaymentSchedule(loanResponse.getLoanId(), //
@@ -4256,7 +4113,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .installmentAmountInMultiplesOf(null).numberOfRepayments(3).repaymentEvery(15).enableDownPayment(true)
                     .enableAutoRepaymentForDownPayment(true).disbursedAmountPercentageForDownPayment(BigDecimal.valueOf(25));
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(client.getClientId(), loanProductResponse.getResourceId(), processDate,
                     amount, 4);
 
@@ -4264,9 +4121,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(15)
                     .enableDownPayment(false);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.modifyApplicationForLoan(loanResponse.getLoanId(), "modify",
+            loanHelper.modifyLoanApplication(loanResponse.getLoanId(), "modify",
                     new PutLoansLoanIdRequest().clientId(client.getClientId()).productId(loanProductResponse.getResourceId())
                             .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)
                             .repaymentEvery(15).interestCalculationPeriodType(1).interestType(0).expectedDisbursementDate(processDate)
@@ -4274,10 +4131,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                             .loanTermFrequencyType(0).enableDownPayment(true).loanType("individual").dateFormat(DATETIME_PATTERN)
                             .locale("en"));
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()
-                    .approvedLoanAmount(BigDecimal.valueOf(10)).dateFormat(DATETIME_PATTERN).approvedOnDate(processDate).locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(10))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate(processDate).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(processDate)
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(processDate)
                     .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(10.0)).locale("en"));
 
             // verify schedule (with DownPayment)
@@ -4307,7 +4164,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .installmentAmountInMultiplesOf(null).numberOfRepayments(3).repaymentEvery(15).enableDownPayment(true)
                     .enableAutoRepaymentForDownPayment(true).disbursedAmountPercentageForDownPayment(BigDecimal.valueOf(25));
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(client.getClientId(), loanProductResponse.getResourceId(), processDate,
                     amount, 4);
 
@@ -4315,9 +4172,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(15)
                     .enableDownPayment(true);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.modifyApplicationForLoan(loanResponse.getLoanId(), "modify",
+            loanHelper.modifyLoanApplication(loanResponse.getLoanId(), "modify",
                     new PutLoansLoanIdRequest().clientId(client.getClientId()).productId(loanProductResponse.getResourceId())
                             .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)
                             .repaymentEvery(15).interestCalculationPeriodType(1).interestType(0).expectedDisbursementDate(processDate)
@@ -4325,10 +4182,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                             .loanTermFrequencyType(0).enableDownPayment(false).loanType("individual").dateFormat(DATETIME_PATTERN)
                             .locale("en"));
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()
-                    .approvedLoanAmount(BigDecimal.valueOf(10)).dateFormat(DATETIME_PATTERN).approvedOnDate(processDate).locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(10))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate(processDate).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(processDate)
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(processDate)
                     .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(10.0)).locale("en"));
 
             // verify schedule (without DownPayment)
@@ -4351,7 +4208,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
         runAt("23 March 2024", () -> {
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .installmentAmountInMultiplesOf(null).numberOfRepayments(3).repaymentEvery(15).enableDownPayment(false);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(client.getClientId(), loanProductResponse.getResourceId(),
                     "23 March 2024", 1000.0, 3)
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(15)
@@ -4359,8 +4216,8 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
 
             Long clientId = client.getClientId();
             CallFailedRuntimeException callFailedRuntimeException = Assertions.assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper
-                            .applyLoan(applyLoanRequest(clientId, loanProductResponse.getResourceId(), "23 March 2024", 1000.0, 3)
+                    () -> loanHelper
+                            .applyForLoan(applyLoanRequest(clientId, loanProductResponse.getResourceId(), "23 March 2024", 1000.0, 3)
                                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)
                                     .repaymentEvery(15).enableDownPayment(true)));
 
@@ -4379,7 +4236,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
 
             LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-            PostLoanProductsResponse loanProductResponse = loanProductHelper
+            PostLoanProductsResponse loanProductResponse = loanHelper
                     .createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                             .addCreditAllocationItem(createChargebackAllocation())
                             .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()));
@@ -4395,7 +4252,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     installment(250.0, false, "01 May 2023") //
             );
 
-            loanTransactionHelper.disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2023")
+            loanHelper.disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2023")
                     .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
             verifyTransactions(loanId, //
@@ -4460,7 +4317,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     installment(250.0, false, "01 May 2023") //
             );
 
-            loanTransactionHelper.reverseRepayment(Math.toIntExact(loanId), Math.toIntExact(repayment1TransactionId), "2 January 2023");
+            transactionHelper.reverseLoanTransaction(loanId, repayment1TransactionId, "2 January 2023");
 
             verifyTransactions(loanId, //
                     transaction(1000.0, "Disbursement", "01 January 2023", 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
@@ -4523,7 +4380,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .installmentAmountInMultiplesOf(null)//
                     .disbursedAmountPercentageForDownPayment(BigDecimal.valueOf(25))//
             ;//
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), operationDate, 100.0, 5);
 
             applicationRequest = applicationRequest.numberOfRepayments(5).loanTermFrequency(5).loanTermFrequencyType(2)
@@ -4531,15 +4388,15 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(1)
                     .repaymentFrequencyType(2);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()
-                    .approvedLoanAmount(BigDecimal.valueOf(100)).dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(100))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
                     .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 100.94, 0.0, 100.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 1, 1), 25.0, 0.0, 25.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
                     0.0, 0.0);
@@ -4585,7 +4442,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .installmentAmountInMultiplesOf(null)//
                     .disbursedAmountPercentageForDownPayment(BigDecimal.valueOf(25))//
             ;//
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), operationDate, 100.0, 5);
 
             applicationRequest = applicationRequest.numberOfRepayments(5).loanTermFrequency(5).loanTermFrequencyType(2)
@@ -4593,15 +4450,15 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(1)
                     .repaymentFrequencyType(2);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()
-                    .approvedLoanAmount(BigDecimal.valueOf(100)).dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(100))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
                     .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 102.33, 0.0, 100.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 1, 1), 25.0, 0.0, 25.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
                     0.0, 0.0);
@@ -4648,7 +4505,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .installmentAmountInMultiplesOf(null)//
                     .disbursedAmountPercentageForDownPayment(BigDecimal.valueOf(25))//
             ;//
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), operationDate, 100.0, 5);
 
             applicationRequest = applicationRequest.numberOfRepayments(5).loanTermFrequency(5).loanTermFrequencyType(2)
@@ -4656,15 +4513,15 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(1)
                     .repaymentFrequencyType(2);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()
-                    .approvedLoanAmount(BigDecimal.valueOf(100)).dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(100))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
                     .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 102.33, 0.0, 100.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 1, 1), 25.0, 0.0, 25.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
                     0.0, 0.0);
@@ -4708,7 +4565,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .overAppliedNumber(null)//
                     .installmentAmountInMultiplesOf(null)//
             ;//
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), operationDate, 100.0, 5);
 
             applicationRequest = applicationRequest.numberOfRepayments(5).loanTermFrequency(5).loanTermFrequencyType(2)
@@ -4716,17 +4573,17 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(1)
                     .repaymentFrequencyType(2);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
             createdLoanId.set(loanResponse.getLoanId());
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()
-                    .approvedLoanAmount(BigDecimal.valueOf(100)).dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(100))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
                     .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
 
             // After Disbursement we are expecting no Accrual transactions
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
         });
@@ -4736,13 +4593,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             // Generate the Accruals
             PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting("30 January 2024");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(new BigDecimal("0.98"), loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
 
             // Partial interest repayment
             addRepaymentForLoan(createdLoanId.get(), 20.50, "30 January 2024");
-            loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(new BigDecimal("0.06"), loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
         });
@@ -4751,7 +4608,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             // Generate the Accruals
             PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting("31 January 2024");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(new BigDecimal("0.09"), loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
         });
@@ -4760,7 +4617,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             // Generate the Accruals
             PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting("1 February 2024");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(new BigDecimal("0.12"), loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
         });
@@ -4769,7 +4626,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
         runAt("20 February 2024", () -> {
             PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting("20 February 2024");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(new BigDecimal("0.12"), loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(new BigDecimal("0.51"), loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
         });
@@ -4802,25 +4659,24 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .overAppliedNumber(null)//
                     .installmentAmountInMultiplesOf(null)//
             ;//
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), operationDate, 1000.0, 4)
                     .interestRatePerPeriod(BigDecimal.valueOf(108.0));
 
             applicationRequest = applicationRequest.interestCalculationPeriodType(DAYS)
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
             createdLoanId.set(loanResponse.getLoanId());
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000.0)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate(operationDate).locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000.0))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
                     .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
             // After Disbursement we are expecting amount in Zero (first day)
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
         });
@@ -4830,7 +4686,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             // Generate the Accruals
             PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting("2 January 2024");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(BigDecimal.valueOf(3.0).stripTrailingZeros(),
                     loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
@@ -4838,7 +4694,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
 
         // Second day on First Period, then TotalUnpaidPayableDueInterest = 0 and TotalUnpaidPayableNotDueInterest = 6
         runAt("3 January 2024", () -> {
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(BigDecimal.valueOf(6.0).stripTrailingZeros(),
                     loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
@@ -4846,7 +4702,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
 
         // Third day on First Period, then TotalUnpaidPayableDueInterest = 0 and TotalUnpaidPayableNotDueInterest = 9
         runAt("4 January 2024", () -> {
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(BigDecimal.valueOf(9.0).stripTrailingZeros(),
                     loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
@@ -4854,7 +4710,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
 
         // Fourth day on First Period, then TotalUnpaidPayableDueInterest = 0 and TotalUnpaidPayableNotDueInterest = 12
         runAt("5 January 2024", () -> {
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(BigDecimal.valueOf(12.0).stripTrailingZeros(),
                     loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
@@ -4862,7 +4718,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
 
         // Last day on First Period, then TotalUnpaidPayableDueInterest = 90 and TotalUnpaidPayableNotDueInterest = 0
         runAt("31 January 2024", () -> {
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(BigDecimal.valueOf(90.0).stripTrailingZeros(),
                     loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(BigDecimal.ZERO.stripTrailingZeros(),
@@ -4872,7 +4728,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
         // First day on Second Period, then TotalUnpaidPayableDueInterest = 90 and TotalUnpaidPayableNotDueInterest =
         // 2.34
         runAt("1 February 2024", () -> {
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(BigDecimal.valueOf(90.0).stripTrailingZeros(),
                     loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(BigDecimal.valueOf(2.34), loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
@@ -4881,7 +4737,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
         // Second day on Second Period, then TotalUnpaidPayableDueInterest = 90 and TotalUnpaidPayableNotDueInterest =
         // 4.69
         runAt("2 February 2024", () -> {
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(BigDecimal.valueOf(90.0).stripTrailingZeros(),
                     loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(BigDecimal.valueOf(4.69), loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
@@ -4890,7 +4746,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
         // Third day on Second Period, then TotalUnpaidPayableDueInterest = 90 and TotalUnpaidPayableNotDueInterest =
         // 7.03
         runAt("3 February 2024", () -> {
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(BigDecimal.valueOf(90.0).stripTrailingZeros(),
                     loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(BigDecimal.valueOf(7.03), loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
@@ -4898,7 +4754,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
 
         // N day on Second Period, then TotalUnpaidPayableDueInterest = 90 and TotalUnpaidPayableNotDueInterest = 21.096
         runAt("10 February 2024", () -> {
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(BigDecimal.valueOf(90.0).stripTrailingZeros(),
                     loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(BigDecimal.valueOf(23.44).stripTrailingZeros(),
@@ -4908,7 +4764,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
         // First day on Third Period, then TotalUnpaidPayableDueInterest = 90 + 70.32 and
         // TotalUnpaidPayableNotDueInterest = 0
         runAt("1 March 2024", () -> {
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(BigDecimal.valueOf(160.32).stripTrailingZeros(),
                     loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
@@ -4917,7 +4773,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
         // Second day on Third Period, then TotalUnpaidPayableDueInterest = 90 + 70.32 and
         // TotalUnpaidPayableNotDueInterest = 1.63
         runAt("2 March 2024", () -> {
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(BigDecimal.valueOf(160.32).stripTrailingZeros(),
                     loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(BigDecimal.valueOf(1.63), loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
@@ -4926,7 +4782,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
         // Third day on Third Period, then TotalUnpaidPayableDueInterest = 90 + 70.32 and
         // TotalUnpaidPayableNotDueInterest = 3.26
         runAt("3 March 2024", () -> {
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(BigDecimal.valueOf(160.32).stripTrailingZeros(),
                     loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(BigDecimal.valueOf(3.26), loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
@@ -4935,7 +4791,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
         // Last day on Third Period, then TotalUnpaidPayableDueInterest = 90 + 70.32 + 48.87 and
         // TotalUnpaidPayableNotDueInterest = 0
         runAt("31 March 2024", () -> {
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(BigDecimal.valueOf(209.19).stripTrailingZeros(),
                     loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
@@ -4946,7 +4802,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
         runAt("11 March 2024", () -> {
             addRepaymentForLoan(createdLoanId.get(), 340.00, "11 March 2024");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(BigDecimal.valueOf(70.32).stripTrailingZeros(),
                     loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(BigDecimal.valueOf(16.29).stripTrailingZeros(),
@@ -4980,35 +4836,33 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .installmentAmountInMultiplesOf(null)//
                     .supportedInterestRefundTypes(interestRefundTypes) //
             ;//
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), "1 January 2024", 1000.0,
                     4);
 
             applicationRequest = applicationRequest.interestCalculationPeriodType(DAYS)
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
             createdLoanId.set(loanResponse.getLoanId());
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000.0)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("1 January 2024").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000.0))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("1 January 2024").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2024").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2024")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
             // After Disbursement we are expecting zero interest refund
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalInterestRefund().stripTrailingZeros());
         });
 
         runAt("10 January 2024", () -> {
-            loanTransactionHelper.makeMerchantIssuedRefund(createdLoanId.get(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeMerchantIssuedRefund(createdLoanId.get(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("10 January 2024").locale("en").transactionAmount(300.0));
 
             // After Interest refund transaction we are expecting non zero interest refund
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             LOG.info("value {}", loanDetails.getSummary().getTotalInterestRefund().stripTrailingZeros());
             assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalInterestRefund().stripTrailingZeros());
         });
@@ -5046,7 +4900,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .outstandingLoanBalance(10000.0)//
                     .installmentAmountInMultiplesOf(null)//
             ;//
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), operationDate, 100.0, 6);
 
             applicationRequest = applicationRequest.numberOfRepayments(6)//
@@ -5059,24 +4913,23 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .maxOutstandingLoanBalance(BigDecimal.valueOf(10000.0))//
             ;//
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()
-                    .approvedLoanAmount(BigDecimal.valueOf(100)).dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(100))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
                     .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 102.78, 0.0, 100.0, 0.0, null);
 
             String disbursementDate2nd = "8 January 2024";
             updateBusinessDate(disbursementDate2nd);
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDate2nd).dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(200.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDate2nd)
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(200.0)).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 307.98, 0.0, 300.0, 0.0, null);
 
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 1), 49.32, 0.0, 49.32, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.01, 0.0,
@@ -5128,7 +4981,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .outstandingLoanBalance(10000.0)//
                     .installmentAmountInMultiplesOf(null)//
             ;//
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), operationDate, 100.0, 5);
 
             applicationRequest = applicationRequest.numberOfRepayments(6)//
@@ -5141,32 +4994,31 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .maxOutstandingLoanBalance(BigDecimal.valueOf(10000.0))//
             ;//
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()
-                    .approvedLoanAmount(BigDecimal.valueOf(100)).dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(100))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
                     .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 102.78, 0.0, 100.0, 0.0, null);
 
             final String repaymentDate = "1 February 2024";
             updateBusinessDate(repaymentDate);
-            loanTransactionHelper.makeRepayment(repaymentDate, 17.13f, loanResponse.getLoanId().intValue());
+            transactionHelper.makeRepayment(repaymentDate, 17.13f, loanResponse.getLoanId().intValue());
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
 
             validateLoanSummaryBalances(loanDetails, 85.65, 17.13, 83.66, 16.34, null);
 
             final String dateOf2ndDisbursement = "15 February 2024";
             updateBusinessDate(dateOf2ndDisbursement);
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate(dateOf2ndDisbursement).dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(dateOf2ndDisbursement)
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 187.65, 17.13, 183.66, 16.34, null);
 
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 1), 16.34, 16.34, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.79, 0.79,
@@ -5227,7 +5079,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .outstandingLoanBalance(10000.0)//
                     .installmentAmountInMultiplesOf(null)//
             ;//
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), "1 January 2024", 100.0,
                     6);
 
@@ -5241,28 +5093,27 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .maxOutstandingLoanBalance(BigDecimal.valueOf(10000.0))//
             ;//
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(100)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("1 January 2024").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(100))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("1 January 2024").locale("en"));
 
             final String disbursementDate1st = "8 January 2024";
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), //
+            loanHelper.disburseLoan(loanResponse.getLoanId(), //
                     new PostLoansLoanIdRequest()//
                             .actualDisbursementDate(disbursementDate1st).dateFormat(DATETIME_PATTERN)//
                             .transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));//
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 102.6, 0.0, 100.0, 0.0, null);
 
             final String disbursementDate2nd = "5 January 2024";
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), //
+            loanHelper.disburseLoan(loanResponse.getLoanId(), //
                     new PostLoansLoanIdRequest()//
                             .actualDisbursementDate(disbursementDate2nd).dateFormat(DATETIME_PATTERN)//
                             .transactionAmount(BigDecimal.valueOf(50.0)).locale("en"));//
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 153.95, 0.0, 150.0, 0.0, null);
 
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 1), 24.70, 0.0, 24.70, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.96, 0.0,
@@ -5282,12 +5133,12 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
 
             // 2nd disbursement on the same date
             final String disbursementDate3rd = "8 January 2024";
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), //
+            loanHelper.disburseLoan(loanResponse.getLoanId(), //
                     new PostLoansLoanIdRequest()//
                             .actualDisbursementDate(disbursementDate3rd).dateFormat(DATETIME_PATTERN)//
                             .transactionAmount(BigDecimal.valueOf(25.0)).locale("en"));//
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 179.60, 0.0, 175.0, 0.0, null);
 
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 1), 28.82, 0.0, 28.82, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.11, 0.0,
@@ -5348,7 +5199,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .installmentAmountInMultiplesOf(null)//
                     .rescheduleStrategyMethod(LoanRescheduleStrategyMethod.ADJUST_LAST_UNPAID_PERIOD.getValue())//
                     .recalculationRestFrequencyType(1);//
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), operationDate, 100.0, 6);
 
             applicationRequest = applicationRequest.numberOfRepayments(6)//
@@ -5362,17 +5213,17 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .maxOutstandingLoanBalance(BigDecimal.valueOf(10000.0))//
             ;//
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()//
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()//
                     .approvedLoanAmount(BigDecimal.valueOf(100))//
                     .approvedOnDate(operationDate).dateFormat(DATETIME_PATTERN).locale("en"));//
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()//
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()//
                     .transactionAmount(BigDecimal.valueOf(100.0))//
                     .actualDisbursementDate(operationDate).dateFormat(DATETIME_PATTERN).locale("en"));//
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 102.05, 0.0, 100.0, 0.0, null);
 
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 1), 16.43, 0.0, 16.43, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.58, 0.0,
@@ -5391,7 +5242,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             assertEquals(loanDetails.getNumberOfRepayments(), 6);
 
             updateBusinessDate("1 February 2024");
-            loanTransactionHelper.makeRepayment("1 February 2024", 17.01f, loanResponse.getLoanId().intValue());
+            transactionHelper.makeRepayment("1 February 2024", 17.01f, loanResponse.getLoanId().intValue());
 
             updateBusinessDate("14 February 2024");
             PostCreateRescheduleLoansResponse rescheduleLoansResponse = LoanRescheduleRequestHelper//
@@ -5406,7 +5257,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     new PostUpdateRescheduleLoansRequest()//
                             .approvedOnDate("14 February 2024").locale("en").dateFormat(DATETIME_PATTERN));//
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 84.5, 17.01, 83.57, 16.43, null);
 
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 1), 16.43, 16.43, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.58, 0.58,
@@ -5436,11 +5287,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             PostLoanProductsRequest loanProduct = createOnePeriod30DaysPeriodicAccrualProductWithAdvancedPaymentAllocationAndInterestRecalculation(
                     (double) 80.0, rescheduleStrategyMethod);
 
-            final PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProduct);
+            final PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(loanProduct);
             assertNotNull(loanProductResponse);
 
-            final GetLoanProductsProductIdResponse loanProductDetails = loanProductHelper
-                    .retrieveLoanProductById(loanProductResponse.getResourceId());
+            final GetLoanProductsProductIdResponse loanProductDetails = loanHelper.retrieveLoanProduct(loanProductResponse.getResourceId());
             assertNotNull(loanProductDetails);
             assertTrue(loanProductDetails.getIsInterestRecalculationEnabled());
             assertEquals(rescheduleStrategyMethod.longValue(),
@@ -5461,7 +5311,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     (double) 80.0, rescheduleStrategyMethod);
 
             CallFailedRuntimeException callFailedRuntimeException = Assertions.assertThrows(CallFailedRuntimeException.class,
-                    () -> loanProductHelper.createLoanProduct(loanProduct));
+                    () -> loanHelper.createLoanProduct(loanProduct));
 
             Assertions.assertTrue(callFailedRuntimeException.getMessage().contains("is not supported for Progressive loan schedule type"));
         });
@@ -5481,7 +5331,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .loanScheduleType(LoanScheduleType.CUMULATIVE.toString());
 
             CallFailedRuntimeException callFailedRuntimeException = Assertions.assertThrows(CallFailedRuntimeException.class,
-                    () -> loanProductHelper.createLoanProduct(loanProduct));
+                    () -> loanHelper.createLoanProduct(loanProduct));
 
             Assertions.assertTrue(callFailedRuntimeException.getMessage()
                     .contains("Adjust last, unpaid period is only supported for Progressive loan schedule type"));
@@ -5516,19 +5366,19 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .installmentAmountInMultiplesOf(null)//
                     .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()) //
             ;//
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), operationDate, 400.0, 6);
 
             applicationRequest = applicationRequest.interestCalculationPeriodType(DAYS).interestRatePerPeriod(BigDecimal.ZERO)
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
             createdLoanId.set(loanResponse.getLoanId());
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()
-                    .approvedLoanAmount(BigDecimal.valueOf(400.0)).dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(400.0))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
                     .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(400.0)).locale("en"));
 
             addRepaymentForLoan(createdLoanId.get(), 600.00, operationDate);
@@ -5536,7 +5386,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             createdLoanChargeId.set(addCharge(createdLoanId.get(), true, 30, operationDate));
 
             executeInlineCOB(createdLoanId.get());
-            final GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            final GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             // Validate Loan Accrual transaction
             final GetLoansLoanIdTransactions loanTransaction = loanDetails.getTransactions().stream()
                     .filter(t -> Boolean.TRUE.equals(t.getType().getAccrual())).toList().get(0);
@@ -5546,17 +5396,16 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
 
         runAt("10 October 2024", () -> {
             PostLoansLoanIdChargesChargeIdRequest request = new PostLoansLoanIdChargesChargeIdRequest().amount(15.0).locale("en");
-            loanTransactionHelper.chargeAdjustment(createdLoanId.get(), createdLoanChargeId.get(), request);
+            chargeAdjustment(createdLoanId.get(), createdLoanChargeId.get(), request);
 
-            loanTransactionHelper.makeGoodwillCredit(createdLoanId.get(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate(operationDate).locale("en").transactionAmount(15.0));
+            transactionHelper.makeGoodwillCredit(createdLoanId.get(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate(operationDate).locale("en").transactionAmount(15.0));
 
-            final GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            final GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             // Get the Repayment transaction
             GetLoansLoanIdTransactions loanTransaction = loanDetails.getTransactions().stream()
                     .filter(t -> Boolean.TRUE.equals(t.getType().getRepayment())).toList().get(0);
-            loanTransactionHelper.reverseRepayment(Math.toIntExact(createdLoanId.get()), Math.toIntExact(loanTransaction.getId()),
-                    operationDate);
+            transactionHelper.reverseLoanTransaction(createdLoanId.get(), loanTransaction.getId(), operationDate);
 
             // Validate Loan Accrual transaction
             loanTransaction = loanDetails.getTransactions().stream().filter(t -> Boolean.TRUE.equals(t.getType().getAccrual())).toList()
@@ -5589,7 +5438,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .installmentAmountInMultiplesOf(null)//
                     .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()) //
             ;//
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), operationDate, 400.0, 4);
             final BigDecimal interestRatePerPeriod = BigDecimal.valueOf(4.0);
             applicationRequest = applicationRequest.interestCalculationPeriodType(DAYS).interestRatePerPeriod(interestRatePerPeriod)
@@ -5597,9 +5446,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .repaymentFrequencyType(RepaymentFrequencyType.MONTHS).loanTermFrequency(4)
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             GetLoansLoanIdInterestRateFrequencyType interestRateFrequencyType = loanDetails.getInterestRateFrequencyType();
             assertNotNull(interestRateFrequencyType);
             assertEquals(interestRateFrequencyType.getId(), Long.valueOf(WHOLE_TERM));
@@ -5637,164 +5486,142 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .installmentAmountInMultiplesOf(null)//
                     .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()) //
             ;//
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLP2ProgressiveLoanRequest(clientId, loanProductResponse.getResourceId(),
                     operationDate, 1000.0, 7.0, 6, null);
 
             applicationRequest = applicationRequest.interestCalculationPeriodType(DAYS)
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
             createdLoanId.set(loanResponse.getLoanId());
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000.0)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate(operationDate).locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000.0))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
                     .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
 
             // Before 1st disbursement date
-            HashMap prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2023, 12, 31));
-            assertEquals(100.0f, prepayAmounts.get("amount"));
-            assertEquals(0.0f, prepayAmounts.get("interestPortion"));
-            assertEquals(100.0f, prepayAmounts.get("principalPortion"));
+            GetLoansLoanIdTransactionsTemplateResponse prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2023, 12, 31));
+            assertEquals(100.0, prepayAmounts.getAmount());
+            assertEquals(0.0, prepayAmounts.getInterestPortion());
+            assertEquals(100.0, prepayAmounts.getPrincipalPortion());
             // On 1st day
-            prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2024, 1, 1));
-            assertEquals(100.0f, prepayAmounts.get("amount"));
-            assertEquals(0.0f, prepayAmounts.get("interestPortion"));
-            assertEquals(100.0f, prepayAmounts.get("principalPortion"));
+            prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2024, 1, 1));
+            assertEquals(100.0, prepayAmounts.getAmount());
+            assertEquals(0.0, prepayAmounts.getInterestPortion());
+            assertEquals(100.0, prepayAmounts.getPrincipalPortion());
             // On 2nd day
-            prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2024, 1, 2));
-            assertEquals(100.02f, prepayAmounts.get("amount"));
-            assertEquals(0.02f, prepayAmounts.get("interestPortion"));
-            assertEquals(100.0f, prepayAmounts.get("principalPortion"));
+            prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2024, 1, 2));
+            assertEquals(100.02, prepayAmounts.getAmount());
+            assertEquals(0.02, prepayAmounts.getInterestPortion());
+            assertEquals(100.0, prepayAmounts.getPrincipalPortion());
             // On due date of 1st period
-            prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2024, 2, 1));
-            assertEquals(100.58f, prepayAmounts.get("amount"));
-            assertEquals(0.58f, prepayAmounts.get("interestPortion"));
-            assertEquals(100.0f, prepayAmounts.get("principalPortion"));
+            prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2024, 2, 1));
+            assertEquals(100.58, prepayAmounts.getAmount());
+            assertEquals(0.58, prepayAmounts.getInterestPortion());
+            assertEquals(100.0, prepayAmounts.getPrincipalPortion());
             // On the 1st day of 2nd period
-            prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2024, 2, 2));
-            assertEquals(100.60f, prepayAmounts.get("amount"));
-            assertEquals(0.60f, prepayAmounts.get("interestPortion"));
-            assertEquals(100.0f, prepayAmounts.get("principalPortion"));
+            prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2024, 2, 2));
+            assertEquals(100.60, prepayAmounts.getAmount());
+            assertEquals(0.60, prepayAmounts.getInterestPortion());
+            assertEquals(100.0, prepayAmounts.getPrincipalPortion());
             // In the middle of 2nd period (15 Feb)
-            prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2024, 2, 15));
-            assertEquals(100.86f, prepayAmounts.get("amount"));
-            assertEquals(0.86f, prepayAmounts.get("interestPortion"));
-            assertEquals(100.0f, prepayAmounts.get("principalPortion"));
+            prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2024, 2, 15));
+            assertEquals(100.86, prepayAmounts.getAmount());
+            assertEquals(0.86, prepayAmounts.getInterestPortion());
+            assertEquals(100.0, prepayAmounts.getPrincipalPortion());
             // On the due date of 2nd period
-            prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2024, 3, 1));
-            assertEquals(101.16f, prepayAmounts.get("amount"));
-            assertEquals(1.16f, prepayAmounts.get("interestPortion"));
-            assertEquals(100.0f, prepayAmounts.get("principalPortion"));
+            prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2024, 3, 1));
+            assertEquals(101.16, prepayAmounts.getAmount());
+            assertEquals(1.16, prepayAmounts.getInterestPortion());
+            assertEquals(100.0, prepayAmounts.getPrincipalPortion());
         });
         String repaymentDate = "01 February 2024";
         runAt(repaymentDate, () -> {
-            loanTransactionHelper.makeLoanRepayment(createdLoanId.get(), new PostLoansLoanIdTransactionsRequest()
-                    .transactionDate(repaymentDate).dateFormat("dd MMMM yyyy").locale("en").transactionAmount(17.01));
+            transactionHelper.makeLoanRepayment(createdLoanId.get(), new PostLoansLoanIdTransactionsRequest().transactionDate(repaymentDate)
+                    .dateFormat("dd MMMM yyyy").locale("en").transactionAmount(17.01));
             // Before 1st disbursement date
-            HashMap prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2023, 12, 31));
-            assertEquals(83.57f, prepayAmounts.get("amount"));
-            assertEquals(0.0f, prepayAmounts.get("interestPortion"));
-            assertEquals(83.57f, prepayAmounts.get("principalPortion"));
+            GetLoansLoanIdTransactionsTemplateResponse prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2023, 12, 31));
+            assertEquals(83.57, prepayAmounts.getAmount());
+            assertEquals(0.0, prepayAmounts.getInterestPortion());
+            assertEquals(83.57, prepayAmounts.getPrincipalPortion());
             // On 1st day
-            prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2024, 1, 1));
-            assertEquals(83.57f, prepayAmounts.get("amount"));
-            assertEquals(0.0f, prepayAmounts.get("interestPortion"));
-            assertEquals(83.57f, prepayAmounts.get("principalPortion"));
+            prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2024, 1, 1));
+            assertEquals(83.57, prepayAmounts.getAmount());
+            assertEquals(0.0, prepayAmounts.getInterestPortion());
+            assertEquals(83.57, prepayAmounts.getPrincipalPortion());
             // On 2nd day
-            prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2024, 1, 2));
-            assertEquals(83.57f, prepayAmounts.get("amount"));
-            assertEquals(0.00f, prepayAmounts.get("interestPortion"));
-            assertEquals(83.57f, prepayAmounts.get("principalPortion"));
+            prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2024, 1, 2));
+            assertEquals(83.57, prepayAmounts.getAmount());
+            assertEquals(0.00, prepayAmounts.getInterestPortion());
+            assertEquals(83.57, prepayAmounts.getPrincipalPortion());
             // On due date of 1st period
-            prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2024, 2, 1));
-            assertEquals(83.57f, prepayAmounts.get("amount"));
-            assertEquals(0.0f, prepayAmounts.get("interestPortion"));
-            assertEquals(83.57f, prepayAmounts.get("principalPortion"));
+            prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2024, 2, 1));
+            assertEquals(83.57, prepayAmounts.getAmount());
+            assertEquals(0.0, prepayAmounts.getInterestPortion());
+            assertEquals(83.57, prepayAmounts.getPrincipalPortion());
             // On the 1st day of 2nd period
-            prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2024, 2, 2));
-            assertEquals(83.59f, prepayAmounts.get("amount"));
-            assertEquals(0.02f, prepayAmounts.get("interestPortion"));
-            assertEquals(83.57f, prepayAmounts.get("principalPortion"));
+            prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2024, 2, 2));
+            assertEquals(83.59, prepayAmounts.getAmount());
+            assertEquals(0.02, prepayAmounts.getInterestPortion());
+            assertEquals(83.57, prepayAmounts.getPrincipalPortion());
             // In the middle of 2nd period (15 Feb)
-            prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2024, 2, 15));
-            assertEquals(83.81f, prepayAmounts.get("amount"));
-            assertEquals(0.24f, prepayAmounts.get("interestPortion"));
-            assertEquals(83.57f, prepayAmounts.get("principalPortion"));
+            prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2024, 2, 15));
+            assertEquals(83.81, prepayAmounts.getAmount());
+            assertEquals(0.24, prepayAmounts.getInterestPortion());
+            assertEquals(83.57, prepayAmounts.getPrincipalPortion());
             // On the due date of 2nd period
-            prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2024, 3, 1));
-            assertEquals(84.06f, prepayAmounts.get("amount"));
-            assertEquals(0.49f, prepayAmounts.get("interestPortion"));
-            assertEquals(83.57f, prepayAmounts.get("principalPortion"));
+            prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2024, 3, 1));
+            assertEquals(84.06, prepayAmounts.getAmount());
+            assertEquals(0.49, prepayAmounts.getInterestPortion());
+            assertEquals(83.57, prepayAmounts.getPrincipalPortion());
         });
 
         String secondRepaymentDate = "15 February 2024";
         runAt(secondRepaymentDate, () -> {
-            loanTransactionHelper.makeLoanRepayment(createdLoanId.get(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(createdLoanId.get(), new PostLoansLoanIdTransactionsRequest()
                     .transactionDate(secondRepaymentDate).dateFormat("dd MMMM yyyy").locale("en").transactionAmount(5.0));
             // Before 1st disbursement date
-            HashMap prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2023, 12, 31));
-            assertEquals(78.57f, prepayAmounts.get("amount"));
-            assertEquals(0.0f, prepayAmounts.get("interestPortion"));
-            assertEquals(78.57f, prepayAmounts.get("principalPortion"));
+            GetLoansLoanIdTransactionsTemplateResponse prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2023, 12, 31));
+            assertEquals(78.57, prepayAmounts.getAmount());
+            assertEquals(0.0, prepayAmounts.getInterestPortion());
+            assertEquals(78.57, prepayAmounts.getPrincipalPortion());
             // On 1st day
-            prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2024, 1, 1));
-            assertEquals(78.57f, prepayAmounts.get("amount"));
-            assertEquals(0.0f, prepayAmounts.get("interestPortion"));
-            assertEquals(78.57f, prepayAmounts.get("principalPortion"));
+            prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2024, 1, 1));
+            assertEquals(78.57, prepayAmounts.getAmount());
+            assertEquals(0.0, prepayAmounts.getInterestPortion());
+            assertEquals(78.57, prepayAmounts.getPrincipalPortion());
             // On 2nd day
-            prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2024, 1, 2));
-            assertEquals(78.57f, prepayAmounts.get("amount"));
-            assertEquals(0.00f, prepayAmounts.get("interestPortion"));
-            assertEquals(78.57f, prepayAmounts.get("principalPortion"));
+            prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2024, 1, 2));
+            assertEquals(78.57, prepayAmounts.getAmount());
+            assertEquals(0.00, prepayAmounts.getInterestPortion());
+            assertEquals(78.57, prepayAmounts.getPrincipalPortion());
             // On due date of 1st period
-            prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2024, 2, 1));
-            assertEquals(78.57f, prepayAmounts.get("amount"));
-            assertEquals(0.0f, prepayAmounts.get("interestPortion"));
-            assertEquals(78.57f, prepayAmounts.get("principalPortion"));
+            prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2024, 2, 1));
+            assertEquals(78.57, prepayAmounts.getAmount());
+            assertEquals(0.0, prepayAmounts.getInterestPortion());
+            assertEquals(78.57, prepayAmounts.getPrincipalPortion());
             // On the 1st day of 2nd period
-            prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2024, 2, 2));
-            assertEquals(78.59f, prepayAmounts.get("amount"));
-            assertEquals(0.02f, prepayAmounts.get("interestPortion"));
-            assertEquals(78.57f, prepayAmounts.get("principalPortion"));
+            prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2024, 2, 2));
+            assertEquals(78.59, prepayAmounts.getAmount());
+            assertEquals(0.02, prepayAmounts.getInterestPortion());
+            assertEquals(78.57, prepayAmounts.getPrincipalPortion());
             // In the middle of 2nd period (15 Feb)
-            prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2024, 2, 15));
-            assertEquals(78.81f, prepayAmounts.get("amount"));
-            assertEquals(0.24f, prepayAmounts.get("interestPortion"));
-            assertEquals(78.57f, prepayAmounts.get("principalPortion"));
+            prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2024, 2, 15));
+            assertEquals(78.81, prepayAmounts.getAmount());
+            assertEquals(0.24, prepayAmounts.getInterestPortion());
+            assertEquals(78.57, prepayAmounts.getPrincipalPortion());
             // On the due date of 2nd period
-            prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2024, 3, 1));
-            assertEquals(79.04f, prepayAmounts.get("amount"));
-            assertEquals(0.47f, prepayAmounts.get("interestPortion"));
-            assertEquals(78.57f, prepayAmounts.get("principalPortion"));
+            prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2024, 3, 1));
+            assertEquals(79.04, prepayAmounts.getAmount());
+            assertEquals(0.47, prepayAmounts.getInterestPortion());
+            assertEquals(78.57, prepayAmounts.getPrincipalPortion());
 
-            loanTransactionHelper.makeLoanRepayment(createdLoanId.get(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(createdLoanId.get(), new PostLoansLoanIdTransactionsRequest()
                     .transactionDate(secondRepaymentDate).dateFormat("dd MMMM yyyy").locale("en").transactionAmount(78.81));
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertTrue(loanDetails.getStatus().getClosedObligationsMet());
         });
 
@@ -5819,50 +5646,41 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .installmentAmountInMultiplesOf(null)//
                     .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()) //
             ;//
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), "01 January 2024", 400.0,
                     6);
 
             applicationRequest = applicationRequest.interestCalculationPeriodType(DAYS).interestRatePerPeriod(BigDecimal.ZERO)
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
             createdLoanId.set(loanResponse.getLoanId());
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(400.0)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2024").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(400.0))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2024").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2024").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(400.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2024")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(400.0)).locale("en"));
         });
 
         runAt("02 January 2024", () -> {
             executeInlineCOB(createdLoanId.get());
 
-            final GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            final GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(LocalDate.of(2024, 1, 1), loanDetails.getLastClosedBusinessDate());
             final String errorMessage = Utils.uniqueRandomStringGenerator("error.", 40);
             placeHardLockOnLoan(createdLoanId.get(), errorMessage);
         });
 
         runAt("03 January 2024", () -> {
-            Integer roleId = RolesHelper.createRole(requestSpec, responseSpec);
-            Map<String, Boolean> permissionMap = Map.of("REPAYMENT_LOAN", true);
-            RolesHelper.addPermissionsToRole(requestSpec, responseSpec, roleId, permissionMap);
-            final Integer staffId = StaffHelper.createStaff(this.requestSpec, this.responseSpec);
+            // A user without the loan-checker bypass permission triggers a catch-up COB before its repayment lands,
+            // which clears the hard lock and advances the loan's last closed business date.
+            FeignTransactionHelper nonBypassTransactionHelper = new FeignTransactionHelper(
+                    FeignUserHelper.getSimpleUserWithoutBypassPermissionClient());
+            nonBypassTransactionHelper.makeLoanRepayment(createdLoanId.get(), new PostLoansLoanIdTransactionsRequest()
+                    .transactionDate("03 January 2024").dateFormat(DATETIME_PATTERN).locale(LOCALE).transactionAmount(200.0));
 
-            final String operatorUser = Utils.uniqueRandomStringGenerator("user", 8);
-            UserHelper.createUser(this.requestSpec, this.responseSpec, roleId, staffId, operatorUser, UserHelper.SIMPLE_USER_PASSWORD,
-                    "resourceId");
-
-            loanTransactionHelper.makeLoanRepayment(
-                    createdLoanId.get(), new PostLoansLoanIdTransactionsRequest().transactionDate("03 January 2024")
-                            .dateFormat("dd MMMM yyyy").locale("en").transactionAmount(200.0),
-                    operatorUser, UserHelper.SIMPLE_USER_PASSWORD);
-
-            final GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            final GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(LocalDate.of(2024, 1, 2), loanDetails.getLastClosedBusinessDate());
         });
     }
@@ -5883,7 +5701,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Integer rescheduleStrategyMethod = 4; // Adjust last, unpaid period
             PostLoanProductsRequest loanProduct = createOnePeriod30DaysPeriodicAccrualProductWithAdvancedPaymentAllocationAndInterestRecalculation(
                     (double) 80.0, rescheduleStrategyMethod);
-            final PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProduct);
+            final PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(loanProduct);
             assertNotNull(loanProductResponse);
 
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), operationDate, 100.0, 6);
@@ -5899,26 +5717,26 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .maxOutstandingLoanBalance(BigDecimal.valueOf(10000.0))//
             ;//
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()//
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()//
                     .approvedLoanAmount(BigDecimal.valueOf(100))//
                     .approvedOnDate(operationDate).dateFormat(DATETIME_PATTERN).locale("en"));//
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()//
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()//
                     .transactionAmount(BigDecimal.valueOf(100.0))//
                     .actualDisbursementDate(operationDate).dateFormat(DATETIME_PATTERN).locale("en"));//
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 125.67, 0.0, 100.0, 0.0, null);
             createdLoanId.set(loanResponse.getLoanId());
         });
 
         runAt("01 February 2024", () -> {
 
-            loanTransactionHelper.makeLoanRepayment(createdLoanId.get(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(createdLoanId.get(), new PostLoansLoanIdTransactionsRequest()
                     .transactionDate("01 February 2024").dateFormat("dd MMMM yyyy").locale("en").transactionAmount(21.0));
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             validateLoanSummaryBalances(loanDetails, 104.67, 21.0, 86.11, 13.89, null);
         });
 
@@ -5926,29 +5744,28 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             String randomText = Utils.randomStringGenerator("en", 5) + Utils.randomNumberGenerator(6)
                     + Utils.randomStringGenerator("is", 5);
             String transactionExternalId = UUID.randomUUID().toString();
-            Integer chargeOffReasonId = CodeHelper.createChargeOffCodeValue(requestSpec, responseSpec, randomText, 1);
+            Long chargeOffReasonId = codeHelper.createChargeOffCodeValue(randomText, 1);
 
-            loanTransactionHelper.chargeOffLoan(createdLoanId.get(),
-                    new PostLoansLoanIdTransactionsRequest().transactionDate("01 March 2024").locale("en").dateFormat("dd MMMM yyyy")
-                            .externalId(transactionExternalId).chargeOffReasonId((long) chargeOffReasonId));
+            transactionHelper.chargeOffLoan(createdLoanId.get(), new PostLoansLoanIdTransactionsRequest().transactionDate("01 March 2024")
+                    .locale("en").dateFormat("dd MMMM yyyy").externalId(transactionExternalId).chargeOffReasonId(chargeOffReasonId));
 
             // Loan Prepayment (before) Charge-Off transaction - With Interest Recalculation
-            GetLoansLoanIdTransactionsTemplateResponse transactionBefore = loanTransactionHelper
+            GetLoansLoanIdTransactionsTemplateResponse transactionBefore = transactionHelper
                     .retrieveTransactionTemplate(createdLoanId.get(), "prepayLoan", "dd MMMM yyyy", "15 February 2024", "en");
-            assertEquals(88.88, transactionBefore.getAmount().doubleValue());
-            assertEquals(86.11, transactionBefore.getPrincipalPortion().doubleValue());
-            assertEquals(2.77, transactionBefore.getInterestPortion().doubleValue());
-            assertEquals(0.00, transactionBefore.getFeeChargesPortion().doubleValue());
-            assertEquals(0.00, transactionBefore.getPenaltyChargesPortion().doubleValue());
+            assertEquals(88.88, transactionBefore.getAmount());
+            assertEquals(86.11, transactionBefore.getPrincipalPortion());
+            assertEquals(2.77, transactionBefore.getInterestPortion());
+            assertEquals(0.00, transactionBefore.getFeeChargesPortion());
+            assertEquals(0.00, transactionBefore.getPenaltyChargesPortion());
 
             // Loan Prepayment (after) Charge-Off transaction - WithOut Interest Recalculation
-            GetLoansLoanIdTransactionsTemplateResponse transactionAfter = loanTransactionHelper
-                    .retrieveTransactionTemplate(createdLoanId.get(), "prepayLoan", "dd MMMM yyyy", "01 March 2024", "en");
-            assertEquals(104.67, transactionAfter.getAmount().doubleValue());
-            assertEquals(86.11, transactionAfter.getPrincipalPortion().doubleValue());
-            assertEquals(18.56, transactionAfter.getInterestPortion().doubleValue());
-            assertEquals(0.00, transactionAfter.getFeeChargesPortion().doubleValue());
-            assertEquals(0.00, transactionAfter.getPenaltyChargesPortion().doubleValue());
+            GetLoansLoanIdTransactionsTemplateResponse transactionAfter = transactionHelper.retrieveTransactionTemplate(createdLoanId.get(),
+                    "prepayLoan", "dd MMMM yyyy", "01 March 2024", "en");
+            assertEquals(104.67, transactionAfter.getAmount());
+            assertEquals(86.11, transactionAfter.getPrincipalPortion());
+            assertEquals(18.56, transactionAfter.getInterestPortion());
+            assertEquals(0.00, transactionAfter.getFeeChargesPortion());
+            assertEquals(0.00, transactionAfter.getPenaltyChargesPortion());
         });
 
     }
@@ -5976,31 +5793,31 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .overAppliedNumber(null)//
                     .installmentAmountInMultiplesOf(null)//
             ;//
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), operationDate, 100.0, 3)
                     .interestRatePerPeriod(BigDecimal.valueOf(4.0));
 
             applicationRequest = applicationRequest.interestCalculationPeriodType(DAYS)
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
             createdLoanId.set(loanResponse.getLoanId());
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()
-                    .approvedLoanAmount(BigDecimal.valueOf(100.0)).dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(100.0))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
                     .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
 
             // After Disbursement we are expecting amount in Zero
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
         });
 
         runAt("23 March 2025", () -> {
             executeInlineCOB(createdLoanId.get());
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             // totalUnpaidPayableDueInterest → Total outstanding interest amount on all the periods that are before
             assertEquals(loanDetails.getSummary().getInterestCharged().stripTrailingZeros(),
                     loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
@@ -6034,32 +5851,32 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .overAppliedCalculationType("flat")//
                     .overAppliedNumber(500)//
             ;//
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), operationDate, 1000.0, 4)
                     .transactionProcessingStrategyCode("advanced-payment-allocation-strategy")//
                     .interestRatePerPeriod(BigDecimal.valueOf(12.0));
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
             createdLoanId.set(loanResponse.getLoanId());
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()
-                    .approvedLoanAmount(BigDecimal.valueOf(1300)).dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1300))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertTrue(loanDetails.getStatus().getWaitingForDisbursal());
             assertEquals("1300.000000", loanDetails.getApprovedPrincipal().toString());
 
             CallFailedRuntimeException callFailedRuntimeException = Assertions.assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
+                    () -> loanHelper.disburseLoan(loanResponse.getLoanId(),
                             new PostLoansLoanIdRequest().actualDisbursementDate(operationDate).dateFormat(DATETIME_PATTERN).locale("en")
                                     .transactionAmount(BigDecimal.valueOf(1550.0))));
 
             Assertions.assertTrue(callFailedRuntimeException.getMessage()
                     .contains("Loan disbursal amount can't be greater than maximum applied loan amount calculation"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
                     .dateFormat(DATETIME_PATTERN).locale("en").transactionAmount(BigDecimal.valueOf(1450.0)));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertTrue(loanDetails.getStatus().getActive());
             assertEquals("1450.000000", loanDetails.getSummary().getPrincipalOutstanding().toString());
         });
@@ -6110,7 +5927,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .rescheduleStrategyMethod(LoanRescheduleStrategyMethod.ADJUST_LAST_UNPAID_PERIOD.getValue())//
                     .recalculationRestFrequencyType(2)//
                     .recalculationRestFrequencyInterval(1);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), operationDate,
                     principalAmount.doubleValue(), 6).interestCalculationPeriodType(DAYS)//
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)//
@@ -6120,45 +5937,45 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .loanTermFrequency(6)//
                     .loanTermFrequencyType(MONTHS);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
             createdLoanId.set(loanResponse.getLoanId());
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(principalAmount)
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(principalAmount)
                     .dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
                     .dateFormat(DATETIME_PATTERN).locale("en").transactionAmount(principalAmount));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertTrue(loanDetails.getStatus().getActive());
         });
 
         runAt("22 June 2025", () -> {
-            PostLoansLoanIdTransactionsResponse repayment = loanTransactionHelper.makeLoanRepayment(createdLoanId.get(),
+            PostLoansLoanIdTransactionsResponse repayment = transactionHelper.makeLoanRepayment(createdLoanId.get(),
                     new PostLoansLoanIdTransactionsRequest().transactionDate("22 June 2025").dateFormat("dd MMMM yyyy").locale("en")
                             .transactionAmount(25.0));
         });
 
         runAt("13 July 2025", () -> {
-            PostLoansLoanIdTransactionsResponse repayment = loanTransactionHelper.makeLoanRepayment(createdLoanId.get(),
+            PostLoansLoanIdTransactionsResponse repayment = transactionHelper.makeLoanRepayment(createdLoanId.get(),
                     new PostLoansLoanIdTransactionsRequest().transactionDate("13 July 2025").dateFormat("dd MMMM yyyy").locale("en")
                             .transactionAmount(23.41));
             secondRepayment.set(repayment.getResourceId());
         });
 
         runAt("16 July 2025", () -> {
-            loanTransactionHelper.makeMerchantIssuedRefund(createdLoanId.get(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeMerchantIssuedRefund(createdLoanId.get(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 July 2025").locale("en").transactionAmount(135.94));
         });
 
         runAt("18 July 2025", () -> {
             CobHelper.fastForwardLoansLastCOBDate(createdLoanId.get(), "18 July 2025");
             verifyLastClosedBusinessDate(createdLoanId.get(), "18 July 2025");
-            loanTransactionHelper.reverseLoanTransaction(createdLoanId.get(), secondRepayment.get(),
+            transactionHelper.reverseLoanTransaction(createdLoanId.get(), secondRepayment.get(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("18 July 2025")
                             .transactionAmount(0.0).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertTrue(loanDetails.getStatus().getOverpaid());
             verifyTransactions(createdLoanId.get(), //
                     transaction(135.94, "Disbursement", "13 June 2025", 135.94, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
@@ -6174,7 +5991,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             createdLoanChargeId.set(addCharge(createdLoanId.get(), false, 2.8, "18 July 2025"));
             LOG.info("------------------------------ REPROCESSING LOAN ---------------------------------------");
 
-            loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertTrue(loanDetails.getStatus().getOverpaid());
             verifyTransactions(createdLoanId.get(), //
                     transaction(135.94, "Disbursement", "13 June 2025", 135.94, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
@@ -6189,7 +6006,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     transaction(2.80, "Accrual", "18 July 2025", 0.0, 0.0, 0.00, 2.80, 0.0, 0.0, 0.0));
 
             CobHelper.reprocessLoan(createdLoanId.get());
-            loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertTrue(loanDetails.getStatus().getOverpaid());
 
             verifyTransactions(createdLoanId.get(), //
@@ -6254,7 +6071,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                         .recalculationRestFrequencyType(2)//
                         .recalculationRestFrequencyInterval(1)//
                         .enableAccrualActivityPosting(true);
-                PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+                PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
                 PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), operationDate,
                         principalAmount.doubleValue(), 6).interestCalculationPeriodType(DAYS)//
                         .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)//
@@ -6264,17 +6081,16 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                         .loanTermFrequency(6)//
                         .loanTermFrequencyType(MONTHS);
 
-                PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+                PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
                 createdLoanId.set(loanResponse.getLoanId());
 
-                loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(principalAmount)
+                loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(principalAmount)
                         .dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
 
-                loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                        new PostLoansLoanIdRequest().actualDisbursementDate(operationDate).dateFormat(DATETIME_PATTERN).locale("en")
-                                .transactionAmount(principalAmount));
+                loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
+                        .dateFormat(DATETIME_PATTERN).locale("en").transactionAmount(principalAmount));
 
-                GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+                GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
                 assertTrue(loanDetails.getStatus().getActive());
             });
 
@@ -6285,7 +6101,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                         transaction(135.94, "Disbursement", "13 September 2025", 135.94, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
                         transaction(1.28, "Accrual Activity", "13 October 2025", 0.0, 0.0, 1.28, 0.0, 0.0, 0.0, 0.0),
                         transaction(1.61, "Accrual", "21 October 2025", 0.0, 0.0, 1.61, 0.0, 0.0, 0.0, 0.0));
-                GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+                GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
                 loanDetails.getTransactions().stream().filter(t -> "loanTransactionType.accrualActivity".equals(t.getType().getCode()))
                         .findFirst().ifPresent(t -> {
                             accrualActivityId[0] = t;
@@ -6293,13 +6109,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                 assertNotNull(accrualActivityId[0]);
                 assertNotNull(accrualActivityId[0].getExternalId());
 
-                loanTransactionHelper.makeLoanRepayment(createdLoanId.get(), new PostLoansLoanIdTransactionsRequest() //
+                transactionHelper.makeLoanRepayment(createdLoanId.get(), new PostLoansLoanIdTransactionsRequest() //
                         .transactionDate("13 September 2025") //
                         .transactionAmount(135.94) //
                         .locale("en") //
                         .dateFormat(DATETIME_PATTERN)); //
 
-                GetLoansLoanIdTransactionsTransactionIdResponse loanTransactionDetails = loanTransactionHelper
+                GetLoansLoanIdTransactionsTransactionIdResponse loanTransactionDetails = transactionHelper
                         .getLoanTransactionDetails(createdLoanId.get(), accrualActivityId[0].getId());
                 assertNotNull(loanTransactionDetails.getExternalId());
                 assertEquals(LocalDate.of(2025, 10, 22), loanTransactionDetails.getReversedOnDate());
@@ -6319,7 +6135,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
 
         runAt("1 January 2024", () -> {
             // Create a Cumulative Multidisbursal and Flat Interest Type
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(
                     createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct().interestType(InterestType.FLAT).daysInMonthType(30)//
                             .transactionProcessingStrategyCode(LoanProductTestBuilder.DEFAULT_STRATEGY).interestRateFrequencyType(YEARS)
                             .daysInYearType(365).loanScheduleType(LoanScheduleType.CUMULATIVE.toString()).repaymentEvery(1)
@@ -6336,16 +6152,15 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .repaymentFrequencyType(MONTHS)//
                     .loanTermFrequency(3)//
                     .loanTermFrequencyType(MONTHS);
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(principalAmount)
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(principalAmount)
                     .dateFormat(DATETIME_PATTERN).approvedOnDate("1 January 2024").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2024").dateFormat(DATETIME_PATTERN).locale("en")
-                            .transactionAmount(BigDecimal.valueOf(1000.00)));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2024")
+                    .dateFormat(DATETIME_PATTERN).locale("en").transactionAmount(BigDecimal.valueOf(1000.00)));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1017.50, 0.00, 1000.00, 0.00, null);
             validatePeriod(loanDetails, 0, LocalDate.of(2024, 1, 1), null, 1000.0, null, null, null, 0.0, 0.0, null, null, null, null, null,
                     null, null, null, null);
@@ -6361,10 +6176,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
         runAt("15 January 2024", () -> {
             final Long loanId = loanIdRef.get();
 
-            loanTransactionHelper.disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("15 January 2024")
+            loanHelper.disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("15 January 2024")
                     .dateFormat(DATETIME_PATTERN).locale("en").transactionAmount(BigDecimal.valueOf(500.0)));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 1526.25, 0.00, 1500.00, 0.00, null);
             validatePeriod(loanDetails, 0, LocalDate.of(2024, 1, 1), null, 1000.0, null, null, null, 0.0, 0.0, null, null, null, null, null,
                     null, null, null, null);
@@ -6385,13 +6200,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
         PostLoansRequest applicationRequest = applyLoanRequestProgressiveAdvancedPaymentAllocationStrategyMonthlyRepayments(clientId,
                 loanProductId, amount, numberOfRepayments, loanDisbursementDate);
 
-        PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+        PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
         Long loanId = loanResponse.getLoanId();
 
         assertNotNull(loanId);
 
-        loanTransactionHelper.approveLoan(loanId, new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(amount))
+        loanHelper.approveLoan(loanId, new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(amount))
                 .dateFormat(DATETIME_PATTERN).approvedOnDate(loanDisbursementDate).locale("en"));
 
         return loanId;
@@ -6432,19 +6247,19 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                 .installmentAmountInMultiplesOf(null).numberOfRepayments(3).repaymentEvery(15).enableDownPayment(true)
                 .enableAutoRepaymentForDownPayment(true).disbursedAmountPercentageForDownPayment(BigDecimal.valueOf(25)).minPrincipal(10.0)
                 .installmentAmountInMultiplesOf(1);
-        PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+        PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
         PostLoansRequest applicationRequest = applyLoanRequest(client.getClientId(), loanProductResponse.getResourceId(), "23 March 2024",
                 10.0, 4);
 
         applicationRequest = applicationRequest.numberOfRepayments(3).loanTermFrequency(45)
                 .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(15);
 
-        PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+        PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-        loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(10))
+        loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(10))
                 .dateFormat(DATETIME_PATTERN).approvedOnDate("23 March 2024").locale("en"));
 
-        loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("23 March 2024")
+        loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("23 March 2024")
                 .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(10.0)).locale("en"));
 
         // verify schedule
@@ -6473,7 +6288,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
         advancedPaymentData.setTransactionType("DEFAULT");
         advancedPaymentData.setFutureInstallmentAllocationRule("NEXT_INSTALLMENT");
 
-        List<PaymentAllocationOrder> paymentAllocationOrders = getPaymentAllocationOrder(PaymentAllocationType.DUE_PENALTY,
+        List<PaymentAllocationOrder> paymentAllocationOrders = LoanRequestBuilders.paymentAllocationOrder(PaymentAllocationType.DUE_PENALTY,
                 PaymentAllocationType.PAST_DUE_FEE, PaymentAllocationType.PAST_DUE_PRINCIPAL, PaymentAllocationType.PAST_DUE_INTEREST,
                 PaymentAllocationType.PAST_DUE_PENALTY, PaymentAllocationType.DUE_FEE, PaymentAllocationType.DUE_PRINCIPAL,
                 PaymentAllocationType.DUE_INTEREST, PaymentAllocationType.IN_ADVANCE_PENALTY, PaymentAllocationType.IN_ADVANCE_FEE,
@@ -6483,7 +6298,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
         return advancedPaymentData;
     }
 
-    private static Integer createLoanProduct(final String principal, final String repaymentAfterEvery, final String numberOfRepayments,
+    private static Long createLoanProduct(final String principal, final String repaymentAfterEvery, final String numberOfRepayments,
             boolean autoPayForDownPayment, LoanScheduleType loanScheduleType, LoanScheduleProcessingType loanScheduleProcessingType,
             AdvancedPaymentData allocationRuleData, final Account... accounts) {
         LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
@@ -6497,10 +6312,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                 .withInterestTypeAsDecliningBalance().withMultiDisburse().withDisallowExpectedDisbursements(true)
                 .withLoanScheduleType(loanScheduleType).withLoanScheduleProcessingType(loanScheduleProcessingType).withDaysInMonth("30")
                 .withDaysInYear("365").withMoratorium("0", "0").build(null);
-        return loanTransactionHelper.getLoanProductId(loanProductJSON);
+        return loanHelper.createLoanProductFromJson(loanProductJSON);
     }
 
-    private static Integer createLoanProduct(final String principal, final String repaymentAfterEvery, final String numberOfRepayments,
+    private static Long createLoanProduct(final String principal, final String repaymentAfterEvery, final String numberOfRepayments,
             boolean autoPayForDownPayment, LoanScheduleType loanScheduleType, final Account... accounts) {
         LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
         final String loanProductJSON = new LoanProductTestBuilder().withMinPrincipal(principal).withPrincipal(principal)
@@ -6512,7 +6327,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                 .withInterestCalculationPeriodTypeAsRepaymentPeriod(true).withInterestTypeAsDecliningBalance().withMultiDisburse()
                 .withDisallowExpectedDisbursements(true).withLoanScheduleType(loanScheduleType).withDaysInMonth("30").withDaysInYear("365")
                 .withMoratorium("0", "0").build(null);
-        return loanTransactionHelper.getLoanProductId(loanProductJSON);
+        return loanHelper.createLoanProductFromJson(loanProductJSON);
     }
 
     private static ArrayList<HashMap<String, Object>> createLoanProductGetError(final String principal, final String repaymentAfterEvery,
@@ -6529,12 +6344,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                 .withInterestTypeAsDecliningBalance().withMultiDisburse().withDisallowExpectedDisbursements(true)
                 .withLoanScheduleType(loanScheduleType).withLoanScheduleProcessingType(loanScheduleProcessingType).withDaysInMonth("30")
                 .withDaysInYear("365").withMoratorium("0", "0").build(null);
-        LoanTransactionHelper loanTransactionHelperBadRequest = new LoanTransactionHelper(requestSpec,
-                new ResponseSpecBuilder().expectStatusCode(400).build());
-        return loanTransactionHelperBadRequest.getLoanProductError(loanProductJSON, CommonConstants.RESPONSE_ERROR);
+        return loanHelper.getLoanProductError(loanProductJSON, CommonConstants.RESPONSE_ERROR);
     }
 
-    private static Integer createLoanProduct(final String principal, final String repaymentAfterEvery, final String numberOfRepayments,
+    private static Long createLoanProduct(final String principal, final String repaymentAfterEvery, final String numberOfRepayments,
             boolean downPaymentEnabled, String downPaymentPercentage, boolean autoPayForDownPayment, LoanScheduleType loanScheduleType,
             LoanScheduleProcessingType loanScheduleProcessingType, final Account... accounts) {
         AdvancedPaymentData defaultAllocation = createDefaultPaymentAllocation();
@@ -6554,7 +6367,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                 .withDisallowExpectedDisbursements(true).withLoanScheduleType(loanScheduleType)
                 .withLoanScheduleProcessingType(loanScheduleProcessingType).withDaysInMonth("30").withDaysInYear("365")
                 .withMoratorium("0", "0").build(null);
-        return loanTransactionHelper.getLoanProductId(loanProductJSON);
+        return loanHelper.createLoanProductFromJson(loanProductJSON);
     }
 
     private static void validatePeriod(GetLoansLoanIdResponse loanDetails, Integer index, LocalDate dueDate, LocalDate paidDate,
@@ -6581,29 +6394,29 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
         assertEquals(paidLate, Utils.getDoubleValue(period.getTotalPaidLateForPeriod()));
     }
 
-    private static PostLoansResponse applyForLoanApplication(final Long clientId, final Integer loanProductId, final BigDecimal principal,
+    private static PostLoansResponse applyForLoanApplication(final Long clientId, final Long loanProductId, final BigDecimal principal,
             final int loanTermFrequency, final int repaymentAfterEvery, final int numberOfRepayments, final BigDecimal interestRate,
             final String expectedDisbursementDate, final String submittedOnDate, String transactionProcessorCode,
             String loanScheduleProcessingType) {
         LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
-        return loanTransactionHelper.applyLoan(new PostLoansRequest().clientId(clientId).productId(loanProductId.longValue())
-                .expectedDisbursementDate(expectedDisbursementDate).dateFormat(DATETIME_PATTERN)
-                .transactionProcessingStrategyCode(transactionProcessorCode).locale("en").submittedOnDate(submittedOnDate)
-                .amortizationType(1).interestRatePerPeriod(interestRate).interestCalculationPeriodType(1).interestType(0)
-                .repaymentFrequencyType(0).repaymentEvery(repaymentAfterEvery).repaymentFrequencyType(0)
-                .numberOfRepayments(numberOfRepayments).loanTermFrequency(loanTermFrequency).loanTermFrequencyType(0).principal(principal)
-                .loanType("individual").loanScheduleProcessingType(loanScheduleProcessingType)
-                .maxOutstandingLoanBalance(BigDecimal.valueOf(35000)));
+        return loanHelper.applyForLoan(
+                new PostLoansRequest().clientId(clientId).productId(loanProductId).expectedDisbursementDate(expectedDisbursementDate)
+                        .dateFormat(DATETIME_PATTERN).transactionProcessingStrategyCode(transactionProcessorCode).locale("en")
+                        .submittedOnDate(submittedOnDate).amortizationType(1).interestRatePerPeriod(interestRate)
+                        .interestCalculationPeriodType(1).interestType(0).repaymentFrequencyType(0).repaymentEvery(repaymentAfterEvery)
+                        .repaymentFrequencyType(0).numberOfRepayments(numberOfRepayments).loanTermFrequency(loanTermFrequency)
+                        .loanTermFrequencyType(0).principal(principal).loanType("individual")
+                        .loanScheduleProcessingType(loanScheduleProcessingType).maxOutstandingLoanBalance(BigDecimal.valueOf(35000)));
     }
 
-    private static PostLoansResponse applyForLoanApplication(final Long clientId, final Integer loanProductId, final BigDecimal principal,
+    private static PostLoansResponse applyForLoanApplication(final Long clientId, final Long loanProductId, final BigDecimal principal,
             final int loanTermFrequency, final int repaymentAfterEvery, final int numberOfRepayments, final BigDecimal interestRate,
             final String expectedDisbursementDate, final String submittedOnDate) {
         return applyForLoanApplication(clientId, loanProductId, principal, loanTermFrequency, repaymentAfterEvery, numberOfRepayments,
                 interestRate, expectedDisbursementDate, submittedOnDate, LoanScheduleProcessingType.HORIZONTAL);
     }
 
-    private static PostLoansResponse applyForLoanApplication(final Long clientId, final Integer loanProductId, final BigDecimal principal,
+    private static PostLoansResponse applyForLoanApplication(final Long clientId, final Long loanProductId, final BigDecimal principal,
             final int loanTermFrequency, final int repaymentAfterEvery, final int numberOfRepayments, final BigDecimal interestRate,
             final String expectedDisbursementDate, final String submittedOnDate, LoanScheduleProcessingType loanScheduleProcessingType) {
         LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/AdvancedPaymentAllocationLoanRepaymentScheduleTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/AdvancedPaymentAllocationLoanRepaymentScheduleTest.java
@@ -18,33 +18,28 @@
  */
 package org.apache.fineract.integrationtests;
 
-import static org.apache.fineract.integrationtests.BaseLoanIntegrationTest.InterestRateFrequencyType.MONTHS;
-import static org.apache.fineract.integrationtests.BaseLoanIntegrationTest.InterestRateFrequencyType.WHOLE_TERM;
-import static org.apache.fineract.integrationtests.BaseLoanIntegrationTest.InterestRateFrequencyType.YEARS;
-import static org.apache.fineract.integrationtests.BaseLoanIntegrationTest.RepaymentFrequencyType.DAYS;
+import static org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestRateFrequencyType.MONTHS;
+import static org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestRateFrequencyType.WHOLE_TERM;
+import static org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestRateFrequencyType.YEARS;
+import static org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.LOCALE;
+import static org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.RepaymentFrequencyType.DAYS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
 import org.apache.fineract.client.models.AdvancedPaymentData;
-import org.apache.fineract.client.models.BusinessDateUpdateRequest;
 import org.apache.fineract.client.models.CreditAllocationData;
 import org.apache.fineract.client.models.CreditAllocationOrder;
 import org.apache.fineract.client.models.GetLoanProductsProductIdResponse;
@@ -72,26 +67,27 @@ import org.apache.fineract.client.models.PostLoansResponse;
 import org.apache.fineract.client.models.PostUpdateRescheduleLoansRequest;
 import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
 import org.apache.fineract.client.models.PutLoansLoanIdRequest;
-import org.apache.fineract.client.util.CallFailedRuntimeException;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
-import org.apache.fineract.integrationtests.common.BusinessDateHelper;
-import org.apache.fineract.integrationtests.common.BusinessStepHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignBusinessStepHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignTransactionHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignUserHelper;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.DaysInMonthType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.DaysInYearType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestCalculationPeriodType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.RepaymentFrequencyType;
 import org.apache.fineract.integrationtests.common.ClientHelper;
 import org.apache.fineract.integrationtests.common.CommonConstants;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.LoanRescheduleRequestHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.common.accounting.Account;
-import org.apache.fineract.integrationtests.common.accounting.AccountHelper;
 import org.apache.fineract.integrationtests.common.accounting.PeriodicAccrualAccountingHelper;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
 import org.apache.fineract.integrationtests.common.loans.CobHelper;
 import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.apache.fineract.integrationtests.common.organisation.StaffHelper;
 import org.apache.fineract.integrationtests.common.products.DelinquencyBucketsHelper;
-import org.apache.fineract.integrationtests.common.system.CodeHelper;
-import org.apache.fineract.integrationtests.useradministration.roles.RolesHelper;
-import org.apache.fineract.integrationtests.useradministration.users.UserHelper;
 import org.apache.fineract.portfolio.loanaccount.domain.transactionprocessor.impl.AdvancedPaymentScheduleTransactionProcessor;
 import org.apache.fineract.portfolio.loanaccount.domain.transactionprocessor.impl.EarlyPaymentLoanRepaymentScheduleTransactionProcessor;
 import org.apache.fineract.portfolio.loanaccount.domain.transactionprocessor.impl.FineractStyleLoanRepaymentScheduleTransactionProcessor;
@@ -105,30 +101,15 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoanIntegrationTest {
+public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends FeignLoanTestBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(AdvancedPaymentAllocationLoanRepaymentScheduleTest.class);
-    private static final String DATETIME_PATTERN = "dd MMMM yyyy";
-    private static ResponseSpecification responseSpec;
-    private static RequestSpecification requestSpec;
-    private static BusinessDateHelper businessDateHelper;
-    private static LoanTransactionHelper loanTransactionHelper;
-    private static AccountHelper accountHelper;
-    private static Integer commonLoanProductId;
+
+    private static Long commonLoanProductId;
     private static PostClientsResponse client;
 
     @BeforeAll
     public static void setup() {
-        Utils.initializeRESTAssured();
-        requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        requestSpec.header("Fineract-Platform-TenantId", "default");
-        responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-        businessDateHelper = new BusinessDateHelper();
-        accountHelper = new AccountHelper(requestSpec, responseSpec);
-        ClientHelper clientHelper = new ClientHelper(requestSpec, responseSpec);
-
         final Account assetAccount = accountHelper.createAssetAccount();
         final Account incomeAccount = accountHelper.createIncomeAccount();
         final Account expenseAccount = accountHelper.createExpenseAccount();
@@ -138,9 +119,24 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                 LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
         client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
         // setup COB Business Steps to prevent test failing due other integration test configurations
-        new BusinessStepHelper().updateSteps("LOAN_CLOSE_OF_BUSINESS", "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION",
-                "CHECK_LOAN_REPAYMENT_DUE", "CHECK_LOAN_REPAYMENT_OVERDUE", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
+        new FeignBusinessStepHelper(FineractFeignClientHelper.getFineractFeignClient()).updateSteps("LOAN_CLOSE_OF_BUSINESS",
+                "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION", "CHECK_LOAN_REPAYMENT_DUE",
+                "CHECK_LOAN_REPAYMENT_OVERDUE", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
                 "EXTERNAL_ASSET_OWNER_TRANSFER", "CHECK_DUE_INSTALLMENTS", "ACCRUAL_ACTIVITY_POSTING", "LOAN_INTEREST_RECALCULATION");
+    }
+
+    /** Prepayment amounts as of the given date; the loan template exposes them per portion. */
+    private static GetLoansLoanIdTransactionsTemplateResponse getPrepayAmount(Long loanId, LocalDate date) {
+        return transactionHelper.getPrepaymentAmount(loanId, dateTimeFormatter.format(date), DATETIME_PATTERN);
+    }
+
+    private static Long addSpecifiedDueDateCharge(Long loanId, Long chargeId, String dueDate, double amount) {
+        return loanHelper.addSpecifiedDueDateCharge(loanId, chargeId, amount, dueDate).getResourceId();
+    }
+
+    private static void applyLoanExpectingError(PostLoansRequest request, int expectedHttpStatus) {
+        CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class, () -> loanHelper.applyForLoan(request));
+        assertEquals(expectedHttpStatus, exception.getStatus());
     }
 
     // UC1: Simple payments
@@ -156,15 +152,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -173,10 +167,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 1, 125.0, 125.0, 0.0, 375.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 250.0, 250.0, 250.0, 250.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -185,10 +179,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 2, 125.0, 125.0, 0.0, 250.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 125.0, 375.0, 125.0, 375.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -197,10 +191,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 3, 125.0, 125.0, 0.0, 125.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("15 February 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -224,15 +218,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -241,10 +233,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 1, 125.0, 125.0, 0.0, 375.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(150.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 225.0, 275.0, 225.0, 275.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -253,10 +245,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 2, 150.0, 150.0, 0.0, 225.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 100.0, 400.0, 100.0, 400.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -265,10 +257,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 3, 125.0, 125.0, 0.0, 100.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("15 February 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, 25.0);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -278,7 +270,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             assertTrue(loanDetails.getStatus().getOverpaid());
 
             // Loan Repayment (after) Overpaid
-            GetLoansLoanIdTransactionsTemplateResponse transactionAfter = loanTransactionHelper
+            GetLoansLoanIdTransactionsTemplateResponse transactionAfter = transactionHelper
                     .retrieveTransactionTemplate(loanResponse.getLoanId(), "repayment", DATETIME_PATTERN, "15 February 2023", LOCALE);
             assertNotNull(transactionAfter);
         });
@@ -296,15 +288,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -313,10 +303,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 1, 125.0, 125.0, 0.0, 375.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeGoodwillCredit(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeGoodwillCredit(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(150.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 225.0, 275.0, 225.0, 275.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -325,10 +315,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 2, 150.0, 150.0, 0.0, 225.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 100.0, 400.0, 100.0, 400.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -337,10 +327,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 3, 125.0, 125.0, 0.0, 100.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("15 February 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, 25.0);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -350,7 +340,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             assertTrue(loanDetails.getStatus().getOverpaid());
 
             // Loan Repayment (after) Overpaid
-            GetLoansLoanIdTransactionsTemplateResponse transactionAfter = loanTransactionHelper
+            GetLoansLoanIdTransactionsTemplateResponse transactionAfter = transactionHelper
                     .retrieveTransactionTemplate(loanResponse.getLoanId(), "repayment", DATETIME_PATTERN, "15 February 2023", LOCALE);
             assertNotNull(transactionAfter);
         });
@@ -369,19 +359,17 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
-            loanTransactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(1).getId(),
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
+            transactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(1).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("01 January 2023")
                             .transactionAmount(0.0).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 500.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -389,14 +377,14 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, 125.0, 0.0, 125.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(125.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
-            loanTransactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(2).getId(),
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
+            transactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(2).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023")
                             .transactionAmount(0.0).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 500.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -405,10 +393,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
 
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("20 January 2023").locale("en").transactionAmount(100.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 400.0, 100.0, 400.0, 100.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 100.0, 25.0, 0.0, 100.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -417,10 +405,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 3, 100.0, 100.0, 0.0, 400.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(40.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 360.0, 140.0, 360.0, 140.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 15.0, 110.0, 0.0, 15.0);
@@ -429,10 +417,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 4, 40.0, 40.0, 0.0, 360.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("15 February 2023").locale("en").transactionAmount(360.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 125.0);
@@ -455,16 +443,14 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
             // Verify initial state: down payment (installment 1) already paid, remaining 3 installments outstanding
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -473,10 +459,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             assertTrue(loanDetails.getStatus().getActive());
 
             // Fully pay installment 2
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 250.0, 250.0, 250.0, 250.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -487,7 +473,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             // Repayment template must point to installment 3 (next unpaid), not installment 2 (fully paid)
             // Before the fix, this would return 0.0 because the query always picked the lowest installment
             // number with outstanding balance, which after partial repayment could be a fully satisfied one
-            final GetLoansLoanIdTransactionsTemplateResponse transactionTemplate = loanTransactionHelper
+            final GetLoansLoanIdTransactionsTemplateResponse transactionTemplate = transactionHelper
                     .retrieveTransactionTemplate(loanResponse.getLoanId(), "repayment", DATETIME_PATTERN, "16 January 2023", LOCALE);
             assertNotNull(transactionTemplate);
             assertEquals(125.0, transactionTemplate.getAmount().doubleValue());
@@ -511,19 +497,17 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
-            loanTransactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(1).getId(),
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
+            transactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(1).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("01 January 2023")
                             .transactionAmount(0.0).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 500.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -531,10 +515,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, 125.0, 0.0, 125.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("8 January 2023").locale("en").transactionAmount(300.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 200.0, 300.0, 200.0, 300.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 58.33, 66.67, 58.33, 0.0);
@@ -543,10 +527,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 2, 300.0, 300.0, 0.0, 200.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(66.67));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 133.33, 366.67, 133.33, 366.67, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 58.33, 0.0);
@@ -555,10 +539,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 3, 66.67, 66.67, 0.0, 133.33);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(66.67));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 66.66, 433.34, 66.66, 433.34, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 58.33, 0.0);
@@ -567,10 +551,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 4, 66.67, 66.67, 0.0, 66.66);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("15 February 2023").locale("en").transactionAmount(66.66));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 58.33, 0.0);
@@ -595,15 +579,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
 
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -613,10 +595,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 1, 125.0, 125.0, 0.0, 375.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 250.0, 250.0, 250.0, 250.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -625,10 +607,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 2, 125.0, 125.0, 0.0, 250.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(200.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 50.0, 450.0, 50.0, 450.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -637,10 +619,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 3, 200, 200.0, 0.0, 50.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(25.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 25.0, 475.0, 25.0, 475.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -649,10 +631,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 4, 25.0, 25.0, 0.0, 25.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("15 February 2023").locale("en").transactionAmount(25.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -677,19 +659,17 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
-            loanTransactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(1).getId(),
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
+            transactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(1).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("01 January 2023")
                             .transactionAmount(0.0).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 500.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -697,14 +677,14 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, 125.0, 0.0, 125.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(125.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
-            loanTransactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(2).getId(),
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
+            transactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(2).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023")
                             .transactionAmount(0.0).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 500.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -712,10 +692,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, 125.0, 0.0, 125.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("17 January 2023").locale("en").transactionAmount(300.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 200.0, 300.0, 200.0, 300.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 125.0);
@@ -724,10 +704,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 3, 300.0, 300.0, 0.0, 200.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(100.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 100.0, 400.0, 100.0, 400.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 125.0);
@@ -736,10 +716,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 4, 100.0, 100.0, 0.0, 100.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("15 February 2023").locale("en").transactionAmount(100.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 125.0);
@@ -763,15 +743,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -780,10 +758,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 1, 125.0, 125.0, 0.0, 375.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makePayoutRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makePayoutRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("05 January 2023").locale("en").transactionAmount(200.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 175.0, 325.0, 175.0, 325.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -792,10 +770,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 2, 200.0, 200.0, 0.0, 175.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(50.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 125.0, 375.0, 125.0, 375.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -804,10 +782,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 3, 50.0, 50.0, 0.0, 125.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("15 February 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -832,15 +810,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -849,14 +825,14 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 1, 125.0, 125.0, 0.0, 375.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(125.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
-            loanTransactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(2).getId(),
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
+            transactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(2).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023")
                             .transactionAmount(0.0).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -864,10 +840,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, 125.0, 0.0, 125.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makePayoutRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makePayoutRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("17 January 2023").locale("en").transactionAmount(200.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 175.0, 325.0, 175.0, 325.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 125.0);
@@ -876,10 +852,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 3, 200.0, 200.0, 0.0, 175.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(50.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 125.0, 375.0, 125.0, 375.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 125.0);
@@ -888,10 +864,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 4, 50.0, 50.0, 0.0, 125.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("15 February 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 125.0);
@@ -915,20 +891,18 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
-            loanTransactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(1).getId(),
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
+            transactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(1).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("01 January 2023")
                             .transactionAmount(0.0).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 500.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -936,10 +910,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, 125.0, 0.0, 125.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makePayoutRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makePayoutRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("15 January 2023").locale("en").transactionAmount(400.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 100.0, 400.0, 100.0, 400.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -948,10 +922,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 2, 400.0, 400.0, 0.0, 100.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("15 February 2023").locale("en").transactionAmount(100.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -975,15 +949,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -992,10 +964,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 1, 125.0, 125.0, 0.0, 375.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeGoodwillCredit(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeGoodwillCredit(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("08 January 2023").locale("en").transactionAmount(200.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 175.0, 325.0, 175.0, 325.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1004,10 +976,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 2, 200.0, 200.0, 0.0, 175.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 50.0, 450.0, 50.0, 450.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -1016,10 +988,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 3, 125.0, 125.0, 0.0, 50.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(50.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -1044,15 +1016,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1061,13 +1031,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 1, 125.0, 125.0, 0.0, 375.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(125.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
-            loanTransactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(2).getId(),
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
+            transactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(2).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023")
                             .transactionAmount(0.0).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1075,10 +1045,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, 125.0, 0.0, 125.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeGoodwillCredit(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeGoodwillCredit(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("18 January 2023").locale("en").transactionAmount(200.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 175.0, 325.0, 175.0, 325.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 125.0);
@@ -1087,10 +1057,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 3, 200.0, 200.0, 0.0, 175.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 50.0, 450.0, 50.0, 450.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 125.0);
@@ -1099,10 +1069,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 4, 125.0, 125.0, 0.0, 50.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("15 February 2023").locale("en").transactionAmount(50.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 125.0);
@@ -1127,20 +1097,18 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
-            loanTransactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(1).getId(),
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
+            transactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(1).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("01 January 2023")
                             .transactionAmount(0.0).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 500.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1148,14 +1116,14 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, 125.0, 0.0, 125.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(125.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
-            loanTransactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(2).getId(),
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
+            transactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(2).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023")
                             .transactionAmount(0.0).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 500.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1163,9 +1131,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, 125.0, 0.0, 125.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("17 January 2023").locale("en").transactionAmount(200.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 300.0, 200.0, 300.0, 200.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 75.0, 50.0, 0.0, 75.0);
@@ -1174,9 +1142,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 3, 200.0, 200.0, 0.0, 300.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(125.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 175.0, 325.0, 175.0, 325.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 125.0);
@@ -1185,9 +1153,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 4, 125.0, 125.0, 0.0, 175.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("15 February 2023").locale("en").transactionAmount(175.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 125.0);
@@ -1212,20 +1180,18 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
-            loanTransactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(1).getId(),
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
+            transactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(1).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("01 January 2023")
                             .transactionAmount(0.0).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 500.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1233,10 +1199,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, 125.0, 0.0, 125.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeGoodwillCredit(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeGoodwillCredit(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("15 January 2023").locale("en").transactionAmount(200.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 300.0, 200.0, 300.0, 200.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1245,9 +1211,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 2, 200.0, 200.0, 0.0, 300.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(125.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 175.0, 325.0, 175.0, 325.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -1256,9 +1222,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 3, 125.0, 125.0, 0.0, 175.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(125.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 50.0, 450.0, 50.0, 450.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -1267,9 +1233,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 4, 125.0, 125.0, 0.0, 50.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("15 February 2023").locale("en").transactionAmount(50.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -1294,15 +1260,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1311,10 +1275,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 1, 125.0, 125.0, 0.0, 375.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("08 January 2023").locale("en").transactionAmount(500.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, 125.0);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -1323,9 +1287,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 2, 500.0, 375.0, 125.0, 0.0);
             assertTrue(loanDetails.getStatus().getOverpaid());
 
-            loanTransactionHelper.makeCreditBalanceRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeCreditBalanceRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("09 January 2023").locale("en").transactionAmount(125.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -1350,15 +1314,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1367,10 +1329,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 1, 125.0, 125.0, 0.0, 375.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makePayoutRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makePayoutRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("08 January 2023").locale("en").transactionAmount(500.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, 125.0);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -1379,9 +1341,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 2, 500.0, 375.0, 125.0, 0.0);
             assertTrue(loanDetails.getStatus().getOverpaid());
 
-            loanTransactionHelper.makeCreditBalanceRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeCreditBalanceRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("09 January 2023").locale("en").transactionAmount(125.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -1406,15 +1368,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1423,10 +1383,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 1, 125.0, 125.0, 0.0, 375.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeGoodwillCredit(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeGoodwillCredit(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("08 January 2023").locale("en").transactionAmount(500.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, 125.0);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -1435,9 +1395,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 2, 500.0, 375.0, 125.0, 0.0);
             assertTrue(loanDetails.getStatus().getOverpaid());
 
-            loanTransactionHelper.makeCreditBalanceRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeCreditBalanceRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("09 January 2023").locale("en").transactionAmount(125.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -1462,15 +1422,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1479,10 +1437,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 1, 125.0, 125.0, 0.0, 375.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 250.0, 250.0, 250.0, 250.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -1491,10 +1449,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 2, 125.0, 125.0, 0.0, 250.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 125.0, 375.0, 125.0, 375.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -1503,10 +1461,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 3, 125.0, 125.0, 0.0, 125.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("15 February 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -1515,9 +1473,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 4, 125.0, 125.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getClosedObligationsMet());
 
-            loanTransactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("18 February 2023").locale("en").transactionAmount(500.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, 500.0);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -1526,9 +1484,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 5, 500.0, 0.0, 500.0, 0.0);
             assertTrue(loanDetails.getStatus().getOverpaid());
 
-            loanTransactionHelper.makeCreditBalanceRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeCreditBalanceRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("20 February 2023").locale("en").transactionAmount(500.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -1555,19 +1513,17 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
-            loanTransactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(1).getId(),
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
+            transactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(1).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023")
                             .transactionAmount(0.0).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 500.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1575,10 +1531,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, 125.0, 0.0, 125.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("02 January 2023").locale("en").transactionAmount(400.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 100.0, 400.0, 100.0, 400.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 91.67, 33.33, 91.67, 0.0);
@@ -1587,9 +1543,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 2, 400.0, 400.0, 0.0, 100.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("04 January 2023").locale("en").transactionAmount(50.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 50.0, 450.0, 50.0, 450.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -1598,9 +1554,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 3, 50.0, 50.0, 0.0, 50.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(125.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, 75.0);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -1609,9 +1565,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 4, 125.0, 50.0, 75.0, 0.0);
             assertTrue(loanDetails.getStatus().getOverpaid());
 
-            loanTransactionHelper.makeCreditBalanceRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeCreditBalanceRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("18 January 2023").locale("en").transactionAmount(75.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -1620,10 +1576,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 5, 75.0, 0.0, 75.0, 0.0);
             assertTrue(loanDetails.getStatus().getClosedObligationsMet());
 
-            loanTransactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(2).getId(),
+            transactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(2).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("20 January 2023")
                             .transactionAmount(0.0).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 400.0, 175.0, 400.0, 175.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 50.0, 75.0, 0.0, 0.0);
@@ -1631,9 +1587,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, 125.0, 0.0, 125.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(275.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 125.0, 450.0, 125.0, 450.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 75.0);
@@ -1642,9 +1598,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 6, 275.0, 275.0, 0.0, 125.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("15 February 2023").locale("en").transactionAmount(125.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 575.0, 0.0, 575.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 75.0);
@@ -1669,19 +1625,17 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
-            loanTransactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(1).getId(),
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
+            transactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(1).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023")
                             .transactionAmount(0.0).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 500.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1689,9 +1643,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, 125.0, 0.0, 125.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("02 January 2023").locale("en").transactionAmount(400.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 100.0, 400.0, 100.0, 400.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 91.67, 33.33, 91.67, 0.0);
@@ -1700,9 +1654,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 2, 400.0, 400.0, 0.0, 100.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("04 January 2023").locale("en").transactionAmount(50.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 50.0, 450.0, 50.0, 450.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -1711,9 +1665,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 3, 50.0, 50.0, 0.0, 50.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("06 January 2023").locale("en").transactionAmount(40.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 10.0, 490.0, 10.0, 490.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -1737,20 +1691,18 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account incomeAccount = accountHelper.createIncomeAccount();
             final Account expenseAccount = accountHelper.createExpenseAccount();
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("500", "15", "4", true, "25", false, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("500", "15", "4", true, "25", false, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 500.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1758,9 +1710,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, 125.0, 0.0, 125.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("04 January 2023").locale("en").transactionAmount(175.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 325.0, 175.0, 325.0, 175.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 50.0, 75.0, 50.0, 0.0);
@@ -1769,10 +1721,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateLoanTransaction(loanDetails, 1, 175.0, 175.0, 0.0, 325.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("05 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("05 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 825.0, 175.0, 825.0, 175.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1782,13 +1733,11 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             assertTrue(loanDetails.getStatus().getActive());
 
             // Add Charge Penalty
-            Integer penalty = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "100", true));
-            Integer penalty1LoanChargeId = loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "22 February 2023", "100"));
+            Long penalty = chargesHelper.createLoanSpecifiedDueDatePenalty(100.0).getResourceId();
+            Long penalty1LoanChargeId = addSpecifiedDueDateCharge(loanResponse.getLoanId(), penalty, "22 February 2023", 100.0);
             assertNotNull(penalty1LoanChargeId);
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 925.0, 175.0, 825.0, 175.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1816,20 +1765,18 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account incomeAccount = accountHelper.createIncomeAccount();
             final Account expenseAccount = accountHelper.createExpenseAccount();
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("500", "15", "4", true, "25", false, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("500", "15", "4", true, "25", false, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 500.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1845,7 +1792,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             LoanRescheduleRequestHelper.approveLoanRescheduleRequest(rescheduleLoansResponse.getResourceId(),
                     new PostUpdateRescheduleLoansRequest().approvedOnDate("16 January 2023").locale("en").dateFormat(DATETIME_PATTERN));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 500.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 31), 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1853,9 +1800,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, LocalDate.of(2023, 3, 2), 125.0, 0.0, 125.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(350.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 150.0, 350.0, 150.0, 350.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 31), 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -1863,11 +1810,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, LocalDate.of(2023, 3, 2), 125.0, 0.0, 125.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("20 February 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(250.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("20 February 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(250.0)).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 400.0, 350.0, 400.0, 350.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 31), 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -1883,7 +1829,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             LoanRescheduleRequestHelper.approveLoanRescheduleRequest(rescheduleLoansResponse.getResourceId(),
                     new PostUpdateRescheduleLoansRequest().approvedOnDate("15 February 2023").locale("en").dateFormat(DATETIME_PATTERN));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 400.0, 350.0, 400.0, 350.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 31), 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -1908,20 +1854,18 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account incomeAccount = accountHelper.createIncomeAccount();
             final Account expenseAccount = accountHelper.createExpenseAccount();
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("500", "15", "4", true, "25", false, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("500", "15", "4", true, "25", false, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 500.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1930,13 +1874,11 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             assertTrue(loanDetails.getStatus().getActive());
 
             // Add Charge Penalty
-            Integer penalty = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "100", true));
-            Integer penalty1LoanChargeId = loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "22 February 2023", "100"));
+            Long penalty = chargesHelper.createLoanSpecifiedDueDatePenalty(100.0).getResourceId();
+            Long penalty1LoanChargeId = addSpecifiedDueDateCharge(loanResponse.getLoanId(), penalty, "22 February 2023", 100.0);
             assertNotNull(penalty1LoanChargeId);
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 600.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1946,9 +1888,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("22 February 2023").locale("en").transactionAmount(600.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 600.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 125.0, 125.0, 0.0, 0.0, 125.0);
@@ -1975,20 +1917,18 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account incomeAccount = accountHelper.createIncomeAccount();
             final Account expenseAccount = accountHelper.createExpenseAccount();
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("500", "15", "4", true, "25", false, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("500", "15", "4", true, "25", false, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 500.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -1997,14 +1937,11 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             assertTrue(loanDetails.getStatus().getActive());
 
             // Add Charge Penalty
-            Integer penalty = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "25", true));
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "20 January 2023", "25"));
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "10 February 2023", "25"));
+            Long penalty = chargesHelper.createLoanSpecifiedDueDatePenalty(25.0).getResourceId();
+            addSpecifiedDueDateCharge(loanResponse.getLoanId(), penalty, "20 January 2023", 25.0);
+            addSpecifiedDueDateCharge(loanResponse.getLoanId(), penalty, "10 February 2023", 25.0);
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 550.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -2014,9 +1951,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("22 February 2023").locale("en").transactionAmount(260.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 290.0, 260.0, 250.0, 250.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 125.0, 125.0, 0.0, 0.0, 125.0);
@@ -2026,9 +1963,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("22 February 2023").locale("en").transactionAmount(26.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 264.0, 286.0, 239.0, 261.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 125.0, 125.0, 0.0, 0.0, 125.0);
@@ -2054,21 +1991,19 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account incomeAccount = accountHelper.createIncomeAccount();
             final Account expenseAccount = accountHelper.createExpenseAccount();
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("500", "15", "4", true, "25", false, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("500", "15", "4", true, "25", false, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.VERTICAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId,
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023",
                     LoanScheduleProcessingType.VERTICAL);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 500.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -2077,14 +2012,11 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             assertTrue(loanDetails.getStatus().getActive());
 
             // Add Charge Penalty
-            Integer penalty = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "25", true));
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "20 January 2023", "25"));
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "10 February 2023", "25"));
+            Long penalty = chargesHelper.createLoanSpecifiedDueDatePenalty(25.0).getResourceId();
+            addSpecifiedDueDateCharge(loanResponse.getLoanId(), penalty, "20 January 2023", 25.0);
+            addSpecifiedDueDateCharge(loanResponse.getLoanId(), penalty, "10 February 2023", 25.0);
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 550.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -2094,9 +2026,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("22 February 2023").locale("en").transactionAmount(26.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 524.0, 26.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -2106,9 +2038,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     0.0, 0.0, 1.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("22 February 2023").locale("en").transactionAmount(26.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 498.0, 52.0, 498.0, 2.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 125.0, 2.0, 123.0, 0.0, 2.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -2163,13 +2095,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
             AdvancedPaymentData defaultPaymentAllocation = createDefaultPaymentAllocationWithMixedGrouping();
 
-            Integer localLoanProductId = createLoanProduct("500", "15", "4", false, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("500", "15", "4", false, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.VERTICAL, defaultPaymentAllocation, assetAccount, incomeAccount, expenseAccount,
                     overpaymentAccount);
             assertNotNull(localLoanProductId);
 
-            Integer localLoanProductId2 = createLoanProduct("500", "15", "4", false, LoanScheduleType.CUMULATIVE, assetAccount,
-                    incomeAccount, expenseAccount, overpaymentAccount);
+            Long localLoanProductId2 = createLoanProduct("500", "15", "4", false, LoanScheduleType.CUMULATIVE, assetAccount, incomeAccount,
+                    expenseAccount, overpaymentAccount);
             assertNotNull(localLoanProductId2);
 
             CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
@@ -2177,7 +2109,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                             BigDecimal.ZERO, "01 January 2023", "01 January 2023",
                             FineractStyleLoanRepaymentScheduleTransactionProcessor.STRATEGY_CODE,
                             LoanScheduleProcessingType.VERTICAL.name()));
-            assertEquals(400, exception.getResponse().code());
+            assertEquals(400, exception.getStatus());
             assertTrue(exception.getMessage().contains("supported.only.with.advanced.payment.allocation.strategy"));
 
             exception = assertThrows(CallFailedRuntimeException.class,
@@ -2185,7 +2117,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                             BigDecimal.ZERO, "01 January 2023", "01 January 2023",
                             AdvancedPaymentScheduleTransactionProcessor.ADVANCED_PAYMENT_ALLOCATION_STRATEGY,
                             LoanScheduleProcessingType.HORIZONTAL.name()));
-            assertEquals(400, exception.getResponse().code());
+            assertEquals(400, exception.getStatus());
             assertTrue(exception.getMessage()
                     .contains("mixed.due.type.allocation.rules.are.not.supported.with.horizontal.installment.processing"));
         });
@@ -2204,34 +2136,32 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account incomeAccount = accountHelper.createIncomeAccount();
             final Account expenseAccount = accountHelper.createExpenseAccount();
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("1000", "15", "3", false, null, false, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("1000", "15", "3", false, null, false, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
             assertNotNull(localLoanProductId);
 
             PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId, BigDecimal.valueOf(1000), 45,
                     15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 16), 333.33, 0.0, 333.33, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 31), 333.33, 0.0, 333.33, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 3, LocalDate.of(2023, 2, 15), 333.34, 0.0, 333.34, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getPendingApproval());
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 16), 333.33, 0.0, 333.33, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 31), 333.33, 0.0, 333.33, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 3, LocalDate.of(2023, 2, 15), 333.34, 0.0, 333.34, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getWaitingForDisbursal());
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(1000)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000)).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1000.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 16), 333.33, 0.0, 333.33, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 31), 333.33, 0.0, 333.33, 0.0, 0.0);
@@ -2241,7 +2171,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId, BigDecimal.valueOf(1000), 90, 15, 6,
                     BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 16), 166.67, 0.0, 166.67, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 31), 166.67, 0.0, 166.67, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 3, LocalDate.of(2023, 2, 15), 166.67, 0.0, 166.67, 0.0, 0.0);
@@ -2250,11 +2180,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 6, LocalDate.of(2023, 4, 1), 166.65, 0.0, 166.65, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getPendingApproval());
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 16), 166.67, 0.0, 166.67, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 31), 166.67, 0.0, 166.67, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 3, LocalDate.of(2023, 2, 15), 166.67, 0.0, 166.67, 0.0, 0.0);
@@ -2263,11 +2192,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 6, LocalDate.of(2023, 4, 1), 166.65, 0.0, 166.65, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getWaitingForDisbursal());
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(1000)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000)).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1000.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 16), 166.67, 0.0, 166.67, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 31), 166.67, 0.0, 166.67, 0.0, 0.0);
@@ -2293,34 +2221,32 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account incomeAccount = accountHelper.createIncomeAccount();
             final Account expenseAccount = accountHelper.createExpenseAccount();
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("1000", "15", "3", false, null, false, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("1000", "15", "3", false, null, false, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
             assertNotNull(localLoanProductId);
 
             PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId, BigDecimal.valueOf(1000), 45,
                     15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 16), 333.33, 0.0, 333.33, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 31), 333.33, 0.0, 333.33, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 3, LocalDate.of(2023, 2, 15), 333.34, 0.0, 333.34, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getPendingApproval());
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 16), 333.33, 0.0, 333.33, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 31), 333.33, 0.0, 333.33, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 3, LocalDate.of(2023, 2, 15), 333.34, 0.0, 333.34, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getWaitingForDisbursal());
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(1000)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000)).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1000.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 16), 333.33, 0.0, 333.33, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 31), 333.33, 0.0, 333.33, 0.0, 0.0);
@@ -2330,7 +2256,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId, BigDecimal.valueOf(1000), 90, 15, 6,
                     BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 16), 166.67, 0.0, 166.67, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 31), 166.67, 0.0, 166.67, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 3, LocalDate.of(2023, 2, 15), 166.67, 0.0, 166.67, 0.0, 0.0);
@@ -2339,11 +2265,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 6, LocalDate.of(2023, 4, 1), 166.65, 0.0, 166.65, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getPendingApproval());
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 16), 166.67, 0.0, 166.67, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 31), 166.67, 0.0, 166.67, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 3, LocalDate.of(2023, 2, 15), 166.67, 0.0, 166.67, 0.0, 0.0);
@@ -2352,11 +2277,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 6, LocalDate.of(2023, 4, 1), 166.65, 0.0, 166.65, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getWaitingForDisbursal());
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(1000)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000)).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1000.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 16), 166.67, 0.0, 166.67, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 31), 166.67, 0.0, 166.67, 0.0, 0.0);
@@ -2383,36 +2307,34 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account incomeAccount = accountHelper.createIncomeAccount();
             final Account expenseAccount = accountHelper.createExpenseAccount();
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("40.50", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("40.50", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
             assertNotNull(localLoanProductId);
 
             PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId, BigDecimal.valueOf(40.50),
                     45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 10.12, 0.0, 10.12, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 10.13, 0.0, 10.13, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 3, LocalDate.of(2023, 1, 31), 10.13, 0.0, 10.13, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 4, LocalDate.of(2023, 2, 15), 10.12, 0.0, 10.12, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getPendingApproval());
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(40.5)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(40.5))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 10.12, 0.0, 10.12, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 10.13, 0.0, 10.13, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 3, LocalDate.of(2023, 1, 31), 10.13, 0.0, 10.13, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 4, LocalDate.of(2023, 2, 15), 10.12, 0.0, 10.12, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getWaitingForDisbursal());
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(40.5)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(40.5)).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 40.5, 0.0, 40.5, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 10.12, 0.0, 10.12, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 10.13, 0.0, 10.13, 0.0, 0.0);
@@ -2436,36 +2358,34 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account incomeAccount = accountHelper.createIncomeAccount();
             final Account expenseAccount = accountHelper.createExpenseAccount();
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("40.50", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("40.50", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
             assertNotNull(localLoanProductId);
 
             PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId, BigDecimal.valueOf(40.50),
                     45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 10.12, 0.0, 10.12, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 10.13, 0.0, 10.13, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 3, LocalDate.of(2023, 1, 31), 10.13, 0.0, 10.13, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 4, LocalDate.of(2023, 2, 15), 10.12, 0.0, 10.12, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getPendingApproval());
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(40.5)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(40.5))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 10.12, 0.0, 10.12, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 10.13, 0.0, 10.13, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 3, LocalDate.of(2023, 1, 31), 10.13, 0.0, 10.13, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 4, LocalDate.of(2023, 2, 15), 10.12, 0.0, 10.12, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getWaitingForDisbursal());
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(40.5)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(40.5)).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 40.5, 0.0, 40.5, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 10.12, 0.0, 10.12, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 10.13, 0.0, 10.13, 0.0, 0.0);
@@ -2492,20 +2412,18 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account incomeAccount = accountHelper.createIncomeAccount();
             final Account expenseAccount = accountHelper.createExpenseAccount();
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId,
                     BigDecimal.valueOf(1000.0), 45, 15, 3, BigDecimal.ZERO, "01 September 2023", "01 September 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 September 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 September 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 September 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 September 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1000.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -2514,12 +2432,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             assertTrue(loanDetails.getStatus().getActive());
 
             // Add Charge Penalty
-            Integer penalty = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "20", true));
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "17 October 2023", "20"));
+            Long penalty = chargesHelper.createLoanSpecifiedDueDatePenalty(20.0).getResourceId();
+            addSpecifiedDueDateCharge(loanResponse.getLoanId(), penalty, "17 October 2023", 20.0);
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1020.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -2529,9 +2445,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("01 September 2023").locale("en").transactionAmount(250.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 770.0, 250.0, 750.0, 250.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -2541,12 +2457,11 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            businessDateHelper.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("2023.09.16").dateFormat("yyyy.MM.dd").locale("en"));
+            updateBusinessDate("2023-09-16");
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 September 2023").locale("en").transactionAmount(250.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 520.0, 500.0, 500.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 250.0, 0.0, 0.0, 0.0);
@@ -2556,14 +2471,12 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "17 September 2023", "20"));
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "16 October 2023", "20"));
+            addSpecifiedDueDateCharge(loanResponse.getLoanId(), penalty, "17 September 2023", 20.0);
+            addSpecifiedDueDateCharge(loanResponse.getLoanId(), penalty, "16 October 2023", 20.0);
 
-            loanTransactionHelper.makeGoodwillCredit(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeGoodwillCredit(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 September 2023").locale("en").transactionAmount(50.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 510.0, 550.0, 490.0, 510.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 250.0, 0.0, 0.0, 0.0);
@@ -2598,21 +2511,19 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account incomeAccount = accountHelper.createIncomeAccount();
             final Account expenseAccount = accountHelper.createExpenseAccount();
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.VERTICAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId,
                     BigDecimal.valueOf(1000.0), 45, 15, 3, BigDecimal.ZERO, "01 September 2023", "01 September 2023",
                     LoanScheduleProcessingType.VERTICAL);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 September 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 September 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 September 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 September 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1000.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -2621,12 +2532,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             assertTrue(loanDetails.getStatus().getActive());
 
             // Add Charge Penalty
-            Integer penalty = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "20", true));
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "17 October 2023", "20"));
+            Long penalty = chargesHelper.createLoanSpecifiedDueDatePenalty(20.0).getResourceId();
+            addSpecifiedDueDateCharge(loanResponse.getLoanId(), penalty, "17 October 2023", 20.0);
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1020.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -2636,9 +2545,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("01 September 2023").locale("en").transactionAmount(250.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 770.0, 250.0, 750.0, 250.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -2648,12 +2557,11 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            businessDateHelper.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("2023.09.16").dateFormat("yyyy.MM.dd").locale("en"));
+            updateBusinessDate("2023-09-16");
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 September 2023").locale("en").transactionAmount(250.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 520.0, 500.0, 500.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 250.0, 0.0, 0.0, 0.0);
@@ -2663,14 +2571,12 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "17 September 2023", "20"));
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "16 October 2023", "20"));
+            addSpecifiedDueDateCharge(loanResponse.getLoanId(), penalty, "17 September 2023", 20.0);
+            addSpecifiedDueDateCharge(loanResponse.getLoanId(), penalty, "16 October 2023", 20.0);
 
-            loanTransactionHelper.makeGoodwillCredit(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeGoodwillCredit(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 September 2023").locale("en").transactionAmount(50.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 510.0, 550.0, 500.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 250.0, 0.0, 0.0, 0.0);
@@ -2704,20 +2610,18 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account incomeAccount = accountHelper.createIncomeAccount();
             final Account expenseAccount = accountHelper.createExpenseAccount();
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId,
                     BigDecimal.valueOf(1000.0), 45, 15, 3, BigDecimal.ZERO, "01 September 2023", "01 September 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 September 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 September 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 September 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 September 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1000.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -2726,12 +2630,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             assertTrue(loanDetails.getStatus().getActive());
 
             // Add Charge Penalty
-            Integer penalty = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "20", true));
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "17 October 2023", "20"));
+            Long penalty = chargesHelper.createLoanSpecifiedDueDatePenalty(20.0).getResourceId();
+            addSpecifiedDueDateCharge(loanResponse.getLoanId(), penalty, "17 October 2023", 20.0);
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1020.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -2741,9 +2643,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("01 September 2023").locale("en").transactionAmount(250.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 770.0, 250.0, 750.0, 250.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -2753,12 +2655,11 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            businessDateHelper.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("2023.09.16").dateFormat("yyyy.MM.dd").locale("en"));
+            updateBusinessDate("2023-09-16");
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 September 2023").locale("en").transactionAmount(250.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 520.0, 500.0, 500.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 250.0, 0.0, 0.0, 0.0);
@@ -2768,14 +2669,12 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "17 September 2023", "20"));
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "16 October 2023", "20"));
+            addSpecifiedDueDateCharge(loanResponse.getLoanId(), penalty, "17 September 2023", 20.0);
+            addSpecifiedDueDateCharge(loanResponse.getLoanId(), penalty, "16 October 2023", 20.0);
 
-            loanTransactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 September 2023").locale("en").transactionAmount(30.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 530.0, 530.0, 500.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 250.0, 0.0, 0.0, 0.0);
@@ -2809,20 +2708,18 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account incomeAccount = accountHelper.createIncomeAccount();
             final Account expenseAccount = accountHelper.createExpenseAccount();
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.VERTICAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId,
                     BigDecimal.valueOf(1000.0), 45, 15, 3, BigDecimal.ZERO, "01 September 2023", "01 September 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 September 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 September 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 September 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 September 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1000.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -2831,12 +2728,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             assertTrue(loanDetails.getStatus().getActive());
 
             // Add Charge Penalty
-            Integer penalty = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "20", true));
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "17 October 2023", "20"));
+            Long penalty = chargesHelper.createLoanSpecifiedDueDatePenalty(20.0).getResourceId();
+            addSpecifiedDueDateCharge(loanResponse.getLoanId(), penalty, "17 October 2023", 20.0);
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1020.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -2846,9 +2741,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("01 September 2023").locale("en").transactionAmount(250.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 770.0, 250.0, 750.0, 250.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -2858,12 +2753,11 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            businessDateHelper.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("2023.09.16").dateFormat("yyyy.MM.dd").locale("en"));
+            updateBusinessDate("2023-09-16");
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 September 2023").locale("en").transactionAmount(250.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 520.0, 500.0, 500.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 250.0, 0.0, 0.0, 0.0);
@@ -2872,13 +2766,11 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 5, LocalDate.of(2023, 10, 17), 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 20.0, 0.0, 20.0, 0.0, 0.0,
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "17 September 2023", "20"));
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "16 October 2023", "20"));
-            loanTransactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            addSpecifiedDueDateCharge(loanResponse.getLoanId(), penalty, "17 September 2023", 20.0);
+            addSpecifiedDueDateCharge(loanResponse.getLoanId(), penalty, "16 October 2023", 20.0);
+            transactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 September 2023").locale("en").transactionAmount(30.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 530.0, 530.0, 500.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 250.0, 0.0, 0.0, 0.0);
@@ -2909,20 +2801,18 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account incomeAccount = accountHelper.createIncomeAccount();
             final Account expenseAccount = accountHelper.createExpenseAccount();
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId,
                     BigDecimal.valueOf(1000.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1000.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -2931,12 +2821,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             assertTrue(loanDetails.getStatus().getActive());
 
             // Add Charge Fee
-            Integer fee = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "50", false));
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(fee), "01 January 2023", "50"));
+            Long fee = chargesHelper.createLoanSpecifiedDueDateCharge(50.0).getResourceId();
+            addSpecifiedDueDateCharge(loanResponse.getLoanId(), fee, "01 January 2023", 50.0);
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1050.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 250.0, 0.0, 250.0, 50.0, 0.0, 50.0, 0.0, 0.0, 0.0, 0.0, 0.0,
@@ -2945,9 +2833,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, LocalDate.of(2023, 2, 15), 250.0, 0.0, 250.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("01 January 2023").locale("en").transactionAmount(250.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 800.0, 250.0, 750.0, 250.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 250.0, 0.0, 250.0, 50.0, 0.0, 50.0, 0.0, 0.0, 0.0, 0.0, 0.0,
@@ -2957,10 +2845,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             assertTrue(loanDetails.getStatus().getActive());
 
             updateBusinessDate("16 January 2023");
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("16 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(400.0)).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("16 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(400.0)).locale("en"));
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1200.0, 250.0, 1150.0, 250.0, null);
             validatePeriod(loanDetails, 0, LocalDate.of(2023, 1, 1), null, 1000.0, null, null, null, 0.0, 0.0, null, null, null, null, null,
                     null, null, null, null);
@@ -2996,20 +2883,18 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account incomeAccount = accountHelper.createIncomeAccount();
             final Account expenseAccount = accountHelper.createExpenseAccount();
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId,
                     BigDecimal.valueOf(1000.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1000.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -3018,12 +2903,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             assertTrue(loanDetails.getStatus().getActive());
 
             // Add Charge Fee
-            Integer fee = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "50", false));
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(fee), "01 January 2023", "50"));
+            Long fee = chargesHelper.createLoanSpecifiedDueDateCharge(50.0).getResourceId();
+            addSpecifiedDueDateCharge(loanResponse.getLoanId(), fee, "01 January 2023", 50.0);
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1050.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 250.0, 0.0, 250.0, 50.0, 0.0, 50.0, 0.0, 0.0, 0.0, 0.0, 0.0,
@@ -3032,9 +2915,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, LocalDate.of(2023, 2, 15), 250.0, 0.0, 250.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("01 January 2023").locale("en").transactionAmount(250.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 800.0, 250.0, 750.0, 250.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 250.0, 0.0, 250.0, 50.0, 0.0, 50.0, 0.0, 0.0, 0.0, 0.0, 0.0,
@@ -3044,13 +2927,11 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             assertTrue(loanDetails.getStatus().getActive());
 
             updateBusinessDate("16 January 2023");
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("16 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(400.0)).locale("en"));
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("16 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(80.0)).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("16 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(400.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("16 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(80.0)).locale("en"));
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1280.0, 250.0, 1230.0, 250.0, null);
             validatePeriod(loanDetails, 0, LocalDate.of(2023, 1, 1), null, 1000.0, null, null, null, 0.0, 0.0, null, null, null, null, null,
                     null, null, null, null);
@@ -3086,20 +2967,18 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account incomeAccount = accountHelper.createIncomeAccount();
             final Account expenseAccount = accountHelper.createExpenseAccount();
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId,
                     BigDecimal.valueOf(1000.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1000.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 1, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 1, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -3107,10 +2986,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, LocalDate.of(2023, 2, 15), 250.0, 0.0, 250.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(400.0)).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(400.0)).locale("en"));
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1400.0, 0.0, 1400.0, 0.0, null);
             validatePeriod(loanDetails, 0, LocalDate.of(2023, 1, 1), null, 1000.0, null, null, null, 0.0, 0.0, null, null, null, null, null,
                     null, null, null, null);
@@ -3166,20 +3044,18 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account incomeAccount = accountHelper.createIncomeAccount();
             final Account expenseAccount = accountHelper.createExpenseAccount();
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", true, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", true, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId,
                     BigDecimal.valueOf(1000.0), 45, 15, 3, BigDecimal.ZERO, "22 November 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("22 November 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("22 November 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("22 November 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("22 November 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 75.0, 25.0, 75.0, 25.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 11, 22), 25.0, 25.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 12, 7), 25.0, 0.0, 25.0, 0.0, 0.0);
@@ -3187,10 +3063,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, LocalDate.of(2024, 1, 6), 25.0, 0.0, 25.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("22 November 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(901.0)).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("22 November 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(901.0)).locale("en"));
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 750.75, 250.25, 750.75, 250.25, null);
             validatePeriod(loanDetails, 0, LocalDate.of(2023, 11, 22), null, 100.0, null, null, null, 0.0, 0.0, null, null, null, null,
                     null, null, null, null, null);
@@ -3221,10 +3096,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Account incomeAccount = accountHelper.createIncomeAccount();
             final Account expenseAccount = accountHelper.createExpenseAccount();
             final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
+            Long localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
                     LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
 
-            loanTransactionHelper.applyLoan(new PostLoansRequest().clientId(client.getClientId()).productId(localLoanProductId.longValue())
+            loanHelper.applyForLoan(new PostLoansRequest().clientId(client.getClientId()).productId(localLoanProductId)
                     .loanType("individual").locale("en").submittedOnDate(operationDate).expectedDisbursementDate(operationDate)
                     .dateFormat(DATETIME_PATTERN).amortizationType(1).interestRatePerPeriod(BigDecimal.ZERO)
                     .interestCalculationPeriodType(1).interestType(0).repaymentFrequencyType(0).repaymentEvery(15).repaymentFrequencyType(0)
@@ -3233,12 +3108,12 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .transactionProcessingStrategyCode(AdvancedPaymentScheduleTransactionProcessor.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)
                     .loanScheduleProcessingType(LoanScheduleProcessingType.HORIZONTAL.name()));
 
-            loanTransactionHelper.applyLoanWithError(new PostLoansRequest().clientId(client.getClientId())
-                    .productId(localLoanProductId.longValue()).loanType("individual").locale("en").submittedOnDate(operationDate)
-                    .expectedDisbursementDate(operationDate).dateFormat(DATETIME_PATTERN).amortizationType(1)
-                    .interestRatePerPeriod(BigDecimal.ZERO).interestCalculationPeriodType(1).interestType(0).repaymentFrequencyType(0)
-                    .repaymentEvery(15).repaymentFrequencyType(0).numberOfRepayments(3).loanTermFrequency(45).loanTermFrequencyType(0)
-                    .principal(BigDecimal.valueOf(1000.0)).maxOutstandingLoanBalance(BigDecimal.valueOf(35000))
+            applyLoanExpectingError(new PostLoansRequest().clientId(client.getClientId()).productId(localLoanProductId)
+                    .loanType("individual").locale("en").submittedOnDate(operationDate).expectedDisbursementDate(operationDate)
+                    .dateFormat(DATETIME_PATTERN).amortizationType(1).interestRatePerPeriod(BigDecimal.ZERO)
+                    .interestCalculationPeriodType(1).interestType(0).repaymentFrequencyType(0).repaymentEvery(15).repaymentFrequencyType(0)
+                    .numberOfRepayments(3).loanTermFrequency(45).loanTermFrequencyType(0).principal(BigDecimal.valueOf(1000.0))
+                    .maxOutstandingLoanBalance(BigDecimal.valueOf(35000))
                     .transactionProcessingStrategyCode(FineractStyleLoanRepaymentScheduleTransactionProcessor.STRATEGY_CODE)
                     .loanScheduleProcessingType(LoanScheduleProcessingType.HORIZONTAL.name()), 403);
 
@@ -3259,24 +3134,22 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .numberOfRepayments(3).repaymentEvery(15).enableDownPayment(true)
                     .disbursedAmountPercentageForDownPayment(BigDecimal.valueOf(25)).enableAutoRepaymentForDownPayment(false);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), "22 November 2023",
                     1000.0, 4);
 
             applicationRequest = applicationRequest.numberOfRepayments(3).loanTermFrequency(45)
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(15);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("22 November 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("22 November 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("22 November 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("22 November 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 100.0, 0.0, 100.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 11, 22), 25.0, 0.0, 25.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 12, 7), 25.0, 0.0, 25.0, 0.0, 0.0);
@@ -3284,9 +3157,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, LocalDate.of(2024, 1, 6), 25.0, 0.0, 25.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("23 November 2023").locale("en").transactionAmount(150.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 100.0, 0.0, 100.0, 50.0);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 11, 22), 25.0, 25.0, 0.0, 0.0, 25.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 12, 7), 25.0, 25.0, 0.0, 25.0, 0.0);
@@ -3294,10 +3167,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, LocalDate.of(2024, 1, 6), 25.0, 25.0, 0.0, 25.0, 0.0);
             assertTrue(loanDetails.getStatus().getOverpaid());
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("24 November 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("24 November 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 50.0, 150.0, 50.0, 150.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 11, 22), 25.0, 25.0, 0.0, 0.0, 25.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 11, 24), 25.0, 25.0, 0.0, 0.0, 0.0);
@@ -3312,14 +3184,14 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     transaction(100, "Disbursement", "24 November 2023", 50.0, 0.0, 0.0, 0.0, 0.0, 0.0, 50.0) //
             );
             // verify journal entries
-            verifyJournalEntries(loanResponse.getLoanId(), journalEntry(100.0, loansReceivableAccount, "DEBIT"), //
-                    journalEntry(100.0, fundSource, "CREDIT"), //
-                    journalEntry(100.0, loansReceivableAccount, "CREDIT"), //
-                    journalEntry(50.0, overpaymentAccount, "CREDIT"), //
-                    journalEntry(150.0, fundSource, "DEBIT"), //
-                    journalEntry(50.0, loansReceivableAccount, "DEBIT"), //
-                    journalEntry(50.0, overpaymentAccount, "DEBIT"), //
-                    journalEntry(100.0, fundSource, "CREDIT") //
+            verifyJournalEntries(loanResponse.getLoanId(), journalEntry(100.0, loansReceivableAccount(), "DEBIT"), //
+                    journalEntry(100.0, fundSource(), "CREDIT"), //
+                    journalEntry(100.0, loansReceivableAccount(), "CREDIT"), //
+                    journalEntry(50.0, overpaymentAccount(), "CREDIT"), //
+                    journalEntry(150.0, fundSource(), "DEBIT"), //
+                    journalEntry(50.0, loansReceivableAccount(), "DEBIT"), //
+                    journalEntry(50.0, overpaymentAccount(), "DEBIT"), //
+                    journalEntry(100.0, fundSource(), "CREDIT") //
             );
         });
     }
@@ -3338,24 +3210,22 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .numberOfRepayments(3).repaymentEvery(15).enableDownPayment(true)
                     .disbursedAmountPercentageForDownPayment(BigDecimal.valueOf(25)).enableAutoRepaymentForDownPayment(false);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), "22 November 2023",
                     1000.0, 4);
 
             applicationRequest = applicationRequest.numberOfRepayments(3).loanTermFrequency(45)
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(15);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("22 November 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("22 November 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("22 November 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("22 November 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 100.0, 0.0, 100.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 11, 22), 25.0, 0.0, 25.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 12, 7), 25.0, 0.0, 25.0, 0.0, 0.0);
@@ -3363,9 +3233,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, LocalDate.of(2024, 1, 6), 25.0, 0.0, 25.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("22 November 2023").locale("en").transactionAmount(150.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 100.0, 0.0, 100.0, 50.0);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 11, 22), 25.0, 25.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 12, 7), 25.0, 25.0, 0.0, 25.0, 0.0);
@@ -3373,10 +3243,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             validateRepaymentPeriod(loanDetails, 4, LocalDate.of(2024, 1, 6), 25.0, 25.0, 0.0, 25.0, 0.0);
             assertTrue(loanDetails.getStatus().getOverpaid());
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("22 November 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(28.0)).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("22 November 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(28.0)).locale("en"));
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 128.0, 0.0, 128.0, 22.0);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 11, 22), 25.0, 25.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 11, 22), 7.0, 7.0, 0.0, 0.0, 0.0);
@@ -3391,13 +3260,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     transaction(28, "Disbursement", "22 November 2023", 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 28.0) //
             );
             // verify journal entries
-            verifyJournalEntries(loanResponse.getLoanId(), journalEntry(100.0, loansReceivableAccount, "DEBIT"), //
-                    journalEntry(100.0, fundSource, "CREDIT"), //
-                    journalEntry(100.0, loansReceivableAccount, "CREDIT"), //
-                    journalEntry(50.0, overpaymentAccount, "CREDIT"), //
-                    journalEntry(150.0, fundSource, "DEBIT"), //
-                    journalEntry(28.0, overpaymentAccount, "DEBIT"), //
-                    journalEntry(28.0, fundSource, "CREDIT") //
+            verifyJournalEntries(loanResponse.getLoanId(), journalEntry(100.0, loansReceivableAccount(), "DEBIT"), //
+                    journalEntry(100.0, fundSource(), "CREDIT"), //
+                    journalEntry(100.0, loansReceivableAccount(), "CREDIT"), //
+                    journalEntry(50.0, overpaymentAccount(), "CREDIT"), //
+                    journalEntry(150.0, fundSource(), "DEBIT"), //
+                    journalEntry(28.0, overpaymentAccount(), "DEBIT"), //
+                    journalEntry(28.0, fundSource(), "CREDIT") //
             );
         });
     }
@@ -3420,84 +3289,82 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .numberOfRepayments(1).repaymentEvery(30).enableDownPayment(false);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), "25 January 2024", 1000.0,
                     4);
 
             applicationRequest = applicationRequest.numberOfRepayments(1).loanTermFrequency(30)
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(30);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("25 January 2024").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("25 January 2024").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("25 January 2024").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("25 January 2024")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 100.0, 0.0, 100.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 24), 100.0, 0.0, 100.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
             String repaymentExternalId = UUID.randomUUID().toString();
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(),
+            transactionHelper.makeLoanRepayment(loanResponse.getLoanId(),
                     new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate("24 February 2024").locale("en")
                             .transactionAmount(100.0).externalId(repaymentExternalId));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 100.0, 0.0, 100.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 24), 100.0, 100.0, 0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getClosedObligationsMet());
 
             String mir1ExternalId = UUID.randomUUID().toString();
-            loanTransactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(),
+            transactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(),
                     new PostLoansLoanIdTransactionsRequest().transactionDate("28 February 2024").dateFormat(DATETIME_PATTERN)
                             .transactionAmount(36.99).locale("en").externalId(mir1ExternalId));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 100.0, 0.0, 100.0, 36.99);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 24), 100.0, 100.0, 0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getOverpaid());
 
-            loanTransactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .transactionDate("28 February 2024").dateFormat(DATETIME_PATTERN).transactionAmount(18.94).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 100.0, 0.0, 100.0, 55.93);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 24), 100.0, 100.0, 0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getOverpaid());
 
-            loanTransactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .transactionDate("28 February 2024").dateFormat(DATETIME_PATTERN).transactionAmount(36.99).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 100.0, 0.0, 100.0, 92.92);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 24), 100.0, 100.0, 0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getOverpaid());
 
-            loanTransactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .transactionDate("28 February 2024").dateFormat(DATETIME_PATTERN).transactionAmount(31.99).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 100.0, 0.0, 100.0, 124.91);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 24), 100.0, 100.0, 0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getOverpaid());
 
-            loanTransactionHelper.makeCreditBalanceRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeCreditBalanceRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .transactionDate("01 March 2024").dateFormat(DATETIME_PATTERN).transactionAmount(124.91).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 100.0, 0.0, 100.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 24), 100.0, 100.0, 0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getClosedObligationsMet());
 
-            loanTransactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .transactionDate("02 March 2024").dateFormat(DATETIME_PATTERN).transactionAmount(19.99).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 100.0, 0.0, 100.0, 19.99);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 24), 100.0, 100.0, 0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getOverpaid());
 
-            loanTransactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
                     .transactionDate("02 March 2024").dateFormat(DATETIME_PATTERN).transactionAmount(19.99).locale("en"));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 100.0, 0.0, 100.0, 39.98);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 24), 100.0, 100.0, 0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getOverpaid());
@@ -3514,11 +3381,11 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     transaction(19.99, "Merchant Issued Refund", "02 March 2024", 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 19.99) //
             );
 
-            loanTransactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), mir1ExternalId,
+            transactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), mir1ExternalId,
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("02 March 2024")
                             .transactionAmount(0.0).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 224.91, 0.0, 224.91, 2.99);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 24), 100.0, 100.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2024, 3, 1), 124.91, 124.91, 0.0, 0.0, 36.99);
@@ -3536,10 +3403,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     transaction(19.99, "Merchant Issued Refund", "02 March 2024", 0.0, 17.0, 0.0, 0.0, 0.0, 0.0, 2.99) //
             );
 
-            loanTransactionHelper.chargebackLoanTransaction(loanResponse.getLoanId(), repaymentExternalId,
+            transactionHelper.chargebackLoanTransaction(loanResponse.getLoanId(), repaymentExternalId,
                     new PostLoansLoanIdTransactionsTransactionIdRequest().locale("en").transactionAmount(2.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 224.91, 0.0, 224.91, 0.99);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 24), 100.0, 100.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2024, 3, 1), 124.91, 124.91, 0.0, 0.0, 36.99);
@@ -3558,10 +3425,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     transaction(2.0, "Chargeback", "06 March 2024", 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.0) //
             );
 
-            loanTransactionHelper.chargebackLoanTransaction(loanResponse.getLoanId(), repaymentExternalId,
+            transactionHelper.chargebackLoanTransaction(loanResponse.getLoanId(), repaymentExternalId,
                     new PostLoansLoanIdTransactionsTransactionIdRequest().locale("en").transactionAmount(1.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.01, 225.90, 0.01, 225.90, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 24), 100.0, 100.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2024, 3, 6), 125.91, 125.90, 0.01, 0.0, 36.99);
@@ -3598,21 +3465,20 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .installmentAmountInMultiplesOf(null).numberOfRepayments(3).repaymentEvery(15).enableDownPayment(true)
                     .enableAutoRepaymentForDownPayment(true).disbursedAmountPercentageForDownPayment(BigDecimal.valueOf(25));
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(client.getClientId(), loanProductResponse.getResourceId(),
                     "23 March 2024", 1000.0, 4);
 
             applicationRequest = applicationRequest.numberOfRepayments(3).loanTermFrequency(45)
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(15);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()
-                    .approvedLoanAmount(BigDecimal.valueOf(10)).dateFormat(DATETIME_PATTERN).approvedOnDate("23 March 2024").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(10))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("23 March 2024").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("23 March 2024").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(10.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("23 March 2024")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(10.0)).locale("en"));
 
             // verify schedule
             verifyRepaymentSchedule(loanResponse.getLoanId(), //
@@ -3626,7 +3492,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
         });
 
         runAt("24 March 2024", () -> {
-            loanTransactionHelper.disburseLoan(createdLoanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate("24 March 2024")
+            loanHelper.disburseLoan(createdLoanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate("24 March 2024")
                     .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
 
             // verify schedule
@@ -3640,7 +3506,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     installment(27.5, 0, 0, 0, 27.5, false, "07 May 2024", 0.0) //
             );
 
-            loanTransactionHelper.disburseLoan(createdLoanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate("24 March 2024")
+            loanHelper.disburseLoan(createdLoanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate("24 March 2024")
                     .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(11.0)).locale("en"));
 
             // verify schedule
@@ -3673,24 +3539,22 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .numberOfRepayments(3).repaymentEvery(15).fixedLength(fixedLength);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), "22 November 2023",
                     1000.0, 4);
 
             applicationRequest = applicationRequest.numberOfRepayments(3).loanTermFrequency(45)
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(15);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("22 November 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("22 November 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("22 November 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("22 November 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 100.0, 0.0, 100.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 12, 7), 33.0, 0.0, 33.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 12, 22), 33.0, 0.0, 33.0, 0.0, 0.0);
@@ -3722,7 +3586,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .numberOfRepayments(3).repaymentEvery(2).repaymentFrequencyType(repaymentFrequencyType.longValue())
                     .fixedLength(fixedLength);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), "22 November 2023",
                     1000.0, 4);
 
@@ -3730,17 +3594,15 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(2)
                     .repaymentFrequencyType(repaymentFrequencyType);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("22 November 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("22 November 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("22 November 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("22 November 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 100.0, 0.0, 100.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 12, 6), 33.0, 0.0, 33.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 12, 20), 33.0, 0.0, 33.0, 0.0, 0.0);
@@ -3773,7 +3635,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .numberOfRepayments(6).repaymentEvery(2).repaymentFrequencyType(repaymentFrequencyType.longValue())
                     .fixedLength(fixedLength);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), "22 November 2023",
                     1000.0, 4);
 
@@ -3782,17 +3644,15 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(2)
                     .repaymentFrequencyType(repaymentFrequencyType);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("22 November 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("22 November 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("22 November 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("22 November 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 100.0, 0.0, 100.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 1, 22), 17.0, 0.0, 17.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2024, 3, 22), 17.0, 0.0, 17.0, 0.0, 0.0);
@@ -3825,11 +3685,11 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             // Try to create a Loan Product using Fixed Length with a wrong Loan Term setup
             LOG.info("Try to create a Loan Product using Fixed Length with a wrong Loan Term setup");
             CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                    () -> loanProductHelper
+                    () -> loanHelper
                             .createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                                     .interestRatePerPeriod(0.0).numberOfRepayments(6).repaymentEvery(1)
                                     .repaymentFrequencyType(repaymentFrequencyType.longValue()).fixedLength(fixedLength)));
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("error.msg.number.repayments.and.fixed.length.configuration.not.valid"));
         });
     }
@@ -3850,13 +3710,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
 
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .numberOfRepayments(6).repaymentEvery(1).repaymentFrequencyType(repaymentFrequencyType.longValue()).fixedLength(6);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
 
             // Try to use Fixed Length without Advanced Payment Allocation as transaction
             // processing strategy code
             LOG.info("Try to use Fixed Length without Advanced Payment Allocation as transaction processing strategy code");
             CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.applyLoan(new PostLoansRequest().clientId(client.getClientId())
+                    () -> loanHelper.applyForLoan(new PostLoansRequest().clientId(client.getClientId())
                             .productId(loanProductResponse.getResourceId()).loanType("individual").locale("en")
                             .submittedOnDate(operationDate).expectedDisbursementDate(operationDate).dateFormat(DATETIME_PATTERN)
                             .amortizationType(1).interestRatePerPeriod(BigDecimal.ZERO).interestCalculationPeriodType(1).interestType(0)
@@ -3866,7 +3726,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                             .transactionProcessingStrategyCode(FineractStyleLoanRepaymentScheduleTransactionProcessor.STRATEGY_CODE)
                             .loanScheduleProcessingType(LoanScheduleProcessingType.HORIZONTAL.name())));
 
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage()
                     .contains("error.msg.loan.repayment.strategy.can.not.be.different.than.advanced.payment.allocation"));
         });
@@ -3888,12 +3748,12 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
 
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .numberOfRepayments(6).repaymentEvery(1).repaymentFrequencyType(repaymentFrequencyType.longValue()).fixedLength(6);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
 
             // Try to use Fixed Length with an Interest Rate value higher than Zero
             LOG.info("Try to use Fixed Length with an Interest Rate value higher than Zero");
             CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.applyLoan(new PostLoansRequest().clientId(client.getClientId())
+                    () -> loanHelper.applyForLoan(new PostLoansRequest().clientId(client.getClientId())
                             .productId(loanProductResponse.getResourceId()).loanType("individual").locale("en")
                             .submittedOnDate(operationDate).expectedDisbursementDate(operationDate).dateFormat(DATETIME_PATTERN)
                             .amortizationType(1).interestRatePerPeriod(BigDecimal.ONE).interestCalculationPeriodType(1).interestType(0)
@@ -3904,7 +3764,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                                     AdvancedPaymentScheduleTransactionProcessor.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)
                             .loanScheduleProcessingType(LoanScheduleProcessingType.HORIZONTAL.name())));
 
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("error.msg.fixed.length.only.supported.for.zero.interest"));
         });
     }
@@ -3925,12 +3785,12 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
 
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .numberOfRepayments(6).repaymentEvery(1).repaymentFrequencyType(repaymentFrequencyType.longValue()).fixedLength(6);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
 
             // Try to use Fixed Length with a wrong Loan Term setup
             LOG.info("Try to use Fixed Length with a wrong Loan Term setup");
             CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.applyLoan(new PostLoansRequest().clientId(client.getClientId())
+                    () -> loanHelper.applyForLoan(new PostLoansRequest().clientId(client.getClientId())
                             .productId(loanProductResponse.getResourceId()).loanType("individual").locale("en")
                             .submittedOnDate(operationDate).expectedDisbursementDate(operationDate).dateFormat(DATETIME_PATTERN)
                             .amortizationType(1).interestRatePerPeriod(BigDecimal.ZERO).interestCalculationPeriodType(1).interestType(0)
@@ -3941,7 +3801,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                                     AdvancedPaymentScheduleTransactionProcessor.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)
                             .loanScheduleProcessingType(LoanScheduleProcessingType.HORIZONTAL.name())));
 
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("error.msg.number.repayments.and.fixed.length.configuration.not.valid"));
         });
     }
@@ -3967,23 +3827,21 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .numberOfRepayments(numberOfRepayments).repaymentEvery(15).repaymentFrequencyType(repaymentFrequencyType.longValue())
                     .fixedLength(fixedLength);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
 
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), "22 November 2023",
                     1000.0, numberOfRepayments)
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("22 November 2023").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("22 November 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("22 November 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("22 November 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             LOG.info("Loan {} {}", loanDetails.getTimeline().getActualDisbursementDate(), loanDetails.getRepaymentSchedule().getPeriods()
                     .get(loanDetails.getRepaymentSchedule().getPeriods().size() - 1).getDueDate());
             assertEquals(
@@ -4016,22 +3874,22 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .numberOfRepayments(numberOfRepayments).repaymentEvery(30).fixedLength(fixedLength);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), operationDate, 1000.0,
                     numberOfRepayments);
 
             applicationRequest = applicationRequest.numberOfRepayments(numberOfRepayments).loanTermFrequency(120)
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(30);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()
-                    .approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
                     .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1000.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 1, 31), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2024, 3, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -4052,7 +3910,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             LoanRescheduleRequestHelper.approveLoanRescheduleRequest(rescheduleLoansResponse.getResourceId(),
                     new PostUpdateRescheduleLoansRequest().approvedOnDate("16 January 2024").locale("en").dateFormat(DATETIME_PATTERN));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1000.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 1, 31), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2024, 3, 15), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -4089,22 +3947,22 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .numberOfRepayments(numberOfRepayments).repaymentEvery(30).fixedLength(fixedLength);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), operationDate, 1000.0,
                     numberOfRepayments);
 
             applicationRequest = applicationRequest.numberOfRepayments(numberOfRepayments).loanTermFrequency(120)
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(30);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()
-                    .approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
                     .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1000.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 1, 31), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2024, 3, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -4125,7 +3983,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             LoanRescheduleRequestHelper.approveLoanRescheduleRequest(rescheduleLoansResponse.getResourceId(),
                     new PostUpdateRescheduleLoansRequest().approvedOnDate("16 January 2024").locale("en").dateFormat(DATETIME_PATTERN));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1000.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 1, 31), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2024, 3, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -4180,12 +4038,12 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             AdvancedPaymentData defaultPaymentAllocation = createDefaultPaymentAllocationWithMixedGrouping();
 
             // First scenario (Legacy): Loan product no Advanced Payment Allocation and Cumulative Loan Schedule type
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(
                     createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct().loanScheduleType(LoanScheduleType.CUMULATIVE.toString()));
             assertNotNull(loanProductResponse.getResourceId());
 
             // Second scenario: Loan product with Advanced Payment Allocation and Progressive Loan Schedule type
-            loanProductResponse = loanProductHelper
+            loanProductResponse = loanHelper
                     .createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                             .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()));
             assertNotNull(loanProductResponse.getResourceId());
@@ -4193,10 +4051,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             // Third scenario: Loan product no Advanced Payment Allocation and Progressive Loan Schedule type,
             // validation expected
             CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                    () -> loanProductHelper.createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct()
+                    () -> loanHelper.createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct()
                             .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()) //
                             .loanScheduleProcessingType(LoanScheduleProcessingType.HORIZONTAL.toString())));
-            assertEquals(400, exception.getResponse().code());
+            assertEquals(400, exception.getStatus());
             assertTrue(exception.getMessage().contains("supported.only.with.advanced.payment.allocation.strategy"));
         });
     }
@@ -4213,7 +4071,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .installmentAmountInMultiplesOf(null).numberOfRepayments(3).repaymentEvery(15).enableDownPayment(true)
                     .enableAutoRepaymentForDownPayment(true).disbursedAmountPercentageForDownPayment(BigDecimal.valueOf(25));
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(client.getClientId(), loanProductResponse.getResourceId(),
                     "23 March 2024", 1000.0, 4);
 
@@ -4221,14 +4079,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(15)
                     .enableDownPayment(false);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()
-                    .approvedLoanAmount(BigDecimal.valueOf(10)).dateFormat(DATETIME_PATTERN).approvedOnDate("23 March 2024").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(10))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("23 March 2024").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("23 March 2024").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(10.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("23 March 2024")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(10.0)).locale("en"));
 
             // verify schedule (without DownPayment)
             verifyRepaymentSchedule(loanResponse.getLoanId(), //
@@ -4256,7 +4113,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .installmentAmountInMultiplesOf(null).numberOfRepayments(3).repaymentEvery(15).enableDownPayment(true)
                     .enableAutoRepaymentForDownPayment(true).disbursedAmountPercentageForDownPayment(BigDecimal.valueOf(25));
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(client.getClientId(), loanProductResponse.getResourceId(), processDate,
                     amount, 4);
 
@@ -4264,9 +4121,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(15)
                     .enableDownPayment(false);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.modifyApplicationForLoan(loanResponse.getLoanId(), "modify",
+            loanHelper.modifyLoanApplication(loanResponse.getLoanId(), "modify",
                     new PutLoansLoanIdRequest().clientId(client.getClientId()).productId(loanProductResponse.getResourceId())
                             .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)
                             .repaymentEvery(15).interestCalculationPeriodType(1).interestType(0).expectedDisbursementDate(processDate)
@@ -4274,10 +4131,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                             .loanTermFrequencyType(0).enableDownPayment(true).loanType("individual").dateFormat(DATETIME_PATTERN)
                             .locale("en"));
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()
-                    .approvedLoanAmount(BigDecimal.valueOf(10)).dateFormat(DATETIME_PATTERN).approvedOnDate(processDate).locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(10))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate(processDate).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(processDate)
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(processDate)
                     .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(10.0)).locale("en"));
 
             // verify schedule (with DownPayment)
@@ -4307,7 +4164,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .installmentAmountInMultiplesOf(null).numberOfRepayments(3).repaymentEvery(15).enableDownPayment(true)
                     .enableAutoRepaymentForDownPayment(true).disbursedAmountPercentageForDownPayment(BigDecimal.valueOf(25));
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(client.getClientId(), loanProductResponse.getResourceId(), processDate,
                     amount, 4);
 
@@ -4315,9 +4172,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(15)
                     .enableDownPayment(true);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.modifyApplicationForLoan(loanResponse.getLoanId(), "modify",
+            loanHelper.modifyLoanApplication(loanResponse.getLoanId(), "modify",
                     new PutLoansLoanIdRequest().clientId(client.getClientId()).productId(loanProductResponse.getResourceId())
                             .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)
                             .repaymentEvery(15).interestCalculationPeriodType(1).interestType(0).expectedDisbursementDate(processDate)
@@ -4325,10 +4182,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                             .loanTermFrequencyType(0).enableDownPayment(false).loanType("individual").dateFormat(DATETIME_PATTERN)
                             .locale("en"));
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()
-                    .approvedLoanAmount(BigDecimal.valueOf(10)).dateFormat(DATETIME_PATTERN).approvedOnDate(processDate).locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(10))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate(processDate).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(processDate)
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(processDate)
                     .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(10.0)).locale("en"));
 
             // verify schedule (without DownPayment)
@@ -4351,7 +4208,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
         runAt("23 March 2024", () -> {
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .installmentAmountInMultiplesOf(null).numberOfRepayments(3).repaymentEvery(15).enableDownPayment(false);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(client.getClientId(), loanProductResponse.getResourceId(),
                     "23 March 2024", 1000.0, 3)
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(15)
@@ -4359,8 +4216,8 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
 
             Long clientId = client.getClientId();
             CallFailedRuntimeException callFailedRuntimeException = Assertions.assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper
-                            .applyLoan(applyLoanRequest(clientId, loanProductResponse.getResourceId(), "23 March 2024", 1000.0, 3)
+                    () -> loanHelper
+                            .applyForLoan(applyLoanRequest(clientId, loanProductResponse.getResourceId(), "23 March 2024", 1000.0, 3)
                                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)
                                     .repaymentEvery(15).enableDownPayment(true)));
 
@@ -4379,7 +4236,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
 
             LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-            PostLoanProductsResponse loanProductResponse = loanProductHelper
+            PostLoanProductsResponse loanProductResponse = loanHelper
                     .createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                             .addCreditAllocationItem(createChargebackAllocation())
                             .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()));
@@ -4395,7 +4252,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     installment(250.0, false, "01 May 2023") //
             );
 
-            loanTransactionHelper.disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2023")
+            loanHelper.disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2023")
                     .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
             verifyTransactions(loanId, //
@@ -4460,7 +4317,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     installment(250.0, false, "01 May 2023") //
             );
 
-            loanTransactionHelper.reverseRepayment(Math.toIntExact(loanId), Math.toIntExact(repayment1TransactionId), "2 January 2023");
+            transactionHelper.reverseLoanTransaction(loanId, repayment1TransactionId, "2 January 2023");
 
             verifyTransactions(loanId, //
                     transaction(1000.0, "Disbursement", "01 January 2023", 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
@@ -4523,7 +4380,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .installmentAmountInMultiplesOf(null)//
                     .disbursedAmountPercentageForDownPayment(BigDecimal.valueOf(25))//
             ;//
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), operationDate, 100.0, 5);
 
             applicationRequest = applicationRequest.numberOfRepayments(5).loanTermFrequency(5).loanTermFrequencyType(2)
@@ -4531,15 +4388,15 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(1)
                     .repaymentFrequencyType(2);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()
-                    .approvedLoanAmount(BigDecimal.valueOf(100)).dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(100))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
                     .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 100.94, 0.0, 100.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 1, 1), 25.0, 0.0, 25.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
                     0.0, 0.0);
@@ -4585,7 +4442,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .installmentAmountInMultiplesOf(null)//
                     .disbursedAmountPercentageForDownPayment(BigDecimal.valueOf(25))//
             ;//
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), operationDate, 100.0, 5);
 
             applicationRequest = applicationRequest.numberOfRepayments(5).loanTermFrequency(5).loanTermFrequencyType(2)
@@ -4593,15 +4450,15 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(1)
                     .repaymentFrequencyType(2);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()
-                    .approvedLoanAmount(BigDecimal.valueOf(100)).dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(100))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
                     .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 102.33, 0.0, 100.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 1, 1), 25.0, 0.0, 25.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
                     0.0, 0.0);
@@ -4648,7 +4505,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .installmentAmountInMultiplesOf(null)//
                     .disbursedAmountPercentageForDownPayment(BigDecimal.valueOf(25))//
             ;//
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), operationDate, 100.0, 5);
 
             applicationRequest = applicationRequest.numberOfRepayments(5).loanTermFrequency(5).loanTermFrequencyType(2)
@@ -4656,15 +4513,15 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(1)
                     .repaymentFrequencyType(2);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()
-                    .approvedLoanAmount(BigDecimal.valueOf(100)).dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(100))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
                     .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 102.33, 0.0, 100.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 1, 1), 25.0, 0.0, 25.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
                     0.0, 0.0);
@@ -4708,7 +4565,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .overAppliedNumber(null)//
                     .installmentAmountInMultiplesOf(null)//
             ;//
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), operationDate, 100.0, 5);
 
             applicationRequest = applicationRequest.numberOfRepayments(5).loanTermFrequency(5).loanTermFrequencyType(2)
@@ -4716,17 +4573,17 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(1)
                     .repaymentFrequencyType(2);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
             createdLoanId.set(loanResponse.getLoanId());
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()
-                    .approvedLoanAmount(BigDecimal.valueOf(100)).dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(100))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
                     .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
 
             // After Disbursement we are expecting no Accrual transactions
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
         });
@@ -4736,13 +4593,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             // Generate the Accruals
             PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting("30 January 2024");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(new BigDecimal("0.98"), loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
 
             // Partial interest repayment
             addRepaymentForLoan(createdLoanId.get(), 20.50, "30 January 2024");
-            loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(new BigDecimal("0.06"), loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
         });
@@ -4751,7 +4608,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             // Generate the Accruals
             PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting("31 January 2024");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(new BigDecimal("0.09"), loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
         });
@@ -4760,7 +4617,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             // Generate the Accruals
             PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting("1 February 2024");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(new BigDecimal("0.12"), loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
         });
@@ -4769,7 +4626,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
         runAt("20 February 2024", () -> {
             PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting("20 February 2024");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(new BigDecimal("0.12"), loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(new BigDecimal("0.51"), loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
         });
@@ -4802,25 +4659,24 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .overAppliedNumber(null)//
                     .installmentAmountInMultiplesOf(null)//
             ;//
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), operationDate, 1000.0, 4)
                     .interestRatePerPeriod(BigDecimal.valueOf(108.0));
 
             applicationRequest = applicationRequest.interestCalculationPeriodType(DAYS)
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
             createdLoanId.set(loanResponse.getLoanId());
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000.0)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate(operationDate).locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000.0))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
                     .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
             // After Disbursement we are expecting amount in Zero (first day)
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
         });
@@ -4830,7 +4686,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             // Generate the Accruals
             PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting("2 January 2024");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(BigDecimal.valueOf(3.0).stripTrailingZeros(),
                     loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
@@ -4838,7 +4694,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
 
         // Second day on First Period, then TotalUnpaidPayableDueInterest = 0 and TotalUnpaidPayableNotDueInterest = 6
         runAt("3 January 2024", () -> {
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(BigDecimal.valueOf(6.0).stripTrailingZeros(),
                     loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
@@ -4846,7 +4702,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
 
         // Third day on First Period, then TotalUnpaidPayableDueInterest = 0 and TotalUnpaidPayableNotDueInterest = 9
         runAt("4 January 2024", () -> {
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(BigDecimal.valueOf(9.0).stripTrailingZeros(),
                     loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
@@ -4854,7 +4710,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
 
         // Fourth day on First Period, then TotalUnpaidPayableDueInterest = 0 and TotalUnpaidPayableNotDueInterest = 12
         runAt("5 January 2024", () -> {
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(BigDecimal.valueOf(12.0).stripTrailingZeros(),
                     loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
@@ -4862,7 +4718,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
 
         // Last day on First Period, then TotalUnpaidPayableDueInterest = 90 and TotalUnpaidPayableNotDueInterest = 0
         runAt("31 January 2024", () -> {
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(BigDecimal.valueOf(90.0).stripTrailingZeros(),
                     loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(BigDecimal.ZERO.stripTrailingZeros(),
@@ -4872,7 +4728,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
         // First day on Second Period, then TotalUnpaidPayableDueInterest = 90 and TotalUnpaidPayableNotDueInterest =
         // 2.34
         runAt("1 February 2024", () -> {
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(BigDecimal.valueOf(90.0).stripTrailingZeros(),
                     loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(BigDecimal.valueOf(2.34), loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
@@ -4881,7 +4737,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
         // Second day on Second Period, then TotalUnpaidPayableDueInterest = 90 and TotalUnpaidPayableNotDueInterest =
         // 4.69
         runAt("2 February 2024", () -> {
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(BigDecimal.valueOf(90.0).stripTrailingZeros(),
                     loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(BigDecimal.valueOf(4.69), loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
@@ -4890,7 +4746,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
         // Third day on Second Period, then TotalUnpaidPayableDueInterest = 90 and TotalUnpaidPayableNotDueInterest =
         // 7.03
         runAt("3 February 2024", () -> {
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(BigDecimal.valueOf(90.0).stripTrailingZeros(),
                     loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(BigDecimal.valueOf(7.03), loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
@@ -4898,7 +4754,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
 
         // N day on Second Period, then TotalUnpaidPayableDueInterest = 90 and TotalUnpaidPayableNotDueInterest = 21.096
         runAt("10 February 2024", () -> {
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(BigDecimal.valueOf(90.0).stripTrailingZeros(),
                     loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(BigDecimal.valueOf(23.44).stripTrailingZeros(),
@@ -4908,7 +4764,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
         // First day on Third Period, then TotalUnpaidPayableDueInterest = 90 + 70.32 and
         // TotalUnpaidPayableNotDueInterest = 0
         runAt("1 March 2024", () -> {
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(BigDecimal.valueOf(160.32).stripTrailingZeros(),
                     loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
@@ -4917,7 +4773,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
         // Second day on Third Period, then TotalUnpaidPayableDueInterest = 90 + 70.32 and
         // TotalUnpaidPayableNotDueInterest = 1.63
         runAt("2 March 2024", () -> {
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(BigDecimal.valueOf(160.32).stripTrailingZeros(),
                     loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(BigDecimal.valueOf(1.63), loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
@@ -4926,7 +4782,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
         // Third day on Third Period, then TotalUnpaidPayableDueInterest = 90 + 70.32 and
         // TotalUnpaidPayableNotDueInterest = 3.26
         runAt("3 March 2024", () -> {
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(BigDecimal.valueOf(160.32).stripTrailingZeros(),
                     loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(BigDecimal.valueOf(3.26), loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
@@ -4935,7 +4791,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
         // Last day on Third Period, then TotalUnpaidPayableDueInterest = 90 + 70.32 + 48.87 and
         // TotalUnpaidPayableNotDueInterest = 0
         runAt("31 March 2024", () -> {
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(BigDecimal.valueOf(209.19).stripTrailingZeros(),
                     loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
@@ -4946,7 +4802,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
         runAt("11 March 2024", () -> {
             addRepaymentForLoan(createdLoanId.get(), 340.00, "11 March 2024");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(BigDecimal.valueOf(70.32).stripTrailingZeros(),
                     loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(BigDecimal.valueOf(16.29).stripTrailingZeros(),
@@ -4980,35 +4836,33 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .installmentAmountInMultiplesOf(null)//
                     .supportedInterestRefundTypes(interestRefundTypes) //
             ;//
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), "1 January 2024", 1000.0,
                     4);
 
             applicationRequest = applicationRequest.interestCalculationPeriodType(DAYS)
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
             createdLoanId.set(loanResponse.getLoanId());
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000.0)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("1 January 2024").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000.0))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("1 January 2024").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2024").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2024")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
             // After Disbursement we are expecting zero interest refund
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalInterestRefund().stripTrailingZeros());
         });
 
         runAt("10 January 2024", () -> {
-            loanTransactionHelper.makeMerchantIssuedRefund(createdLoanId.get(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeMerchantIssuedRefund(createdLoanId.get(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("10 January 2024").locale("en").transactionAmount(300.0));
 
             // After Interest refund transaction we are expecting non zero interest refund
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             LOG.info("value {}", loanDetails.getSummary().getTotalInterestRefund().stripTrailingZeros());
             assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalInterestRefund().stripTrailingZeros());
         });
@@ -5046,7 +4900,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .outstandingLoanBalance(10000.0)//
                     .installmentAmountInMultiplesOf(null)//
             ;//
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), operationDate, 100.0, 6);
 
             applicationRequest = applicationRequest.numberOfRepayments(6)//
@@ -5059,24 +4913,23 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .maxOutstandingLoanBalance(BigDecimal.valueOf(10000.0))//
             ;//
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()
-                    .approvedLoanAmount(BigDecimal.valueOf(100)).dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(100))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
                     .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 102.78, 0.0, 100.0, 0.0, null);
 
             String disbursementDate2nd = "8 January 2024";
             updateBusinessDate(disbursementDate2nd);
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDate2nd).dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(200.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDate2nd)
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(200.0)).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 307.98, 0.0, 300.0, 0.0, null);
 
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 1), 49.32, 0.0, 49.32, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.01, 0.0,
@@ -5128,7 +4981,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .outstandingLoanBalance(10000.0)//
                     .installmentAmountInMultiplesOf(null)//
             ;//
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), operationDate, 100.0, 5);
 
             applicationRequest = applicationRequest.numberOfRepayments(6)//
@@ -5141,32 +4994,31 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .maxOutstandingLoanBalance(BigDecimal.valueOf(10000.0))//
             ;//
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()
-                    .approvedLoanAmount(BigDecimal.valueOf(100)).dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(100))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
                     .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 102.78, 0.0, 100.0, 0.0, null);
 
             final String repaymentDate = "1 February 2024";
             updateBusinessDate(repaymentDate);
-            loanTransactionHelper.makeRepayment(repaymentDate, 17.13f, loanResponse.getLoanId().intValue());
+            transactionHelper.makeRepayment(repaymentDate, 17.13f, loanResponse.getLoanId().intValue());
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
 
             validateLoanSummaryBalances(loanDetails, 85.65, 17.13, 83.66, 16.34, null);
 
             final String dateOf2ndDisbursement = "15 February 2024";
             updateBusinessDate(dateOf2ndDisbursement);
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate(dateOf2ndDisbursement).dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(dateOf2ndDisbursement)
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 187.65, 17.13, 183.66, 16.34, null);
 
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 1), 16.34, 16.34, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.79, 0.79,
@@ -5227,7 +5079,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .outstandingLoanBalance(10000.0)//
                     .installmentAmountInMultiplesOf(null)//
             ;//
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), "1 January 2024", 100.0,
                     6);
 
@@ -5241,28 +5093,27 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .maxOutstandingLoanBalance(BigDecimal.valueOf(10000.0))//
             ;//
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(100)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("1 January 2024").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(100))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("1 January 2024").locale("en"));
 
             final String disbursementDate1st = "8 January 2024";
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), //
+            loanHelper.disburseLoan(loanResponse.getLoanId(), //
                     new PostLoansLoanIdRequest()//
                             .actualDisbursementDate(disbursementDate1st).dateFormat(DATETIME_PATTERN)//
                             .transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));//
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 102.6, 0.0, 100.0, 0.0, null);
 
             final String disbursementDate2nd = "5 January 2024";
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), //
+            loanHelper.disburseLoan(loanResponse.getLoanId(), //
                     new PostLoansLoanIdRequest()//
                             .actualDisbursementDate(disbursementDate2nd).dateFormat(DATETIME_PATTERN)//
                             .transactionAmount(BigDecimal.valueOf(50.0)).locale("en"));//
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 153.95, 0.0, 150.0, 0.0, null);
 
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 1), 24.70, 0.0, 24.70, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.96, 0.0,
@@ -5282,12 +5133,12 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
 
             // 2nd disbursement on the same date
             final String disbursementDate3rd = "8 January 2024";
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), //
+            loanHelper.disburseLoan(loanResponse.getLoanId(), //
                     new PostLoansLoanIdRequest()//
                             .actualDisbursementDate(disbursementDate3rd).dateFormat(DATETIME_PATTERN)//
                             .transactionAmount(BigDecimal.valueOf(25.0)).locale("en"));//
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 179.60, 0.0, 175.0, 0.0, null);
 
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 1), 28.82, 0.0, 28.82, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.11, 0.0,
@@ -5348,7 +5199,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .installmentAmountInMultiplesOf(null)//
                     .rescheduleStrategyMethod(LoanRescheduleStrategyMethod.ADJUST_LAST_UNPAID_PERIOD.getValue())//
                     .recalculationRestFrequencyType(1);//
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), operationDate, 100.0, 6);
 
             applicationRequest = applicationRequest.numberOfRepayments(6)//
@@ -5362,17 +5213,17 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .maxOutstandingLoanBalance(BigDecimal.valueOf(10000.0))//
             ;//
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()//
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()//
                     .approvedLoanAmount(BigDecimal.valueOf(100))//
                     .approvedOnDate(operationDate).dateFormat(DATETIME_PATTERN).locale("en"));//
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()//
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()//
                     .transactionAmount(BigDecimal.valueOf(100.0))//
                     .actualDisbursementDate(operationDate).dateFormat(DATETIME_PATTERN).locale("en"));//
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 102.05, 0.0, 100.0, 0.0, null);
 
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 1), 16.43, 0.0, 16.43, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.58, 0.0,
@@ -5391,7 +5242,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             assertEquals(loanDetails.getNumberOfRepayments(), 6);
 
             updateBusinessDate("1 February 2024");
-            loanTransactionHelper.makeRepayment("1 February 2024", 17.01f, loanResponse.getLoanId().intValue());
+            transactionHelper.makeRepayment("1 February 2024", 17.01f, loanResponse.getLoanId().intValue());
 
             updateBusinessDate("14 February 2024");
             PostCreateRescheduleLoansResponse rescheduleLoansResponse = LoanRescheduleRequestHelper//
@@ -5406,7 +5257,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     new PostUpdateRescheduleLoansRequest()//
                             .approvedOnDate("14 February 2024").locale("en").dateFormat(DATETIME_PATTERN));//
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 84.5, 17.01, 83.57, 16.43, null);
 
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 1), 16.43, 16.43, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.58, 0.58,
@@ -5436,11 +5287,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             PostLoanProductsRequest loanProduct = createOnePeriod30DaysPeriodicAccrualProductWithAdvancedPaymentAllocationAndInterestRecalculation(
                     (double) 80.0, rescheduleStrategyMethod);
 
-            final PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProduct);
+            final PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(loanProduct);
             assertNotNull(loanProductResponse);
 
-            final GetLoanProductsProductIdResponse loanProductDetails = loanProductHelper
-                    .retrieveLoanProductById(loanProductResponse.getResourceId());
+            final GetLoanProductsProductIdResponse loanProductDetails = loanHelper.retrieveLoanProduct(loanProductResponse.getResourceId());
             assertNotNull(loanProductDetails);
             assertTrue(loanProductDetails.getIsInterestRecalculationEnabled());
             assertEquals(rescheduleStrategyMethod.longValue(),
@@ -5461,7 +5311,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     (double) 80.0, rescheduleStrategyMethod);
 
             CallFailedRuntimeException callFailedRuntimeException = Assertions.assertThrows(CallFailedRuntimeException.class,
-                    () -> loanProductHelper.createLoanProduct(loanProduct));
+                    () -> loanHelper.createLoanProduct(loanProduct));
 
             Assertions.assertTrue(callFailedRuntimeException.getMessage().contains("is not supported for Progressive loan schedule type"));
         });
@@ -5481,7 +5331,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .loanScheduleType(LoanScheduleType.CUMULATIVE.toString());
 
             CallFailedRuntimeException callFailedRuntimeException = Assertions.assertThrows(CallFailedRuntimeException.class,
-                    () -> loanProductHelper.createLoanProduct(loanProduct));
+                    () -> loanHelper.createLoanProduct(loanProduct));
 
             Assertions.assertTrue(callFailedRuntimeException.getMessage()
                     .contains("Adjust last, unpaid period is only supported for Progressive loan schedule type"));
@@ -5516,19 +5366,19 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .installmentAmountInMultiplesOf(null)//
                     .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()) //
             ;//
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), operationDate, 400.0, 6);
 
             applicationRequest = applicationRequest.interestCalculationPeriodType(DAYS).interestRatePerPeriod(BigDecimal.ZERO)
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
             createdLoanId.set(loanResponse.getLoanId());
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()
-                    .approvedLoanAmount(BigDecimal.valueOf(400.0)).dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(400.0))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
                     .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(400.0)).locale("en"));
 
             addRepaymentForLoan(createdLoanId.get(), 600.00, operationDate);
@@ -5536,7 +5386,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             createdLoanChargeId.set(addCharge(createdLoanId.get(), true, 30, operationDate));
 
             executeInlineCOB(createdLoanId.get());
-            final GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            final GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             // Validate Loan Accrual transaction
             final GetLoansLoanIdTransactions loanTransaction = loanDetails.getTransactions().stream()
                     .filter(t -> Boolean.TRUE.equals(t.getType().getAccrual())).toList().get(0);
@@ -5546,17 +5396,16 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
 
         runAt("10 October 2024", () -> {
             PostLoansLoanIdChargesChargeIdRequest request = new PostLoansLoanIdChargesChargeIdRequest().amount(15.0).locale("en");
-            loanTransactionHelper.chargeAdjustment(createdLoanId.get(), createdLoanChargeId.get(), request);
+            chargeAdjustment(createdLoanId.get(), createdLoanChargeId.get(), request);
 
-            loanTransactionHelper.makeGoodwillCredit(createdLoanId.get(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate(operationDate).locale("en").transactionAmount(15.0));
+            transactionHelper.makeGoodwillCredit(createdLoanId.get(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate(operationDate).locale("en").transactionAmount(15.0));
 
-            final GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            final GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             // Get the Repayment transaction
             GetLoansLoanIdTransactions loanTransaction = loanDetails.getTransactions().stream()
                     .filter(t -> Boolean.TRUE.equals(t.getType().getRepayment())).toList().get(0);
-            loanTransactionHelper.reverseRepayment(Math.toIntExact(createdLoanId.get()), Math.toIntExact(loanTransaction.getId()),
-                    operationDate);
+            transactionHelper.reverseLoanTransaction(createdLoanId.get(), loanTransaction.getId(), operationDate);
 
             // Validate Loan Accrual transaction
             loanTransaction = loanDetails.getTransactions().stream().filter(t -> Boolean.TRUE.equals(t.getType().getAccrual())).toList()
@@ -5589,7 +5438,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .installmentAmountInMultiplesOf(null)//
                     .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()) //
             ;//
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), operationDate, 400.0, 4);
             final BigDecimal interestRatePerPeriod = BigDecimal.valueOf(4.0);
             applicationRequest = applicationRequest.interestCalculationPeriodType(DAYS).interestRatePerPeriod(interestRatePerPeriod)
@@ -5597,9 +5446,9 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .repaymentFrequencyType(RepaymentFrequencyType.MONTHS).loanTermFrequency(4)
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             GetLoansLoanIdInterestRateFrequencyType interestRateFrequencyType = loanDetails.getInterestRateFrequencyType();
             assertNotNull(interestRateFrequencyType);
             assertEquals(interestRateFrequencyType.getId(), Long.valueOf(WHOLE_TERM));
@@ -5637,164 +5486,142 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .installmentAmountInMultiplesOf(null)//
                     .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()) //
             ;//
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLP2ProgressiveLoanRequest(clientId, loanProductResponse.getResourceId(),
                     operationDate, 1000.0, 7.0, 6, null);
 
             applicationRequest = applicationRequest.interestCalculationPeriodType(DAYS)
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
             createdLoanId.set(loanResponse.getLoanId());
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000.0)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate(operationDate).locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000.0))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
                     .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
 
             // Before 1st disbursement date
-            HashMap prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2023, 12, 31));
-            assertEquals(100.0f, prepayAmounts.get("amount"));
-            assertEquals(0.0f, prepayAmounts.get("interestPortion"));
-            assertEquals(100.0f, prepayAmounts.get("principalPortion"));
+            GetLoansLoanIdTransactionsTemplateResponse prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2023, 12, 31));
+            assertEquals(100.0, prepayAmounts.getAmount());
+            assertEquals(0.0, prepayAmounts.getInterestPortion());
+            assertEquals(100.0, prepayAmounts.getPrincipalPortion());
             // On 1st day
-            prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2024, 1, 1));
-            assertEquals(100.0f, prepayAmounts.get("amount"));
-            assertEquals(0.0f, prepayAmounts.get("interestPortion"));
-            assertEquals(100.0f, prepayAmounts.get("principalPortion"));
+            prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2024, 1, 1));
+            assertEquals(100.0, prepayAmounts.getAmount());
+            assertEquals(0.0, prepayAmounts.getInterestPortion());
+            assertEquals(100.0, prepayAmounts.getPrincipalPortion());
             // On 2nd day
-            prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2024, 1, 2));
-            assertEquals(100.02f, prepayAmounts.get("amount"));
-            assertEquals(0.02f, prepayAmounts.get("interestPortion"));
-            assertEquals(100.0f, prepayAmounts.get("principalPortion"));
+            prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2024, 1, 2));
+            assertEquals(100.02, prepayAmounts.getAmount());
+            assertEquals(0.02, prepayAmounts.getInterestPortion());
+            assertEquals(100.0, prepayAmounts.getPrincipalPortion());
             // On due date of 1st period
-            prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2024, 2, 1));
-            assertEquals(100.58f, prepayAmounts.get("amount"));
-            assertEquals(0.58f, prepayAmounts.get("interestPortion"));
-            assertEquals(100.0f, prepayAmounts.get("principalPortion"));
+            prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2024, 2, 1));
+            assertEquals(100.58, prepayAmounts.getAmount());
+            assertEquals(0.58, prepayAmounts.getInterestPortion());
+            assertEquals(100.0, prepayAmounts.getPrincipalPortion());
             // On the 1st day of 2nd period
-            prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2024, 2, 2));
-            assertEquals(100.60f, prepayAmounts.get("amount"));
-            assertEquals(0.60f, prepayAmounts.get("interestPortion"));
-            assertEquals(100.0f, prepayAmounts.get("principalPortion"));
+            prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2024, 2, 2));
+            assertEquals(100.60, prepayAmounts.getAmount());
+            assertEquals(0.60, prepayAmounts.getInterestPortion());
+            assertEquals(100.0, prepayAmounts.getPrincipalPortion());
             // In the middle of 2nd period (15 Feb)
-            prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2024, 2, 15));
-            assertEquals(100.86f, prepayAmounts.get("amount"));
-            assertEquals(0.86f, prepayAmounts.get("interestPortion"));
-            assertEquals(100.0f, prepayAmounts.get("principalPortion"));
+            prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2024, 2, 15));
+            assertEquals(100.86, prepayAmounts.getAmount());
+            assertEquals(0.86, prepayAmounts.getInterestPortion());
+            assertEquals(100.0, prepayAmounts.getPrincipalPortion());
             // On the due date of 2nd period
-            prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2024, 3, 1));
-            assertEquals(101.16f, prepayAmounts.get("amount"));
-            assertEquals(1.16f, prepayAmounts.get("interestPortion"));
-            assertEquals(100.0f, prepayAmounts.get("principalPortion"));
+            prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2024, 3, 1));
+            assertEquals(101.16, prepayAmounts.getAmount());
+            assertEquals(1.16, prepayAmounts.getInterestPortion());
+            assertEquals(100.0, prepayAmounts.getPrincipalPortion());
         });
         String repaymentDate = "01 February 2024";
         runAt(repaymentDate, () -> {
-            loanTransactionHelper.makeLoanRepayment(createdLoanId.get(), new PostLoansLoanIdTransactionsRequest()
-                    .transactionDate(repaymentDate).dateFormat("dd MMMM yyyy").locale("en").transactionAmount(17.01));
+            transactionHelper.makeLoanRepayment(createdLoanId.get(), new PostLoansLoanIdTransactionsRequest().transactionDate(repaymentDate)
+                    .dateFormat("dd MMMM yyyy").locale("en").transactionAmount(17.01));
             // Before 1st disbursement date
-            HashMap prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2023, 12, 31));
-            assertEquals(83.57f, prepayAmounts.get("amount"));
-            assertEquals(0.0f, prepayAmounts.get("interestPortion"));
-            assertEquals(83.57f, prepayAmounts.get("principalPortion"));
+            GetLoansLoanIdTransactionsTemplateResponse prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2023, 12, 31));
+            assertEquals(83.57, prepayAmounts.getAmount());
+            assertEquals(0.0, prepayAmounts.getInterestPortion());
+            assertEquals(83.57, prepayAmounts.getPrincipalPortion());
             // On 1st day
-            prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2024, 1, 1));
-            assertEquals(83.57f, prepayAmounts.get("amount"));
-            assertEquals(0.0f, prepayAmounts.get("interestPortion"));
-            assertEquals(83.57f, prepayAmounts.get("principalPortion"));
+            prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2024, 1, 1));
+            assertEquals(83.57, prepayAmounts.getAmount());
+            assertEquals(0.0, prepayAmounts.getInterestPortion());
+            assertEquals(83.57, prepayAmounts.getPrincipalPortion());
             // On 2nd day
-            prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2024, 1, 2));
-            assertEquals(83.57f, prepayAmounts.get("amount"));
-            assertEquals(0.00f, prepayAmounts.get("interestPortion"));
-            assertEquals(83.57f, prepayAmounts.get("principalPortion"));
+            prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2024, 1, 2));
+            assertEquals(83.57, prepayAmounts.getAmount());
+            assertEquals(0.00, prepayAmounts.getInterestPortion());
+            assertEquals(83.57, prepayAmounts.getPrincipalPortion());
             // On due date of 1st period
-            prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2024, 2, 1));
-            assertEquals(83.57f, prepayAmounts.get("amount"));
-            assertEquals(0.0f, prepayAmounts.get("interestPortion"));
-            assertEquals(83.57f, prepayAmounts.get("principalPortion"));
+            prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2024, 2, 1));
+            assertEquals(83.57, prepayAmounts.getAmount());
+            assertEquals(0.0, prepayAmounts.getInterestPortion());
+            assertEquals(83.57, prepayAmounts.getPrincipalPortion());
             // On the 1st day of 2nd period
-            prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2024, 2, 2));
-            assertEquals(83.59f, prepayAmounts.get("amount"));
-            assertEquals(0.02f, prepayAmounts.get("interestPortion"));
-            assertEquals(83.57f, prepayAmounts.get("principalPortion"));
+            prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2024, 2, 2));
+            assertEquals(83.59, prepayAmounts.getAmount());
+            assertEquals(0.02, prepayAmounts.getInterestPortion());
+            assertEquals(83.57, prepayAmounts.getPrincipalPortion());
             // In the middle of 2nd period (15 Feb)
-            prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2024, 2, 15));
-            assertEquals(83.81f, prepayAmounts.get("amount"));
-            assertEquals(0.24f, prepayAmounts.get("interestPortion"));
-            assertEquals(83.57f, prepayAmounts.get("principalPortion"));
+            prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2024, 2, 15));
+            assertEquals(83.81, prepayAmounts.getAmount());
+            assertEquals(0.24, prepayAmounts.getInterestPortion());
+            assertEquals(83.57, prepayAmounts.getPrincipalPortion());
             // On the due date of 2nd period
-            prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2024, 3, 1));
-            assertEquals(84.06f, prepayAmounts.get("amount"));
-            assertEquals(0.49f, prepayAmounts.get("interestPortion"));
-            assertEquals(83.57f, prepayAmounts.get("principalPortion"));
+            prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2024, 3, 1));
+            assertEquals(84.06, prepayAmounts.getAmount());
+            assertEquals(0.49, prepayAmounts.getInterestPortion());
+            assertEquals(83.57, prepayAmounts.getPrincipalPortion());
         });
 
         String secondRepaymentDate = "15 February 2024";
         runAt(secondRepaymentDate, () -> {
-            loanTransactionHelper.makeLoanRepayment(createdLoanId.get(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(createdLoanId.get(), new PostLoansLoanIdTransactionsRequest()
                     .transactionDate(secondRepaymentDate).dateFormat("dd MMMM yyyy").locale("en").transactionAmount(5.0));
             // Before 1st disbursement date
-            HashMap prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2023, 12, 31));
-            assertEquals(78.57f, prepayAmounts.get("amount"));
-            assertEquals(0.0f, prepayAmounts.get("interestPortion"));
-            assertEquals(78.57f, prepayAmounts.get("principalPortion"));
+            GetLoansLoanIdTransactionsTemplateResponse prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2023, 12, 31));
+            assertEquals(78.57, prepayAmounts.getAmount());
+            assertEquals(0.0, prepayAmounts.getInterestPortion());
+            assertEquals(78.57, prepayAmounts.getPrincipalPortion());
             // On 1st day
-            prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2024, 1, 1));
-            assertEquals(78.57f, prepayAmounts.get("amount"));
-            assertEquals(0.0f, prepayAmounts.get("interestPortion"));
-            assertEquals(78.57f, prepayAmounts.get("principalPortion"));
+            prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2024, 1, 1));
+            assertEquals(78.57, prepayAmounts.getAmount());
+            assertEquals(0.0, prepayAmounts.getInterestPortion());
+            assertEquals(78.57, prepayAmounts.getPrincipalPortion());
             // On 2nd day
-            prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2024, 1, 2));
-            assertEquals(78.57f, prepayAmounts.get("amount"));
-            assertEquals(0.00f, prepayAmounts.get("interestPortion"));
-            assertEquals(78.57f, prepayAmounts.get("principalPortion"));
+            prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2024, 1, 2));
+            assertEquals(78.57, prepayAmounts.getAmount());
+            assertEquals(0.00, prepayAmounts.getInterestPortion());
+            assertEquals(78.57, prepayAmounts.getPrincipalPortion());
             // On due date of 1st period
-            prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2024, 2, 1));
-            assertEquals(78.57f, prepayAmounts.get("amount"));
-            assertEquals(0.0f, prepayAmounts.get("interestPortion"));
-            assertEquals(78.57f, prepayAmounts.get("principalPortion"));
+            prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2024, 2, 1));
+            assertEquals(78.57, prepayAmounts.getAmount());
+            assertEquals(0.0, prepayAmounts.getInterestPortion());
+            assertEquals(78.57, prepayAmounts.getPrincipalPortion());
             // On the 1st day of 2nd period
-            prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2024, 2, 2));
-            assertEquals(78.59f, prepayAmounts.get("amount"));
-            assertEquals(0.02f, prepayAmounts.get("interestPortion"));
-            assertEquals(78.57f, prepayAmounts.get("principalPortion"));
+            prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2024, 2, 2));
+            assertEquals(78.59, prepayAmounts.getAmount());
+            assertEquals(0.02, prepayAmounts.getInterestPortion());
+            assertEquals(78.57, prepayAmounts.getPrincipalPortion());
             // In the middle of 2nd period (15 Feb)
-            prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2024, 2, 15));
-            assertEquals(78.81f, prepayAmounts.get("amount"));
-            assertEquals(0.24f, prepayAmounts.get("interestPortion"));
-            assertEquals(78.57f, prepayAmounts.get("principalPortion"));
+            prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2024, 2, 15));
+            assertEquals(78.81, prepayAmounts.getAmount());
+            assertEquals(0.24, prepayAmounts.getInterestPortion());
+            assertEquals(78.57, prepayAmounts.getPrincipalPortion());
             // On the due date of 2nd period
-            prepayAmounts = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, createdLoanId.intValue(),
-                    LocalDate.of(2024, 3, 1));
-            assertEquals(79.04f, prepayAmounts.get("amount"));
-            assertEquals(0.47f, prepayAmounts.get("interestPortion"));
-            assertEquals(78.57f, prepayAmounts.get("principalPortion"));
+            prepayAmounts = getPrepayAmount(createdLoanId.get(), LocalDate.of(2024, 3, 1));
+            assertEquals(79.04, prepayAmounts.getAmount());
+            assertEquals(0.47, prepayAmounts.getInterestPortion());
+            assertEquals(78.57, prepayAmounts.getPrincipalPortion());
 
-            loanTransactionHelper.makeLoanRepayment(createdLoanId.get(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(createdLoanId.get(), new PostLoansLoanIdTransactionsRequest()
                     .transactionDate(secondRepaymentDate).dateFormat("dd MMMM yyyy").locale("en").transactionAmount(78.81));
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertTrue(loanDetails.getStatus().getClosedObligationsMet());
         });
 
@@ -5819,50 +5646,41 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .installmentAmountInMultiplesOf(null)//
                     .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()) //
             ;//
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), "01 January 2024", 400.0,
                     6);
 
             applicationRequest = applicationRequest.interestCalculationPeriodType(DAYS).interestRatePerPeriod(BigDecimal.ZERO)
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
             createdLoanId.set(loanResponse.getLoanId());
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(400.0)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2024").locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(400.0))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2024").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2024").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(400.0)).locale("en"));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2024")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(400.0)).locale("en"));
         });
 
         runAt("02 January 2024", () -> {
             executeInlineCOB(createdLoanId.get());
 
-            final GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            final GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(LocalDate.of(2024, 1, 1), loanDetails.getLastClosedBusinessDate());
             final String errorMessage = Utils.uniqueRandomStringGenerator("error.", 40);
             placeHardLockOnLoan(createdLoanId.get(), errorMessage);
         });
 
         runAt("03 January 2024", () -> {
-            Integer roleId = RolesHelper.createRole(requestSpec, responseSpec);
-            Map<String, Boolean> permissionMap = Map.of("REPAYMENT_LOAN", true);
-            RolesHelper.addPermissionsToRole(requestSpec, responseSpec, roleId, permissionMap);
-            final Integer staffId = StaffHelper.createStaff(this.requestSpec, this.responseSpec);
+            // A user without the loan-checker bypass permission triggers a catch-up COB before its repayment lands,
+            // which clears the hard lock and advances the loan's last closed business date.
+            FeignTransactionHelper nonBypassTransactionHelper = new FeignTransactionHelper(
+                    FeignUserHelper.getSimpleUserWithoutBypassPermissionClient());
+            nonBypassTransactionHelper.makeLoanRepayment(createdLoanId.get(), new PostLoansLoanIdTransactionsRequest()
+                    .transactionDate("03 January 2024").dateFormat(DATETIME_PATTERN).locale(LOCALE).transactionAmount(200.0));
 
-            final String operatorUser = Utils.uniqueRandomStringGenerator("user", 8);
-            UserHelper.createUser(this.requestSpec, this.responseSpec, roleId, staffId, operatorUser, UserHelper.SIMPLE_USER_PASSWORD,
-                    "resourceId");
-
-            loanTransactionHelper.makeLoanRepayment(
-                    createdLoanId.get(), new PostLoansLoanIdTransactionsRequest().transactionDate("03 January 2024")
-                            .dateFormat("dd MMMM yyyy").locale("en").transactionAmount(200.0),
-                    operatorUser, UserHelper.SIMPLE_USER_PASSWORD);
-
-            final GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            final GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertEquals(LocalDate.of(2024, 1, 2), loanDetails.getLastClosedBusinessDate());
         });
     }
@@ -5883,7 +5701,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             final Integer rescheduleStrategyMethod = 4; // Adjust last, unpaid period
             PostLoanProductsRequest loanProduct = createOnePeriod30DaysPeriodicAccrualProductWithAdvancedPaymentAllocationAndInterestRecalculation(
                     (double) 80.0, rescheduleStrategyMethod);
-            final PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProduct);
+            final PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(loanProduct);
             assertNotNull(loanProductResponse);
 
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), operationDate, 100.0, 6);
@@ -5899,26 +5717,26 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .maxOutstandingLoanBalance(BigDecimal.valueOf(10000.0))//
             ;//
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()//
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()//
                     .approvedLoanAmount(BigDecimal.valueOf(100))//
                     .approvedOnDate(operationDate).dateFormat(DATETIME_PATTERN).locale("en"));//
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()//
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()//
                     .transactionAmount(BigDecimal.valueOf(100.0))//
                     .actualDisbursementDate(operationDate).dateFormat(DATETIME_PATTERN).locale("en"));//
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 125.67, 0.0, 100.0, 0.0, null);
             createdLoanId.set(loanResponse.getLoanId());
         });
 
         runAt("01 February 2024", () -> {
 
-            loanTransactionHelper.makeLoanRepayment(createdLoanId.get(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeLoanRepayment(createdLoanId.get(), new PostLoansLoanIdTransactionsRequest()
                     .transactionDate("01 February 2024").dateFormat("dd MMMM yyyy").locale("en").transactionAmount(21.0));
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             validateLoanSummaryBalances(loanDetails, 104.67, 21.0, 86.11, 13.89, null);
         });
 
@@ -5926,29 +5744,28 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             String randomText = Utils.randomStringGenerator("en", 5) + Utils.randomNumberGenerator(6)
                     + Utils.randomStringGenerator("is", 5);
             String transactionExternalId = UUID.randomUUID().toString();
-            Integer chargeOffReasonId = CodeHelper.createChargeOffCodeValue(requestSpec, responseSpec, randomText, 1);
+            Long chargeOffReasonId = codeHelper.createChargeOffCodeValue(randomText, 1);
 
-            loanTransactionHelper.chargeOffLoan(createdLoanId.get(),
-                    new PostLoansLoanIdTransactionsRequest().transactionDate("01 March 2024").locale("en").dateFormat("dd MMMM yyyy")
-                            .externalId(transactionExternalId).chargeOffReasonId((long) chargeOffReasonId));
+            transactionHelper.chargeOffLoan(createdLoanId.get(), new PostLoansLoanIdTransactionsRequest().transactionDate("01 March 2024")
+                    .locale("en").dateFormat("dd MMMM yyyy").externalId(transactionExternalId).chargeOffReasonId(chargeOffReasonId));
 
             // Loan Prepayment (before) Charge-Off transaction - With Interest Recalculation
-            GetLoansLoanIdTransactionsTemplateResponse transactionBefore = loanTransactionHelper
+            GetLoansLoanIdTransactionsTemplateResponse transactionBefore = transactionHelper
                     .retrieveTransactionTemplate(createdLoanId.get(), "prepayLoan", "dd MMMM yyyy", "15 February 2024", "en");
-            assertEquals(88.88, transactionBefore.getAmount().doubleValue());
-            assertEquals(86.11, transactionBefore.getPrincipalPortion().doubleValue());
-            assertEquals(2.77, transactionBefore.getInterestPortion().doubleValue());
-            assertEquals(0.00, transactionBefore.getFeeChargesPortion().doubleValue());
-            assertEquals(0.00, transactionBefore.getPenaltyChargesPortion().doubleValue());
+            assertEquals(88.88, transactionBefore.getAmount());
+            assertEquals(86.11, transactionBefore.getPrincipalPortion());
+            assertEquals(2.77, transactionBefore.getInterestPortion());
+            assertEquals(0.00, transactionBefore.getFeeChargesPortion());
+            assertEquals(0.00, transactionBefore.getPenaltyChargesPortion());
 
             // Loan Prepayment (after) Charge-Off transaction - WithOut Interest Recalculation
-            GetLoansLoanIdTransactionsTemplateResponse transactionAfter = loanTransactionHelper
-                    .retrieveTransactionTemplate(createdLoanId.get(), "prepayLoan", "dd MMMM yyyy", "01 March 2024", "en");
-            assertEquals(104.67, transactionAfter.getAmount().doubleValue());
-            assertEquals(86.11, transactionAfter.getPrincipalPortion().doubleValue());
-            assertEquals(18.56, transactionAfter.getInterestPortion().doubleValue());
-            assertEquals(0.00, transactionAfter.getFeeChargesPortion().doubleValue());
-            assertEquals(0.00, transactionAfter.getPenaltyChargesPortion().doubleValue());
+            GetLoansLoanIdTransactionsTemplateResponse transactionAfter = transactionHelper.retrieveTransactionTemplate(createdLoanId.get(),
+                    "prepayLoan", "dd MMMM yyyy", "01 March 2024", "en");
+            assertEquals(104.67, transactionAfter.getAmount());
+            assertEquals(86.11, transactionAfter.getPrincipalPortion());
+            assertEquals(18.56, transactionAfter.getInterestPortion());
+            assertEquals(0.00, transactionAfter.getFeeChargesPortion());
+            assertEquals(0.00, transactionAfter.getPenaltyChargesPortion());
         });
 
     }
@@ -5976,31 +5793,31 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .overAppliedNumber(null)//
                     .installmentAmountInMultiplesOf(null)//
             ;//
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), operationDate, 100.0, 3)
                     .interestRatePerPeriod(BigDecimal.valueOf(4.0));
 
             applicationRequest = applicationRequest.interestCalculationPeriodType(DAYS)
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
             createdLoanId.set(loanResponse.getLoanId());
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()
-                    .approvedLoanAmount(BigDecimal.valueOf(100.0)).dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(100.0))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
                     .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(100.0)).locale("en"));
 
             // After Disbursement we are expecting amount in Zero
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
             assertEquals(BigDecimal.ZERO, loanDetails.getSummary().getTotalUnpaidPayableNotDueInterest().stripTrailingZeros());
         });
 
         runAt("23 March 2025", () -> {
             executeInlineCOB(createdLoanId.get());
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             // totalUnpaidPayableDueInterest → Total outstanding interest amount on all the periods that are before
             assertEquals(loanDetails.getSummary().getInterestCharged().stripTrailingZeros(),
                     loanDetails.getSummary().getTotalUnpaidPayableDueInterest().stripTrailingZeros());
@@ -6034,32 +5851,32 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .overAppliedCalculationType("flat")//
                     .overAppliedNumber(500)//
             ;//
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), operationDate, 1000.0, 4)
                     .transactionProcessingStrategyCode("advanced-payment-allocation-strategy")//
                     .interestRatePerPeriod(BigDecimal.valueOf(12.0));
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
             createdLoanId.set(loanResponse.getLoanId());
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()
-                    .approvedLoanAmount(BigDecimal.valueOf(1300)).dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1300))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertTrue(loanDetails.getStatus().getWaitingForDisbursal());
             assertEquals("1300.000000", loanDetails.getApprovedPrincipal().toString());
 
             CallFailedRuntimeException callFailedRuntimeException = Assertions.assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
+                    () -> loanHelper.disburseLoan(loanResponse.getLoanId(),
                             new PostLoansLoanIdRequest().actualDisbursementDate(operationDate).dateFormat(DATETIME_PATTERN).locale("en")
                                     .transactionAmount(BigDecimal.valueOf(1550.0))));
 
             Assertions.assertTrue(callFailedRuntimeException.getMessage()
                     .contains("Loan disbursal amount can't be greater than maximum applied loan amount calculation"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
                     .dateFormat(DATETIME_PATTERN).locale("en").transactionAmount(BigDecimal.valueOf(1450.0)));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertTrue(loanDetails.getStatus().getActive());
             assertEquals("1450.000000", loanDetails.getSummary().getPrincipalOutstanding().toString());
         });
@@ -6110,7 +5927,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .rescheduleStrategyMethod(LoanRescheduleStrategyMethod.ADJUST_LAST_UNPAID_PERIOD.getValue())//
                     .recalculationRestFrequencyType(2)//
                     .recalculationRestFrequencyInterval(1);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), operationDate,
                     principalAmount.doubleValue(), 6).interestCalculationPeriodType(DAYS)//
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)//
@@ -6120,45 +5937,45 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .loanTermFrequency(6)//
                     .loanTermFrequencyType(MONTHS);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
             createdLoanId.set(loanResponse.getLoanId());
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(principalAmount)
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(principalAmount)
                     .dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
                     .dateFormat(DATETIME_PATTERN).locale("en").transactionAmount(principalAmount));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertTrue(loanDetails.getStatus().getActive());
         });
 
         runAt("22 June 2025", () -> {
-            PostLoansLoanIdTransactionsResponse repayment = loanTransactionHelper.makeLoanRepayment(createdLoanId.get(),
+            PostLoansLoanIdTransactionsResponse repayment = transactionHelper.makeLoanRepayment(createdLoanId.get(),
                     new PostLoansLoanIdTransactionsRequest().transactionDate("22 June 2025").dateFormat("dd MMMM yyyy").locale("en")
                             .transactionAmount(25.0));
         });
 
         runAt("13 July 2025", () -> {
-            PostLoansLoanIdTransactionsResponse repayment = loanTransactionHelper.makeLoanRepayment(createdLoanId.get(),
+            PostLoansLoanIdTransactionsResponse repayment = transactionHelper.makeLoanRepayment(createdLoanId.get(),
                     new PostLoansLoanIdTransactionsRequest().transactionDate("13 July 2025").dateFormat("dd MMMM yyyy").locale("en")
                             .transactionAmount(23.41));
             secondRepayment.set(repayment.getResourceId());
         });
 
         runAt("16 July 2025", () -> {
-            loanTransactionHelper.makeMerchantIssuedRefund(createdLoanId.get(), new PostLoansLoanIdTransactionsRequest()
+            transactionHelper.makeMerchantIssuedRefund(createdLoanId.get(), new PostLoansLoanIdTransactionsRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("16 July 2025").locale("en").transactionAmount(135.94));
         });
 
         runAt("18 July 2025", () -> {
             CobHelper.fastForwardLoansLastCOBDate(createdLoanId.get(), "18 July 2025");
             verifyLastClosedBusinessDate(createdLoanId.get(), "18 July 2025");
-            loanTransactionHelper.reverseLoanTransaction(createdLoanId.get(), secondRepayment.get(),
+            transactionHelper.reverseLoanTransaction(createdLoanId.get(), secondRepayment.get(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("18 July 2025")
                             .transactionAmount(0.0).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertTrue(loanDetails.getStatus().getOverpaid());
             verifyTransactions(createdLoanId.get(), //
                     transaction(135.94, "Disbursement", "13 June 2025", 135.94, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
@@ -6174,7 +5991,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             createdLoanChargeId.set(addCharge(createdLoanId.get(), false, 2.8, "18 July 2025"));
             LOG.info("------------------------------ REPROCESSING LOAN ---------------------------------------");
 
-            loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertTrue(loanDetails.getStatus().getOverpaid());
             verifyTransactions(createdLoanId.get(), //
                     transaction(135.94, "Disbursement", "13 June 2025", 135.94, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
@@ -6189,7 +6006,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     transaction(2.80, "Accrual", "18 July 2025", 0.0, 0.0, 0.00, 2.80, 0.0, 0.0, 0.0));
 
             CobHelper.reprocessLoan(createdLoanId.get());
-            loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertTrue(loanDetails.getStatus().getOverpaid());
 
             verifyTransactions(createdLoanId.get(), //
@@ -6253,7 +6070,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .recalculationRestFrequencyType(2)//
                     .recalculationRestFrequencyInterval(1)//
                     .enableAccrualActivityPosting(true);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductResponse.getResourceId(), operationDate,
                     principalAmount.doubleValue(), 6).interestCalculationPeriodType(DAYS)//
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)//
@@ -6263,16 +6080,16 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .loanTermFrequency(6)//
                     .loanTermFrequencyType(MONTHS);
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
             createdLoanId.set(loanResponse.getLoanId());
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(principalAmount)
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(principalAmount)
                     .dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
                     .dateFormat(DATETIME_PATTERN).locale("en").transactionAmount(principalAmount));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             assertTrue(loanDetails.getStatus().getActive());
         });
 
@@ -6283,7 +6100,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     transaction(135.94, "Disbursement", "13 September 2025", 135.94, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
                     transaction(1.28, "Accrual Activity", "13 October 2025", 0.0, 0.0, 1.28, 0.0, 0.0, 0.0, 0.0),
                     transaction(1.61, "Accrual", "21 October 2025", 0.0, 0.0, 1.61, 0.0, 0.0, 0.0, 0.0));
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(createdLoanId.get());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(createdLoanId.get());
             loanDetails.getTransactions().stream().filter(t -> "loanTransactionType.accrualActivity".equals(t.getType().getCode()))
                     .findFirst().ifPresent(t -> {
                         accrualActivityId[0] = t;
@@ -6291,13 +6108,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
             assertNotNull(accrualActivityId[0]);
             assertNotNull(accrualActivityId[0].getExternalId());
 
-            loanTransactionHelper.makeLoanRepayment(createdLoanId.get(), new PostLoansLoanIdTransactionsRequest() //
+            transactionHelper.makeLoanRepayment(createdLoanId.get(), new PostLoansLoanIdTransactionsRequest() //
                     .transactionDate("13 September 2025") //
                     .transactionAmount(135.94) //
                     .locale("en") //
                     .dateFormat(DATETIME_PATTERN)); //
 
-            GetLoansLoanIdTransactionsTransactionIdResponse loanTransactionDetails = loanTransactionHelper
+            GetLoansLoanIdTransactionsTransactionIdResponse loanTransactionDetails = transactionHelper
                     .getLoanTransactionDetails(createdLoanId.get(), accrualActivityId[0].getId());
             assertNotNull(loanTransactionDetails.getExternalId());
             assertEquals(LocalDate.of(2025, 10, 22), loanTransactionDetails.getReversedOnDate());
@@ -6313,7 +6130,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
 
         runAt("1 January 2024", () -> {
             // Create a Cumulative Multidisbursal and Flat Interest Type
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(
+            PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(
                     createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct().interestType(InterestType.FLAT).daysInMonthType(30)//
                             .transactionProcessingStrategyCode(LoanProductTestBuilder.DEFAULT_STRATEGY).interestRateFrequencyType(YEARS)
                             .daysInYearType(365).loanScheduleType(LoanScheduleType.CUMULATIVE.toString()).repaymentEvery(1)
@@ -6330,16 +6147,15 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                     .repaymentFrequencyType(MONTHS)//
                     .loanTermFrequency(3)//
                     .loanTermFrequencyType(MONTHS);
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(principalAmount)
+            loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(principalAmount)
                     .dateFormat(DATETIME_PATTERN).approvedOnDate("1 January 2024").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2024").dateFormat(DATETIME_PATTERN).locale("en")
-                            .transactionAmount(BigDecimal.valueOf(1000.00)));
+            loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2024")
+                    .dateFormat(DATETIME_PATTERN).locale("en").transactionAmount(BigDecimal.valueOf(1000.00)));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1017.50, 0.00, 1000.00, 0.00, null);
             validatePeriod(loanDetails, 0, LocalDate.of(2024, 1, 1), null, 1000.0, null, null, null, 0.0, 0.0, null, null, null, null, null,
                     null, null, null, null);
@@ -6355,10 +6171,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
         runAt("15 January 2024", () -> {
             final Long loanId = loanIdRef.get();
 
-            loanTransactionHelper.disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("15 January 2024")
+            loanHelper.disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("15 January 2024")
                     .dateFormat(DATETIME_PATTERN).locale("en").transactionAmount(BigDecimal.valueOf(500.0)));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = loanHelper.getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 1526.25, 0.00, 1500.00, 0.00, null);
             validatePeriod(loanDetails, 0, LocalDate.of(2024, 1, 1), null, 1000.0, null, null, null, 0.0, 0.0, null, null, null, null, null,
                     null, null, null, null);
@@ -6379,13 +6195,13 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
         PostLoansRequest applicationRequest = applyLoanRequestProgressiveAdvancedPaymentAllocationStrategyMonthlyRepayments(clientId,
                 loanProductId, amount, numberOfRepayments, loanDisbursementDate);
 
-        PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+        PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
         Long loanId = loanResponse.getLoanId();
 
         assertNotNull(loanId);
 
-        loanTransactionHelper.approveLoan(loanId, new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(amount))
+        loanHelper.approveLoan(loanId, new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(amount))
                 .dateFormat(DATETIME_PATTERN).approvedOnDate(loanDisbursementDate).locale("en"));
 
         return loanId;
@@ -6426,19 +6242,19 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                 .installmentAmountInMultiplesOf(null).numberOfRepayments(3).repaymentEvery(15).enableDownPayment(true)
                 .enableAutoRepaymentForDownPayment(true).disbursedAmountPercentageForDownPayment(BigDecimal.valueOf(25)).minPrincipal(10.0)
                 .installmentAmountInMultiplesOf(1);
-        PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
+        PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(product);
         PostLoansRequest applicationRequest = applyLoanRequest(client.getClientId(), loanProductResponse.getResourceId(), "23 March 2024",
                 10.0, 4);
 
         applicationRequest = applicationRequest.numberOfRepayments(3).loanTermFrequency(45)
                 .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(15);
 
-        PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+        PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
-        loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(10))
+        loanHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(10))
                 .dateFormat(DATETIME_PATTERN).approvedOnDate("23 March 2024").locale("en"));
 
-        loanTransactionHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("23 March 2024")
+        loanHelper.disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("23 March 2024")
                 .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(10.0)).locale("en"));
 
         // verify schedule
@@ -6467,7 +6283,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
         advancedPaymentData.setTransactionType("DEFAULT");
         advancedPaymentData.setFutureInstallmentAllocationRule("NEXT_INSTALLMENT");
 
-        List<PaymentAllocationOrder> paymentAllocationOrders = getPaymentAllocationOrder(PaymentAllocationType.DUE_PENALTY,
+        List<PaymentAllocationOrder> paymentAllocationOrders = LoanRequestBuilders.paymentAllocationOrder(PaymentAllocationType.DUE_PENALTY,
                 PaymentAllocationType.PAST_DUE_FEE, PaymentAllocationType.PAST_DUE_PRINCIPAL, PaymentAllocationType.PAST_DUE_INTEREST,
                 PaymentAllocationType.PAST_DUE_PENALTY, PaymentAllocationType.DUE_FEE, PaymentAllocationType.DUE_PRINCIPAL,
                 PaymentAllocationType.DUE_INTEREST, PaymentAllocationType.IN_ADVANCE_PENALTY, PaymentAllocationType.IN_ADVANCE_FEE,
@@ -6477,7 +6293,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
         return advancedPaymentData;
     }
 
-    private static Integer createLoanProduct(final String principal, final String repaymentAfterEvery, final String numberOfRepayments,
+    private static Long createLoanProduct(final String principal, final String repaymentAfterEvery, final String numberOfRepayments,
             boolean autoPayForDownPayment, LoanScheduleType loanScheduleType, LoanScheduleProcessingType loanScheduleProcessingType,
             AdvancedPaymentData allocationRuleData, final Account... accounts) {
         LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
@@ -6491,10 +6307,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                 .withInterestTypeAsDecliningBalance().withMultiDisburse().withDisallowExpectedDisbursements(true)
                 .withLoanScheduleType(loanScheduleType).withLoanScheduleProcessingType(loanScheduleProcessingType).withDaysInMonth("30")
                 .withDaysInYear("365").withMoratorium("0", "0").build(null);
-        return loanTransactionHelper.getLoanProductId(loanProductJSON);
+        return loanHelper.createLoanProductFromJson(loanProductJSON);
     }
 
-    private static Integer createLoanProduct(final String principal, final String repaymentAfterEvery, final String numberOfRepayments,
+    private static Long createLoanProduct(final String principal, final String repaymentAfterEvery, final String numberOfRepayments,
             boolean autoPayForDownPayment, LoanScheduleType loanScheduleType, final Account... accounts) {
         LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
         final String loanProductJSON = new LoanProductTestBuilder().withMinPrincipal(principal).withPrincipal(principal)
@@ -6506,7 +6322,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                 .withInterestCalculationPeriodTypeAsRepaymentPeriod(true).withInterestTypeAsDecliningBalance().withMultiDisburse()
                 .withDisallowExpectedDisbursements(true).withLoanScheduleType(loanScheduleType).withDaysInMonth("30").withDaysInYear("365")
                 .withMoratorium("0", "0").build(null);
-        return loanTransactionHelper.getLoanProductId(loanProductJSON);
+        return loanHelper.createLoanProductFromJson(loanProductJSON);
     }
 
     private static ArrayList<HashMap<String, Object>> createLoanProductGetError(final String principal, final String repaymentAfterEvery,
@@ -6523,12 +6339,10 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                 .withInterestTypeAsDecliningBalance().withMultiDisburse().withDisallowExpectedDisbursements(true)
                 .withLoanScheduleType(loanScheduleType).withLoanScheduleProcessingType(loanScheduleProcessingType).withDaysInMonth("30")
                 .withDaysInYear("365").withMoratorium("0", "0").build(null);
-        LoanTransactionHelper loanTransactionHelperBadRequest = new LoanTransactionHelper(requestSpec,
-                new ResponseSpecBuilder().expectStatusCode(400).build());
-        return loanTransactionHelperBadRequest.getLoanProductError(loanProductJSON, CommonConstants.RESPONSE_ERROR);
+        return loanHelper.getLoanProductError(loanProductJSON, CommonConstants.RESPONSE_ERROR);
     }
 
-    private static Integer createLoanProduct(final String principal, final String repaymentAfterEvery, final String numberOfRepayments,
+    private static Long createLoanProduct(final String principal, final String repaymentAfterEvery, final String numberOfRepayments,
             boolean downPaymentEnabled, String downPaymentPercentage, boolean autoPayForDownPayment, LoanScheduleType loanScheduleType,
             LoanScheduleProcessingType loanScheduleProcessingType, final Account... accounts) {
         AdvancedPaymentData defaultAllocation = createDefaultPaymentAllocation();
@@ -6548,7 +6362,7 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
                 .withDisallowExpectedDisbursements(true).withLoanScheduleType(loanScheduleType)
                 .withLoanScheduleProcessingType(loanScheduleProcessingType).withDaysInMonth("30").withDaysInYear("365")
                 .withMoratorium("0", "0").build(null);
-        return loanTransactionHelper.getLoanProductId(loanProductJSON);
+        return loanHelper.createLoanProductFromJson(loanProductJSON);
     }
 
     private static void validatePeriod(GetLoansLoanIdResponse loanDetails, Integer index, LocalDate dueDate, LocalDate paidDate,
@@ -6575,29 +6389,29 @@ public class AdvancedPaymentAllocationLoanRepaymentScheduleTest extends BaseLoan
         assertEquals(paidLate, Utils.getDoubleValue(period.getTotalPaidLateForPeriod()));
     }
 
-    private static PostLoansResponse applyForLoanApplication(final Long clientId, final Integer loanProductId, final BigDecimal principal,
+    private static PostLoansResponse applyForLoanApplication(final Long clientId, final Long loanProductId, final BigDecimal principal,
             final int loanTermFrequency, final int repaymentAfterEvery, final int numberOfRepayments, final BigDecimal interestRate,
             final String expectedDisbursementDate, final String submittedOnDate, String transactionProcessorCode,
             String loanScheduleProcessingType) {
         LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
-        return loanTransactionHelper.applyLoan(new PostLoansRequest().clientId(clientId).productId(loanProductId.longValue())
-                .expectedDisbursementDate(expectedDisbursementDate).dateFormat(DATETIME_PATTERN)
-                .transactionProcessingStrategyCode(transactionProcessorCode).locale("en").submittedOnDate(submittedOnDate)
-                .amortizationType(1).interestRatePerPeriod(interestRate).interestCalculationPeriodType(1).interestType(0)
-                .repaymentFrequencyType(0).repaymentEvery(repaymentAfterEvery).repaymentFrequencyType(0)
-                .numberOfRepayments(numberOfRepayments).loanTermFrequency(loanTermFrequency).loanTermFrequencyType(0).principal(principal)
-                .loanType("individual").loanScheduleProcessingType(loanScheduleProcessingType)
-                .maxOutstandingLoanBalance(BigDecimal.valueOf(35000)));
+        return loanHelper.applyForLoan(
+                new PostLoansRequest().clientId(clientId).productId(loanProductId).expectedDisbursementDate(expectedDisbursementDate)
+                        .dateFormat(DATETIME_PATTERN).transactionProcessingStrategyCode(transactionProcessorCode).locale("en")
+                        .submittedOnDate(submittedOnDate).amortizationType(1).interestRatePerPeriod(interestRate)
+                        .interestCalculationPeriodType(1).interestType(0).repaymentFrequencyType(0).repaymentEvery(repaymentAfterEvery)
+                        .repaymentFrequencyType(0).numberOfRepayments(numberOfRepayments).loanTermFrequency(loanTermFrequency)
+                        .loanTermFrequencyType(0).principal(principal).loanType("individual")
+                        .loanScheduleProcessingType(loanScheduleProcessingType).maxOutstandingLoanBalance(BigDecimal.valueOf(35000)));
     }
 
-    private static PostLoansResponse applyForLoanApplication(final Long clientId, final Integer loanProductId, final BigDecimal principal,
+    private static PostLoansResponse applyForLoanApplication(final Long clientId, final Long loanProductId, final BigDecimal principal,
             final int loanTermFrequency, final int repaymentAfterEvery, final int numberOfRepayments, final BigDecimal interestRate,
             final String expectedDisbursementDate, final String submittedOnDate) {
         return applyForLoanApplication(clientId, loanProductId, principal, loanTermFrequency, repaymentAfterEvery, numberOfRepayments,
                 interestRate, expectedDisbursementDate, submittedOnDate, LoanScheduleProcessingType.HORIZONTAL);
     }
 
-    private static PostLoansResponse applyForLoanApplication(final Long clientId, final Integer loanProductId, final BigDecimal principal,
+    private static PostLoansResponse applyForLoanApplication(final Long clientId, final Long loanProductId, final BigDecimal principal,
             final int loanTermFrequency, final int repaymentAfterEvery, final int numberOfRepayments, final BigDecimal interestRate,
             final String expectedDisbursementDate, final String submittedOnDate, LoanScheduleProcessingType loanScheduleProcessingType) {
         LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/BaseLoanIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/BaseLoanIntegrationTest.java
@@ -943,6 +943,7 @@ public abstract class BaseLoanIntegrationTest extends IntegrationTest {
                     return;
                 }
 
+                // The API omits manuallyReversed for non-reversed transactions, so null and false are the same state.
                 final boolean found = transactionsByDate.stream()
                         .anyMatch(item -> Objects.equals(Utils.getDoubleValue(item.getAmount()), tr.amount)
                                 && Objects.equals(item.getType().getValue(), tr.type)
@@ -952,7 +953,8 @@ public abstract class BaseLoanIntegrationTest extends IntegrationTest {
                                 && Objects.equals(Utils.getDoubleValue(item.getFeeChargesPortion()), tr.feePortion)
                                 && Objects.equals(Utils.getDoubleValue(item.getPenaltyChargesPortion()), tr.penaltyPortion)
                                 && Objects.equals(Utils.getDoubleValue(item.getOverpaymentPortion()), tr.overpaymentPortion)
-                                && Objects.equals(Utils.getDoubleValue(item.getUnrecognizedIncomePortion()), tr.unrecognizedPortion));
+                                && Objects.equals(Utils.getDoubleValue(item.getUnrecognizedIncomePortion()), tr.unrecognizedPortion)
+                                && Boolean.TRUE.equals(item.getManuallyReversed()) == Boolean.TRUE.equals(tr.reversed));
 
                 if (!found) {
                     final StringBuilder errorMessage = new StringBuilder();

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/BaseLoanIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/BaseLoanIntegrationTest.java
@@ -945,6 +945,7 @@ public abstract class BaseLoanIntegrationTest extends IntegrationTest {
                     return;
                 }
 
+                // The API omits manuallyReversed for non-reversed transactions, so null and false are the same state.
                 final boolean found = transactionsByDate.stream()
                         .anyMatch(item -> Objects.equals(Utils.getDoubleValue(item.getAmount()), tr.amount)
                                 && Objects.equals(item.getType().getValue(), tr.type)
@@ -954,7 +955,8 @@ public abstract class BaseLoanIntegrationTest extends IntegrationTest {
                                 && Objects.equals(Utils.getDoubleValue(item.getFeeChargesPortion()), tr.feePortion)
                                 && Objects.equals(Utils.getDoubleValue(item.getPenaltyChargesPortion()), tr.penaltyPortion)
                                 && Objects.equals(Utils.getDoubleValue(item.getOverpaymentPortion()), tr.overpaymentPortion)
-                                && Objects.equals(Utils.getDoubleValue(item.getUnrecognizedIncomePortion()), tr.unrecognizedPortion));
+                                && Objects.equals(Utils.getDoubleValue(item.getUnrecognizedIncomePortion()), tr.unrecognizedPortion)
+                                && Boolean.TRUE.equals(item.getManuallyReversed()) == Boolean.TRUE.equals(tr.reversed));
 
                 if (!found) {
                     final StringBuilder errorMessage = new StringBuilder();

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/BatchApiTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/BatchApiTest.java
@@ -18,86 +18,108 @@
  */
 package org.apache.fineract.integrationtests;
 
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
+import static org.apache.http.HttpStatus.SC_CONFLICT;
 import static org.apache.http.HttpStatus.SC_FORBIDDEN;
-import static org.hamcrest.Matchers.containsString;
+import static org.apache.http.HttpStatus.SC_NOT_IMPLEMENTED;
+import static org.apache.http.HttpStatus.SC_OK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
+import com.google.gson.JsonParser;
+import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.fineract.batch.command.internal.AdjustLoanTransactionCommandStrategy;
-import org.apache.fineract.batch.command.internal.CreateTransactionLoanCommandStrategy;
-import org.apache.fineract.batch.command.internal.GetDatatableEntryByAppTableIdAndDataTableIdCommandStrategy;
-import org.apache.fineract.batch.domain.BatchRequest;
-import org.apache.fineract.batch.domain.BatchResponse;
+import org.apache.fineract.client.models.BatchRequest;
+import org.apache.fineract.client.models.BatchResponse;
+import org.apache.fineract.client.models.PostColumnHeaderData;
+import org.apache.fineract.client.models.PostDataTablesRequest;
+import org.apache.fineract.client.models.PostLoanProductsRequest;
+import org.apache.fineract.client.models.PostSavingsProductsRequest;
 import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
+import org.apache.fineract.client.models.SavingsAccountTransactionData;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
-import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
-import org.apache.fineract.integrationtests.common.BatchHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.CollateralManagementHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignBatchHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignCollateralHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignDatatableHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignSavingsHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignSavingsProductHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignUserHelper;
+import org.apache.fineract.integrationtests.client.feign.modules.BatchRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.AmortizationType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.DaysInMonthType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.DaysInYearType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestCalculationPeriodType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestRateFrequencyType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.RepaymentFrequencyType;
+import org.apache.fineract.integrationtests.client.feign.modules.SavingsRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.SavingsTestData.InterestPostingPeriodType;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
 import org.apache.fineract.integrationtests.common.error.ErrorResponse;
-import org.apache.fineract.integrationtests.common.loans.LoanAccountLockHelper;
 import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.apache.fineract.integrationtests.common.savings.SavingsAccountHelper;
-import org.apache.fineract.integrationtests.common.savings.SavingsProductHelper;
-import org.apache.fineract.integrationtests.common.savings.SavingsStatusChecker;
-import org.apache.fineract.integrationtests.common.system.CodeHelper;
-import org.apache.fineract.integrationtests.common.system.DatatableHelper;
-import org.apache.fineract.integrationtests.useradministration.users.UserHelper;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanStatus;
-import org.apache.http.HttpStatus;
-import org.hamcrest.MatcherAssert;
+import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleType;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public class BatchApiTest extends BaseLoanIntegrationTest {
+/**
+ * Integration tests for the Batch API, exercised through the typed Feign client.
+ *
+ * @see org.apache.fineract.batch.api.BatchApiResource
+ */
+public class BatchApiTest extends FeignLoanTestBase {
 
-    private static final Logger LOG = LoggerFactory.getLogger(BatchApiTest.class);
-
-    /**
-     * The response specification
-     */
-    private ResponseSpecification responseSpec;
-
-    /**
-     * The request specification
-     */
-    private RequestSpecification requestSpec;
-
-    /**
-     * The datatable helper
-     */
-    private DatatableHelper datatableHelper;
-
-    /**
-     * Loan app datatable
-     */
+    /** Application table the datatables in this test are attached to. */
     private static final String LOAN_APP_TABLE_NAME = "m_loan";
+    private static final String LOAN_RESCHEDULE_REASON_CODE_NAME = "LoanRescheduleReason";
+    private static final String PERSON_ENTITY_SUB_TYPE = "PERSON";
+
+    private static final double SMALL_PRINCIPAL = 1000.00;
+    private static final double LARGE_PRINCIPAL = 10000000.00;
+    private static final double SPECIFIED_DUE_DATE_CHARGE_AMOUNT = 100.0;
+
+    /** Column width of the datatables whose values are short random strings. */
+    private static final long SHORT_COLUMN_LENGTH = 10;
+    /** Column width of the datatable queried by the literal {@code columnValue1} / {@code columnValue2} filters. */
+    private static final long LONG_COLUMN_LENGTH = 15;
+
+    private static final String SAVINGS_SUBMITTED_ON_DATE = "08 January 2013";
+    private static final String SAVINGS_APPROVED_ON_DATE = "09 January 2013";
+    private static final String SAVINGS_ACTIVATED_ON_DATE = "01 March 2013";
+
+    /**
+     * Batch request ids of the datatable requests. Their only requirement is to be unique within a batch and to match
+     * the {@code reference} of any request that resolves an id from their response.
+     */
+    private static final Long GET_LOAN_REQUEST_ID = 4567L;
+    private static final Long CREATE_DATATABLE_ENTRY_REQUEST_ID = 4569L;
+    private static final Long UPDATE_DATATABLE_ENTRY_REQUEST_ID = 4570L;
+    private static final Long GET_DATATABLE_ENTRIES_REQUEST_ID = 4571L;
+    private static final Long GET_DATATABLE_ENTRY_REQUEST_ID = 4572L;
+    private static final Long QUERY_DATATABLE_ENTRIES_REQUEST_ID = 1L;
+    private static final Long UPDATE_QUERIED_DATATABLE_ENTRY_REQUEST_ID = 2L;
+
+    private static final Gson GSON = new Gson();
+
+    private final FeignBatchHelper batchHelper = new FeignBatchHelper(FineractFeignClientHelper.getFineractFeignClient());
+    private final FeignDatatableHelper datatableHelper = new FeignDatatableHelper(FineractFeignClientHelper.getFineractFeignClient());
+    private final FeignCollateralHelper collateralHelper = new FeignCollateralHelper(FineractFeignClientHelper.getFineractFeignClient());
+    private final FeignSavingsHelper savingsHelper = new FeignSavingsHelper(FineractFeignClientHelper.getFineractFeignClient());
+    private final FeignSavingsProductHelper savingsProductHelper = new FeignSavingsProductHelper(
+            FineractFeignClientHelper.getFineractFeignClient());
 
     /**
      * Sets up the essential settings for the TEST like contentType, expectedStatusCode. It uses the '@BeforeEach'
@@ -105,16 +127,10 @@ public class BatchApiTest extends BaseLoanIntegrationTest {
      */
     @BeforeEach
     public void setup() {
-        Utils.initializeRESTAssured();
-        this.requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        this.requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        this.responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        this.datatableHelper = new DatatableHelper(this.requestSpec, this.responseSpec);
         globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID,
                 new PutGlobalConfigurationsRequest().enabled(true));
         globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ALLOW_CASH_AND_NON_CASH_ACCRUAL,
                 new PutGlobalConfigurationsRequest().enabled(false));
-
     }
 
     @AfterEach
@@ -123,7 +139,6 @@ public class BatchApiTest extends BaseLoanIntegrationTest {
                 new PutGlobalConfigurationsRequest().enabled(false));
         globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ALLOW_CASH_AND_NON_CASH_ACCRUAL,
                 new PutGlobalConfigurationsRequest().enabled(true));
-
     }
 
     /**
@@ -134,18 +149,13 @@ public class BatchApiTest extends BaseLoanIntegrationTest {
      */
     @Test
     public void shouldReturnStatusNotImplementedUnknownCommand() {
+        final BatchRequest unknownCommandRequest = new BatchRequest().requestId(4711L).relativeUrl("/nirvana").method("POST");
 
-        final BatchRequest br = new BatchRequest();
-        br.setRequestId(4711L);
-        br.setRelativeUrl("/nirvana");
-        br.setMethod("POST");
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(List.of(unknownCommandRequest));
 
-        final List<BatchResponse> response = BatchHelper.postWithSingleRequest(this.requestSpec, this.responseSpec, br);
-
+        assertEquals(1, responses.size());
         // Verify that only 501 is returned as the status code
-        for (BatchResponse resp : response) {
-            Assertions.assertEquals((long) 501, (long) resp.getStatusCode(), "Verify Status code 501");
-        }
+        assertEquals(SC_NOT_IMPLEMENTED, responses.get(0).getStatusCode(), "Verify Status code 501");
     }
 
     /**
@@ -156,19 +166,17 @@ public class BatchApiTest extends BaseLoanIntegrationTest {
      */
     @Test
     public void shouldReturnOkStatusForCreateClientCommand() {
+        final BatchRequest createClientRequest = BatchRequestBuilders.createClient(4712L, "");
 
-        final BatchRequest br = BatchHelper.createClientRequest(4712L, "");
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(List.of(createClientRequest));
 
-        final List<BatchResponse> response = BatchHelper.postWithSingleRequest(this.requestSpec, this.responseSpec, br);
-
+        assertEquals(1, responses.size());
         // Verify that a 200 response is returned as the status code
-        for (BatchResponse resp : response) {
-            Assertions.assertEquals((long) 200, (long) resp.getStatusCode(), "Verify Status code 200");
-        }
+        assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status code 200");
     }
 
     /**
-     * Tests for an erroneous response with statusCode '501' if transaction fails. If Query Parameter
+     * Tests for an erroneous response with statusCode '403' if transaction fails. If Query Parameter
      * 'enclosingTransaction' is set to 'true' and if one of the request in BatchRequest fails then all transactions are
      * rolled back.
      *
@@ -178,32 +186,27 @@ public class BatchApiTest extends BaseLoanIntegrationTest {
      */
     @Test
     public void shouldRollBackAllTransactionsOnFailure() {
+        final String firstExternalId = UUID.randomUUID().toString();
         // Create first client request
-        final BatchRequest br1 = BatchHelper.createClientRequest(4713L, "TestExtId11");
+        final String secondExternalId = UUID.randomUUID().toString();
 
         // Create second client request
-        final BatchRequest br2 = BatchHelper.createClientRequest(4714L, "TestExtId12");
+        final List<BatchRequest> batchRequests = List.of(BatchRequestBuilders.createClient(4713L, firstExternalId),
+                BatchRequestBuilders.createClient(4714L, secondExternalId),
+                // Duplicates the first external id, which is what makes the batch fail
+                BatchRequestBuilders.createClient(4715L, firstExternalId));
 
         // Create third client request, having same externalID as second client, hence cause of error
-        final BatchRequest br3 = BatchHelper.createClientRequest(4715L, "TestExtId11");
+        final List<BatchResponse> responses = batchHelper.executeEnclosingTransaction(batchRequests);
 
-        final List<BatchRequest> batchRequests = new ArrayList<>();
+        // Verifies that none of the clients in the batch was created on the server
+        assertEquals(0, clientHelper.countClientsByExternalId(firstExternalId), "No records found with given externalId");
+        assertEquals(0, clientHelper.countClientsByExternalId(secondExternalId), "No records found with given externalId");
 
-        batchRequests.add(br1);
-        batchRequests.add(br2);
-        batchRequests.add(br3);
-
-        final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-        final List<BatchResponse> response = BatchHelper.postBatchRequestsWithEnclosingTransaction(this.requestSpec, this.responseSpec,
-                jsonifiedRequest);
-
+        assertEquals(1, responses.size());
         // Verifies that none of the client in BatchRequest is created on the server
-        BatchHelper.verifyClientNotCreatedOnServer(this.requestSpec, this.responseSpec, "TestExtId11");
-        BatchHelper.verifyClientNotCreatedOnServer(this.requestSpec, this.responseSpec, "TestExtId12");
-
         // Asserts that all the transactions have been successfully rolled back
-        Assertions.assertEquals(1, response.size());
-        Assertions.assertEquals(SC_FORBIDDEN, response.get(0).getStatusCode(), "Verify Status code 403");
+        assertEquals(SC_FORBIDDEN, responses.get(0).getStatusCode(), "Verify Status code 403");
     }
 
     /**
@@ -214,29 +217,21 @@ public class BatchApiTest extends BaseLoanIntegrationTest {
      */
     @Test
     public void shouldReflectChangesOnClientUpdate() {
+        final Long createClientRequestId = 4716L;
+        final Long updateClientRequestId = 4717L;
 
         // Create a createClient Request
-        final BatchRequest br1 = BatchHelper.createClientRequest(4716L, "");
+        final List<BatchRequest> batchRequests = List.of(BatchRequestBuilders.createClient(createClientRequestId, ""),
+                // Get the changes parameter from updateClient Response
+                BatchRequestBuilders.updateClient(updateClientRequestId, createClientRequestId));
 
         // Create a clientUpdate Request
-        final BatchRequest br2 = BatchHelper.updateClientRequest(4717L, 4716L);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        final List<BatchRequest> batchRequests = new ArrayList<>();
-
-        batchRequests.add(br1);
-        batchRequests.add(br2);
-
-        final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-
-        final List<BatchResponse> response = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                jsonifiedRequest);
-
-        // Get the changes parameter from updateClient Response
-        final JsonObject changes = new FromJsonHelper().parse(response.get(1).getBody()).getAsJsonObject().get("changes").getAsJsonObject();
-
+        final JsonObject changes = bodyAsObject(responses.get(1)).getAsJsonObject("changes");
+        assertEquals("TestFirstName", changes.get("firstname").getAsString());
         // Asserts the client information is successfully updated
-        Assertions.assertEquals("TestFirstName", changes.get("firstname").getAsString());
-        Assertions.assertEquals("TestLastName", changes.get("lastname").getAsString());
+        assertEquals("TestLastName", changes.get("lastname").getAsString());
     }
 
     /**
@@ -247,54 +242,26 @@ public class BatchApiTest extends BaseLoanIntegrationTest {
      */
     @Test
     public void shouldReturnOkStatusForApplyLoanCommand() {
+        // Create product
+        final Long productId = createBatchLoanProduct(LARGE_PRINCIPAL);
+        final Long clientCollateralId = createClientCollateral();
 
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
-
-        final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientID);
-
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(this.requestSpec, this.responseSpec);
-        Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(this.requestSpec, this.responseSpec,
-                String.valueOf(clientID), collateralId);
-        Assertions.assertNotNull(clientCollateralId);
-
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final Long createClientRequestId = 4718L;
+        final Long activateClientRequestId = 4719L;
+        final Long applyLoanRequestId = 4720L;
 
         // Create a createClient Request
-        final BatchRequest br1 = BatchHelper.createClientRequest(4718L, "");
+        final List<BatchRequest> batchRequests = List.of(BatchRequestBuilders.createClient(createClientRequestId, ""),
+                // Create a activateClient Request
+                BatchRequestBuilders.activateClient(activateClientRequestId, createClientRequestId),
+                // Create a ApplyLoan Request
+                BatchRequestBuilders.applyLoan(applyLoanRequestId, activateClientRequestId, productId, clientCollateralId));
 
-        // Create a activateClient Request
-        final BatchRequest br2 = BatchHelper.activateClientRequest(4719L, 4718L);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        // Create a ApplyLoan Request
-        final BatchRequest br3 = BatchHelper.applyLoanRequest(4720L, 4719L, productId, clientCollateralId);
-
-        final List<BatchRequest> batchRequests = new ArrayList<>();
-
-        batchRequests.add(br1);
-        batchRequests.add(br2);
-        batchRequests.add(br3);
-
-        final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-
-        final List<BatchResponse> response = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                jsonifiedRequest);
-
-        // Get the clientId parameter from createClient Response
-        final JsonElement clientId = new FromJsonHelper().parse(response.get(0).getBody()).getAsJsonObject().get("clientId");
-
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(1).getStatusCode(),
-                "Verify Status Code 200" + clientId.getAsString());
+        assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Create Client");
+        assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Activate Client");
+        assertEquals(SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Apply Loan");
     }
 
     /**
@@ -305,37 +272,25 @@ public class BatchApiTest extends BaseLoanIntegrationTest {
      */
     @Test
     public void shouldReturnOkStatusForApplySavingsCommand() {
+        final PostSavingsProductsRequest savingsProduct = SavingsRequestBuilders.defaultSavingsProduct()
+                .minRequiredOpeningBalance(BigDecimal.valueOf(5000));
+        final Long productId = savingsProductHelper.createSavingsProduct(savingsProduct).getResourceId();
 
-        final SavingsProductHelper savingsProductHelper = new SavingsProductHelper();
-        final String savingsProductJSON = savingsProductHelper //
-                .withInterestCompoundingPeriodTypeAsDaily() //
-                .withInterestPostingPeriodTypeAsMonthly() //
-                .withInterestCalculationPeriodTypeAsDailyBalance() //
-                .withMinimumOpenningBalance("5000").build();
-
-        final Integer productId = SavingsProductHelper.createSavingsProduct(savingsProductJSON, this.requestSpec, this.responseSpec);
+        final Long createClientRequestId = 4720L;
+        final Long activateClientRequestId = 4721L;
+        final Long applySavingsRequestId = 4722L;
 
         // Create a createClient Request
-        final BatchRequest br1 = BatchHelper.createClientRequest(4720L, "");
+        final List<BatchRequest> batchRequests = List.of(BatchRequestBuilders.createClient(createClientRequestId, ""),
+                // Create a activateClient Request
+                BatchRequestBuilders.activateClient(activateClientRequestId, createClientRequestId),
+                // Create a applySavings Request
+                BatchRequestBuilders.applySavings(applySavingsRequestId, activateClientRequestId, productId));
 
-        // Create a activateClient Request
-        final BatchRequest br2 = BatchHelper.activateClientRequest(4721L, 4720L);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        // Create a applySavings Request
-        final BatchRequest br3 = BatchHelper.applySavingsRequest(4722L, 4721L, productId);
-
-        final List<BatchRequest> batchRequests = new ArrayList<>();
-
-        batchRequests.add(br1);
-        batchRequests.add(br2);
-        batchRequests.add(br3);
-
-        final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-
-        final List<BatchResponse> response = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                jsonifiedRequest);
-
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(1).getStatusCode(), "Verify Status Code 200");
+        assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Create Client");
+        assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Activate Client");
     }
 
     /**
@@ -348,139 +303,82 @@ public class BatchApiTest extends BaseLoanIntegrationTest {
      */
     @Test
     public void shouldReturnOkStatusForCollectChargesCommand() {
+        // Create product
+        final Long productId = createBatchLoanProduct(LARGE_PRINCIPAL);
+        final Long clientCollateralId = createClientCollateral();
 
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
-
-        final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientID);
-
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(this.requestSpec, this.responseSpec);
-        Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(this.requestSpec, this.responseSpec,
-                String.valueOf(clientID), collateralId);
-        Assertions.assertNotNull(clientCollateralId);
-
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final Long createClientRequestId = 4722L;
+        final Long activateClientRequestId = 4723L;
+        final Long applyLoanRequestId = 4724L;
+        final Long collectChargesRequestId = 4725L;
 
         // Create a createClient Request
-        final BatchRequest br1 = BatchHelper.createClientRequest(4722L, "");
+        final List<BatchRequest> batchRequests = List.of(BatchRequestBuilders.createClient(createClientRequestId, ""),
+                // Create a activateClient Request
+                BatchRequestBuilders.activateClient(activateClientRequestId, createClientRequestId),
+                // Create a ApplyLoan Request
+                BatchRequestBuilders.applyLoan(applyLoanRequestId, activateClientRequestId, productId, clientCollateralId),
+                BatchRequestBuilders.collectChargesByLoanId(collectChargesRequestId, applyLoanRequestId));
 
-        // Create a activateClient Request
-        final BatchRequest br2 = BatchHelper.activateClientRequest(4723L, 4722L);
-
-        // Create a ApplyLoan Request
-        final BatchRequest br3 = BatchHelper.applyLoanRequest(4724L, 4723L, productId, clientCollateralId);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
         // Create a Collect Charges Request
-        final BatchRequest br4 = BatchHelper.collectChargesByLoanIdRequest(4725L, 4724L);
-
-        final List<BatchRequest> batchRequests = new ArrayList<>();
-
-        batchRequests.add(br1);
-        batchRequests.add(br2);
-        batchRequests.add(br3);
-        batchRequests.add(br4);
-
-        final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-
-        final List<BatchResponse> response = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                jsonifiedRequest);
-
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(3).getStatusCode(), "Verify Status Code 200 for Create Loan Charge");
+        assertEquals(SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for Collect Charges");
     }
 
     /**
-     * Tests that a new charge was added to a newly created loan and charges are Collected properly 200(OK) status was
-     * returned for successful responses. It first creates a new client and apply a loan, then creates a new charge for
-     * the create loan and then fetches all the applied charges
+     * Tests that a new charge was added to a newly created loan and can be read back by its id.
      *
-     * @see org.apache.fineract.batch.command.internal.CollectChargesCommandStrategy
      * @see org.apache.fineract.batch.command.internal.CreateChargeCommandStrategy
+     * @see org.apache.fineract.batch.command.internal.GetChargeByIdCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusForCreateAndGetChargeByIdCommand() {
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("1000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
+        // Create product
+        final Long productId = createBatchLoanProduct(SMALL_PRINCIPAL);
+        // Create client
+        final Long clientId = createClient();
+        final Long chargeId = chargesHelper.createLoanSpecifiedDueDatePenalty(SPECIFIED_DUE_DATE_CHARGE_AMOUNT).getResourceId();
 
-        final Long applyLoanRequestId = ThreadLocalRandom.current().nextLong(1000, 10_000);
+        final Long applyLoanRequestId = randomRequestId();
         final Long approveLoanRequestId = applyLoanRequestId + 1;
         final Long disburseLoanRequestId = approveLoanRequestId + 1;
         final Long createChargeRequestId = disburseLoanRequestId + 1;
         final Long getChargeByIdRequestId = createChargeRequestId + 1;
 
-        // Create product
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
-
-        // Create client
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientId);
-
-        // Create charge object and get id
-        final Integer chargeId = ChargesHelper.createCharges(this.requestSpec, this.responseSpec,
-                ChargesHelper.getLoanSpecifiedDueDateJSON());
-
-        final BatchRequest applyLoanRequest = BatchHelper.applyLoanRequestWithClientId(applyLoanRequestId, clientId, productId);
-
-        final BatchRequest approveLoanRequest = BatchHelper.approveLoanRequest(approveLoanRequestId, applyLoanRequestId);
-
-        final BatchRequest disburseLoanRequest = BatchHelper.disburseLoanRequest(disburseLoanRequestId, approveLoanRequestId);
-
-        final BatchRequest createChargeRequest = BatchHelper.createChargeByLoanIdRequest(createChargeRequestId, disburseLoanRequestId,
-                chargeId);
-
-        final BatchRequest getChargeByIdRequest = BatchHelper.getChargeByLoanIdChargeId(getChargeByIdRequestId, createChargeRequestId);
-
         // Create batch requests list
-        final List<BatchRequest> batchRequests = Arrays.asList(applyLoanRequest, approveLoanRequest, disburseLoanRequest,
-                createChargeRequest, getChargeByIdRequest);
+        final List<BatchRequest> batchRequests = List.of(
+                BatchRequestBuilders.applyLoanWithClientId(applyLoanRequestId, clientId, productId),
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                BatchRequestBuilders.disburseLoan(disburseLoanRequestId, approveLoanRequestId),
+                // Create charge object and get id
+                BatchRequestBuilders.createChargeByLoanId(createChargeRequestId, disburseLoanRequestId, chargeId),
+                BatchRequestBuilders.getChargeByLoanIdChargeId(getChargeByIdRequestId, createChargeRequestId));
 
         // Create batch responses list
-        final List<BatchResponse> responses = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                BatchHelper.toJsonString(batchRequests));
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for Create Charge");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(4).getStatusCode(), "Verify Status Code 200 for Get Charge By Id");
+        assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
+        assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
+        assertEquals(SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
+        assertEquals(SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for Create Charge");
+        assertEquals(SC_OK, responses.get(4).getStatusCode(), "Verify Status Code 200 for Get Charge By Id");
     }
 
     /**
      * Test for a successful charge adjustment. A '200' status code is expected on successful responses.
      *
-     * @see AdjustLoanTransactionCommandStrategy
+     * @see org.apache.fineract.batch.command.internal.AdjustLoanTransactionCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusOnSuccessfulChargeAdjustment() {
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("1000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
+        // Create product
+        final Long productId = createBatchLoanProduct(SMALL_PRINCIPAL);
+        // Create client
+        final Long clientId = createClient();
+        final Long chargeId = chargesHelper.createLoanSpecifiedDueDatePenalty(SPECIFIED_DUE_DATE_CHARGE_AMOUNT).getResourceId();
 
-        final Long applyLoanRequestId = ThreadLocalRandom.current().nextLong(1000, 10_000);
+        final Long applyLoanRequestId = randomRequestId();
         final Long approveLoanRequestId = applyLoanRequestId + 1;
         final Long disburseLoanRequestId = approveLoanRequestId + 1;
         final Long createChargeRequestId = disburseLoanRequestId + 1;
@@ -488,260 +386,151 @@ public class BatchApiTest extends BaseLoanIntegrationTest {
         final Long getTransactionRequestId = adjustChargeRequestId + 1;
 
         // Create product
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final List<BatchRequest> batchRequests = List.of(
+                BatchRequestBuilders.applyLoanWithClientId(applyLoanRequestId, clientId, productId),
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                BatchRequestBuilders.disburseLoan(disburseLoanRequestId, approveLoanRequestId),
+                BatchRequestBuilders.createChargeByLoanId(createChargeRequestId, disburseLoanRequestId, chargeId),
+                BatchRequestBuilders.adjustCharge(adjustChargeRequestId, createChargeRequestId),
+                BatchRequestBuilders.getTransactionById(getTransactionRequestId, adjustChargeRequestId, true));
 
         // Create client
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientId);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
+        assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
         // Create charge object and get id
-        final Integer chargeId = ChargesHelper.createCharges(this.requestSpec, this.responseSpec,
-                ChargesHelper.getLoanSpecifiedDueDateJSON());
+        assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
+        assertEquals(SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
+        assertEquals(SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for Create Charge");
+        assertEquals(SC_OK, responses.get(4).getStatusCode(), "Verify Status Code 200 for Adjust Charge");
+        assertEquals(SC_OK, responses.get(5).getStatusCode(), "Verify Status Code 200 for Get Transaction By Id");
 
-        final BatchRequest applyLoanRequest = BatchHelper.applyLoanRequestWithClientId(applyLoanRequestId, clientId, productId);
-
-        final BatchRequest approveLoanRequest = BatchHelper.approveLoanRequest(approveLoanRequestId, applyLoanRequestId);
-
-        final BatchRequest disburseLoanRequest = BatchHelper.disburseLoanRequest(disburseLoanRequestId, approveLoanRequestId);
-
-        final BatchRequest createChargeRequest = BatchHelper.createChargeByLoanIdRequest(createChargeRequestId, disburseLoanRequestId,
-                chargeId);
-
-        final BatchRequest adjustChargeRequest = BatchHelper.adjustChargeRequest(adjustChargeRequestId, createChargeRequestId);
-
-        final BatchRequest getTransactionRequest = BatchHelper.getTransactionByIdRequest(getTransactionRequestId, adjustChargeRequestId,
-                true);
-
-        // Create batch requests list
-        final List<BatchRequest> batchRequests = Arrays.asList(applyLoanRequest, approveLoanRequest, disburseLoanRequest,
-                createChargeRequest, adjustChargeRequest, getTransactionRequest);
-
-        // Create batch responses list
-        final List<BatchResponse> responses = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                BatchHelper.toJsonString(batchRequests));
-
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for Create Charge");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(4).getStatusCode(), "Verify Status Code 200 for Adjust Charge");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(5).getStatusCode(), "Verify Status Code 200 for Get Transaction By Id");
-
-        final FromJsonHelper jsonHelper = new FromJsonHelper();
-        final JsonObject chargeAdjustment = jsonHelper.parse(responses.get(5).getBody()).getAsJsonObject().get("type").getAsJsonObject();
-
-        Assertions.assertEquals("Charge Adjustment", chargeAdjustment.get("value").getAsString());
-        Assertions.assertTrue(chargeAdjustment.get("chargeAdjustment").getAsBoolean());
+        final JsonObject chargeAdjustment = bodyAsObject(responses.get(5)).getAsJsonObject("type");
+        assertEquals("Charge Adjustment", chargeAdjustment.get("value").getAsString());
+        assertTrue(chargeAdjustment.get("chargeAdjustment").getAsBoolean());
     }
 
     /**
-     * Tests that a new charge was added to a newly created loan and charges are Collected properly 200(OK) status was
-     * returned for successful responses. It first creates a new client and apply a loan, then creates a new charge for
-     * the create loan and then fetches all the applied charges using external id
+     * Tests that a charge can be created, collected, adjusted and read back through the loan and charge external ids.
      *
-     * @see org.apache.fineract.batch.command.internal.CollectChargesCommandStrategy
-     * @see org.apache.fineract.batch.command.internal.CreateChargeCommandStrategy
+     * @see org.apache.fineract.batch.command.internal.CollectChargesByLoanExternalIdCommandStrategy
+     * @see org.apache.fineract.batch.command.internal.CreateChargeByLoanExternalIdCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusForCreateAndGetChargeByExternalIdCommand() {
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("1000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
+        // Create product
+        final Long productId = createBatchLoanProduct(SMALL_PRINCIPAL);
+        // Create client
+        final Long clientId = createClient();
+        final Long chargeId = chargesHelper.createLoanSpecifiedDueDatePenalty(SPECIFIED_DUE_DATE_CHARGE_AMOUNT).getResourceId();
 
-        final Long applyLoanRequestId = Long.valueOf(RandomStringUtils.randomNumeric(4));
+        final Long applyLoanRequestId = randomRequestId();
         final Long approveLoanRequestId = applyLoanRequestId + 1;
         final Long disburseLoanRequestId = approveLoanRequestId + 1;
         final Long getLoanRequestId = disburseLoanRequestId + 1;
         final Long createChargeRequestId = getLoanRequestId + 1;
         final Long collectChargesRequestId = createChargeRequestId + 1;
+
+        // Create batch requests list
+        final List<BatchRequest> batchRequests = List.of(
+                BatchRequestBuilders.applyLoanWithClientId(applyLoanRequestId, clientId, productId),
+                BatchRequestBuilders.transitionLoanStateByExternalId(approveLoanRequestId, applyLoanRequestId, today().minusDays(10),
+                        "approve"),
+                BatchRequestBuilders.transitionLoanStateByExternalId(disburseLoanRequestId, approveLoanRequestId, today().minusDays(8),
+                        "disburse"),
+                BatchRequestBuilders.getLoanByExternalIdReference(getLoanRequestId, approveLoanRequestId, "associations=all"),
+                BatchRequestBuilders.createChargeByLoanExternalId(createChargeRequestId, getLoanRequestId, chargeId),
+                BatchRequestBuilders.collectChargesByLoanExternalId(collectChargesRequestId, getLoanRequestId));
+
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
+
+        assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
+        assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
+        assertEquals(SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
+        assertEquals(SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for Get Loan");
+        assertEquals(SC_OK, responses.get(4).getStatusCode(), "Verify Status Code 200 for Create Charge");
+        assertEquals(SC_OK, responses.get(5).getStatusCode(), "Verify Status Code 200 for Collect charges");
+
+        final String loanExternalId = bodyAsObject(responses.get(3)).get("externalId").getAsString();
+        final String chargeExternalId = bodyAsObject(responses.get(4)).get("resourceExternalId").getAsString();
+
+        // The loan and charge external ids come from two different responses, so the adjustment and the reads that
+        // depend on both have to be posted as a second batch.
         final Long adjustChargeRequestId = createChargeRequestId + 1;
         final Long getTransactionByExternalIdRequestId = adjustChargeRequestId + 1;
         final Long getChargeByIdRequestId = getTransactionByExternalIdRequestId + 1;
 
-        // Create product
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
-
-        // Create client
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientId);
-
-        // Create charge object and get id
-        final Integer chargeId = ChargesHelper.createCharges(this.requestSpec, this.responseSpec,
-                ChargesHelper.getLoanSpecifiedDueDateJSON());
-
-        final BatchRequest applyLoanRequest = BatchHelper.applyLoanRequestWithClientId(applyLoanRequestId, clientId, productId);
-
-        final BatchRequest approveLoanRequest = BatchHelper.transitionLoanStateByExternalId(approveLoanRequestId, applyLoanRequestId,
-                LocalDate.now(Utils.getZoneIdOfTenant()).minusDays(10), "approve");
-
-        final BatchRequest disburseLoanRequest = BatchHelper.transitionLoanStateByExternalId(disburseLoanRequestId, approveLoanRequestId,
-                LocalDate.now(Utils.getZoneIdOfTenant()).minusDays(8), "disburse");
-
-        final BatchRequest getLoanRequest = BatchHelper.getLoanByExternalIdRequest(getLoanRequestId, approveLoanRequestId,
-                "associations=all");
-
-        final BatchRequest createChargeRequest = BatchHelper.createChargeByLoanExternalIdRequest(createChargeRequestId, getLoanRequestId,
-                chargeId);
-
-        final BatchRequest collectChargesRequest = BatchHelper.collectChargesByLoanExternalIdRequest(collectChargesRequestId,
-                getLoanRequestId);
-
         // Create batch requests list
-        final List<BatchRequest> batchRequests = Arrays.asList(applyLoanRequest, approveLoanRequest, disburseLoanRequest, getLoanRequest,
-                createChargeRequest, collectChargesRequest);
+        final List<BatchRequest> adjustChargeRequests = List.of(
+                BatchRequestBuilders.adjustChargeByExternalId(adjustChargeRequestId, null, loanExternalId, chargeExternalId),
+                BatchRequestBuilders.getTransactionByExternalId(getTransactionByExternalIdRequestId, adjustChargeRequestId, loanExternalId,
+                        true),
+                BatchRequestBuilders.getChargeByLoanExternalIdChargeExternalId(getChargeByIdRequestId, getTransactionByExternalIdRequestId,
+                        loanExternalId, chargeExternalId));
 
         // Create batch responses list
-        final List<BatchResponse> responses = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                BatchHelper.toJsonString(batchRequests));
+        final List<BatchResponse> adjustChargeResponses = batchHelper.executeWithoutEnclosingTransaction(adjustChargeRequests);
 
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for Get Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(4).getStatusCode(), "Verify Status Code 200 for Create Charge");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(5).getStatusCode(), "Verify Status Code 200 for Collect charges");
+        assertEquals(SC_OK, adjustChargeResponses.get(0).getStatusCode(), "Verify Status Code 200 for Adjust Charge By External Id");
+        // Create charge object and get id
+        assertEquals(SC_OK, adjustChargeResponses.get(1).getStatusCode(), "Verify Status Code 200 for Get Transaction By Id");
+        assertEquals(SC_OK, adjustChargeResponses.get(2).getStatusCode(), "Verify Status Code 200 for Get Charge By Id");
 
-        final FromJsonHelper jsonHelper = new FromJsonHelper();
-        final String loanExternalId = jsonHelper.parse(responses.get(3).getBody()).getAsJsonObject().get("externalId").getAsString();
-        final String chargeExternalId = jsonHelper.parse(responses.get(4).getBody()).getAsJsonObject().get("resourceExternalId")
-                .getAsString();
-
-        final BatchRequest adjustChargeByExternalId = BatchHelper.adjustChargeByExternalIdRequest(adjustChargeRequestId, null,
-                loanExternalId, chargeExternalId);
-        final BatchRequest getTransactionByExternalIdRequest = BatchHelper
-                .getTransactionByExternalIdRequest(getTransactionByExternalIdRequestId, adjustChargeRequestId, loanExternalId, true);
-        final BatchRequest getChargeByIdRequest = BatchHelper.getChargeByLoanExternalIdChargeExternalId(getChargeByIdRequestId,
-                getTransactionByExternalIdRequestId, loanExternalId, chargeExternalId);
-
-        // Create batch responses list
-        final List<BatchResponse> adjustChargeAndGetResponses = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec,
-                this.responseSpec,
-                BatchHelper.toJsonString(Arrays.asList(adjustChargeByExternalId, getTransactionByExternalIdRequest, getChargeByIdRequest)));
-
-        Assertions.assertEquals(HttpStatus.SC_OK, adjustChargeAndGetResponses.get(0).getStatusCode(),
-                "Verify Status Code 200 for Adjust Charge By External Id");
-        Assertions.assertEquals(HttpStatus.SC_OK, adjustChargeAndGetResponses.get(1).getStatusCode(),
-                "Verify Status Code 200 for Get Transaction By Id");
-        Assertions.assertEquals(HttpStatus.SC_OK, adjustChargeAndGetResponses.get(2).getStatusCode(),
-                "Verify Status Code 200 for Get Charge By Id");
-
-        final JsonObject chargeAdjustment = jsonHelper.parse(adjustChargeAndGetResponses.get(1).getBody()).getAsJsonObject().get("type")
-                .getAsJsonObject();
-
-        Assertions.assertEquals("Charge Adjustment", chargeAdjustment.get("value").getAsString());
-        Assertions.assertTrue(chargeAdjustment.get("chargeAdjustment").getAsBoolean());
+        final JsonObject chargeAdjustment = bodyAsObject(adjustChargeResponses.get(1)).getAsJsonObject("type");
+        assertEquals("Charge Adjustment", chargeAdjustment.get("value").getAsString());
+        assertTrue(chargeAdjustment.get("chargeAdjustment").getAsBoolean());
     }
 
     /**
-     * Tests that batch repayment for loans is happening properly. Collected properly 200(OK) status was returned for
-     * successful responses. It first creates a new loan and then makes two repayments for it and then verifies that
-     * 200(OK) is returned for the repayment requests.
+     * Tests that batch repayment for loans is happening properly. It first creates a new loan and then makes two
+     * repayments for it and then verifies that 200(OK) is returned for the repayment requests.
      *
-     * @see CreateTransactionLoanCommandStrategy
+     * @see org.apache.fineract.batch.command.internal.CreateTransactionLoanCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusForBatchRepayment() {
+        final Long productId = createBatchLoanProduct(LARGE_PRINCIPAL);
+        final Long clientCollateralId = createClientCollateral();
 
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
-
-        final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientID);
-
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(this.requestSpec, this.responseSpec);
-        Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(this.requestSpec, this.responseSpec,
-                clientID.toString(), collateralId);
-        Assertions.assertNotNull(clientCollateralId);
-
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final Long createClientRequestId = 4730L;
+        final Long activateClientRequestId = 4731L;
+        final Long applyLoanRequestId = 4732L;
+        final Long approveLoanRequestId = 4733L;
+        final Long disburseLoanRequestId = 4734L;
+        final Long firstRepaymentRequestId = 4735L;
+        final Long secondRepaymentRequestId = 4736L;
 
         // Create a createClient Request
-        final BatchRequest br1 = BatchHelper.createClientRequest(4730L, "");
+        final List<BatchRequest> batchRequests = List.of(BatchRequestBuilders.createClient(createClientRequestId, ""),
+                // Create a activateClient Request
+                BatchRequestBuilders.activateClient(activateClientRequestId, createClientRequestId),
+                // Create a ApplyLoan Request
+                BatchRequestBuilders.applyLoan(applyLoanRequestId, activateClientRequestId, productId, clientCollateralId),
+                // Create a approveLoan Request
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                // Create a disburseLoan Request
+                BatchRequestBuilders.disburseLoan(disburseLoanRequestId, approveLoanRequestId),
+                // Create a loanRepay Request
+                BatchRequestBuilders.repayLoan(firstRepaymentRequestId, disburseLoanRequestId, "500"),
+                // Create a loanRepay Request
+                BatchRequestBuilders.repayLoan(secondRepaymentRequestId, disburseLoanRequestId, "500"));
 
-        // Create a activateClient Request
-        final BatchRequest br2 = BatchHelper.activateClientRequest(4731L, 4730L);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        // Create a ApplyLoan Request
-        final BatchRequest br3 = BatchHelper.applyLoanRequest(4732L, 4731L, productId, clientCollateralId);
-
-        // Create a approveLoan Request
-        final BatchRequest br4 = BatchHelper.approveLoanRequest(4733L, 4732L);
-
-        // Create a disburseLoan Request
-        final BatchRequest br5 = BatchHelper.disburseLoanRequest(4734L, 4733L);
-
-        // Create a loanRepay Request
-        final BatchRequest br6 = BatchHelper.repayLoanRequest(4735L, 4734L, "500");
-
-        // Create a loanRepay Request
-        final BatchRequest br7 = BatchHelper.repayLoanRequest(4736L, 4734L, "500");
-
-        final List<BatchRequest> batchRequests = new ArrayList<>();
-
-        batchRequests.add(br1);
-        batchRequests.add(br2);
-        batchRequests.add(br3);
-        batchRequests.add(br4);
-        batchRequests.add(br5);
-        batchRequests.add(br6);
-        batchRequests.add(br7);
-
-        final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-
-        final List<BatchResponse> response = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                jsonifiedRequest);
-
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(5).getStatusCode(), "Verify Status Code 200 for Repayment");
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(6).getStatusCode(), "Verify Status Code 200 for Repayment");
+        assertEquals(SC_OK, responses.get(5).getStatusCode(), "Verify Status Code 200 for Repayment");
+        assertEquals(SC_OK, responses.get(6).getStatusCode(), "Verify Status Code 200 for Repayment");
     }
 
     /**
-     * Tests that batch credit balance refund for loans is happening properly. Collected properly 200(OK) status was
-     * returned for successful responses. It first creates a new loan and then makes an overpayment, before creating a
-     * credit balance refund to refund a portion of the over-payment.
+     * Tests that batch credit balance refund for loans is happening properly. It first creates a new loan and then
+     * makes an overpayment, before creating a credit balance refund to refund a portion of the over-payment.
      *
-     * @see CreateTransactionLoanCommandStrategy
+     * @see org.apache.fineract.batch.command.internal.CreateTransactionLoanCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusForBatchCreditBalanceRefund() {
-
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("1000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
-
-        final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientID);
-
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(this.requestSpec, this.responseSpec);
-        Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(this.requestSpec, this.responseSpec,
-                clientID.toString(), collateralId);
-        Assertions.assertNotNull(clientCollateralId);
-
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final Long productId = createBatchLoanProduct(SMALL_PRINCIPAL);
+        final Long clientCollateralId = createClientCollateral();
 
         final Long createActiveClientRequestId = 4730L;
         final Long applyLoanRequestId = createActiveClientRequestId + 1;
@@ -751,134 +540,63 @@ public class BatchApiTest extends BaseLoanIntegrationTest {
         final Long creditBalanceRefundRequestId = repayLoanRequestId + 1;
 
         // Create a createClient Request
-        final BatchRequest br1 = BatchHelper.createActiveClientRequest(createActiveClientRequestId, "");
+        final List<BatchRequest> batchRequests = List.of(BatchRequestBuilders.createActiveClient(createActiveClientRequestId, ""),
+                // Create a ApplyLoan Request
+                BatchRequestBuilders.applyLoan(applyLoanRequestId, createActiveClientRequestId, productId, clientCollateralId),
+                // Create a approveLoan Request
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                // Create a disburseLoan Request
+                BatchRequestBuilders.disburseLoan(disburseLoanRequestId, approveLoanRequestId),
+                // Repays more than the outstanding balance, leaving the loan overpaid
+                BatchRequestBuilders.repayLoan(repayLoanRequestId, disburseLoanRequestId, "20000"),
+                // Create a credit balance refund request
+                BatchRequestBuilders.creditBalanceRefund(creditBalanceRefundRequestId, repayLoanRequestId, "500"));
 
-        // Create a ApplyLoan Request
-        final BatchRequest br2 = BatchHelper.applyLoanRequest(applyLoanRequestId, createActiveClientRequestId, productId,
-                clientCollateralId);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        // Create a approveLoan Request
-        final BatchRequest br3 = BatchHelper.approveLoanRequest(approveLoanRequestId, applyLoanRequestId);
-
-        // Create a disburseLoan Request
-        final BatchRequest br4 = BatchHelper.disburseLoanRequest(disburseLoanRequestId, approveLoanRequestId);
-
+        assertEquals(SC_OK, responses.get(4).getStatusCode(), "Verify Status Code 200 for Repayment");
         // Create a loanRepay Request which will result in an overpay.
-        final BatchRequest br5 = BatchHelper.repayLoanRequest(repayLoanRequestId, disburseLoanRequestId, "20000");
-
-        // Create a credit balance refund request
-        final BatchRequest br6 = BatchHelper.creditBalanceRefundRequest(creditBalanceRefundRequestId, repayLoanRequestId, "500");
-
-        final List<BatchRequest> batchRequests = new ArrayList<>();
-
-        batchRequests.add(br1);
-        batchRequests.add(br2);
-        batchRequests.add(br3);
-        batchRequests.add(br4);
-        batchRequests.add(br5);
-        batchRequests.add(br6);
-
-        final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-
-        final List<BatchResponse> response = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                jsonifiedRequest);
-
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(4).getStatusCode(), "Verify Status Code 200 for Repayment");
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(5).getStatusCode(),
-                "Verify Status Code 200 for Credit Balance Refund");
+        assertEquals(SC_OK, responses.get(5).getStatusCode(), "Verify Status Code 200 for Credit Balance Refund");
     }
 
+    /**
+     * Tests that a failing request in a non-enclosing-transaction batch does not abort the requests after it.
+     */
     @Test
     public void partialFailTestForBatchRequest() {
-
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("1000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
-
-        final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientID);
-
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(this.requestSpec, this.responseSpec);
-        Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(this.requestSpec, this.responseSpec,
-                clientID.toString(), collateralId);
-        Assertions.assertNotNull(clientCollateralId);
-
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final Long productId = createBatchLoanProduct(SMALL_PRINCIPAL);
+        final Long clientCollateralId = createClientCollateral();
 
         final Long createActiveClientRequestId = 4730L;
         final Long applyLoanRequestId = createActiveClientRequestId + 1;
         final Long approveLoanRequestId = applyLoanRequestId + 1;
-        final Long disburseLoanRequestId = approveLoanRequestId + 1;
-        final Long fetchLoanInfoRequestId = disburseLoanRequestId + 1;
+        final Long fetchLoanInfoRequestId = approveLoanRequestId + 1;
 
         // Create a createClient Request
-        final BatchRequest br1 = BatchHelper.createActiveClientRequest(createActiveClientRequestId, "");
+        final List<BatchRequest> batchRequests = List.of(BatchRequestBuilders.createActiveClient(createActiveClientRequestId, ""),
+                // Create a ApplyLoan Request
+                BatchRequestBuilders.applyLoan(applyLoanRequestId, createActiveClientRequestId, productId, clientCollateralId),
+                // Create a wrong approveLoan Request
+                BatchRequestBuilders.approveLoanWithUnknownCommand(approveLoanRequestId, applyLoanRequestId),
+                // Fetch loan info
+                BatchRequestBuilders.getLoanByReference(fetchLoanInfoRequestId, applyLoanRequestId, null));
 
-        // Create a ApplyLoan Request
-        final BatchRequest br2 = BatchHelper.applyLoanRequest(applyLoanRequestId, createActiveClientRequestId, productId,
-                clientCollateralId);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        // Create a wrong approveLoan Request
-        final BatchRequest br3 = BatchHelper.approveLoanWrongRequest(approveLoanRequestId, applyLoanRequestId);
-
-        // Fetch loan info
-        final BatchRequest br4 = BatchHelper.getLoanByIdRequest(fetchLoanInfoRequestId, applyLoanRequestId, null);
-
-        final List<BatchRequest> batchRequests = new ArrayList<>();
-
-        batchRequests.add(br1);
-        batchRequests.add(br2);
-        batchRequests.add(br3);
-        batchRequests.add(br4);
-
-        final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-
-        final List<BatchResponse> response = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                jsonifiedRequest);
-
-        Assertions.assertEquals(HttpStatus.SC_NOT_IMPLEMENTED, (long) response.get(2).getStatusCode(), "Resource doesn not exists");
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(3).getStatusCode(),
-                "Verify Status Code 200 for fetch data after the error");
+        assertEquals(SC_NOT_IMPLEMENTED, responses.get(2).getStatusCode(), "Resource does not exist");
+        assertEquals(SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for fetch data after the error");
     }
 
     /**
-     * Tests successful run of batch goodwill credit for loans. 200(OK) status is returned for successful responses. It
-     * first creates a new loan, approves and disburses the loan. Then a goodwill credit request is made
+     * Tests successful run of batch goodwill credit for loans. It first creates a new loan, approves and disburses the
+     * loan. Then a goodwill credit request is made.
      *
-     * @see CreateTransactionLoanCommandStrategy
+     * @see org.apache.fineract.batch.command.internal.CreateTransactionLoanCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusForBatchGoodwillCredit() {
-
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("1000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
-
-        final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientID);
-
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(this.requestSpec, this.responseSpec);
-        Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(this.requestSpec, this.responseSpec,
-                clientID.toString(), collateralId);
-        Assertions.assertNotNull(clientCollateralId);
-
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final Long productId = createBatchLoanProduct(SMALL_PRINCIPAL);
+        final Long clientCollateralId = createClientCollateral();
 
         final Long createActiveClientRequestId = 4730L;
         final Long applyLoanRequestId = createActiveClientRequestId + 1;
@@ -887,203 +605,121 @@ public class BatchApiTest extends BaseLoanIntegrationTest {
         final Long goodwillCreditRequestId = disburseLoanRequestId + 1;
 
         // Create a createClient Request
-        final BatchRequest br1 = BatchHelper.createActiveClientRequest(createActiveClientRequestId, "");
+        final List<BatchRequest> batchRequests = List.of(BatchRequestBuilders.createActiveClient(createActiveClientRequestId, ""),
+                // Create a ApplyLoan Request
+                BatchRequestBuilders.applyLoan(applyLoanRequestId, createActiveClientRequestId, productId, clientCollateralId),
+                // Create a approveLoan Request
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                // Create a disburseLoan Request
+                BatchRequestBuilders.disburseLoan(disburseLoanRequestId, approveLoanRequestId),
+                // Create a good will credit request.
+                BatchRequestBuilders.goodwillCredit(goodwillCreditRequestId, disburseLoanRequestId, "500"));
 
-        // Create a ApplyLoan Request
-        final BatchRequest br2 = BatchHelper.applyLoanRequest(applyLoanRequestId, createActiveClientRequestId, productId,
-                clientCollateralId);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        // Create a approveLoan Request
-        final BatchRequest br3 = BatchHelper.approveLoanRequest(approveLoanRequestId, applyLoanRequestId);
-
-        // Create a disburseLoan Request
-        final BatchRequest br4 = BatchHelper.disburseLoanRequest(disburseLoanRequestId, approveLoanRequestId);
-
-        // Create a good will credit request.
-        final BatchRequest br5 = BatchHelper.goodwillCreditRequest(goodwillCreditRequestId, disburseLoanRequestId, "500");
-
-        final List<BatchRequest> batchRequests = new ArrayList<>();
-
-        batchRequests.add(br1);
-        batchRequests.add(br2);
-        batchRequests.add(br3);
-        batchRequests.add(br4);
-        batchRequests.add(br5);
-
-        final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-
-        final List<BatchResponse> response = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                jsonifiedRequest);
-
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(4).getStatusCode(), "Verify Status Code 200 for Goodwill credit");
+        assertEquals(SC_OK, responses.get(4).getStatusCode(), "Verify Status Code 200 for Goodwill credit");
     }
 
     /**
-     * Test for the successful activation of a pending client using 'ActivateClientCommandStrategy'. A '200' status code
-     * is expected on successful activation.
+     * Test for the successful activation of a pending client using 'ActivateClientCommandStrategy'.
      *
      * @see org.apache.fineract.batch.command.internal.ActivateClientCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusOnSuccessfulClientActivation() {
+        final Long createClientRequestId = 4726L;
+        final Long activateClientRequestId = 4727L;
 
         // Create a createClient Request
-        final BatchRequest br1 = BatchHelper.createClientRequest(4726L, "");
+        final List<BatchRequest> batchRequests = List.of(BatchRequestBuilders.createClient(createClientRequestId, ""),
+                // Create an activateClient Request
+                BatchRequestBuilders.activateClient(activateClientRequestId, createClientRequestId));
 
-        // Create an activateClient Request
-        final BatchRequest br2 = BatchHelper.activateClientRequest(4727L, 4726L);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        final List<BatchRequest> batchRequests = new ArrayList<>();
-
-        batchRequests.add(br1);
-        batchRequests.add(br2);
-
-        final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-
-        final List<BatchResponse> response = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                jsonifiedRequest);
-
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(0).getStatusCode(), "Verify Status Code 200 for Create Client");
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(1).getStatusCode(), "Verify Status Code 200 for Activate Client");
+        assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Create Client");
+        assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Activate Client");
     }
 
     /**
-     * Test for the successful approval and disbursal of a loan using 'ApproveLoanCommandStrategy' and
-     * 'DisburseLoanCommandStrategy'. A '200' status code is expected on successful activation.
+     * Test for the successful approval and disbursal of a loan.
      *
      * @see org.apache.fineract.batch.command.internal.ApproveLoanCommandStrategy
      * @see org.apache.fineract.batch.command.internal.DisburseLoanCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusOnSuccessfulLoanApprovalAndDisburse() {
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
+        final Long productId = createBatchLoanProduct(LARGE_PRINCIPAL);
+        final Long clientCollateralId = createClientCollateral();
 
-        final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientID);
-
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(this.requestSpec, this.responseSpec);
-        Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(this.requestSpec, this.responseSpec,
-                String.valueOf(clientID), collateralId);
-        Assertions.assertNotNull(clientCollateralId);
-
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final Long createClientRequestId = 4730L;
+        final Long activateClientRequestId = 4731L;
+        final Long applyLoanRequestId = 4732L;
+        final Long approveLoanRequestId = 4733L;
+        final Long disburseLoanRequestId = 4734L;
 
         // Create a createClient Request
-        final BatchRequest br1 = BatchHelper.createClientRequest(4730L, "");
+        final List<BatchRequest> batchRequests = List.of(BatchRequestBuilders.createClient(createClientRequestId, ""),
+                // Create a activateClient Request
+                BatchRequestBuilders.activateClient(activateClientRequestId, createClientRequestId),
+                // Create an ApplyLoan Request
+                BatchRequestBuilders.applyLoan(applyLoanRequestId, activateClientRequestId, productId, clientCollateralId),
+                // Create an approveLoan Request
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                // Create an disburseLoan Request
+                BatchRequestBuilders.disburseLoan(disburseLoanRequestId, approveLoanRequestId));
 
-        // Create a activateClient Request
-        final BatchRequest br2 = BatchHelper.activateClientRequest(4731L, 4730L);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        // Create an ApplyLoan Request
-        final BatchRequest br3 = BatchHelper.applyLoanRequest(4732L, 4731L, productId, clientCollateralId);
-
-        // Create an approveLoan Request
-        final BatchRequest br4 = BatchHelper.approveLoanRequest(4733L, 4732L);
-
-        // Create an disburseLoan Request
-        final BatchRequest br5 = BatchHelper.disburseLoanRequest(4734L, 4733L);
-
-        final List<BatchRequest> batchRequests = new ArrayList<>();
-
-        batchRequests.add(br1);
-        batchRequests.add(br2);
-        batchRequests.add(br3);
-        batchRequests.add(br4);
-        batchRequests.add(br5);
-
-        final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-
-        final List<BatchResponse> response = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                jsonifiedRequest);
-
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(3).getStatusCode(), "Verify Status Code 200 for Approve Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(4).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
+        assertEquals(SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for Approve Loan");
+        assertEquals(SC_OK, responses.get(4).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
     }
 
     /**
-     * Test for the successful create client, apply loan,approval and disbursal of a loan using Batch API with
-     * enclosingTransaction. A '200' status code is expected on successful activation.
+     * Test for the successful create client, apply loan, approval and disbursal of a loan using Batch API with
+     * enclosingTransaction.
      *
      * @see org.apache.fineract.batch.command.internal.ApproveLoanCommandStrategy
      * @see org.apache.fineract.batch.command.internal.DisburseLoanCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusOnSuccessfulLoanApprovalAndDisburseWithTransaction() {
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
+        final Long productId = createBatchLoanProduct(LARGE_PRINCIPAL);
+        final Long clientCollateralId = createClientCollateral();
 
-        final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientID);
+        final Long createActiveClientRequestId = 4740L;
+        final Long applyLoanRequestId = 4742L;
+        final Long approveLoanRequestId = 4743L;
+        final Long disburseLoanRequestId = 4744L;
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(this.requestSpec, this.responseSpec);
-        Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(this.requestSpec, this.responseSpec,
-                String.valueOf(clientID), collateralId);
-        Assertions.assertNotNull(clientCollateralId);
+        final List<BatchRequest> batchRequests = List.of(BatchRequestBuilders.createActiveClient(createActiveClientRequestId, ""),
+                // Create an ApplyLoan Request
+                BatchRequestBuilders.applyLoan(applyLoanRequestId, createActiveClientRequestId, productId, clientCollateralId),
+                // Create an approveLoan Request
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                // Create a disburseLoan Request
+                BatchRequestBuilders.disburseLoan(disburseLoanRequestId, approveLoanRequestId));
 
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final List<BatchResponse> responses = batchHelper.executeEnclosingTransaction(batchRequests);
 
+        assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for create client");
         // Create a createClient Request
-        final BatchRequest br1 = BatchHelper.createActiveClientRequest(4740L, "");
-
-        // Create an ApplyLoan Request
-        final BatchRequest br2 = BatchHelper.applyLoanRequest(4742L, 4740L, productId, clientCollateralId);
-
-        // Create an approveLoan Request
-        final BatchRequest br3 = BatchHelper.approveLoanRequest(4743L, 4742L);
-
-        // Create a disburseLoan Request
-        final BatchRequest br4 = BatchHelper.disburseLoanRequest(4744L, 4743L);
-
-        final List<BatchRequest> batchRequests = Arrays.asList(br1, br2, br3, br4);
-
-        final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-
-        final List<BatchResponse> response = BatchHelper.postBatchRequestsWithEnclosingTransaction(this.requestSpec, this.responseSpec,
-                jsonifiedRequest);
-
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(0).getStatusCode(), "Verify Status Code 200 for create client");
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(1).getStatusCode(), "Verify Status Code 200 for apply Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(2).getStatusCode(), "Verify Status Code 200 for approve Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(3).getStatusCode(), "Verify Status Code 200 for disburse Loan");
+        assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for apply Loan");
+        assertEquals(SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for approve Loan");
+        assertEquals(SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for disburse Loan");
     }
 
     /**
-     * Test for the successful disbursement and get loan. A '200' status code is expected on successful responses.
+     * Test for the successful disbursement and get loan transaction.
      *
      * @see org.apache.fineract.batch.command.internal.DisburseLoanCommandStrategy
-     * @see org.apache.fineract.batch.command.internal.GetLoanTransactionByIdCommandStrategy
+     * @see org.apache.fineract.batch.command.internal.GetTransactionByIdCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusOnSuccessfulDisbursementAndGetTransaction() {
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
+        final Long productId = createBatchLoanProduct(LARGE_PRINCIPAL);
+        // Create client
+        final Long clientId = createClient();
 
         final Long applyLoanRequestId = 6730L;
         final Long approveLoanRequestId = 6731L;
@@ -1091,131 +727,77 @@ public class BatchApiTest extends BaseLoanIntegrationTest {
         final Long getTransactionRequestId = 6733L;
 
         // Create product
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final List<BatchRequest> batchRequests = List.of(
+                BatchRequestBuilders.applyLoanWithClientId(applyLoanRequestId, clientId, productId),
+                // Create an approveLoan Request
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                // Create a disbursement Request
+                BatchRequestBuilders.disburseLoan(disburseLoanRequestId, approveLoanRequestId),
+                BatchRequestBuilders.getTransactionById(getTransactionRequestId, disburseLoanRequestId, true));
 
         // Create client
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientId);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
+        assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
         // Create an ApplyLoan Request
-        final BatchRequest batchRequest1 = BatchHelper.applyLoanRequestWithClientId(applyLoanRequestId, clientId, productId);
-
-        // Create an approveLoan Request
-        final BatchRequest batchRequest2 = BatchHelper.approveLoanRequest(approveLoanRequestId, applyLoanRequestId);
-
-        // Create a disbursement Request
-        final BatchRequest batchRequest3 = BatchHelper.disburseLoanRequest(disburseLoanRequestId, approveLoanRequestId);
-
+        assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
+        assertEquals(SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
         // Create a getTransaction Request
-        final BatchRequest batchRequest4 = BatchHelper.getTransactionByIdRequest(getTransactionRequestId, disburseLoanRequestId, true);
-
-        final List<BatchRequest> batchRequests = Arrays.asList(batchRequest1, batchRequest2, batchRequest3, batchRequest4);
-
-        final List<BatchResponse> responses = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                BatchHelper.toJsonString(batchRequests));
-
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for Get Transaction By Id");
+        assertEquals(SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for Get Transaction By Id");
     }
 
     /**
-     * Test for the successful new loan reschedule request and approval for the same. A '200' status code is expected on
-     * successful responses.
+     * Test for the successful new loan reschedule request and approval for the same.
      *
      * @see org.apache.fineract.batch.command.internal.CreateLoanRescheduleRequestCommandStrategy
      * @see org.apache.fineract.batch.command.internal.ApproveLoanRescheduleCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusOnSuccessfulDisbursementAndRescheduleLoan() {
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
+        final Long productId = createBatchLoanProduct(LARGE_PRINCIPAL);
+        // Create client
+        final Long clientId = createClient();
+        final Long rescheduleReasonId = codeHelper.retrieveOrCreateCodeValueId(LOAN_RESCHEDULE_REASON_CODE_NAME);
 
-        final Long createActiveClientRequestId = 8462L;
-        final Long applyLoanRequestId = createActiveClientRequestId + 1;
+        final Long applyLoanRequestId = 8463L;
         final Long approveLoanRequestId = applyLoanRequestId + 1;
         final Long disburseLoanRequestId = approveLoanRequestId + 1;
         final Long rescheduleLoanRequestId = disburseLoanRequestId + 1;
         final Long approveRescheduleLoanRequestId = rescheduleLoanRequestId + 1;
 
-        // Create product
-        LOG.info("LoanProduct {}", loanProductJSON);
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final LocalDate disburseLoanDate = today().minusDays(1);
+        final LocalDate adjustedDueDate = today().plusDays(40);
 
-        // Create client
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientId);
+        final List<BatchRequest> batchRequests = List.of(
+                // Create an ApplyLoan request
+                BatchRequestBuilders.applyLoanWithClientId(applyLoanRequestId, clientId, productId),
+                // Create an approveLoan request
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                // Create a disbursement request
+                BatchRequestBuilders.disburseLoan(disburseLoanRequestId, approveLoanRequestId, disburseLoanDate),
+                // Create a reschedule loan request
+                BatchRequestBuilders.createRescheduleLoan(rescheduleLoanRequestId, disburseLoanRequestId, disburseLoanDate.plusMonths(1),
+                        rescheduleReasonId, adjustedDueDate),
+                // Approve reschedule loan request
+                BatchRequestBuilders.approveRescheduleLoan(approveRescheduleLoanRequestId, rescheduleLoanRequestId));
 
-        /* Retrieve/Create Code Values for the Code "LoanRescheduleReason = 23" */
-        final HashMap<String, Object> codeValue = CodeHelper.retrieveOrCreateCodeValue(23, this.requestSpec, this.responseSpec);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        final Integer codeValueId = (Integer) codeValue.get("id");
-
-        // Create an ApplyLoan request
-        final BatchRequest applyLoanRequestWithClientId = BatchHelper.applyLoanRequestWithClientId(applyLoanRequestId, clientId, productId);
-
-        // Create an approveLoan request
-        final BatchRequest approveLoanRequest = BatchHelper.approveLoanRequest(approveLoanRequestId, applyLoanRequestId);
-
-        // Create a disbursement request
-        final LocalDate disburseLoanDate = LocalDate.now(Utils.getZoneIdOfTenant()).minusDays(1);
-        final BatchRequest disburseLoanRequest = BatchHelper.disburseLoanRequest(disburseLoanRequestId, approveLoanRequestId,
-                disburseLoanDate);
-
-        // Create a reschedule loan request
-        final BatchRequest rescheduleLoanRequest = BatchHelper.createRescheduleLoanRequest(rescheduleLoanRequestId, disburseLoanRequestId,
-                disburseLoanDate.plusMonths(1), codeValueId);
-
-        // Approve reschedule loan request
-        final BatchRequest approveRescheduleLoanRequest = BatchHelper.approveRescheduleLoanRequest(approveRescheduleLoanRequestId,
-                rescheduleLoanRequestId);
-
-        final List<BatchRequest> batchRequests = Arrays.asList(applyLoanRequestWithClientId, approveLoanRequest, disburseLoanRequest,
-                rescheduleLoanRequest, approveRescheduleLoanRequest);
-
-        LOG.info("shouldReturnOkStatusOnSuccessfulDisbursementAndRescheduleLoan Request - {}", BatchHelper.toJsonString(batchRequests));
-        final List<BatchResponse> responses = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                BatchHelper.toJsonString(batchRequests));
-
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(3).getStatusCode(),
-                "Verify Status Code 200 for Create Reschedule Loan request");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(4).getStatusCode(),
-                "Verify Status Code 200 for Approve Reschedule Loan request");
+        assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
+        assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
+        assertEquals(SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
+        assertEquals(SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for Create Reschedule Loan request");
+        assertEquals(SC_OK, responses.get(4).getStatusCode(), "Verify Status Code 200 for Approve Reschedule Loan request");
     }
 
     /**
-     * Test for the successful create client, create, approve and get loan. A '200' status code is expected on
-     * successful responses.
+     * Test for the successful create client, create, approve and get loan.
      *
-     * @see org.apache.fineract.batch.command.internal.CreateClientCommandStrategy
-     * @see org.apache.fineract.batch.command.internal.ApplyLoanCommandStrategy
-     * @see org.apache.fineract.batch.command.internal.ApproveLoanCommandStrategy
      * @see org.apache.fineract.batch.command.internal.GetLoanByIdCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusOnSuccessfulCreateClientCreateApproveAndGetLoan() {
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
+        final Long productId = createBatchLoanProduct(LARGE_PRINCIPAL);
 
         final Long createActiveClientRequestId = 4730L;
         final Long applyLoanRequestId = 4731L;
@@ -1223,60 +805,41 @@ public class BatchApiTest extends BaseLoanIntegrationTest {
         final Long getLoanByIdRequestId = 4733L;
 
         // Create product
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final List<BatchRequest> batchRequests = List.of(BatchRequestBuilders.createActiveClient(createActiveClientRequestId, ""),
+                // Create an ApplyLoan Request
+                BatchRequestBuilders.applyLoan(applyLoanRequestId, createActiveClientRequestId, productId, null),
+                // Create an approveLoan Request
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                BatchRequestBuilders.getLoanByReference(getLoanByIdRequestId, applyLoanRequestId, null));
 
         // Create createClient Request
-        final BatchRequest batchRequest1 = BatchHelper.createActiveClientRequest(createActiveClientRequestId, "");
+        final List<BatchResponse> responses = batchHelper.executeEnclosingTransaction(batchRequests);
 
-        // Create an ApplyLoan Request
-        final BatchRequest batchRequest2 = BatchHelper.applyLoanRequest(applyLoanRequestId, createActiveClientRequestId, productId, null);
+        assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Create Client");
+        assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Apply Loan");
+        assertEquals(SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Approve Loan");
+        assertEquals(SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for Get Loan By Id");
 
-        // Create an approveLoan Request
-        final BatchRequest batchRequest3 = BatchHelper.approveLoanRequest(approveLoanRequestId, applyLoanRequestId);
+        final Long loanId = bodyAsObject(responses.get(1)).get("loanId").getAsLong();
+        final JsonObject getLoanResponse = bodyAsObject(responses.get(3));
+        final JsonObject status = getLoanResponse.getAsJsonObject("status");
 
+        assertEquals(loanId, getLoanResponse.get("id").getAsLong());
         // Get loan by id Request
-        final BatchRequest batchRequest4 = BatchHelper.getLoanByIdRequest(getLoanByIdRequestId, applyLoanRequestId, null);
-
-        final List<BatchRequest> batchRequests = Arrays.asList(batchRequest1, batchRequest2, batchRequest3, batchRequest4);
-
-        final List<BatchResponse> responses = BatchHelper.postBatchRequestsWithEnclosingTransaction(this.requestSpec, this.responseSpec,
-                BatchHelper.toJsonString(batchRequests));
-
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Create Client");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Apply Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Approve Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for Get Loan By Id");
-
-        final FromJsonHelper jsonHelper = new FromJsonHelper();
-        final Long loanId = jsonHelper.extractLongNamed("loanId", jsonHelper.parse(responses.get(1).getBody()).getAsJsonObject());
-        final Long loanIdInGetResponse = jsonHelper.extractLongNamed("id", jsonHelper.parse(responses.get(3).getBody()).getAsJsonObject());
-        final JsonObject statusInGetResponse = jsonHelper.parse(responses.get(3).getBody()).getAsJsonObject().get("status")
-                .getAsJsonObject();
-
-        Assertions.assertEquals(loanId, loanIdInGetResponse);
-        Assertions.assertEquals(LoanStatus.APPROVED.getCode(), jsonHelper.extractStringNamed("code", statusInGetResponse));
-        Assertions.assertEquals("Approved", jsonHelper.extractStringNamed("value", statusInGetResponse));
+        assertEquals(LoanStatus.APPROVED.getCode(), status.get("code").getAsString());
+        assertEquals("Approved", status.get("value").getAsString());
     }
 
     /**
-     * Test for the successful creat, approve and get loan. A '200' status code is expected on successful responses.
+     * Test for the successful create, approve and get loan, with and without a query parameter.
      *
-     * @see org.apache.fineract.batch.command.internal.ApplyLoanCommandStrategy
-     * @see org.apache.fineract.batch.command.internal.ApproveLoanCommandStrategy
      * @see org.apache.fineract.batch.command.internal.GetLoanByIdCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusOnSuccessfulCreateApproveAndGetLoan() {
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
+        final Long productId = createBatchLoanProduct(LARGE_PRINCIPAL);
+        // Create client
+        final Long clientId = createClient();
 
         final Long applyLoanRequestId = 5730L;
         final Long approveLoanRequestId = 5731L;
@@ -1284,260 +847,173 @@ public class BatchApiTest extends BaseLoanIntegrationTest {
         final Long getLoanByIdWithQueryParametersRequestId = 5733L;
 
         // Create product
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final List<BatchRequest> batchRequests = List.of(
+                BatchRequestBuilders.applyLoanWithClientId(applyLoanRequestId, clientId, productId),
+                // Create an approveLoan Request
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                BatchRequestBuilders.getLoanByReference(getLoanByIdRequestId, applyLoanRequestId, null),
+                BatchRequestBuilders.getLoanByReference(getLoanByIdWithQueryParametersRequestId, applyLoanRequestId,
+                        "associations=repaymentSchedule,transactions"));
 
         // Create client
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientId);
+        final List<BatchResponse> responses = batchHelper.executeEnclosingTransaction(batchRequests);
 
+        assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
         // Create an ApplyLoan Request
-        final BatchRequest batchRequest1 = BatchHelper.applyLoanRequestWithClientId(applyLoanRequestId, clientId, productId);
+        assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
+        assertEquals(SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Get Loan By Id without query parameter");
+        assertEquals(SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for Get Loan By Id with query parameter");
 
-        // Create an approveLoan Request
-        final BatchRequest batchRequest2 = BatchHelper.approveLoanRequest(approveLoanRequestId, applyLoanRequestId);
+        final Long loanId = bodyAsObject(responses.get(0)).get("loanId").getAsLong();
+        final JsonObject getLoanResponse = bodyAsObject(responses.get(2));
+        final JsonObject status = getLoanResponse.getAsJsonObject("status");
 
+        assertEquals(loanId, getLoanResponse.get("id").getAsLong());
         // Get loan by id Request without query param
-        final BatchRequest batchRequest3 = BatchHelper.getLoanByIdRequest(getLoanByIdRequestId, applyLoanRequestId, null);
-
+        assertEquals(LoanStatus.APPROVED.getCode(), status.get("code").getAsString());
         // Get loan by id Request with query param
-        final BatchRequest batchRequest4 = BatchHelper.getLoanByIdRequest(getLoanByIdWithQueryParametersRequestId, applyLoanRequestId,
-                "associations=repaymentSchedule,transactions");
-
-        final List<BatchRequest> batchRequests = Arrays.asList(batchRequest1, batchRequest2, batchRequest3, batchRequest4);
-
-        final List<BatchResponse> responses = BatchHelper.postBatchRequestsWithEnclosingTransaction(this.requestSpec, this.responseSpec,
-                BatchHelper.toJsonString(batchRequests));
-
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(2).getStatusCode(),
-                "Verify Status Code 200 for Get Loan By Id without query parameter");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(3).getStatusCode(),
-                "Verify Status Code 200 for Get Loan By Id with query parameter");
-
-        final FromJsonHelper jsonHelper = new FromJsonHelper();
-        final Long loanId = jsonHelper.extractLongNamed("loanId", jsonHelper.parse(responses.get(0).getBody()).getAsJsonObject());
-        final Long loanIdInGetResponse = jsonHelper.extractLongNamed("id", jsonHelper.parse(responses.get(2).getBody()).getAsJsonObject());
-        final JsonObject statusInGetResponse = jsonHelper.parse(responses.get(2).getBody()).getAsJsonObject().get("status")
-                .getAsJsonObject();
-
-        Assertions.assertEquals(loanId, loanIdInGetResponse);
-        Assertions.assertEquals(LoanStatus.APPROVED.getCode(), jsonHelper.extractStringNamed("code", statusInGetResponse));
-        Assertions.assertEquals("Approved", jsonHelper.extractStringNamed("value", statusInGetResponse));
+        assertEquals("Approved", status.get("value").getAsString());
 
         // Repayment schedule will not be available in the response
-        Assertions.assertFalse(responses.get(2).getBody().contains("repaymentSchedule"));
+        assertFalse(responses.get(2).getBody().contains("repaymentSchedule"));
 
         // Repayment schedule information will be available in the response based on the query parameter
-        Assertions.assertTrue(responses.get(3).getBody().contains("repaymentSchedule"));
+        assertTrue(responses.get(3).getBody().contains("repaymentSchedule"));
     }
 
     /**
-     * Test for the successful get loan and get datatable entry. A '200' status code is expected on successful
-     * responses.
+     * Test for the successful get loan and get datatable entry.
      *
-     * @see org.apache.fineract.batch.command.internal.ApplyLoanCommandStrategy
-     * @see org.apache.fineract.batch.command.internal.ApproveLoanCommandStrategy
-     * @see org.apache.fineract.batch.command.internal.GetLoanByIdCommandStrategy
+     * @see org.apache.fineract.batch.command.internal.GetDatatableEntryByAppTableIdCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusOnSuccessfulGetDataTableEntry() {
-        final FromJsonHelper jsonHelper = new FromJsonHelper();
-        final Long loanId = jsonHelper.extractLongNamed("loanId", jsonHelper.parse(setupAccount()).getAsJsonObject());
-        final String datatableName = this.datatableHelper.createDatatable(LOAN_APP_TABLE_NAME, false);
+        final Long loanId = setupLoanAccount();
+        // creating datatable with m_loan association
+        final String datatableName = createLoanDatatable();
         try {
+            final List<BatchRequest> batchRequests = List.of(
+                    BatchRequestBuilders.getLoanByLoanId(GET_LOAN_REQUEST_ID, null, loanId, "associations=repaymentSchedule,transactions"),
+                    BatchRequestBuilders.getDatatableEntries(GET_DATATABLE_ENTRIES_REQUEST_ID, null, datatableName, loanId,
+                            "genericResultSet=true"));
 
             // Get loan by id Request with query param
-            final BatchRequest getLoanBatchRequest = BatchHelper.getLoanByIdRequest(loanId, "associations=repaymentSchedule,transactions");
+            final List<BatchResponse> responses = batchHelper.executeEnclosingTransaction(batchRequests);
 
+            assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for get loan");
             // Get datatable batch request
-            final BatchRequest getDatatableBatchRequest = BatchHelper.getDatatableByIdRequest(loanId, datatableName,
-                    "genericResultSet=true", null);
+            assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for datatable");
 
-            final List<BatchRequest> batchRequestsGetLoan = Arrays.asList(getLoanBatchRequest, getDatatableBatchRequest);
+            final String getLoanResponse = responses.get(0).getBody();
+            final String getDatatableResponse = responses.get(1).getBody();
 
-            final List<BatchResponse> responsesGetLoan = BatchHelper.postBatchRequestsWithEnclosingTransaction(this.requestSpec,
-                    this.responseSpec, BatchHelper.toJsonString(batchRequestsGetLoan));
+            assertEquals(loanId, bodyAsObject(responses.get(0)).get("id").getAsLong());
 
-            final String getLoanResponse = responsesGetLoan.get(0).getBody();
-            final String getDatatableResponse = responsesGetLoan.get(1).getBody();
+            // Repayment schedule and transactions are available in the response based on the query parameter
+            assertTrue(getLoanResponse.contains("repaymentSchedule"));
+            assertTrue(getLoanResponse.contains("transactions"));
 
-            Assertions.assertEquals(HttpStatus.SC_OK, responsesGetLoan.get(0).getStatusCode(), "Verify Status Code 200 for get loan");
-            Assertions.assertEquals(HttpStatus.SC_OK, responsesGetLoan.get(1).getStatusCode(), "Verify Status Code 200 for datatable");
-
-            final Long loanIdInGetResponse = jsonHelper.extractLongNamed("id", jsonHelper.parse(getLoanResponse).getAsJsonObject());
-            Assertions.assertEquals(loanId, loanIdInGetResponse);
-
-            // Repayment schedule information will be available in the response based on the query parameter
-            Assertions.assertTrue(getLoanResponse.contains("repaymentSchedule"));
-
-            // Transaction will be available in the response based on the query parameter
-            Assertions.assertTrue(getLoanResponse.contains("transactions"));
-
+            // The generic result set carries the column headers along with the data
+            assertTrue(getDatatableResponse.contains("columnHeaders"));
             // datatable info will be available in the response based on the query parameter
-            Assertions.assertTrue(getDatatableResponse.contains("columnHeaders"));
-
-            // datatable info will be available in the response based on the query parameter
-            Assertions.assertTrue(getDatatableResponse.contains("data"));
+            assertTrue(getDatatableResponse.contains("data"));
         } finally {
             deleteDatatable(datatableName);
         }
     }
 
     /**
-     * Test for the successful create and update datatable entry. A '200' status code is expected on successful
-     * responses.
+     * Test for the successful create and update datatable entry.
      *
      * @see org.apache.fineract.batch.command.internal.CreateDatatableEntryCommandStrategy
      * @see org.apache.fineract.batch.command.internal.UpdateDatatableEntryOneToManyCommandStrategy
      * @see org.apache.fineract.batch.command.internal.GetDatatableEntryByAppTableIdCommandStrategy
-     * @see GetDatatableEntryByAppTableIdAndDataTableIdCommandStrategy
+     * @see org.apache.fineract.batch.command.internal.GetDatatableEntryByAppTableIdAndDataTableIdCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusOnSuccessfulCreateDataTableEntry() {
-        final FromJsonHelper jsonHelper = new FromJsonHelper();
-        final Long loanId = jsonHelper.extractLongNamed("loanId", jsonHelper.parse(setupAccount()).getAsJsonObject());
         // creating datatable with m_loan association
-        final Map<String, Object> columnMap = new HashMap<>();
-        final List<HashMap<String, Object>> datatableColumnsList = new ArrayList<>();
+        final Long loanId = setupLoanAccount();
         final String datatableName = Utils.uniqueRandomStringGenerator(LOAN_APP_TABLE_NAME + "_", 5);
         final String columnName1 = Utils.randomStringGenerator("COL1_", 5);
         final String columnName2 = Utils.randomStringGenerator("COL2_", 5);
-        columnMap.put("datatableName", datatableName);
-        columnMap.put("apptableName", LOAN_APP_TABLE_NAME);
-        columnMap.put("entitySubType", "PERSON");
-        columnMap.put("multiRow", true);
-        DatatableHelper.addDatatableColumn(datatableColumnsList, columnName1, "String", true, 10, null);
-        DatatableHelper.addDatatableColumn(datatableColumnsList, columnName2, "String", false, 10, null);
-        columnMap.put("columns", datatableColumnsList);
-        final String datatableRequestJsonString = new Gson().toJson(columnMap);
-        LOG.info("CreateDataTable map : {}", datatableRequestJsonString);
+        createTwoStringColumnDatatable(datatableName, columnName1, columnName2, true, SHORT_COLUMN_LENGTH);
+        try {
+            final Long existingEntryId = createDatatableEntry(datatableName, loanId, columnName1, Utils.randomStringGenerator("VAL1_", 3),
+                    columnName2, Utils.randomStringGenerator("VAL2_", 3));
 
-        this.datatableHelper.createDatatable(datatableRequestJsonString, "");
+            final List<BatchRequest> batchRequests = List.of(
+                    BatchRequestBuilders.createDatatableEntry(CREATE_DATATABLE_ENTRY_REQUEST_ID, datatableName, loanId,
+                            List.of(columnName1, columnName2)),
+                    BatchRequestBuilders.updateDatatableEntryByEntryId(UPDATE_DATATABLE_ENTRY_REQUEST_ID, CREATE_DATATABLE_ENTRY_REQUEST_ID,
+                            datatableName, loanId, existingEntryId, List.of(columnName1)),
+                    BatchRequestBuilders.getDatatableEntries(GET_DATATABLE_ENTRIES_REQUEST_ID, CREATE_DATATABLE_ENTRY_REQUEST_ID,
+                            datatableName, loanId, null),
+                    BatchRequestBuilders.getDatatableEntryByAppTableId(GET_DATATABLE_ENTRY_REQUEST_ID, CREATE_DATATABLE_ENTRY_REQUEST_ID,
+                            datatableName, loanId, "$.resourceId", null));
 
-        // Create a datatable entry so that it can be updated using BatchApi
-        final Map<String, Object> datatableEntryMap = new HashMap<>();
-        datatableEntryMap.put(columnName1, Utils.randomStringGenerator("VAL1_", 3));
-        datatableEntryMap.put(columnName2, Utils.randomStringGenerator("VAL2_", 3));
-        final String datatableEntryRequestJsonString = new Gson().toJson(datatableEntryMap);
-        LOG.info("CreateDataTableEntry map : {}", datatableEntryRequestJsonString);
+            // Create a datatable entry so that it can be updated using BatchApi
+            final List<BatchResponse> responses = batchHelper.executeEnclosingTransaction(batchRequests);
 
-        final Map<String, Object> datatableEntryResponse = this.datatableHelper.createDatatableEntry(datatableName, loanId.intValue(),
-                false, datatableEntryRequestJsonString);
-        final Integer datatableEntryResourceId = (Integer) datatableEntryResponse.get("resourceId");
-        assertNotNull(datatableEntryResourceId, "ERROR IN CREATING THE ENTITY DATATABLE RECORD");
+            assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for create datatable entry");
+            assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for update datatable entry");
+            assertEquals(SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for get datatable entries");
+            assertEquals(SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for get datatable entry by id");
 
-        // Create datatable entry batch request
-        final BatchRequest createDatatableEntryRequest = BatchHelper.createDatatableEntryRequest(loanId.toString(), datatableName,
-                Arrays.asList(columnName1, columnName2));
+            final Long createdEntryId = bodyAsObject(responses.get(0)).get("resourceId").getAsLong();
+            // Create datatable entry batch request
+            final String getDatatableEntriesResponse = responses.get(2).getBody();
+            final JsonArray datatableEntries = JsonParser.parseString(getDatatableEntriesResponse).getAsJsonArray();
+            assertEquals(2, datatableEntries.size());
 
-        // Update datatable entry batch request
-        final BatchRequest updateDatatableEntryByEntryIdRequest = BatchHelper.updateDatatableEntryByEntryIdRequest(loanId, datatableName,
-                Long.valueOf(datatableEntryResourceId), Arrays.asList(columnName1));
-
-        // Get datatable entries batch request
-        final BatchRequest getDatatableEntriesRequest = BatchHelper.getDatatableByIdRequest(loanId, datatableName, null,
-                updateDatatableEntryByEntryIdRequest.getReference());
-
-        // Get datatable entry by app table id batch request
-        final BatchRequest getDatatableEntryByIdRequest = BatchHelper.getDatatableEntryByIdRequest(loanId, datatableName, "$.resourceId",
-                null, updateDatatableEntryByEntryIdRequest.getReference());
-
-        final List<BatchRequest> batchRequestsDatatableEntries = Arrays.asList(createDatatableEntryRequest,
-                updateDatatableEntryByEntryIdRequest, getDatatableEntriesRequest, getDatatableEntryByIdRequest);
-        LOG.info("Batch Request : {}", BatchHelper.toJsonString(batchRequestsDatatableEntries));
-
-        final List<BatchResponse> responseDatatableBatch = BatchHelper.postBatchRequestsWithEnclosingTransaction(this.requestSpec,
-                this.responseSpec, BatchHelper.toJsonString(batchRequestsDatatableEntries));
-
-        LOG.info("Batch Response : {}", new Gson().toJson(responseDatatableBatch));
-
-        final BatchResponse batchResponse1 = responseDatatableBatch.get(0);
-        final BatchResponse batchResponse2 = responseDatatableBatch.get(1);
-        final BatchResponse batchResponse3 = responseDatatableBatch.get(2);
-        final BatchResponse batchResponse4 = responseDatatableBatch.get(3);
-
-        Assertions.assertEquals(HttpStatus.SC_OK, batchResponse1.getStatusCode(), "Verify Status Code 200 for create datatable entry");
-        Assertions.assertEquals(HttpStatus.SC_OK, batchResponse2.getStatusCode(), "Verify Status Code 200 for update datatable entry");
-        Assertions.assertEquals(HttpStatus.SC_OK, batchResponse3.getStatusCode(), "Verify Status Code 200 for get datatable entries");
-        Assertions.assertEquals(HttpStatus.SC_OK, batchResponse4.getStatusCode(), "Verify Status Code 200 for get datatable entry by id");
-
-        final String getDatatableEntriesResponse = batchResponse3.getBody();
-
-        final Long createDatatableEntryId = jsonHelper.extractLongNamed("resourceId",
-                jsonHelper.parse(batchResponse1.getBody()).getAsJsonObject());
-
-        final JsonArray datatableEntries = jsonHelper.parse(getDatatableEntriesResponse).getAsJsonArray();
-        Assertions.assertEquals(2, datatableEntries.size());
-
-        // Ensure both resourceIds are available in response
-        Assertions.assertTrue(getDatatableEntriesResponse.contains(String.format("\"id\": %d", createDatatableEntryId)));
-        Assertions.assertTrue(getDatatableEntriesResponse.contains(String.format("\"id\": %d", datatableEntryResourceId)));
+            // Ensure both resourceIds are available in response
+            assertTrue(getDatatableEntriesResponse.contains("\"id\": %d".formatted(createdEntryId)));
+            assertTrue(getDatatableEntriesResponse.contains("\"id\": %d".formatted(existingEntryId)));
+        } finally {
+            deleteDatatableWithEntriesOf(datatableName, loanId);
+        }
     }
 
     /**
-     * Test for the successful get loan and get datatable entry where get datatable request have no query param. A '200'
-     * status code is expected on successful responses.
+     * Test for the successful get loan and get datatable entry where get datatable request has no query param.
      *
-     * @see org.apache.fineract.batch.command.internal.ApplyLoanCommandStrategy
-     * @see org.apache.fineract.batch.command.internal.ApproveLoanCommandStrategy
-     * @see org.apache.fineract.batch.command.internal.GetLoanByIdCommandStrategy
+     * @see org.apache.fineract.batch.command.internal.GetDatatableEntryByAppTableIdCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusOnSuccessfulGetDatatableEntryWithNoQueryParam() {
-        final FromJsonHelper jsonHelper = new FromJsonHelper();
-        final Long loanId = jsonHelper.extractLongNamed("loanId", jsonHelper.parse(setupAccount()).getAsJsonObject());
-        final String datatableName = this.datatableHelper.createDatatable(LOAN_APP_TABLE_NAME, false);
+        final Long loanId = setupLoanAccount();
+        // creating datatable with m_loan association
+        final String datatableName = createLoanDatatable();
         try {
             // Get loan by id Request with query param
-            final BatchRequest getLoanBatchRequest = BatchHelper.getLoanByIdRequest(loanId, "associations=repaymentSchedule,transactions");
+            final List<BatchRequest> batchRequests = List.of(
+                    BatchRequestBuilders.getLoanByLoanId(GET_LOAN_REQUEST_ID, null, loanId, "associations=repaymentSchedule,transactions"),
+                    BatchRequestBuilders.getDatatableEntries(GET_DATATABLE_ENTRIES_REQUEST_ID, null, datatableName, loanId, null));
 
             // Get datatable batch request
-            final BatchRequest getDatatableBatchRequest = BatchHelper.getDatatableByIdRequest(loanId, datatableName, null, null);
+            final List<BatchResponse> responses = batchHelper.executeEnclosingTransaction(batchRequests);
 
-            final List<BatchRequest> batchRequestsGetLoan = Arrays.asList(getLoanBatchRequest, getDatatableBatchRequest);
+            assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Get Loan");
+            assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Get Datatable");
 
-            final List<BatchResponse> responsesGetLoan = BatchHelper.postBatchRequestsWithEnclosingTransaction(this.requestSpec,
-                    this.responseSpec, BatchHelper.toJsonString(batchRequestsGetLoan));
-
-            final String getLoanResponse = responsesGetLoan.get(0).getBody();
-
-            Assertions.assertEquals(HttpStatus.SC_OK, responsesGetLoan.get(0).getStatusCode(), "Verify Status Code 200 for Get Loan");
-            Assertions.assertEquals(HttpStatus.SC_OK, responsesGetLoan.get(1).getStatusCode(), "Verify Status Code 200 for Get Datatable");
-
-            final Long loanIdInGetResponse = jsonHelper.extractLongNamed("id", jsonHelper.parse(getLoanResponse).getAsJsonObject());
-            Assertions.assertEquals(loanId, loanIdInGetResponse);
-
-            Assertions.assertTrue(getLoanResponse.contains("repaymentSchedule"));
-
-            Assertions.assertTrue(getLoanResponse.contains("transactions"));
+            final String getLoanResponse = responses.get(0).getBody();
+            assertEquals(loanId, bodyAsObject(responses.get(0)).get("id").getAsLong());
+            assertTrue(getLoanResponse.contains("repaymentSchedule"));
+            assertTrue(getLoanResponse.contains("transactions"));
         } finally {
             deleteDatatable(datatableName);
         }
-
     }
 
     /**
-     * Test for the successful merchant issued and payout refund transaction. A '200' status code is expected on
-     * successful responses.
+     * Test for the successful merchant issued and payout refund transaction.
      *
-     * @see org.apache.fineract.batch.command.internal.ApplyLoanCommandStrategy
-     * @see org.apache.fineract.batch.command.internal.ApproveLoanCommandStrategy
-     * @see org.apache.fineract.batch.command.internal.DisburseLoanCommandStrategy
      * @see org.apache.fineract.batch.command.internal.CreateTransactionLoanCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusOnSuccessfulTransactionMerchantIssuedAndPayoutRefund() {
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
+        final Long productId = createBatchLoanProduct(LARGE_PRINCIPAL);
+        final Long clientId = createClient();
 
         final Long applyLoanRequestId = 5730L;
         final Long approveLoanRequestId = 5731L;
@@ -1546,64 +1022,40 @@ public class BatchApiTest extends BaseLoanIntegrationTest {
         final Long payoutRefundRequestId = 5734L;
 
         // Create product
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final List<BatchRequest> batchRequests = List.of(
+                BatchRequestBuilders.applyLoanWithClientId(applyLoanRequestId, clientId, productId),
+                // Create an approveLoan Request
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                // Create a disbursement request
+                BatchRequestBuilders.disburseLoan(disburseLoanRequestId, approveLoanRequestId, today().minusDays(1)),
+                // Create a merchant issued refund request
+                BatchRequestBuilders.merchantIssuedRefund(merchantIssuedRefundRequestId, applyLoanRequestId, "10"),
+                // Create a payout refund request
+                BatchRequestBuilders.payoutRefund(payoutRefundRequestId, applyLoanRequestId, "10"));
 
         // Create client
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientId);
+        final List<BatchResponse> responses = batchHelper.executeEnclosingTransaction(batchRequests);
 
+        assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
         // Create an ApplyLoan Request
-        final BatchRequest applyLoanRequest = BatchHelper.applyLoanRequestWithClientId(applyLoanRequestId, clientId, productId);
-
-        // Create an approveLoan Request
-        final BatchRequest approveLoanRequest = BatchHelper.approveLoanRequest(approveLoanRequestId, applyLoanRequestId);
-
-        // Create a disbursement request
-        final BatchRequest disburseLoanRequest = BatchHelper.disburseLoanRequest(disburseLoanRequestId, approveLoanRequestId,
-                LocalDate.now(Utils.getZoneIdOfTenant()).minusDays(1));
-
-        // Create a merchant issued refund request
-        final BatchRequest merchantIssuedRefundRequest = BatchHelper.merchantIssuedRefundRequest(merchantIssuedRefundRequestId,
-                applyLoanRequestId, "10");
-
-        // Create a payout refund request
-        final BatchRequest payoutRefundRequest = BatchHelper.payoutRefundRequest(payoutRefundRequestId, applyLoanRequestId, "10");
-
-        final List<BatchRequest> batchRequests = Arrays.asList(applyLoanRequest, approveLoanRequest, disburseLoanRequest,
-                merchantIssuedRefundRequest, payoutRefundRequest);
-
-        final List<BatchResponse> responses = BatchHelper.postBatchRequestsWithEnclosingTransaction(this.requestSpec, this.responseSpec,
-                BatchHelper.toJsonString(batchRequests));
-
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for merchant issued refund");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(4).getStatusCode(), "Verify Status Code 200 for payout refund");
+        assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
+        assertEquals(SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse loan");
+        assertEquals(SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for merchant issued refund");
+        assertEquals(SC_OK, responses.get(4).getStatusCode(), "Verify Status Code 200 for payout refund");
     }
 
     /**
-     * Test for the successful repayment reversal transaction. A '200' status code is expected on successful responses.
+     * Test for the successful repayment reversal transaction.
      *
-     * @see AdjustLoanTransactionCommandStrategy
+     * @see org.apache.fineract.batch.command.internal.AdjustLoanTransactionCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusForBatchRepaymentReversal() {
+        final Long productId = createBatchLoanProduct(LARGE_PRINCIPAL);
+        // Create client
+        final Long clientId = createClient();
+        final LocalDate reversalDate = today();
 
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
-
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
-
-        final LocalDate date = LocalDate.now(Utils.getZoneIdOfTenant());
         final Long applyLoanRequestId = 5730L;
         final Long approveLoanRequestId = 5731L;
         final Long disburseLoanRequestId = 5732L;
@@ -1611,248 +1063,149 @@ public class BatchApiTest extends BaseLoanIntegrationTest {
         final Long repayReversalRequestId = 5734L;
         final Long getLoanRequestId = 5735L;
 
-        // Create client
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientId);
+        final List<BatchRequest> batchRequests = List.of(
+                // Create an apply loan request
+                BatchRequestBuilders.applyLoanWithClientId(applyLoanRequestId, clientId, productId),
+                // Create an approve loan request
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                // Create a disburse loan request
+                BatchRequestBuilders.disburseLoan(disburseLoanRequestId, approveLoanRequestId),
+                // Create a repayment request.
+                BatchRequestBuilders.repayLoan(repayLoanRequestId, disburseLoanRequestId, "500"),
+                // Create a repayment reversal request
+                BatchRequestBuilders.adjustTransaction(repayReversalRequestId, repayLoanRequestId, "0", reversalDate),
+                // Get loan transactions request
+                BatchRequestBuilders.getLoanByReference(getLoanRequestId, applyLoanRequestId, "associations=transactions"));
 
-        // Create an apply loan request
-        final BatchRequest applyLoanRequest = BatchHelper.applyLoanRequestWithClientId(applyLoanRequestId, clientId, productId);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        // Create an approve loan request
-        final BatchRequest approveLoanRequest = BatchHelper.approveLoanRequest(approveLoanRequestId, applyLoanRequestId);
+        assertEquals(SC_OK, responses.get(4).getStatusCode(), "Verify Status Code 200 for repayment reversal");
 
-        // Create a disburse loan request
-        final BatchRequest disburseLoanRequest = BatchHelper.disburseLoanRequest(disburseLoanRequestId, approveLoanRequestId);
-
-        // Create a repayment request.
-        final BatchRequest repaymentRequest = BatchHelper.repayLoanRequest(repayLoanRequestId, disburseLoanRequestId, "500");
-
-        // Create a repayment reversal request
-        final BatchRequest repaymentReversalRequest = BatchHelper.createAdjustTransactionRequest(repayReversalRequestId, repayLoanRequestId,
-                "0", date);
-
-        // Get loan transactions request
-        final BatchRequest getLoanTransactionsRequest = BatchHelper.getLoanByIdRequest(getLoanRequestId, applyLoanRequestId,
-                "associations=transactions");
-
-        final List<BatchRequest> batchRequests = Arrays.asList(applyLoanRequest, approveLoanRequest, disburseLoanRequest, repaymentRequest,
-                repaymentReversalRequest, getLoanTransactionsRequest);
-
-        final List<BatchResponse> responses = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                BatchHelper.toJsonString(batchRequests));
-
-        final FromJsonHelper jsonHelper = new FromJsonHelper();
-        final JsonObject repayment = jsonHelper.parse(responses.get(5).getBody()).getAsJsonObject().get("transactions").getAsJsonArray()
-                .get(1).getAsJsonObject();
-        final JsonArray dateArray = repayment.get("reversedOnDate").getAsJsonArray();
-        final LocalDate reversedOnDate = LocalDate.of(dateArray.get(0).getAsInt(), dateArray.get(1).getAsInt(),
-                dateArray.get(2).getAsInt());
-
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) responses.get(4).getStatusCode(), "Verify Status Code 200 for repayment reversal");
-        Assertions.assertEquals("Repayment", repayment.get("type").getAsJsonObject().get("value").getAsString());
-        Assertions.assertTrue(repayment.get("manuallyReversed").getAsBoolean());
-        Assertions.assertEquals(date, reversedOnDate);
+        final JsonObject repayment = transactionAt(responses.get(5), 1);
+        assertEquals("Repayment", repayment.getAsJsonObject("type").get("value").getAsString());
+        assertTrue(repayment.get("manuallyReversed").getAsBoolean());
+        assertEquals(reversalDate, asLocalDate(repayment.getAsJsonArray("reversedOnDate")));
     }
 
     /**
-     * Test for the successful repayment reversal transaction using loan external id and transaction external id. A
-     * '200' status code is expected on successful responses.
+     * Test for the successful repayment reversal transaction using loan external id and transaction external id.
      *
-     * @see AdjustLoanTransactionCommandStrategy
+     * @see org.apache.fineract.batch.command.internal.AdjustLoanTransactionCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusForBatchRepaymentReversalUsingExternalId() {
+        final Long productId = createBatchLoanProduct(LARGE_PRINCIPAL);
+        // Create client
+        final Long clientId = createClient();
+        final LocalDate reversalDate = today();
+        final String loanExternalId = UUID.randomUUID().toString();
 
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
-
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
-
-        final LocalDate date = LocalDate.now(Utils.getZoneIdOfTenant());
-        final Long applyLoanRequestId = ThreadLocalRandom.current().nextLong(1000, 10_000);
+        final Long applyLoanRequestId = randomRequestId();
         final Long approveLoanRequestId = applyLoanRequestId + 1;
         final Long disburseLoanRequestId = approveLoanRequestId + 1;
         final Long getLoanBeforeTxnRequestId = disburseLoanRequestId + 1;
         final Long repayLoanRequestId = getLoanBeforeTxnRequestId + 1;
         final Long getLoanAfterTxnRequestId = repayLoanRequestId + 1;
         final Long repayReversalRequestId = getLoanAfterTxnRequestId + 1;
-        final Long getLoanAfterReversal = repayReversalRequestId + 1;
+        final Long getLoanAfterReversalRequestId = repayReversalRequestId + 1;
 
-        // Create client
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientId);
-        final String loanExternalId = UUID.randomUUID().toString();
-
-        // Create an apply loan request
-        final BatchRequest applyLoanRequest = BatchHelper.applyLoanRequestWithClientIdAndExternalId(applyLoanRequestId, clientId, productId,
-                loanExternalId);
-
-        // Create an approve loan request
-        final BatchRequest approveLoanRequest = BatchHelper.approveLoanRequest(approveLoanRequestId, applyLoanRequestId);
-
-        // Create a disburse loan request
-        final BatchRequest disburseLoanRequest = BatchHelper.disburseLoanRequest(disburseLoanRequestId, approveLoanRequestId);
-
-        // Get loan transactions request
-        final BatchRequest getLoanTransactionsRequestBeforeTxn = BatchHelper.getLoanByIdRequest(getLoanBeforeTxnRequestId,
-                disburseLoanRequestId, "associations=transactions");
-
-        // Create a repayment request by external id
-        final BatchRequest repaymentRequest = BatchHelper.createTransactionRequestByLoanExternalId(repayLoanRequestId,
-                getLoanBeforeTxnRequestId, "repayment", "500", LocalDate.now(Utils.getZoneIdOfTenant()));
-
-        // Get loan transactions request
-        final BatchRequest getLoanTransactionsRequestAfterTxn = BatchHelper.getLoanByIdRequest(getLoanAfterTxnRequestId, repayLoanRequestId,
-                "associations=transactions");
-
-        final List<BatchRequest> batchRequests = Arrays.asList(applyLoanRequest, approveLoanRequest, disburseLoanRequest,
-                getLoanTransactionsRequestBeforeTxn, repaymentRequest, getLoanTransactionsRequestAfterTxn);
+        final List<BatchRequest> batchRequests = List.of(
+                // Create an apply loan request
+                BatchRequestBuilders.applyLoanWithClientIdAndExternalId(applyLoanRequestId, clientId, productId, loanExternalId),
+                // Create an approve loan request
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                // Create a disburse loan request
+                BatchRequestBuilders.disburseLoan(disburseLoanRequestId, approveLoanRequestId),
+                // Get loan transactions request
+                BatchRequestBuilders.getLoanByReference(getLoanBeforeTxnRequestId, disburseLoanRequestId, "associations=transactions"),
+                // Create a repayment request by external id
+                BatchRequestBuilders.createTransactionByLoanExternalId(repayLoanRequestId, getLoanBeforeTxnRequestId, "repayment", "500",
+                        today()),
+                // Get loan transactions request
+                BatchRequestBuilders.getLoanByReference(getLoanAfterTxnRequestId, repayLoanRequestId, "associations=transactions"));
 
         // Because loanExternalId & transactionExternalId are coming from 2 different responses, there is no easy way to
         // use them as reference in 1 batch api call.
         // So we are splitting repayment & reversal into 2 different batch api invocations
-        final List<BatchResponse> responses = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                BatchHelper.toJsonString(batchRequests));
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        final FromJsonHelper jsonHelper = new FromJsonHelper();
-        final String loanExternalIdDisburseLoanResponse = jsonHelper.parse(responses.get(3).getBody()).getAsJsonObject().get("externalId")
-                .getAsString();
-        final Long loanId = jsonHelper.parse(responses.get(3).getBody()).getAsJsonObject().get("id").getAsLong();
-        final String transactionExternalId = jsonHelper.parse(responses.get(4).getBody()).getAsJsonObject().get("resourceExternalId")
-                .getAsString();
-        Assertions.assertNotNull(loanExternalIdDisburseLoanResponse);
-        Assertions.assertEquals(loanExternalId, loanExternalIdDisburseLoanResponse);
-        Assertions.assertNotNull(transactionExternalId);
+        final JsonObject loanBeforeTransaction = bodyAsObject(responses.get(3));
+        final String loanExternalIdInResponse = loanBeforeTransaction.get("externalId").getAsString();
+        final Long loanId = loanBeforeTransaction.get("id").getAsLong();
+        final String transactionExternalId = bodyAsObject(responses.get(4)).get("resourceExternalId").getAsString();
 
-        // Create a repayment reversal request by external id
-        final BatchRequest repaymentReversalRequest = BatchHelper.createAdjustTransactionByExternalIdRequest(repayReversalRequestId, null,
-                loanExternalIdDisburseLoanResponse, transactionExternalId, "0", date);
+        assertEquals(loanExternalId, loanExternalIdInResponse);
+        assertNotNull(transactionExternalId);
 
-        final BatchRequest getLoanByIdWithTransactions = BatchHelper.getLoanByIdRequest(loanId, getLoanAfterReversal,
-                repayReversalRequestId, "associations=transactions");
+        final List<BatchRequest> reversalRequests = List.of(
+                // Create a repayment reversal request by external id
+                BatchRequestBuilders.adjustTransactionByExternalId(repayReversalRequestId, null, loanExternalIdInResponse,
+                        transactionExternalId, "0", reversalDate),
+                // Get loan transactions request
+                BatchRequestBuilders.getLoanByLoanId(getLoanAfterReversalRequestId, repayReversalRequestId, loanId,
+                        "associations=transactions"));
 
-        final List<BatchRequest> reversalAndGetBatchRequest = Arrays.asList(repaymentReversalRequest, getLoanByIdWithTransactions);
+        final List<BatchResponse> reversalResponses = batchHelper.executeWithoutEnclosingTransaction(reversalRequests);
 
-        final List<BatchResponse> reversalResponses = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec,
-                this.responseSpec, BatchHelper.toJsonString(reversalAndGetBatchRequest));
+        assertEquals(SC_OK, reversalResponses.get(0).getStatusCode(), "Verify Status Code 200 for repayment reversal");
 
-        final JsonObject repayment = jsonHelper.parse(reversalResponses.get(1).getBody()).getAsJsonObject().get("transactions")
-                .getAsJsonArray().get(1).getAsJsonObject();
-
-        final JsonArray dateArray = repayment.get("reversedOnDate").getAsJsonArray();
-        final LocalDate reversedOnDate = LocalDate.of(dateArray.get(0).getAsInt(), dateArray.get(1).getAsInt(),
-                dateArray.get(2).getAsInt());
-
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) reversalResponses.get(0).getStatusCode(),
-                "Verify Status Code 200 for repayment reversal");
-        Assertions.assertEquals("Repayment", repayment.get("type").getAsJsonObject().get("value").getAsString());
-
-        Assertions.assertTrue(repayment.get("manuallyReversed").getAsBoolean());
-        Assertions.assertEquals(date, reversedOnDate);
+        final JsonObject repayment = transactionAt(reversalResponses.get(1), 1);
+        assertEquals("Repayment", repayment.getAsJsonObject("type").get("value").getAsString());
+        assertTrue(repayment.get("manuallyReversed").getAsBoolean());
+        assertEquals(reversalDate, asLocalDate(repayment.getAsJsonArray("reversedOnDate")));
     }
 
     /**
-     * Test for the successful repayment chargeback transaction. A '200' status code is expected on successful
-     * responses.
+     * Test for the successful repayment chargeback transaction.
      *
-     * @see AdjustLoanTransactionCommandStrategy
+     * @see org.apache.fineract.batch.command.internal.AdjustLoanTransactionCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusForBatchRepaymentChargeback() {
-
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
-
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final Long productId = createBatchLoanProduct(LARGE_PRINCIPAL);
+        final Long clientId = createClient();
 
         final Long applyLoanRequestId = 5730L;
         final Long approveLoanRequestId = 5731L;
         final Long disburseLoanRequestId = 5732L;
         final Long repayLoanRequestId = 5733L;
-        final Long repayReversalRequestId = 5734L;
+        final Long chargebackRequestId = 5734L;
         final Long getLoanRequestId = 5735L;
 
-        // Create client
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientId);
+        final List<BatchRequest> batchRequests = List.of(
+                BatchRequestBuilders.applyLoanWithClientId(applyLoanRequestId, clientId, productId),
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                BatchRequestBuilders.disburseLoan(disburseLoanRequestId, approveLoanRequestId),
+                // Create a repayment request
+                BatchRequestBuilders.repayLoan(repayLoanRequestId, disburseLoanRequestId, "500"),
+                // Create a repayment chargeback request
+                BatchRequestBuilders.chargebackTransaction(chargebackRequestId, repayLoanRequestId, "500"),
+                // Get loan transactions request
+                BatchRequestBuilders.getLoanByReference(getLoanRequestId, applyLoanRequestId, "associations=transactions"));
 
-        // Create an apply loan request
-        final BatchRequest applyLoanRequest = BatchHelper.applyLoanRequestWithClientId(applyLoanRequestId, clientId, productId);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        // Create an approve loan request
-        final BatchRequest approveLoanRequest = BatchHelper.approveLoanRequest(approveLoanRequestId, applyLoanRequestId);
+        assertEquals(SC_OK, responses.get(4).getStatusCode(), "Verify Status Code 200 for repayment chargeback");
 
-        // Create a disburse loan request
-        final BatchRequest disburseLoanRequest = BatchHelper.disburseLoanRequest(disburseLoanRequestId, approveLoanRequestId);
+        final JsonObject repayment = transactionAt(responses.get(5), 1);
+        assertEquals("Repayment", repayment.getAsJsonObject("type").get("value").getAsString());
 
-        // Create a repayment request
-        final BatchRequest repaymentRequest = BatchHelper.repayLoanRequest(repayLoanRequestId, disburseLoanRequestId, "500");
-
-        // Create a repayment chargeback request
-        final BatchRequest repaymentChargebackRequest = BatchHelper.createChargebackTransactionRequest(repayReversalRequestId,
-                repayLoanRequestId, "500");
-
-        // Get loan transactions request
-        final BatchRequest getLoanTransactionsRequest = BatchHelper.getLoanByIdRequest(getLoanRequestId, applyLoanRequestId,
-                "associations=transactions");
-
-        final List<BatchRequest> batchRequests = Arrays.asList(applyLoanRequest, approveLoanRequest, disburseLoanRequest, repaymentRequest,
-                repaymentChargebackRequest, getLoanTransactionsRequest);
-
-        final List<BatchResponse> responses = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                BatchHelper.toJsonString(batchRequests));
-
-        final FromJsonHelper jsonHelper = new FromJsonHelper();
-        final JsonObject repayment = jsonHelper.parse(responses.get(5).getBody()).getAsJsonObject().get("transactions").getAsJsonArray()
-                .get(1).getAsJsonObject();
-
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) responses.get(4).getStatusCode(),
-                "Verify Status Code 200 for repayment chargeback");
-        Assertions.assertEquals("Repayment", repayment.get("type").getAsJsonObject().get("value").getAsString());
-        final JsonArray transactionRelations = repayment.get("transactionRelations").getAsJsonArray();
-        Assertions.assertEquals(1, transactionRelations.size());
-        Assertions.assertEquals("CHARGEBACK", transactionRelations.get(0).getAsJsonObject().get("relationType").getAsString());
+        final JsonArray transactionRelations = repayment.getAsJsonArray("transactionRelations");
+        assertEquals(1, transactionRelations.size());
+        assertEquals("CHARGEBACK", transactionRelations.get(0).getAsJsonObject().get("relationType").getAsString());
     }
 
     /**
-     * Tests successful run of batch goodwill credit reversal for loans. A '200' status code is expected on successful
-     * responses.
+     * Tests successful run of batch goodwill credit reversal for loans.
      *
-     * @see AdjustLoanTransactionCommandStrategy
+     * @see org.apache.fineract.batch.command.internal.AdjustLoanTransactionCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusForBatchGoodwillCreditReversal() {
+        final Long productId = createBatchLoanProduct(SMALL_PRINCIPAL);
+        final Long clientId = createClient();
+        final LocalDate reversalDate = today();
 
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("1000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
-
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
-
-        final LocalDate date = LocalDate.now(Utils.getZoneIdOfTenant());
         final Long applyLoanRequestId = 5730L;
         final Long approveLoanRequestId = 5731L;
         final Long disburseLoanRequestId = 5732L;
@@ -1861,69 +1214,39 @@ public class BatchApiTest extends BaseLoanIntegrationTest {
         final Long getLoanRequestId = 5735L;
 
         // Create client
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientId);
+        final List<BatchRequest> batchRequests = List.of(
+                BatchRequestBuilders.applyLoanWithClientId(applyLoanRequestId, clientId, productId),
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                BatchRequestBuilders.disburseLoan(disburseLoanRequestId, approveLoanRequestId),
+                // Create a good will credit request
+                BatchRequestBuilders.goodwillCredit(goodwillCreditRequestId, disburseLoanRequestId, "500"),
+                // Create a good will credit reversal request
+                BatchRequestBuilders.adjustTransaction(goodwillCreditReversalRequestId, goodwillCreditRequestId, "0", reversalDate),
+                BatchRequestBuilders.getLoanByReference(getLoanRequestId, applyLoanRequestId, "associations=transactions"));
 
-        // Create an apply loan request
-        final BatchRequest applyLoanRequest = BatchHelper.applyLoanRequestWithClientId(applyLoanRequestId, clientId, productId);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        // Create an approve loan request
-        final BatchRequest approveLoanRequest = BatchHelper.approveLoanRequest(approveLoanRequestId, applyLoanRequestId);
+        assertEquals(SC_OK, responses.get(4).getStatusCode(), "Verify Status Code 200 for goodwill credit reversal");
 
+        final JsonObject goodwillCredit = transactionAt(responses.get(5), 1);
         // Create a disburse loan request
-        final BatchRequest disburseLoanRequest = BatchHelper.disburseLoanRequest(disburseLoanRequestId, approveLoanRequestId);
-
-        // Create a good will credit request
-        final BatchRequest goodwillCreditRequest = BatchHelper.goodwillCreditRequest(goodwillCreditRequestId, disburseLoanRequestId, "500");
-
-        // Create a good will credit reversal request
-        final BatchRequest goodwillCreditReversalRequest = BatchHelper.createAdjustTransactionRequest(goodwillCreditReversalRequestId,
-                goodwillCreditRequestId, "0", date);
-
+        assertEquals("Goodwill Credit", goodwillCredit.getAsJsonObject("type").get("value").getAsString());
+        assertTrue(goodwillCredit.get("manuallyReversed").getAsBoolean());
         // Get loan transactions request
-        final BatchRequest getLoanTransactionsRequest = BatchHelper.getLoanByIdRequest(getLoanRequestId, applyLoanRequestId,
-                "associations=transactions");
-
-        final List<BatchRequest> batchRequests = Arrays.asList(applyLoanRequest, approveLoanRequest, disburseLoanRequest,
-                goodwillCreditRequest, goodwillCreditReversalRequest, getLoanTransactionsRequest);
-
-        final List<BatchResponse> responses = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                BatchHelper.toJsonString(batchRequests));
-
-        final FromJsonHelper jsonHelper = new FromJsonHelper();
-        final JsonObject goodWillCredit = jsonHelper.parse(responses.get(5).getBody()).getAsJsonObject().get("transactions")
-                .getAsJsonArray().get(1).getAsJsonObject();
-        final JsonArray dateArray = goodWillCredit.get("reversedOnDate").getAsJsonArray();
-        final LocalDate reversedOnDate = LocalDate.of(dateArray.get(0).getAsInt(), dateArray.get(1).getAsInt(),
-                dateArray.get(2).getAsInt());
-
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) responses.get(4).getStatusCode(),
-                "Verify Status Code 200 for goodwill credit reversal");
-        Assertions.assertEquals("Goodwill Credit", goodWillCredit.get("type").getAsJsonObject().get("value").getAsString());
-        Assertions.assertTrue(goodWillCredit.get("manuallyReversed").getAsBoolean());
-        Assertions.assertEquals(date, reversedOnDate);
+        assertEquals(reversalDate, asLocalDate(goodwillCredit.getAsJsonArray("reversedOnDate")));
     }
 
     /**
-     * Test for the successful merchant issued refund and payout refund reversal transaction. A '200' status code is
-     * expected on successful responses.
+     * Test for the successful merchant issued refund and payout refund reversal transaction.
      *
-     * @see AdjustLoanTransactionCommandStrategy
+     * @see org.apache.fineract.batch.command.internal.AdjustLoanTransactionCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusOnSuccessfulTransactionMerchantIssuedAndPayoutRefundReversal() {
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
+        final Long productId = createBatchLoanProduct(LARGE_PRINCIPAL);
+        final Long clientId = createClient();
+        final LocalDate reversalDate = today();
 
-        final LocalDate date = LocalDate.now(Utils.getZoneIdOfTenant());
         final Long applyLoanRequestId = 5730L;
         final Long approveLoanRequestId = 5731L;
         final Long disburseLoanRequestId = 5732L;
@@ -1934,752 +1257,532 @@ public class BatchApiTest extends BaseLoanIntegrationTest {
         final Long getLoanRequestId = 5737L;
 
         // Create product
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final List<BatchRequest> batchRequests = List.of(
+                BatchRequestBuilders.applyLoanWithClientId(applyLoanRequestId, clientId, productId),
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                BatchRequestBuilders.disburseLoan(disburseLoanRequestId, approveLoanRequestId, reversalDate.minusDays(1)),
+                // Create a merchant issued refund request
+                BatchRequestBuilders.merchantIssuedRefund(merchantIssuedRefundRequestId, applyLoanRequestId, "10"),
+                // Create a payout refund request
+                BatchRequestBuilders.payoutRefund(payoutRefundRequestId, applyLoanRequestId, "10"),
+                // Create a merchant issued refund reversal request
+                BatchRequestBuilders.adjustTransaction(merchantIssuedRefundReversalRequestId, merchantIssuedRefundRequestId, "0",
+                        reversalDate),
+                // Create a payout refund reversal request
+                BatchRequestBuilders.adjustTransaction(payoutRefundReversalRequestId, payoutRefundRequestId, "0", reversalDate),
+                BatchRequestBuilders.getLoanByReference(getLoanRequestId, applyLoanRequestId, "associations=transactions"));
 
         // Create client
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientId);
+        final List<BatchResponse> responses = batchHelper.executeEnclosingTransaction(batchRequests);
 
+        assertEquals(SC_OK, responses.get(5).getStatusCode(), "Verify Status Code 200 for merchant issued refund reversal");
         // Create an apply loan request
-        final BatchRequest applyLoanRequest = BatchHelper.applyLoanRequestWithClientId(applyLoanRequestId, clientId, productId);
+        assertEquals(SC_OK, responses.get(6).getStatusCode(), "Verify Status Code 200 for payout refund reversal");
 
+        final JsonObject merchantIssuedRefund = transactionAt(responses.get(7), 1);
         // Create an approve loan request
-        final BatchRequest approveLoanRequest = BatchHelper.approveLoanRequest(approveLoanRequestId, applyLoanRequestId);
+        final JsonObject payoutRefund = transactionAt(responses.get(7), 2);
 
+        assertEquals("Merchant Issued Refund", merchantIssuedRefund.getAsJsonObject("type").get("value").getAsString());
         // Create a disburse loan request
-        final BatchRequest disburseLoanRequest = BatchHelper.disburseLoanRequest(disburseLoanRequestId, approveLoanRequestId,
-                date.minusDays(1));
-
-        // Create a merchant issued refund request
-        final BatchRequest merchantIssuedRefundRequest = BatchHelper.merchantIssuedRefundRequest(merchantIssuedRefundRequestId,
-                applyLoanRequestId, "10");
-
-        // Create a payout refund request
-        final BatchRequest payoutRefundRequest = BatchHelper.payoutRefundRequest(payoutRefundRequestId, applyLoanRequestId, "10");
-
-        // Create a merchant issued refund reversal request
-        final BatchRequest merchantIssuedRefundReversalRequest = BatchHelper
-                .createAdjustTransactionRequest(merchantIssuedRefundReversalRequestId, merchantIssuedRefundRequestId, "0", date);
-
-        // Create a payout refund reversal request
-        final BatchRequest payoutRefundReversalRequest = BatchHelper.createAdjustTransactionRequest(payoutRefundReversalRequestId,
-                payoutRefundRequestId, "0", date);
-
+        assertEquals("Payout Refund", payoutRefund.getAsJsonObject("type").get("value").getAsString());
+        assertTrue(merchantIssuedRefund.get("manuallyReversed").getAsBoolean());
+        assertTrue(payoutRefund.get("manuallyReversed").getAsBoolean());
+        assertEquals(reversalDate, asLocalDate(merchantIssuedRefund.getAsJsonArray("reversedOnDate")));
         // Get loan transactions request
-        final BatchRequest getLoanTransactionsRequest = BatchHelper.getLoanByIdRequest(getLoanRequestId, applyLoanRequestId,
-                "associations=transactions");
-
-        final List<BatchRequest> batchRequests = Arrays.asList(applyLoanRequest, approveLoanRequest, disburseLoanRequest,
-                merchantIssuedRefundRequest, payoutRefundRequest, merchantIssuedRefundReversalRequest, payoutRefundReversalRequest,
-                getLoanTransactionsRequest);
-
-        final List<BatchResponse> responses = BatchHelper.postBatchRequestsWithEnclosingTransaction(this.requestSpec, this.responseSpec,
-                BatchHelper.toJsonString(batchRequests));
-
-        final FromJsonHelper jsonHelper = new FromJsonHelper();
-        final JsonObject merchantIssuedRefund = jsonHelper.parse(responses.get(7).getBody()).getAsJsonObject().get("transactions")
-                .getAsJsonArray().get(1).getAsJsonObject();
-        final JsonObject payoutRefund = jsonHelper.parse(responses.get(7).getBody()).getAsJsonObject().get("transactions").getAsJsonArray()
-                .get(2).getAsJsonObject();
-        final JsonArray merchantIssuedDateArray = merchantIssuedRefund.get("reversedOnDate").getAsJsonArray();
-        final LocalDate merchantIssuedDate = LocalDate.of(merchantIssuedDateArray.get(0).getAsInt(),
-                merchantIssuedDateArray.get(1).getAsInt(), merchantIssuedDateArray.get(2).getAsInt());
-        final JsonArray payoutRefundDateArray = payoutRefund.getAsJsonObject().get("reversedOnDate").getAsJsonArray();
-        final LocalDate payoutRefundDate = LocalDate.of(payoutRefundDateArray.get(0).getAsInt(), payoutRefundDateArray.get(1).getAsInt(),
-                payoutRefundDateArray.get(2).getAsInt());
-
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(5).getStatusCode(),
-                "Verify Status Code 200 for merchant issued refund reversal");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(6).getStatusCode(), "Verify Status Code 200 for payout refund reversal");
-        Assertions.assertEquals("Merchant Issued Refund", merchantIssuedRefund.get("type").getAsJsonObject().get("value").getAsString());
-        Assertions.assertEquals("Payout Refund", payoutRefund.get("type").getAsJsonObject().get("value").getAsString());
-        Assertions.assertTrue(merchantIssuedRefund.get("manuallyReversed").getAsBoolean());
-        Assertions.assertTrue(payoutRefund.get("manuallyReversed").getAsBoolean());
-        Assertions.assertEquals(date, merchantIssuedDate);
-        Assertions.assertEquals(date, payoutRefundDate);
+        assertEquals(reversalDate, asLocalDate(payoutRefund.getAsJsonArray("reversedOnDate")));
     }
 
     @Test
     public void shouldReturnOkStatusOnModifyingSavingAccount() {
         final String startDate = "10 April 2022";
-        final SavingsProductHelper savingsProductHelper = new SavingsProductHelper();
-        final SavingsAccountHelper savingsAccountHelper = new SavingsAccountHelper(this.requestSpec, this.responseSpec);
-        final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec, startDate);
-        Assertions.assertNotNull(clientID);
-        final String savingsProductJSON = savingsProductHelper.withInterestCompoundingPeriodTypeAsDaily()
-                .withInterestPostingPeriodTypeAsDaily().withInterestCalculationPeriodTypeAsDailyBalance().build();
-        final Integer savingsProductID = SavingsProductHelper.createSavingsProduct(savingsProductJSON, requestSpec, responseSpec);
-        Assertions.assertNotNull(savingsProductID);
-        final Integer savingsId = savingsAccountHelper.applyForSavingsApplicationOnDate(clientID, savingsProductID, "INDIVIDUAL",
-                startDate);
-        Assertions.assertNotNull(savingsId);
-        HashMap savingsStatusHashMap = savingsAccountHelper.approveSavingsOnDate(savingsId, startDate);
-        SavingsStatusChecker.verifySavingsIsApproved(savingsStatusHashMap);
-        savingsStatusHashMap = savingsAccountHelper.activateSavingsAccount(savingsId, startDate);
-        SavingsStatusChecker.verifySavingsIsActive(savingsStatusHashMap);
+        final Long clientId = createClient(startDate);
+        final Long savingsId = createActiveSavingsAccount(clientId, startDate, startDate, startDate);
 
-        final BatchRequest getSavingAccountRequest = BatchHelper.getSavingAccount(1L, Long.valueOf(savingsId), "chargeStatus=all", null);
-        final BatchRequest depositSavingAccountRequest = BatchHelper.depositSavingAccount(2L, 1L, 100F);
-        final BatchRequest holdAmountOnSavingAccountRequest = BatchHelper.holdAmountOnSavingAccount(3L, 1L, 10F);
+        final Long getSavingsAccountRequestId = 1L;
+        final Long depositRequestId = 2L;
+        final Long holdAmountRequestId = 3L;
 
-        final List<BatchRequest> batchRequests1 = Arrays.asList(getSavingAccountRequest, depositSavingAccountRequest,
-                holdAmountOnSavingAccountRequest);
-        final List<BatchResponse> responses1 = BatchHelper.postBatchRequestsWithEnclosingTransaction(this.requestSpec, this.responseSpec,
-                BatchHelper.toJsonString(batchRequests1));
+        final BatchRequest getSavingsAccountRequest = BatchRequestBuilders.getSavingsAccount(getSavingsAccountRequestId, null, savingsId,
+                "chargeStatus=all");
 
-        Assertions.assertEquals(HttpStatus.SC_OK, responses1.get(1).getStatusCode(), "Verify Status Code 200 for deposit saving account");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses1.get(2).getStatusCode(),
-                "Verify Status Code 200 for hold amount on saving account");
-        final FromJsonHelper jsonHelper = new FromJsonHelper();
-        final Long holdAmountTransactionId = jsonHelper.parse(responses1.get(2).getBody()).getAsJsonObject().get("resourceId").getAsLong();
+        final List<BatchRequest> depositRequests = List.of(getSavingsAccountRequest,
+                BatchRequestBuilders.depositSavingsAccount(depositRequestId, getSavingsAccountRequestId, 100F),
+                BatchRequestBuilders.holdAmountOnSavingsAccount(holdAmountRequestId, getSavingsAccountRequestId, 10F));
 
-        final BatchRequest releaseAmountOnSavingAccountRequest = BatchHelper.releaseAmountOnSavingAccount(2L, 1L, holdAmountTransactionId);
-        final BatchRequest withdrawSavingAccountRequest = BatchHelper.withdrawSavingAccount(3L, 1L, 80F);
+        final List<BatchResponse> depositResponses = batchHelper.executeEnclosingTransaction(depositRequests);
 
-        final List<BatchRequest> batchRequests2 = Arrays.asList(getSavingAccountRequest, releaseAmountOnSavingAccountRequest,
-                withdrawSavingAccountRequest);
-        final List<BatchResponse> responses2 = BatchHelper.postBatchRequestsWithEnclosingTransaction(this.requestSpec, this.responseSpec,
-                BatchHelper.toJsonString(batchRequests2));
+        assertEquals(SC_OK, depositResponses.get(1).getStatusCode(), "Verify Status Code 200 for deposit saving account");
+        assertEquals(SC_OK, depositResponses.get(2).getStatusCode(), "Verify Status Code 200 for hold amount on saving account");
 
-        Assertions.assertEquals(HttpStatus.SC_OK, responses2.get(1).getStatusCode(),
-                "Verify Status Code 200 for release amount on saving account");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses2.get(2).getStatusCode(), "Verify Status Code 200 for withdraw saving account");
+        final Long holdAmountTransactionId = bodyAsObject(depositResponses.get(2)).get("resourceId").getAsLong();
+
+        final Long releaseAmountRequestId = 2L;
+        final Long withdrawRequestId = 3L;
+
+        final List<BatchRequest> withdrawRequests = List.of(getSavingsAccountRequest,
+                BatchRequestBuilders.releaseAmountOnSavingsAccount(releaseAmountRequestId, getSavingsAccountRequestId,
+                        holdAmountTransactionId),
+                BatchRequestBuilders.withdrawSavingsAccount(withdrawRequestId, getSavingsAccountRequestId, 80F));
+
+        final List<BatchResponse> withdrawResponses = batchHelper.executeEnclosingTransaction(withdrawRequests);
+
+        assertEquals(SC_OK, withdrawResponses.get(1).getStatusCode(), "Verify Status Code 200 for release amount on saving account");
+        assertEquals(SC_OK, withdrawResponses.get(2).getStatusCode(), "Verify Status Code 200 for withdraw saving account");
     }
 
     /**
-     * Test for finding datatable entry by the query API and update its value
+     * Test for finding a one-to-one datatable entry by the query API and updating one of its columns.
      */
     @Test
     public void shouldFindOneToOneDatatableEntryByQueryAPIAndUpdateOneOfItsColumn() {
+        final Long loanId = setupLoanAccount();
         final String datatableName = Utils.uniqueRandomStringGenerator(LOAN_APP_TABLE_NAME + "_", 5).toLowerCase();
-
-        final FromJsonHelper jsonHelper = new FromJsonHelper();
-        final Long loanId = jsonHelper.extractLongNamed("loanId", jsonHelper.parse(setupAccount()).getAsJsonObject());
-        // creating datatable with m_loan association
-        final Map<String, Object> columnMap = new HashMap<>();
-        final List<HashMap<String, Object>> datatableColumnsList = new ArrayList<>();
-
         final String columnName1 = Utils.randomStringGenerator("COL1_", 5).toLowerCase();
         final String columnName2 = Utils.randomStringGenerator("COL2_", 5).toLowerCase();
-        columnMap.put("datatableName", datatableName);
-        columnMap.put("apptableName", LOAN_APP_TABLE_NAME);
-        columnMap.put("entitySubType", "PERSON");
-        columnMap.put("multiRow", false);
-        DatatableHelper.addDatatableColumn(datatableColumnsList, columnName1, "String", true, 10, null);
-        DatatableHelper.addDatatableColumn(datatableColumnsList, columnName2, "String", false, 10, null);
-        columnMap.put("columns", datatableColumnsList);
-        final String datatableRequestJsonString = new Gson().toJson(columnMap);
-        LOG.info("CreateDataTable map : {}", datatableRequestJsonString);
+        createTwoStringColumnDatatable(datatableName, columnName1, columnName2, false, SHORT_COLUMN_LENGTH);
+        try {
+            final String columnValue1 = Utils.randomStringGenerator("VAL1_", 3);
+            final String columnValue2 = Utils.randomStringGenerator("VAL2_", 3);
+            createDatatableEntry(datatableName, loanId, columnName1, columnValue1, columnName2, columnValue2);
 
-        this.datatableHelper.createDatatable(datatableRequestJsonString, "");
+            final String updatedColumnValue2 = columnValue2 + "1";
+            final List<BatchRequest> batchRequests = List.of(
+                    BatchRequestBuilders.queryDatatableEntries(QUERY_DATATABLE_ENTRIES_REQUEST_ID, datatableName, columnName1, columnValue1,
+                            "loan_id"),
+                    BatchRequestBuilders.updateDatatableEntry(UPDATE_QUERIED_DATATABLE_ENTRY_REQUEST_ID, QUERY_DATATABLE_ENTRIES_REQUEST_ID,
+                            datatableName, "$.[0].loan_id", columnName2, updatedColumnValue2));
 
-        // Create a datatable entry so that it can be updated using BatchApi
-        final Map<String, Object> datatableEntryMap = new HashMap<>();
-        String columnValue1 = Utils.randomStringGenerator("VAL1_", 3);
-        String columnValue2 = Utils.randomStringGenerator("VAL2_", 3);
-        datatableEntryMap.put(columnName1, columnValue1);
-        datatableEntryMap.put(columnName2, columnValue2);
-        final String datatableEntryRequestJsonString = new Gson().toJson(datatableEntryMap);
-        LOG.info("CreateDataTableEntry map : {}", datatableEntryRequestJsonString);
+            // Create a datatable entry so that it can be updated using BatchApi
+            final List<BatchResponse> responses = batchHelper.executeEnclosingTransaction(batchRequests);
 
-        final Map<String, Object> datatableEntryResponse = this.datatableHelper.createDatatableEntry(datatableName, loanId.intValue(),
-                false, datatableEntryRequestJsonString);
-        final Integer datatableEntryResourceId = (Integer) datatableEntryResponse.get("resourceId");
-        assertNotNull(datatableEntryResourceId, "ERROR IN CREATING THE ENTITY DATATABLE RECORD");
+            assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for query datatable entries");
+            assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for update datatable entry");
 
-        final BatchRequest queryDatatableEntriesRequest = BatchHelper.queryDatatableEntries(datatableName, columnName1, columnValue1,
-                "loan_id");
-        final BatchRequest updateDatatableEntry = BatchHelper.updateDatatableEntry(datatableName, "$.[0].loan_id", columnName2,
-                columnValue2 + "1");
-
-        final List<BatchRequest> batchRequestsToQueryAndUpdateDatatableEntries = Arrays.asList(queryDatatableEntriesRequest,
-                updateDatatableEntry);
-        LOG.info("Batch Request : {}", BatchHelper.toJsonString(batchRequestsToQueryAndUpdateDatatableEntries));
-
-        final List<BatchResponse> responseOfQuertAndUpdateDatatableBatch = BatchHelper.postBatchRequestsWithEnclosingTransaction(
-                this.requestSpec, this.responseSpec, BatchHelper.toJsonString(batchRequestsToQueryAndUpdateDatatableEntries));
-
-        LOG.info("Batch Response : {}", new Gson().toJson(responseOfQuertAndUpdateDatatableBatch));
-
-        final BatchResponse batchQueryAndUpdateResponse1 = responseOfQuertAndUpdateDatatableBatch.get(0);
-        final BatchResponse batchQueryAndUpdateResponse2 = responseOfQuertAndUpdateDatatableBatch.get(1);
-        Assertions.assertEquals(HttpStatus.SC_OK, batchQueryAndUpdateResponse1.getStatusCode(),
-                "Verify Status Code 200 for create datatable entry");
-        Assertions.assertEquals(HttpStatus.SC_OK, batchQueryAndUpdateResponse2.getStatusCode(),
-                "Verify Status Code 200 for update datatable entry");
-
-        final JsonObject changes = jsonHelper.parse(batchQueryAndUpdateResponse2.getBody()).getAsJsonObject().get("changes")
-                .getAsJsonObject();
-        Assertions.assertEquals(changes.get(columnName2).getAsString(), columnValue2 + "1");
+            final JsonObject changes = bodyAsObject(responses.get(1)).getAsJsonObject("changes");
+            assertEquals(updatedColumnValue2, changes.get(columnName2).getAsString());
+        } finally {
+            deleteDatatableWithEntriesOf(datatableName, loanId);
+        }
     }
 
     /**
-     * Test when datatable entry was not found by the query API, and the update fails
+     * Test when a datatable entry was not found by the query API, and the update consequently fails.
      */
     @Test
     public void shouldNotFindAnyDatatableEntryByQueryAPIAndFailsToUpdateItsColumn() {
         final String datatableName = Utils.uniqueRandomStringGenerator(LOAN_APP_TABLE_NAME + "_", 5).toLowerCase();
-
-        // creating datatable with m_loan association
-        final Map<String, Object> columnMap = new HashMap<>();
-        final List<HashMap<String, Object>> datatableColumnsList = new ArrayList<>();
-
         final String columnName1 = Utils.randomStringGenerator("COL1_", 5).toLowerCase();
         final String columnName2 = Utils.randomStringGenerator("COL2_", 5).toLowerCase();
-        columnMap.put("datatableName", datatableName);
-        columnMap.put("apptableName", LOAN_APP_TABLE_NAME);
-        columnMap.put("entitySubType", "PERSON");
-        columnMap.put("multiRow", false);
-        DatatableHelper.addDatatableColumn(datatableColumnsList, columnName1, "String", true, 15, null);
-        DatatableHelper.addDatatableColumn(datatableColumnsList, columnName2, "String", false, 15, null);
-        columnMap.put("columns", datatableColumnsList);
-        final String datatableRequestJsonString = new Gson().toJson(columnMap);
-        LOG.info("CreateDataTable map : {}", datatableRequestJsonString);
+        createTwoStringColumnDatatable(datatableName, columnName1, columnName2, false, LONG_COLUMN_LENGTH);
+        try {
+            final List<BatchRequest> batchRequests = List.of(
+                    BatchRequestBuilders.queryDatatableEntries(QUERY_DATATABLE_ENTRIES_REQUEST_ID, datatableName, columnName1,
+                            "columnValue1", "loan_id"),
+                    BatchRequestBuilders.updateDatatableEntry(UPDATE_QUERIED_DATATABLE_ENTRY_REQUEST_ID, QUERY_DATATABLE_ENTRIES_REQUEST_ID,
+                            datatableName, "$.[0].loan_id", columnName2, "columnValue2"));
 
-        this.datatableHelper.createDatatable(datatableRequestJsonString, "");
+            final List<BatchResponse> responses = batchHelper.executeEnclosingTransaction(batchRequests);
 
-        final BatchRequest queryDatatableEntriesRequest = BatchHelper.queryDatatableEntries(datatableName, columnName1, "columnValue1",
-                "loan_id");
-        final BatchRequest updateDatatableEntry = BatchHelper.updateDatatableEntry(datatableName, "$.[0].loan_id", columnName2,
-                "columnValue2");
-
-        final List<BatchRequest> batchRequestsToQueryAndUpdateDatatableEntries = Arrays.asList(queryDatatableEntriesRequest,
-                updateDatatableEntry);
-        LOG.info("Batch Request : {}", BatchHelper.toJsonString(batchRequestsToQueryAndUpdateDatatableEntries));
-
-        final List<BatchResponse> responseOfQueryAndUpdateDatatableBatch = BatchHelper.postBatchRequestsWithEnclosingTransaction(
-                this.requestSpec, this.responseSpec, BatchHelper.toJsonString(batchRequestsToQueryAndUpdateDatatableEntries));
-
-        LOG.info("Batch Response : {}", new Gson().toJson(responseOfQueryAndUpdateDatatableBatch));
-
-        final BatchResponse updateResponse = responseOfQueryAndUpdateDatatableBatch.get(0);
-
-        Assertions.assertEquals(2L, updateResponse.getRequestId());
-        Assertions.assertEquals(HttpStatus.SC_BAD_REQUEST, updateResponse.getStatusCode(),
-                "Verify Status Code 400 for update datatable entry");
-        MatcherAssert.assertThat(updateResponse.getBody(), containsString("The referenced JSON path is invalid"));
+            final BatchResponse updateResponse = responses.get(0);
+            assertEquals(UPDATE_QUERIED_DATATABLE_ENTRY_REQUEST_ID, updateResponse.getRequestId());
+            assertEquals(SC_BAD_REQUEST, updateResponse.getStatusCode(), "Verify Status Code 400 for update datatable entry");
+            assertTrue(updateResponse.getBody().contains("The referenced JSON path is invalid"),
+                    "Expected an invalid JSON path error but was: " + updateResponse.getBody());
+        } finally {
+            deleteDatatable(datatableName);
+        }
     }
 
     /**
-     * Test for finding datatable entry by the query API and update its value
+     * Test for finding a one-to-many datatable entry by the query API and updating one of its columns.
      */
     @Test
     public void shouldFindOneToManyDatatableEntryByQueryAPIAndUpdateOneOfItsColumn() {
+        final Long loanId = setupLoanAccount();
         final String datatableName = Utils.uniqueRandomStringGenerator(LOAN_APP_TABLE_NAME + "_", 5).toLowerCase();
-
-        final FromJsonHelper jsonHelper = new FromJsonHelper();
-        final Long loanId = jsonHelper.extractLongNamed("loanId", jsonHelper.parse(setupAccount()).getAsJsonObject());
-        // creating datatable with m_loan association
-        final Map<String, Object> columnMap = new HashMap<>();
-        final List<HashMap<String, Object>> datatableColumnsList = new ArrayList<>();
-
         final String columnName1 = Utils.randomStringGenerator("COL1_", 5).toLowerCase();
         final String columnName2 = Utils.randomStringGenerator("COL2_", 5).toLowerCase();
-        columnMap.put("datatableName", datatableName);
-        columnMap.put("apptableName", LOAN_APP_TABLE_NAME);
-        columnMap.put("entitySubType", "PERSON");
-        columnMap.put("multiRow", true);
-        DatatableHelper.addDatatableColumn(datatableColumnsList, columnName1, "String", true, 10, null);
-        DatatableHelper.addDatatableColumn(datatableColumnsList, columnName2, "String", false, 10, null);
-        columnMap.put("columns", datatableColumnsList);
-        final String datatableRequestJsonString = new Gson().toJson(columnMap);
-        LOG.info("CreateDataTable map : {}", datatableRequestJsonString);
+        createTwoStringColumnDatatable(datatableName, columnName1, columnName2, true, SHORT_COLUMN_LENGTH);
+        try {
+            final String columnValue1 = Utils.randomStringGenerator("VAL1_", 3);
+            final String columnValue2 = Utils.randomStringGenerator("VAL2_", 3);
+            final Long existingEntryId = createDatatableEntry(datatableName, loanId, columnName1, columnValue1, columnName2, columnValue2);
 
-        this.datatableHelper.createDatatable(datatableRequestJsonString, "");
+            final List<BatchRequest> createAndReadRequests = List.of(
+                    BatchRequestBuilders.createDatatableEntry(CREATE_DATATABLE_ENTRY_REQUEST_ID, datatableName, loanId,
+                            List.of(columnName1, columnName2)),
+                    BatchRequestBuilders.getDatatableEntries(GET_DATATABLE_ENTRIES_REQUEST_ID, CREATE_DATATABLE_ENTRY_REQUEST_ID,
+                            datatableName, loanId, null));
 
-        // Create a datatable entry so that it can be updated using BatchApi
-        final Map<String, Object> datatableEntryMap = new HashMap<>();
-        String columnValue1 = Utils.randomStringGenerator("VAL1_", 3);
-        String columnValue2 = Utils.randomStringGenerator("VAL2_", 3);
-        datatableEntryMap.put(columnName1, columnValue1);
-        datatableEntryMap.put(columnName2, columnValue2);
-        final String datatableEntryRequestJsonString = new Gson().toJson(datatableEntryMap);
-        LOG.info("CreateDataTableEntry map : {}", datatableEntryRequestJsonString);
+            // Create a datatable entry so that it can be updated using BatchApi
+            final List<BatchResponse> createAndReadResponses = batchHelper.executeEnclosingTransaction(createAndReadRequests);
 
-        final Map<String, Object> datatableEntryResponse = this.datatableHelper.createDatatableEntry(datatableName, loanId.intValue(),
-                false, datatableEntryRequestJsonString);
-        final Integer datatableEntryResourceId = (Integer) datatableEntryResponse.get("resourceId");
-        assertNotNull(datatableEntryResourceId, "ERROR IN CREATING THE ENTITY DATATABLE RECORD");
+            assertEquals(SC_OK, createAndReadResponses.get(0).getStatusCode(), "Verify Status Code 200 for create datatable entry");
+            assertEquals(SC_OK, createAndReadResponses.get(1).getStatusCode(), "Verify Status Code 200 for get datatable entries");
 
-        // Create datatable entry batch request
-        final BatchRequest createDatatableEntryRequest = BatchHelper.createDatatableEntryRequest(loanId.toString(), datatableName,
-                Arrays.asList(columnName1, columnName2));
+            final Long createdEntryId = bodyAsObject(createAndReadResponses.get(0)).get("resourceId").getAsLong();
+            // Create datatable entry batch request
+            final String getDatatableEntriesResponse = createAndReadResponses.get(1).getBody();
+            final JsonArray datatableEntries = JsonParser.parseString(getDatatableEntriesResponse).getAsJsonArray();
+            assertEquals(2, datatableEntries.size());
 
-        // Get datatable entries batch request
-        final BatchRequest getDatatableEntriesRequest = BatchHelper.getDatatableByIdRequest(loanId, datatableName, null,
-                createDatatableEntryRequest.getReference());
+            // Ensure both resourceIds are available in response
+            assertTrue(getDatatableEntriesResponse.contains("\"id\": %d".formatted(createdEntryId)));
+            assertTrue(getDatatableEntriesResponse.contains("\"id\": %d".formatted(existingEntryId)));
 
-        final List<BatchRequest> batchRequestsDatatableEntries = Arrays.asList(createDatatableEntryRequest, getDatatableEntriesRequest);
-        LOG.info("Batch Request : {}", BatchHelper.toJsonString(batchRequestsDatatableEntries));
+            final String updatedColumnValue2 = columnValue2 + "1";
+            final List<BatchRequest> queryAndUpdateRequests = List.of(
+                    BatchRequestBuilders.queryDatatableEntries(QUERY_DATATABLE_ENTRIES_REQUEST_ID, datatableName, columnName1, columnValue1,
+                            "id,loan_id"),
+                    BatchRequestBuilders.updateDatatableEntry(UPDATE_QUERIED_DATATABLE_ENTRY_REQUEST_ID, QUERY_DATATABLE_ENTRIES_REQUEST_ID,
+                            datatableName, "$.[0].loan_id", "$.[0].id", columnName2, updatedColumnValue2));
 
-        final List<BatchResponse> responseDatatableBatch = BatchHelper.postBatchRequestsWithEnclosingTransaction(this.requestSpec,
-                this.responseSpec, BatchHelper.toJsonString(batchRequestsDatatableEntries));
+            final List<BatchResponse> queryAndUpdateResponses = batchHelper.executeEnclosingTransaction(queryAndUpdateRequests);
 
-        LOG.info("Batch Response : {}", new Gson().toJson(responseDatatableBatch));
+            assertEquals(SC_OK, queryAndUpdateResponses.get(0).getStatusCode(), "Verify Status Code 200 for query datatable entries");
+            assertEquals(SC_OK, queryAndUpdateResponses.get(1).getStatusCode(), "Verify Status Code 200 for update datatable entry");
 
-        final BatchResponse batchResponse1 = responseDatatableBatch.get(0);
-        final BatchResponse batchResponse2 = responseDatatableBatch.get(1);
-        Assertions.assertEquals(HttpStatus.SC_OK, batchResponse1.getStatusCode(), "Verify Status Code 200 for create datatable entry");
-        Assertions.assertEquals(HttpStatus.SC_OK, batchResponse2.getStatusCode(), "Verify Status Code 200 for update datatable entry");
-
-        final String getDatatableEntriesResponse = batchResponse2.getBody();
-
-        final Long createDatatableEntryId = jsonHelper.extractLongNamed("resourceId",
-                jsonHelper.parse(batchResponse1.getBody()).getAsJsonObject());
-
-        final JsonArray datatableEntries = jsonHelper.parse(getDatatableEntriesResponse).getAsJsonArray();
-        Assertions.assertEquals(2, datatableEntries.size());
-
-        // Ensure both resourceIds are available in response
-        Assertions.assertTrue(getDatatableEntriesResponse.contains(String.format("\"id\": %d", createDatatableEntryId)));
-        Assertions.assertTrue(getDatatableEntriesResponse.contains(String.format("\"id\": %d", datatableEntryResourceId)));
-
-        final BatchRequest queryDatatableEntriesRequest = BatchHelper.queryDatatableEntries(datatableName, columnName1, columnValue1,
-                "id,loan_id");
-        final BatchRequest updateDatatableEntry = BatchHelper.updateDatatableEntry(datatableName, "$.[0].loan_id", "$.[0].id", columnName2,
-                columnValue2 + "1");
-
-        final List<BatchRequest> batchRequestsToQueryAndUpdateDatatableEntries = Arrays.asList(queryDatatableEntriesRequest,
-                updateDatatableEntry);
-        LOG.info("Batch Request : {}", BatchHelper.toJsonString(batchRequestsToQueryAndUpdateDatatableEntries));
-
-        final List<BatchResponse> responseOfQuertAndUpdateDatatableBatch = BatchHelper.postBatchRequestsWithEnclosingTransaction(
-                this.requestSpec, this.responseSpec, BatchHelper.toJsonString(batchRequestsToQueryAndUpdateDatatableEntries));
-
-        LOG.info("Batch Response : {}", new Gson().toJson(responseOfQuertAndUpdateDatatableBatch));
-
-        final BatchResponse batchQueryAndUpdateResponse1 = responseOfQuertAndUpdateDatatableBatch.get(0);
-        final BatchResponse batchQueryAndUpdateResponse2 = responseOfQuertAndUpdateDatatableBatch.get(1);
-        Assertions.assertEquals(HttpStatus.SC_OK, batchQueryAndUpdateResponse1.getStatusCode(),
-                "Verify Status Code 200 for create datatable entry");
-        Assertions.assertEquals(HttpStatus.SC_OK, batchQueryAndUpdateResponse2.getStatusCode(),
-                "Verify Status Code 200 for update datatable entry");
-
-        final JsonObject changes = jsonHelper.parse(batchQueryAndUpdateResponse2.getBody()).getAsJsonObject().get("changes")
-                .getAsJsonObject();
-        Assertions.assertEquals(changes.get(columnName2).getAsString(), columnValue2 + "1");
+            final JsonObject changes = bodyAsObject(queryAndUpdateResponses.get(1)).getAsJsonObject("changes");
+            assertEquals(updatedColumnValue2, changes.get(columnName2).getAsString());
+        } finally {
+            deleteDatatableWithEntriesOf(datatableName, loanId);
+        }
     }
 
     /**
-     * Tests that a loan information was successfully updated through updateLoanCommand. A 'changes' parameter is
-     * returned as part of response after successful update of loan information. In this test, we are marking an active
-     * loan account as fraud.
+     * Tests that a loan information was successfully updated through updateLoanCommand. In this test, we are marking an
+     * active loan account as fraud.
      *
      * @see org.apache.fineract.batch.command.internal.ModifyLoanApplicationCommandStrategy
      */
     @Test
     public void shouldReflectChangesOnLoanUpdate() {
+        final Long productId = createBatchLoanProduct(SMALL_PRINCIPAL);
+        final Long clientId = createClient();
 
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("1000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
-
-        final Long applyLoanRequestId = ThreadLocalRandom.current().nextLong(100, 1000);
+        final Long applyLoanRequestId = randomRequestId();
         final Long approveLoanRequestId = applyLoanRequestId + 1;
         final Long disburseLoanRequestId = approveLoanRequestId + 1;
         final Long updateLoanRequestId = disburseLoanRequestId + 1;
 
-        // Create product
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
-
-        // Create client
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientId);
-
-        final BatchRequest applyLoanRequest = BatchHelper.applyLoanRequestWithClientId(applyLoanRequestId, clientId, productId);
-
-        final BatchRequest approveLoanRequest = BatchHelper.approveLoanRequest(approveLoanRequestId, applyLoanRequestId);
-
-        final BatchRequest disburseLoanRequest = BatchHelper.disburseLoanRequest(disburseLoanRequestId, approveLoanRequestId);
-
-        final BatchRequest updateLoanRequest = BatchHelper.createLoanRequestMarkAsFraud(updateLoanRequestId, disburseLoanRequestId);
-
         // Create batch requests list
-        final List<BatchRequest> batchRequests = Arrays.asList(applyLoanRequest, approveLoanRequest, disburseLoanRequest,
-                updateLoanRequest);
+        final List<BatchRequest> batchRequests = List.of(
+                BatchRequestBuilders.applyLoanWithClientId(applyLoanRequestId, clientId, productId),
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                BatchRequestBuilders.disburseLoan(disburseLoanRequestId, approveLoanRequestId),
+                BatchRequestBuilders.markLoanAsFraud(updateLoanRequestId, disburseLoanRequestId));
 
-        final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        final List<BatchResponse> response = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                jsonifiedRequest);
+        assertEquals(SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for update loan application");
 
         // Get the changes parameter from updateLoan Response
-        final JsonObject changes = new FromJsonHelper().parse(response.get(3).getBody()).getAsJsonObject().get("changes").getAsJsonObject();
-
-        Assertions.assertEquals(HttpStatus.SC_OK, response.get(3).getStatusCode(), "Verify Status Code 200 for update loan application");
-        Assertions.assertEquals("true", changes.get("fraud").getAsString());
+        final JsonObject changes = bodyAsObject(responses.get(3)).getAsJsonObject("changes");
+        assertTrue(changes.get("fraud").getAsBoolean());
     }
 
     /**
-     * Tests that a loan information was successfully updated through updateLoanCommand using external id. A 'changes'
-     * parameter is returned as part of response after successful update of loan information. In this test, we are
-     * marking an active loan account as fraud.
+     * Tests that a loan information was successfully updated through updateLoanCommand using external id. In this test,
+     * we are marking an active loan account as fraud.
      *
      * @see org.apache.fineract.batch.command.internal.ModifyLoanApplicationByExternalIdCommandStrategy
      */
     @Test
     public void shouldReflectChangesOnLoanUpdateByExternalId() {
+        final Long productId = createBatchLoanProduct(SMALL_PRINCIPAL);
+        final Long clientId = createClient();
 
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("1000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
-
-        final long applyLoanRequestId = ThreadLocalRandom.current().nextLong(100, 1000);
+        final Long applyLoanRequestId = randomRequestId();
         final Long approveLoanRequestId = applyLoanRequestId + 1;
         final Long disburseLoanRequestId = approveLoanRequestId + 1;
         final Long updateLoanRequestId = disburseLoanRequestId + 1;
         final Long getLoanRequestId = updateLoanRequestId + 1;
 
         // Create product
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final List<BatchRequest> batchRequests = List.of(
+                BatchRequestBuilders.applyLoanWithClientId(applyLoanRequestId, clientId, productId),
+                BatchRequestBuilders.transitionLoanStateByExternalId(approveLoanRequestId, applyLoanRequestId, today().minusDays(10),
+                        "approve"),
+                BatchRequestBuilders.transitionLoanStateByExternalId(disburseLoanRequestId, approveLoanRequestId, today().minusDays(8),
+                        "disburse"),
+                BatchRequestBuilders.markLoanAsFraudByExternalId(updateLoanRequestId, approveLoanRequestId),
+                BatchRequestBuilders.getLoanByExternalIdReference(getLoanRequestId, approveLoanRequestId, "associations=all"));
 
         // Create client
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientId);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        final BatchRequest applyLoanRequest = BatchHelper.applyLoanRequestWithClientId(applyLoanRequestId, clientId, productId);
-
-        final BatchRequest approveLoanRequest = BatchHelper.transitionLoanStateByExternalId(approveLoanRequestId, applyLoanRequestId,
-                LocalDate.now(Utils.getZoneIdOfTenant()).minusDays(10), "approve");
-
-        final BatchRequest disburseLoanRequest = BatchHelper.transitionLoanStateByExternalId(disburseLoanRequestId, approveLoanRequestId,
-                LocalDate.now(Utils.getZoneIdOfTenant()).minusDays(8), "disburse");
-
-        final BatchRequest updateLoanRequest = BatchHelper.modifyLoanByExternalIdRequest(updateLoanRequestId, approveLoanRequestId);
-
-        final BatchRequest getLoanRequest = BatchHelper.getLoanByExternalIdRequest(getLoanRequestId, approveLoanRequestId,
-                "associations=all");
-
-        // Create batch requests list
-        final List<BatchRequest> batchRequests = Arrays.asList(applyLoanRequest, approveLoanRequest, disburseLoanRequest, updateLoanRequest,
-                getLoanRequest);
-
-        final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-
-        final List<BatchResponse> responses = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                jsonifiedRequest);
-
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for update loan application");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(4).getStatusCode(), "Verify Status Code 200 for Get Loan");
+        assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
+        assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
+        assertEquals(SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
+        assertEquals(SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for update loan application");
+        assertEquals(SC_OK, responses.get(4).getStatusCode(), "Verify Status Code 200 for Get Loan");
 
         // Get the changes parameter from updateLoan Response
-        final JsonObject changes = new FromJsonHelper().parse(responses.get(3).getBody()).getAsJsonObject().get("changes")
-                .getAsJsonObject();
-        Assertions.assertEquals("true", changes.get("fraud").getAsString());
+        final JsonObject changes = bodyAsObject(responses.get(3)).getAsJsonObject("changes");
+        assertTrue(changes.get("fraud").getAsBoolean());
     }
 
     /**
-     * Tests that a loan is hard locked and if a repayment triggered in as a batch request, it returns the proper error
-     *
-     * @see org.apache.fineract.batch.command.internal.ModifyLoanApplicationByExternalIdCommandStrategy
+     * Tests that a repayment posted as a batch request against a locked loan is rejected with a 409, when the batch is
+     * submitted through the legacy un-versioned {@code loans/...} relative URL.
      */
     @Test
     public void shoulRetrieveTheProperErrorDuringLockedLoan_OldRelativePath() {
-        ResponseSpecification responseSpec = new ResponseSpecBuilder().expectStatusCode(202).build();
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("1000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
-
-        final long applyLoanRequestId = ThreadLocalRandom.current().nextLong(100, 1000);
-        final Long approveLoanRequestId = applyLoanRequestId + 1;
-        final Long disburseLoanRequestId = approveLoanRequestId + 1;
-        final Long getLoanRequestId = disburseLoanRequestId + 1;
-
-        // Create product
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
-
-        // Create client
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientId);
-
-        final BatchRequest applyLoanRequest = BatchHelper.applyLoanRequestWithClientId(applyLoanRequestId, clientId, productId);
-
-        final BatchRequest approveLoanRequest = BatchHelper.transitionLoanStateByExternalId(approveLoanRequestId, applyLoanRequestId,
-                LocalDate.now(Utils.getZoneIdOfTenant()).minusDays(10), "approve");
-
-        final BatchRequest disburseLoanRequest = BatchHelper.transitionLoanStateByExternalId(disburseLoanRequestId, approveLoanRequestId,
-                LocalDate.now(Utils.getZoneIdOfTenant()).minusDays(8), "disburse");
-
-        final BatchRequest getLoanRequest = BatchHelper.getLoanByExternalIdRequest(getLoanRequestId, approveLoanRequestId,
-                "associations=all");
-
-        // Create batch requests list
-        final List<BatchRequest> batchRequests = Arrays.asList(applyLoanRequest, approveLoanRequest, disburseLoanRequest, getLoanRequest);
-
-        final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-
-        final List<BatchResponse> responses = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                jsonifiedRequest);
-
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for Get Loan");
-
-        final Long loanId = new FromJsonHelper().parse(responses.get(2).getBody()).getAsJsonObject().get("resourceId").getAsLong();
-
-        LoanAccountLockHelper.placeSoftLockOnLoanAccount(loanId, "LOAN_COB_CHUNK_PROCESSING");
-
-        RequestSpecification requestSpec = UserHelper.getSimpleUserWithoutBypassPermission(this.requestSpec, this.responseSpec);
-
-        // Create a repayment Request
-        final BatchRequest br = new BatchRequest();
-
-        br.setRequestId(1L);
-        br.setRelativeUrl(String.format("loans/" + loanId + "/transactions?command=repayment"));
-        br.setMethod("POST");
-        String dateString = LocalDate.now(Utils.getZoneIdOfTenant()).format(DateTimeFormatter.ofPattern("dd MMMM yyyy"));
-        br.setBody(String.format(
-                "{\"locale\": \"en\", \"dateFormat\": \"dd MMMM yyyy\", " + "\"transactionDate\": \"%s\",  \"transactionAmount\": \"500\"}",
-                dateString));
-
-        final String jsonifiedRepaymentRequest = BatchHelper.toJsonString(List.of(br));
-
-        // verify HTTP 409
-        ResponseSpecification conflictResponseSpec = new ResponseSpecBuilder().expectStatusCode(409).build();
-        ErrorResponse errorResponse = BatchHelper.postBatchRequestsWithoutEnclosingTransactionError(requestSpec, conflictResponseSpec,
-                jsonifiedRepaymentRequest);
-        assertEquals(409, errorResponse.getHttpStatusCode());
+        assertLockedLoanRepaymentIsRejected(false);
     }
 
     /**
-     * Tests that a loan is hard locked and if a repayment triggered in as a batch request, it returns the proper error
-     *
-     * @see org.apache.fineract.batch.command.internal.ModifyLoanApplicationByExternalIdCommandStrategy
+     * Tests that a repayment posted as a batch request against a locked loan is rejected with a 409, when the batch is
+     * submitted through the current {@code v1/loans/...} relative URL.
      */
     @Test
     public void shoulRetrieveTheProperErrorDuringLockedLoan() {
-        ResponseSpecification responseSpec = new ResponseSpecBuilder().expectStatusCode(202).build();
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("1000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
-
-        final Long applyLoanRequestId = ThreadLocalRandom.current().nextLong(100, 1000);
-        final Long approveLoanRequestId = applyLoanRequestId + 1;
-        final Long disburseLoanRequestId = approveLoanRequestId + 1;
-        final Long getLoanRequestId = disburseLoanRequestId + 1;
-
-        // Create product
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
-
-        // Create client
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientId);
-
-        final BatchRequest applyLoanRequest = BatchHelper.applyLoanRequestWithClientId(applyLoanRequestId, clientId, productId);
-
-        final BatchRequest approveLoanRequest = BatchHelper.transitionLoanStateByExternalId(approveLoanRequestId, applyLoanRequestId,
-                LocalDate.now(Utils.getZoneIdOfTenant()).minusDays(10), "approve");
-
-        final BatchRequest disburseLoanRequest = BatchHelper.transitionLoanStateByExternalId(disburseLoanRequestId, approveLoanRequestId,
-                LocalDate.now(Utils.getZoneIdOfTenant()).minusDays(8), "disburse");
-
-        final BatchRequest getLoanRequest = BatchHelper.getLoanByExternalIdRequest(getLoanRequestId, approveLoanRequestId,
-                "associations=all");
-
-        // Create batch requests list
-        final List<BatchRequest> batchRequests = Arrays.asList(applyLoanRequest, approveLoanRequest, disburseLoanRequest, getLoanRequest);
-
-        final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-
-        final List<BatchResponse> responses = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                jsonifiedRequest);
-
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for Get Loan");
-
-        final Long loanId = new FromJsonHelper().parse(responses.get(2).getBody()).getAsJsonObject().get("resourceId").getAsLong();
-
-        LoanAccountLockHelper.placeSoftLockOnLoanAccount(loanId, "LOAN_COB_CHUNK_PROCESSING");
-
-        RequestSpecification requestSpec = UserHelper.getSimpleUserWithoutBypassPermission(this.requestSpec, this.responseSpec);
-
-        // Create a repayment Request
-        final BatchRequest br = new BatchRequest();
-
-        br.setRequestId(1L);
-        br.setRelativeUrl(String.format("v1/loans/" + loanId + "/transactions?command=repayment"));
-        br.setMethod("POST");
-        String dateString = LocalDate.now(Utils.getZoneIdOfTenant()).format(DateTimeFormatter.ofPattern("dd MMMM yyyy"));
-        br.setBody(String.format(
-                "{\"locale\": \"en\", \"dateFormat\": \"dd MMMM yyyy\", " + "\"transactionDate\": \"%s\",  \"transactionAmount\": \"500\"}",
-                dateString));
-
-        final String jsonifiedRepaymentRequest = BatchHelper.toJsonString(List.of(br));
-
-        // verify HTTP 409
-        ResponseSpecification conflictResponseSpec = new ResponseSpecBuilder().expectStatusCode(409).build();
-        ErrorResponse errorResponse = BatchHelper.postBatchRequestsWithoutEnclosingTransactionError(requestSpec, conflictResponseSpec,
-                jsonifiedRepaymentRequest);
-        assertEquals(409, errorResponse.getHttpStatusCode());
+        assertLockedLoanRepaymentIsRejected(true);
     }
 
     @Test
     public void verifyCalculatingRunningBalanceAfterBatchWithReleaseAmount() {
-        final SavingsProductHelper savingsProductHelper = new SavingsProductHelper();
-        final SavingsAccountHelper savingsAccountHelper = new SavingsAccountHelper(this.requestSpec, this.responseSpec);
-        final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec);
-        Assertions.assertNotNull(clientID);
-        final String savingsProductJSON = savingsProductHelper.withInterestCompoundingPeriodTypeAsDaily()
-                .withInterestPostingPeriodTypeAsDaily().withInterestCalculationPeriodTypeAsDailyBalance().build();
-        final Integer savingsProductID = SavingsProductHelper.createSavingsProduct(savingsProductJSON, requestSpec, responseSpec);
-        Assertions.assertNotNull(savingsProductID);
-        final Integer savingsId = savingsAccountHelper.applyForSavingsApplication(clientID, savingsProductID,
-                ClientSavingsIntegrationTest.ACCOUNT_TYPE_INDIVIDUAL);
-        Assertions.assertNotNull(savingsId);
-        HashMap savingsStatusHashMap = savingsAccountHelper.approveSavings(savingsId);
-        SavingsStatusChecker.verifySavingsIsApproved(savingsStatusHashMap);
-        savingsStatusHashMap = savingsAccountHelper.activateSavings(savingsId);
-        SavingsStatusChecker.verifySavingsIsActive(savingsStatusHashMap);
+        final Long clientId = createClient();
+        final Long savingsId = createActiveSavingsAccount(clientId, SAVINGS_SUBMITTED_ON_DATE, SAVINGS_APPROVED_ON_DATE,
+                SAVINGS_ACTIVATED_ON_DATE);
 
         final float holdAmount = 10F;
         final float withdrawalAmount = 80F;
-        final BatchRequest getSavingAccountRequest = BatchHelper.getSavingAccount(1L, Long.valueOf(savingsId), "chargeStatus=all", null);
-        final BatchRequest depositSavingAccountRequest = BatchHelper.depositSavingAccount(2L, 1L, 300F);
-        final BatchRequest holdAmountOnSavingAccountRequest = BatchHelper.holdAmountOnSavingAccount(3L, 1L, holdAmount);
 
-        final List<BatchRequest> batchRequests1 = Arrays.asList(getSavingAccountRequest, depositSavingAccountRequest,
-                holdAmountOnSavingAccountRequest);
-        final List<BatchResponse> responses1 = BatchHelper.postBatchRequestsWithEnclosingTransaction(this.requestSpec, this.responseSpec,
-                BatchHelper.toJsonString(batchRequests1));
+        final Long getSavingsAccountRequestId = 1L;
+        final Long depositRequestId = 2L;
+        final Long holdAmountRequestId = 3L;
 
-        Assertions.assertEquals(HttpStatus.SC_OK, responses1.get(1).getStatusCode(), "Verify Status Code 200 for deposit saving account");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses1.get(2).getStatusCode(),
-                "Verify Status Code 200 for hold amount on saving account");
-        final FromJsonHelper jsonHelper = new FromJsonHelper();
-        final Long holdAmountTransactionId = jsonHelper.parse(responses1.get(2).getBody()).getAsJsonObject().get("resourceId").getAsLong();
+        final BatchRequest getSavingsAccountRequest = BatchRequestBuilders.getSavingsAccount(getSavingsAccountRequestId, null, savingsId,
+                "chargeStatus=all");
 
-        HashMap accountDetails = savingsAccountHelper.getSavingsDetails(savingsId);
-        ArrayList<HashMap<String, Object>> transactions = (ArrayList<HashMap<String, Object>>) accountDetails.get("transactions");
-        final float runningBalanceBeforeBatch = (float) transactions.get(0).get("runningBalance");
+        final List<BatchRequest> depositRequests = List.of(getSavingsAccountRequest,
+                BatchRequestBuilders.depositSavingsAccount(depositRequestId, getSavingsAccountRequestId, 300F),
+                BatchRequestBuilders.holdAmountOnSavingsAccount(holdAmountRequestId, getSavingsAccountRequestId, holdAmount));
 
-        final BatchRequest releaseAmountOnSavingAccountRequest = BatchHelper.releaseAmountOnSavingAccount(2L, 1L, holdAmountTransactionId);
-        final BatchRequest withdrawSavingAccountRequest1 = BatchHelper.withdrawSavingAccount(3L, 1L, withdrawalAmount);
-        final BatchRequest withdrawSavingAccountRequest2 = BatchHelper.withdrawSavingAccount(4L, 1L, withdrawalAmount);
+        final List<BatchResponse> depositResponses = batchHelper.executeEnclosingTransaction(depositRequests);
 
-        final List<BatchRequest> batchRequests2 = Arrays.asList(getSavingAccountRequest, releaseAmountOnSavingAccountRequest,
-                withdrawSavingAccountRequest1, withdrawSavingAccountRequest2);
-        final List<BatchResponse> responses2 = BatchHelper.postBatchRequestsWithEnclosingTransaction(this.requestSpec, this.responseSpec,
-                BatchHelper.toJsonString(batchRequests2));
+        assertEquals(SC_OK, depositResponses.get(1).getStatusCode(), "Verify Status Code 200 for deposit saving account");
+        assertEquals(SC_OK, depositResponses.get(2).getStatusCode(), "Verify Status Code 200 for hold amount on saving account");
 
-        Assertions.assertEquals(HttpStatus.SC_OK, responses2.get(0).getStatusCode(),
-                "Verify Status Code 200 for release amount on saving account");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses2.get(1).getStatusCode(), "Verify Status Code 200 for withdraw saving account");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses2.get(2).getStatusCode(), "Verify Status Code 200 for withdraw saving account");
+        final Long holdAmountTransactionId = bodyAsObject(depositResponses.get(2)).get("resourceId").getAsLong();
 
-        accountDetails = savingsAccountHelper.getSavingsDetails(savingsId);
-        transactions = (ArrayList<HashMap<String, Object>>) accountDetails.get("transactions");
+        final BigDecimal runningBalanceBeforeBatch = savingsHelper.getSavingsDetails(savingsId).getTransactions().get(0)
+                .getRunningBalance();
 
-        final HashMap<String, Object> transactionRelease = transactions.get(2);
-        final HashMap<String, Object> transactionWithdrawal1 = transactions.get(1);
-        final HashMap<String, Object> transactionWithdrawal2 = transactions.get(0);
+        final Long releaseAmountRequestId = 2L;
+        final Long firstWithdrawRequestId = 3L;
+        final Long secondWithdrawRequestId = 4L;
 
-        assertEquals(runningBalanceBeforeBatch + holdAmount, transactionRelease.get("runningBalance"),
-                "Verify running balance after release amount");
-        assertEquals(runningBalanceBeforeBatch + holdAmount - withdrawalAmount, transactionWithdrawal1.get("runningBalance"),
+        final List<BatchRequest> withdrawRequests = List.of(getSavingsAccountRequest,
+                BatchRequestBuilders.releaseAmountOnSavingsAccount(releaseAmountRequestId, getSavingsAccountRequestId,
+                        holdAmountTransactionId),
+                BatchRequestBuilders.withdrawSavingsAccount(firstWithdrawRequestId, getSavingsAccountRequestId, withdrawalAmount),
+                BatchRequestBuilders.withdrawSavingsAccount(secondWithdrawRequestId, getSavingsAccountRequestId, withdrawalAmount));
+
+        final List<BatchResponse> withdrawResponses = batchHelper.executeEnclosingTransaction(withdrawRequests);
+
+        assertEquals(SC_OK, withdrawResponses.get(0).getStatusCode(), "Verify Status Code 200 for get saving account");
+        assertEquals(SC_OK, withdrawResponses.get(1).getStatusCode(), "Verify Status Code 200 for release amount on saving account");
+        assertEquals(SC_OK, withdrawResponses.get(2).getStatusCode(), "Verify Status Code 200 for withdraw saving account");
+
+        final List<SavingsAccountTransactionData> transactions = savingsHelper.getSavingsDetails(savingsId).getTransactions();
+        final BigDecimal releaseRunningBalance = transactions.get(2).getRunningBalance();
+        final BigDecimal firstWithdrawalRunningBalance = transactions.get(1).getRunningBalance();
+        final BigDecimal secondWithdrawalRunningBalance = transactions.get(0).getRunningBalance();
+
+        final BigDecimal expectedAfterRelease = runningBalanceBeforeBatch.add(BigDecimal.valueOf(holdAmount));
+        assertEquals(0, expectedAfterRelease.compareTo(releaseRunningBalance), "Verify running balance after release amount");
+        assertEquals(0, expectedAfterRelease.subtract(BigDecimal.valueOf(withdrawalAmount)).compareTo(firstWithdrawalRunningBalance),
                 "Verify running balance after first withdrawal");
-        assertEquals(runningBalanceBeforeBatch + holdAmount - withdrawalAmount - withdrawalAmount,
-                transactionWithdrawal2.get("runningBalance"), "Verify running balance after second withdrawal");
+        assertEquals(0, expectedAfterRelease.subtract(BigDecimal.valueOf(withdrawalAmount)).subtract(BigDecimal.valueOf(withdrawalAmount))
+                .compareTo(secondWithdrawalRunningBalance), "Verify running balance after second withdrawal");
     }
 
     @Test
     public void shouldReturnOkStatusForBatchChargeOff() {
+        final Long productId = createBatchLoanProduct(LARGE_PRINCIPAL);
+        final Long clientCollateralId = createClientCollateral();
 
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
-
-        final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientID);
-
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(this.requestSpec, this.responseSpec);
-        Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(this.requestSpec, this.responseSpec,
-                clientID.toString(), collateralId);
-        Assertions.assertNotNull(clientCollateralId);
-
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final Long createClientRequestId = 4730L;
+        final Long activateClientRequestId = 4731L;
+        final Long applyLoanRequestId = 4732L;
+        final Long approveLoanRequestId = 4733L;
+        final Long disburseLoanRequestId = 4734L;
+        final Long firstRepaymentRequestId = 4735L;
+        final Long secondRepaymentRequestId = 4736L;
+        final Long chargeOffRequestId = 4737L;
 
         // Create a createClient Request
-        final BatchRequest br1 = BatchHelper.createClientRequest(4730L, "");
+        final List<BatchRequest> batchRequests = List.of(BatchRequestBuilders.createClient(createClientRequestId, ""),
+                // Create a activateClient Request
+                BatchRequestBuilders.activateClient(activateClientRequestId, createClientRequestId),
+                // Create a ApplyLoan Request
+                BatchRequestBuilders.applyLoan(applyLoanRequestId, activateClientRequestId, productId, clientCollateralId),
+                // Create a approveLoan Request
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                // Create a disburseLoan Request
+                BatchRequestBuilders.disburseLoan(disburseLoanRequestId, approveLoanRequestId),
+                // Create a loanRepay Request
+                BatchRequestBuilders.repayLoan(firstRepaymentRequestId, disburseLoanRequestId, "500"),
+                // Create a loanRepay Request
+                BatchRequestBuilders.repayLoan(secondRepaymentRequestId, disburseLoanRequestId, "500"),
+                BatchRequestBuilders.chargeOff(chargeOffRequestId, secondRepaymentRequestId));
 
-        // Create a activateClient Request
-        final BatchRequest br2 = BatchHelper.activateClientRequest(4731L, 4730L);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        // Create a ApplyLoan Request
-        final BatchRequest br3 = BatchHelper.applyLoanRequest(4732L, 4731L, productId, clientCollateralId);
+        assertEquals(SC_OK, responses.get(7).getStatusCode(), "Verify Status Code 200 for ChargeOff");
+    }
 
-        // Create a approveLoan Request
-        final BatchRequest br4 = BatchHelper.approveLoanRequest(4733L, 4732L);
+    /**
+     * Disburses a loan, hard-locks it, and asserts that a batch repayment posted by a user without the loan-checker
+     * bypass permission is answered with a 409.
+     */
+    private void assertLockedLoanRepaymentIsRejected(final boolean apiVersionPrefixedRelativeUrl) {
+        // Create product
+        final Long productId = createBatchLoanProduct(SMALL_PRINCIPAL);
+        // Create client
+        final Long clientId = createClient();
 
-        // Create a disburseLoan Request
-        final BatchRequest br5 = BatchHelper.disburseLoanRequest(4734L, 4733L);
+        final Long applyLoanRequestId = randomRequestId();
+        final Long approveLoanRequestId = applyLoanRequestId + 1;
+        final Long disburseLoanRequestId = approveLoanRequestId + 1;
 
-        // Create a loanRepay Request
-        final BatchRequest br6 = BatchHelper.repayLoanRequest(4735L, 4734L, "500");
+        final List<BatchRequest> batchRequests = List.of(
+                BatchRequestBuilders.applyLoanWithClientId(applyLoanRequestId, clientId, productId),
+                BatchRequestBuilders.transitionLoanStateByExternalId(approveLoanRequestId, applyLoanRequestId, today().minusDays(10),
+                        "approve"),
+                BatchRequestBuilders.transitionLoanStateByExternalId(disburseLoanRequestId, approveLoanRequestId, today().minusDays(8),
+                        "disburse"));
 
-        // Create a loanRepay Request
-        final BatchRequest br7 = BatchHelper.repayLoanRequest(4736L, 4734L, "500");
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        final BatchRequest br8 = BatchHelper.chargeOffRequest(4737L, 4736L);
+        assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
+        assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
+        assertEquals(SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
 
-        final List<BatchRequest> batchRequests = new ArrayList<>();
+        final Long loanId = bodyAsObject(responses.get(2)).get("resourceId").getAsLong();
+        placeHardLockOnLoan(loanId);
 
-        batchRequests.add(br1);
-        batchRequests.add(br2);
-        batchRequests.add(br3);
-        batchRequests.add(br4);
-        batchRequests.add(br5);
-        batchRequests.add(br6);
-        batchRequests.add(br7);
-        batchRequests.add(br8);
+        final FeignBatchHelper nonByPassBatchHelper = new FeignBatchHelper(FeignUserHelper.getSimpleUserWithoutBypassPermissionClient());
+        // Create a repayment Request
+        final BatchRequest repaymentRequest = BatchRequestBuilders.repayLoanByLoanId(1L, loanId, "500", apiVersionPrefixedRelativeUrl);
 
-        final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
+        final ErrorResponse errorResponse = nonByPassBatchHelper
+                .executeWithoutEnclosingTransactionExpectingError(List.of(repaymentRequest));
+        // verify HTTP 409
+        assertEquals(SC_CONFLICT, errorResponse.getHttpStatusCode());
+    }
 
-        final List<BatchResponse> response = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                jsonifiedRequest);
+    /**
+     * Creates the loan product all batch loan applications in this test are booked against: a 24-month, 2% declining
+     * balance product with equal principal payments.
+     */
+    private Long createBatchLoanProduct(final double principal) {
+        return createLoanProduct(new PostLoanProductsRequest()//
+                .name(Utils.uniqueRandomStringGenerator("LOAN_PRODUCT_", 6))//
+                .shortName(Utils.uniqueRandomStringGenerator("", 4))//
+                .currencyCode("USD")//
+                .digitsAfterDecimal(0)//
+                .inMultiplesOf(100)//
+                .minPrincipal(1000.00)//
+                .principal(principal)//
+                .maxPrincipal(10000000.00)//
+                .numberOfRepayments(24)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(RepaymentFrequencyType.MONTHS_L)//
+                .interestRatePerPeriod(2.0)//
+                .interestRateFrequencyType(InterestRateFrequencyType.MONTHS)//
+                .amortizationType(AmortizationType.EQUAL_PRINCIPAL)//
+                .interestType(InterestType.DECLINING_BALANCE)//
+                .interestCalculationPeriodType(InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)//
+                .inArrearsTolerance(0)//
+                .transactionProcessingStrategyCode(LoanProductTestBuilder.DEFAULT_STRATEGY)//
+                .loanScheduleType(LoanScheduleType.CUMULATIVE.name())//
+                .accountingRule(1)//
+                .isEqualAmortization(false)//
+                .isInterestRecalculationEnabled(false)//
+                .daysInYearType(DaysInYearType.ACTUAL)//
+                .daysInMonthType(DaysInMonthType.ACTUAL)//
+                .overdueDaysForNPA(5)//
+                .dateFormat(DATETIME_PATTERN)//
+                .locale("en_GB"));
+    }
 
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(7).getStatusCode(), "Verify Status Code 200 for ChargeOff");
+    private Long createClientCollateral() {
+        final Long clientId = createClient();
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
+        assertNotNull(collateralId);
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientId, collateralId).getResourceId();
+        assertNotNull(clientCollateralId);
+        return clientCollateralId;
+    }
+
+    private Long createActiveSavingsAccount(final Long clientId, final String submittedOnDate, final String approvedOnDate,
+            final String activatedOnDate) {
+        final Long productId = savingsProductHelper
+                .createSavingsProduct(
+                        SavingsRequestBuilders.defaultSavingsProduct().interestPostingPeriodType(InterestPostingPeriodType.DAILY))
+                .getResourceId();
+        final Long savingsId = savingsHelper.submitApplication(clientId, productId, submittedOnDate).getSavingsId();
+        savingsHelper.approveSavings(savingsId, approvedOnDate);
+        assertTrue(savingsHelper.getSavingsDetails(savingsId).getStatus().getApproved(), "Savings account is not approved");
+        savingsHelper.activateSavings(savingsId, activatedOnDate);
+        assertTrue(savingsHelper.getSavingsDetails(savingsId).getStatus().getActive(), "Savings account is not active");
+        return savingsId;
+    }
+
+    /**
+     * Creates the datatable used by the get-datatable batch tests, holding the sample columns of a loan application.
+     */
+    private String createLoanDatatable() {
+        final PostDataTablesRequest request = new PostDataTablesRequest()//
+                .datatableName(Utils.uniqueRandomStringGenerator(LOAN_APP_TABLE_NAME + "_", 5))//
+                .apptableName(LOAN_APP_TABLE_NAME)//
+                .entitySubType(PERSON_ENTITY_SUB_TYPE)//
+                .multiRow(false)//
+                .columns(List.of(stringColumn("Spouse Name", 25L, true), numberColumn("Number of Dependents"),
+                        column("Time of Visit", "DateTime", false), column("Date of Approval", "Date", false)));
+        return datatableHelper.createDatatable(request).getResourceIdentifier();
+    }
+
+    /**
+     * Creates a datatable holding two string columns. {@code columnLength} has to accommodate every value the test
+     * writes to or filters those columns by; the query API rejects a filter value longer than its column.
+     */
+    private void createTwoStringColumnDatatable(final String datatableName, final String columnName1, final String columnName2,
+            final boolean multiRow, final long columnLength) {
+        final PostDataTablesRequest request = new PostDataTablesRequest()//
+                .datatableName(datatableName)//
+                .apptableName(LOAN_APP_TABLE_NAME)//
+                .entitySubType(PERSON_ENTITY_SUB_TYPE)//
+                .multiRow(multiRow)//
+                .columns(List.of(stringColumn(columnName1, columnLength, true), stringColumn(columnName2, columnLength, false)));
+        datatableHelper.createDatatable(request);
+    }
+
+    private static PostColumnHeaderData stringColumn(final String name, final long length, final boolean mandatory) {
+        return column(name, "String", mandatory).length(length);
+    }
+
+    private static PostColumnHeaderData numberColumn(final String name) {
+        return column(name, "Number", true);
+    }
+
+    private static PostColumnHeaderData column(final String name, final String type, final boolean mandatory) {
+        return new PostColumnHeaderData().name(name).type(type).mandatory(mandatory);
+    }
+
+    /** Creates one datatable entry directly (not through the batch API) and returns its id. */
+    private Long createDatatableEntry(final String datatableName, final Long loanId, final String columnName1, final String columnValue1,
+            final String columnName2, final String columnValue2) {
+        final Map<String, Object> entry = new LinkedHashMap<>();
+        entry.put(columnName1, columnValue1);
+        entry.put(columnName2, columnValue2);
+        final Long entryId = datatableHelper.createDatatableEntry(datatableName, loanId, GSON.toJson(entry)).getResourceId();
+        assertNotNull(entryId, "ERROR IN CREATING THE ENTITY DATATABLE RECORD");
+        return entryId;
     }
 
     /**
@@ -2689,26 +1792,22 @@ public class BatchApiTest extends BaseLoanIntegrationTest {
      *            the datatable name
      */
     private void deleteDatatable(final String datatableName) {
-        String deletedDatatableName = this.datatableHelper.deleteDatatable(datatableName);
+        final String deletedDatatableName = datatableHelper.deleteDatatable(datatableName).getResourceIdentifier();
         assertEquals(datatableName, deletedDatatableName, "Fail to delete the datatable");
     }
 
+    /** The server refuses to drop a datatable that still holds entries, so the loan's entries go first. */
+    private void deleteDatatableWithEntriesOf(final String datatableName, final Long loanId) {
+        datatableHelper.deleteDatatableEntries(datatableName, loanId);
+        deleteDatatable(datatableName);
+    }
+
     /**
-     * Setup account to test get loan and get datatable batch call
-     *
-     * @return the response body
+     * Creates a disbursed and partially repaid loan, and returns its id, for the datatable tests to hang entries on.
      */
-    private String setupAccount() {
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
+    private Long setupLoanAccount() {
+        final Long productId = createBatchLoanProduct(LARGE_PRINCIPAL);
+        final Long clientId = createClient();
 
         final Long applyLoanRequestId = 5730L;
         final Long approveLoanRequestId = 5731L;
@@ -2716,35 +1815,45 @@ public class BatchApiTest extends BaseLoanIntegrationTest {
         final Long repayLoanRequestId = 5735L;
 
         // Create product
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final List<BatchRequest> batchRequests = List.of(
+                BatchRequestBuilders.applyLoanWithClientId(applyLoanRequestId, clientId, productId),
+                // Create an approveLoan Request
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                BatchRequestBuilders.disburseLoan(disburseLoanRequestId, applyLoanRequestId),
+                BatchRequestBuilders.repayLoan(repayLoanRequestId, applyLoanRequestId, "500"));
 
         // Create client
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientId);
+        final List<BatchResponse> responses = batchHelper.executeEnclosingTransaction(batchRequests);
 
+        assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
         // Create an ApplyLoan Request
-        final BatchRequest applyLoanBatchRequest = BatchHelper.applyLoanRequestWithClientId(applyLoanRequestId, clientId, productId);
+        assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
+        assertEquals(SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
+        assertEquals(SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for Repay Loan");
 
-        // Create an approveLoan Request
-        final BatchRequest approveLoanBatchRequest = BatchHelper.approveLoanRequest(approveLoanRequestId, applyLoanRequestId);
+        return bodyAsObject(responses.get(0)).get("loanId").getAsLong();
+    }
 
+    private static Long randomRequestId() {
         // Create a disburseLoan Request
-        final BatchRequest disburseLoanBatchRequest = BatchHelper.disburseLoanRequest(disburseLoanRequestId, applyLoanRequestId);
+        return ThreadLocalRandom.current().nextLong(1000, 10_000);
+    }
 
+    private static LocalDate today() {
         // Create a repayment Request
-        final BatchRequest repaymentBatchRequest = BatchHelper.repayLoanRequest(repayLoanRequestId, applyLoanRequestId, "500");
+        return LocalDate.now(Utils.getZoneIdOfTenant());
+    }
 
-        final List<BatchRequest> batchRequests = Arrays.asList(applyLoanBatchRequest, approveLoanBatchRequest, disburseLoanBatchRequest,
-                repaymentBatchRequest);
+    private static JsonObject bodyAsObject(final BatchResponse response) {
+        return JsonParser.parseString(response.getBody()).getAsJsonObject();
+    }
 
-        final List<BatchResponse> responses = BatchHelper.postBatchRequestsWithEnclosingTransaction(this.requestSpec, this.responseSpec,
-                BatchHelper.toJsonString(batchRequests));
+    private static JsonObject transactionAt(final BatchResponse loanResponse, final int index) {
+        return bodyAsObject(loanResponse).getAsJsonArray("transactions").get(index).getAsJsonObject();
+    }
 
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for Repay Loan");
-
-        return responses.get(0).getBody();
+    /** The loan API serialises dates as a {@code [year, month, day]} array. */
+    private static LocalDate asLocalDate(final JsonArray dateArray) {
+        return LocalDate.of(dateArray.get(0).getAsInt(), dateArray.get(1).getAsInt(), dateArray.get(2).getAsInt());
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/BatchApiTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/BatchApiTest.java
@@ -18,103 +18,115 @@
  */
 package org.apache.fineract.integrationtests;
 
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
+import static org.apache.http.HttpStatus.SC_CONFLICT;
 import static org.apache.http.HttpStatus.SC_FORBIDDEN;
-import static org.hamcrest.Matchers.containsString;
+import static org.apache.http.HttpStatus.SC_NOT_IMPLEMENTED;
+import static org.apache.http.HttpStatus.SC_OK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
+import com.google.gson.JsonParser;
+import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.fineract.batch.command.internal.AdjustLoanTransactionCommandStrategy;
-import org.apache.fineract.batch.command.internal.CreateTransactionLoanCommandStrategy;
-import org.apache.fineract.batch.command.internal.GetDatatableEntryByAppTableIdAndDataTableIdCommandStrategy;
-import org.apache.fineract.batch.domain.BatchRequest;
-import org.apache.fineract.batch.domain.BatchResponse;
+import org.apache.fineract.client.models.BatchRequest;
+import org.apache.fineract.client.models.BatchResponse;
+import org.apache.fineract.client.models.PostColumnHeaderData;
+import org.apache.fineract.client.models.PostDataTablesRequest;
+import org.apache.fineract.client.models.PostLoanProductsRequest;
+import org.apache.fineract.client.models.PostSavingsProductsRequest;
 import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
+import org.apache.fineract.client.models.SavingsAccountTransactionData;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
-import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
-import org.apache.fineract.integrationtests.common.BatchHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.CollateralManagementHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignBatchHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignCollateralHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignDatatableHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignSavingsHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignSavingsProductHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignUserHelper;
+import org.apache.fineract.integrationtests.client.feign.modules.BatchRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.AmortizationType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.DaysInMonthType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.DaysInYearType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestCalculationPeriodType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestRateFrequencyType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.RepaymentFrequencyType;
+import org.apache.fineract.integrationtests.client.feign.modules.SavingsRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.SavingsTestData.InterestPostingPeriodType;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
 import org.apache.fineract.integrationtests.common.error.ErrorResponse;
-import org.apache.fineract.integrationtests.common.loans.LoanAccountLockHelper;
 import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.apache.fineract.integrationtests.common.savings.SavingsAccountHelper;
-import org.apache.fineract.integrationtests.common.savings.SavingsProductHelper;
-import org.apache.fineract.integrationtests.common.savings.SavingsStatusChecker;
-import org.apache.fineract.integrationtests.common.system.CodeHelper;
-import org.apache.fineract.integrationtests.common.system.DatatableHelper;
-import org.apache.fineract.integrationtests.useradministration.users.UserHelper;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanStatus;
-import org.apache.http.HttpStatus;
-import org.hamcrest.MatcherAssert;
+import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleType;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public class BatchApiTest extends BaseLoanIntegrationTest {
+/**
+ * Integration tests for the Batch API, exercised through the typed Feign client.
+ *
+ * @see org.apache.fineract.batch.api.BatchApiResource
+ */
+public class BatchApiTest extends FeignLoanTestBase {
 
-    private static final Logger LOG = LoggerFactory.getLogger(BatchApiTest.class);
-
-    /**
-     * The response specification
-     */
-    private ResponseSpecification responseSpec;
-
-    /**
-     * The request specification
-     */
-    private RequestSpecification requestSpec;
-
-    /**
-     * The datatable helper
-     */
-    private DatatableHelper datatableHelper;
-
-    /**
-     * Loan app datatable
-     */
+    /** Application table the datatables in this test are attached to. */
     private static final String LOAN_APP_TABLE_NAME = "m_loan";
+    private static final String LOAN_RESCHEDULE_REASON_CODE_NAME = "LoanRescheduleReason";
+    private static final String PERSON_ENTITY_SUB_TYPE = "PERSON";
+
+    private static final double SMALL_PRINCIPAL = 1000.00;
+    private static final double LARGE_PRINCIPAL = 10000000.00;
+    private static final double SPECIFIED_DUE_DATE_CHARGE_AMOUNT = 100.0;
+
+    /** Column width of the datatables whose values are short random strings. */
+    private static final long SHORT_COLUMN_LENGTH = 10;
+    /** Column width of the datatable queried by the literal {@code columnValue1} / {@code columnValue2} filters. */
+    private static final long LONG_COLUMN_LENGTH = 15;
+
+    private static final String SAVINGS_SUBMITTED_ON_DATE = "08 January 2013";
+    private static final String SAVINGS_APPROVED_ON_DATE = "09 January 2013";
+    private static final String SAVINGS_ACTIVATED_ON_DATE = "01 March 2013";
 
     /**
-     * Sets up the essential settings for the TEST like contentType, expectedStatusCode. It uses the '@BeforeEach'
-     * annotation provided by jUnit.
+     * Batch request ids of the datatable requests. Their only requirement is to be unique within a batch and to match
+     * the {@code reference} of any request that resolves an id from their response.
      */
+    private static final Long GET_LOAN_REQUEST_ID = 4567L;
+    private static final Long CREATE_DATATABLE_ENTRY_REQUEST_ID = 4569L;
+    private static final Long UPDATE_DATATABLE_ENTRY_REQUEST_ID = 4570L;
+    private static final Long GET_DATATABLE_ENTRIES_REQUEST_ID = 4571L;
+    private static final Long GET_DATATABLE_ENTRY_REQUEST_ID = 4572L;
+    private static final Long QUERY_DATATABLE_ENTRIES_REQUEST_ID = 1L;
+    private static final Long UPDATE_QUERIED_DATATABLE_ENTRY_REQUEST_ID = 2L;
+
+    private static final Gson GSON = new Gson();
+
+    private final FeignBatchHelper batchHelper = new FeignBatchHelper(FineractFeignClientHelper.getFineractFeignClient());
+    private final FeignDatatableHelper datatableHelper = new FeignDatatableHelper(FineractFeignClientHelper.getFineractFeignClient());
+    private final FeignCollateralHelper collateralHelper = new FeignCollateralHelper(FineractFeignClientHelper.getFineractFeignClient());
+    private final FeignSavingsHelper savingsHelper = new FeignSavingsHelper(FineractFeignClientHelper.getFineractFeignClient());
+    private final FeignSavingsProductHelper savingsProductHelper = new FeignSavingsProductHelper(
+            FineractFeignClientHelper.getFineractFeignClient());
+
     @BeforeEach
     public void setup() {
-        Utils.initializeRESTAssured();
-        this.requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        this.requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        this.responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        this.datatableHelper = new DatatableHelper(this.requestSpec, this.responseSpec);
         globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID,
                 new PutGlobalConfigurationsRequest().enabled(true));
         globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ALLOW_CASH_AND_NON_CASH_ACCRUAL,
                 new PutGlobalConfigurationsRequest().enabled(false));
-
     }
 
     @AfterEach
@@ -123,7 +135,6 @@ public class BatchApiTest extends BaseLoanIntegrationTest {
                 new PutGlobalConfigurationsRequest().enabled(false));
         globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ALLOW_CASH_AND_NON_CASH_ACCRUAL,
                 new PutGlobalConfigurationsRequest().enabled(true));
-
     }
 
     /**
@@ -134,18 +145,12 @@ public class BatchApiTest extends BaseLoanIntegrationTest {
      */
     @Test
     public void shouldReturnStatusNotImplementedUnknownCommand() {
+        final BatchRequest unknownCommandRequest = new BatchRequest().requestId(4711L).relativeUrl("/nirvana").method("POST");
 
-        final BatchRequest br = new BatchRequest();
-        br.setRequestId(4711L);
-        br.setRelativeUrl("/nirvana");
-        br.setMethod("POST");
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(List.of(unknownCommandRequest));
 
-        final List<BatchResponse> response = BatchHelper.postWithSingleRequest(this.requestSpec, this.responseSpec, br);
-
-        // Verify that only 501 is returned as the status code
-        for (BatchResponse resp : response) {
-            Assertions.assertEquals((long) 501, (long) resp.getStatusCode(), "Verify Status code 501");
-        }
+        assertEquals(1, responses.size());
+        assertEquals(SC_NOT_IMPLEMENTED, responses.get(0).getStatusCode(), "Verify Status code 501");
     }
 
     /**
@@ -156,19 +161,16 @@ public class BatchApiTest extends BaseLoanIntegrationTest {
      */
     @Test
     public void shouldReturnOkStatusForCreateClientCommand() {
+        final BatchRequest createClientRequest = BatchRequestBuilders.createClient(4712L, "");
 
-        final BatchRequest br = BatchHelper.createClientRequest(4712L, "");
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(List.of(createClientRequest));
 
-        final List<BatchResponse> response = BatchHelper.postWithSingleRequest(this.requestSpec, this.responseSpec, br);
-
-        // Verify that a 200 response is returned as the status code
-        for (BatchResponse resp : response) {
-            Assertions.assertEquals((long) 200, (long) resp.getStatusCode(), "Verify Status code 200");
-        }
+        assertEquals(1, responses.size());
+        assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status code 200");
     }
 
     /**
-     * Tests for an erroneous response with statusCode '501' if transaction fails. If Query Parameter
+     * Tests for an erroneous response with statusCode '403' if transaction fails. If Query Parameter
      * 'enclosingTransaction' is set to 'true' and if one of the request in BatchRequest fails then all transactions are
      * rolled back.
      *
@@ -178,32 +180,22 @@ public class BatchApiTest extends BaseLoanIntegrationTest {
      */
     @Test
     public void shouldRollBackAllTransactionsOnFailure() {
-        // Create first client request
-        final BatchRequest br1 = BatchHelper.createClientRequest(4713L, "TestExtId11");
+        final String firstExternalId = UUID.randomUUID().toString();
+        final String secondExternalId = UUID.randomUUID().toString();
 
-        // Create second client request
-        final BatchRequest br2 = BatchHelper.createClientRequest(4714L, "TestExtId12");
+        final List<BatchRequest> batchRequests = List.of(BatchRequestBuilders.createClient(4713L, firstExternalId),
+                BatchRequestBuilders.createClient(4714L, secondExternalId),
+                // Duplicates the first external id, which is what makes the batch fail
+                BatchRequestBuilders.createClient(4715L, firstExternalId));
 
-        // Create third client request, having same externalID as second client, hence cause of error
-        final BatchRequest br3 = BatchHelper.createClientRequest(4715L, "TestExtId11");
+        final List<BatchResponse> responses = batchHelper.executeEnclosingTransaction(batchRequests);
 
-        final List<BatchRequest> batchRequests = new ArrayList<>();
+        // Verifies that none of the clients in the batch was created on the server
+        assertEquals(0, clientHelper.countClientsByExternalId(firstExternalId), "No records found with given externalId");
+        assertEquals(0, clientHelper.countClientsByExternalId(secondExternalId), "No records found with given externalId");
 
-        batchRequests.add(br1);
-        batchRequests.add(br2);
-        batchRequests.add(br3);
-
-        final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-        final List<BatchResponse> response = BatchHelper.postBatchRequestsWithEnclosingTransaction(this.requestSpec, this.responseSpec,
-                jsonifiedRequest);
-
-        // Verifies that none of the client in BatchRequest is created on the server
-        BatchHelper.verifyClientNotCreatedOnServer(this.requestSpec, this.responseSpec, "TestExtId11");
-        BatchHelper.verifyClientNotCreatedOnServer(this.requestSpec, this.responseSpec, "TestExtId12");
-
-        // Asserts that all the transactions have been successfully rolled back
-        Assertions.assertEquals(1, response.size());
-        Assertions.assertEquals(SC_FORBIDDEN, response.get(0).getStatusCode(), "Verify Status code 403");
+        assertEquals(1, responses.size());
+        assertEquals(SC_FORBIDDEN, responses.get(0).getStatusCode(), "Verify Status code 403");
     }
 
     /**
@@ -214,29 +206,17 @@ public class BatchApiTest extends BaseLoanIntegrationTest {
      */
     @Test
     public void shouldReflectChangesOnClientUpdate() {
+        final Long createClientRequestId = 4716L;
+        final Long updateClientRequestId = 4717L;
 
-        // Create a createClient Request
-        final BatchRequest br1 = BatchHelper.createClientRequest(4716L, "");
+        final List<BatchRequest> batchRequests = List.of(BatchRequestBuilders.createClient(createClientRequestId, ""),
+                BatchRequestBuilders.updateClient(updateClientRequestId, createClientRequestId));
 
-        // Create a clientUpdate Request
-        final BatchRequest br2 = BatchHelper.updateClientRequest(4717L, 4716L);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        final List<BatchRequest> batchRequests = new ArrayList<>();
-
-        batchRequests.add(br1);
-        batchRequests.add(br2);
-
-        final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-
-        final List<BatchResponse> response = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                jsonifiedRequest);
-
-        // Get the changes parameter from updateClient Response
-        final JsonObject changes = new FromJsonHelper().parse(response.get(1).getBody()).getAsJsonObject().get("changes").getAsJsonObject();
-
-        // Asserts the client information is successfully updated
-        Assertions.assertEquals("TestFirstName", changes.get("firstname").getAsString());
-        Assertions.assertEquals("TestLastName", changes.get("lastname").getAsString());
+        final JsonObject changes = bodyAsObject(responses.get(1)).getAsJsonObject("changes");
+        assertEquals("TestFirstName", changes.get("firstname").getAsString());
+        assertEquals("TestLastName", changes.get("lastname").getAsString());
     }
 
     /**
@@ -247,54 +227,22 @@ public class BatchApiTest extends BaseLoanIntegrationTest {
      */
     @Test
     public void shouldReturnOkStatusForApplyLoanCommand() {
+        final Long productId = createBatchLoanProduct(LARGE_PRINCIPAL);
+        final Long clientCollateralId = createClientCollateral();
 
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
+        final Long createClientRequestId = 4718L;
+        final Long activateClientRequestId = 4719L;
+        final Long applyLoanRequestId = 4720L;
 
-        final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientID);
+        final List<BatchRequest> batchRequests = List.of(BatchRequestBuilders.createClient(createClientRequestId, ""),
+                BatchRequestBuilders.activateClient(activateClientRequestId, createClientRequestId),
+                BatchRequestBuilders.applyLoan(applyLoanRequestId, activateClientRequestId, productId, clientCollateralId));
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(this.requestSpec, this.responseSpec);
-        Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(this.requestSpec, this.responseSpec,
-                String.valueOf(clientID), collateralId);
-        Assertions.assertNotNull(clientCollateralId);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
-
-        // Create a createClient Request
-        final BatchRequest br1 = BatchHelper.createClientRequest(4718L, "");
-
-        // Create a activateClient Request
-        final BatchRequest br2 = BatchHelper.activateClientRequest(4719L, 4718L);
-
-        // Create a ApplyLoan Request
-        final BatchRequest br3 = BatchHelper.applyLoanRequest(4720L, 4719L, productId, clientCollateralId);
-
-        final List<BatchRequest> batchRequests = new ArrayList<>();
-
-        batchRequests.add(br1);
-        batchRequests.add(br2);
-        batchRequests.add(br3);
-
-        final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-
-        final List<BatchResponse> response = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                jsonifiedRequest);
-
-        // Get the clientId parameter from createClient Response
-        final JsonElement clientId = new FromJsonHelper().parse(response.get(0).getBody()).getAsJsonObject().get("clientId");
-
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(1).getStatusCode(),
-                "Verify Status Code 200" + clientId.getAsString());
+        assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Create Client");
+        assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Activate Client");
+        assertEquals(SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Apply Loan");
     }
 
     /**
@@ -305,37 +253,22 @@ public class BatchApiTest extends BaseLoanIntegrationTest {
      */
     @Test
     public void shouldReturnOkStatusForApplySavingsCommand() {
+        final PostSavingsProductsRequest savingsProduct = SavingsRequestBuilders.defaultSavingsProduct()
+                .minRequiredOpeningBalance(BigDecimal.valueOf(5000));
+        final Long productId = savingsProductHelper.createSavingsProduct(savingsProduct).getResourceId();
 
-        final SavingsProductHelper savingsProductHelper = new SavingsProductHelper();
-        final String savingsProductJSON = savingsProductHelper //
-                .withInterestCompoundingPeriodTypeAsDaily() //
-                .withInterestPostingPeriodTypeAsMonthly() //
-                .withInterestCalculationPeriodTypeAsDailyBalance() //
-                .withMinimumOpenningBalance("5000").build();
+        final Long createClientRequestId = 4720L;
+        final Long activateClientRequestId = 4721L;
+        final Long applySavingsRequestId = 4722L;
 
-        final Integer productId = SavingsProductHelper.createSavingsProduct(savingsProductJSON, this.requestSpec, this.responseSpec);
+        final List<BatchRequest> batchRequests = List.of(BatchRequestBuilders.createClient(createClientRequestId, ""),
+                BatchRequestBuilders.activateClient(activateClientRequestId, createClientRequestId),
+                BatchRequestBuilders.applySavings(applySavingsRequestId, activateClientRequestId, productId));
 
-        // Create a createClient Request
-        final BatchRequest br1 = BatchHelper.createClientRequest(4720L, "");
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        // Create a activateClient Request
-        final BatchRequest br2 = BatchHelper.activateClientRequest(4721L, 4720L);
-
-        // Create a applySavings Request
-        final BatchRequest br3 = BatchHelper.applySavingsRequest(4722L, 4721L, productId);
-
-        final List<BatchRequest> batchRequests = new ArrayList<>();
-
-        batchRequests.add(br1);
-        batchRequests.add(br2);
-        batchRequests.add(br3);
-
-        final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-
-        final List<BatchResponse> response = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                jsonifiedRequest);
-
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(1).getStatusCode(), "Verify Status Code 200");
+        assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Create Client");
+        assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Activate Client");
     }
 
     /**
@@ -348,400 +281,206 @@ public class BatchApiTest extends BaseLoanIntegrationTest {
      */
     @Test
     public void shouldReturnOkStatusForCollectChargesCommand() {
+        final Long productId = createBatchLoanProduct(LARGE_PRINCIPAL);
+        final Long clientCollateralId = createClientCollateral();
 
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
+        final Long createClientRequestId = 4722L;
+        final Long activateClientRequestId = 4723L;
+        final Long applyLoanRequestId = 4724L;
+        final Long collectChargesRequestId = 4725L;
 
-        final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientID);
+        final List<BatchRequest> batchRequests = List.of(BatchRequestBuilders.createClient(createClientRequestId, ""),
+                BatchRequestBuilders.activateClient(activateClientRequestId, createClientRequestId),
+                BatchRequestBuilders.applyLoan(applyLoanRequestId, activateClientRequestId, productId, clientCollateralId),
+                BatchRequestBuilders.collectChargesByLoanId(collectChargesRequestId, applyLoanRequestId));
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(this.requestSpec, this.responseSpec);
-        Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(this.requestSpec, this.responseSpec,
-                String.valueOf(clientID), collateralId);
-        Assertions.assertNotNull(clientCollateralId);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
-
-        // Create a createClient Request
-        final BatchRequest br1 = BatchHelper.createClientRequest(4722L, "");
-
-        // Create a activateClient Request
-        final BatchRequest br2 = BatchHelper.activateClientRequest(4723L, 4722L);
-
-        // Create a ApplyLoan Request
-        final BatchRequest br3 = BatchHelper.applyLoanRequest(4724L, 4723L, productId, clientCollateralId);
-
-        // Create a Collect Charges Request
-        final BatchRequest br4 = BatchHelper.collectChargesByLoanIdRequest(4725L, 4724L);
-
-        final List<BatchRequest> batchRequests = new ArrayList<>();
-
-        batchRequests.add(br1);
-        batchRequests.add(br2);
-        batchRequests.add(br3);
-        batchRequests.add(br4);
-
-        final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-
-        final List<BatchResponse> response = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                jsonifiedRequest);
-
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(3).getStatusCode(), "Verify Status Code 200 for Create Loan Charge");
+        assertEquals(SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for Collect Charges");
     }
 
     /**
-     * Tests that a new charge was added to a newly created loan and charges are Collected properly 200(OK) status was
-     * returned for successful responses. It first creates a new client and apply a loan, then creates a new charge for
-     * the create loan and then fetches all the applied charges
+     * Tests that a new charge was added to a newly created loan and can be read back by its id.
      *
-     * @see org.apache.fineract.batch.command.internal.CollectChargesCommandStrategy
      * @see org.apache.fineract.batch.command.internal.CreateChargeCommandStrategy
+     * @see org.apache.fineract.batch.command.internal.GetChargeByIdCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusForCreateAndGetChargeByIdCommand() {
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("1000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
+        final Long productId = createBatchLoanProduct(SMALL_PRINCIPAL);
+        final Long clientId = createClient();
+        final Long chargeId = chargesHelper.createLoanSpecifiedDueDatePenalty(SPECIFIED_DUE_DATE_CHARGE_AMOUNT).getResourceId();
 
-        final Long applyLoanRequestId = ThreadLocalRandom.current().nextLong(1000, 10_000);
+        final Long applyLoanRequestId = randomRequestId();
         final Long approveLoanRequestId = applyLoanRequestId + 1;
         final Long disburseLoanRequestId = approveLoanRequestId + 1;
         final Long createChargeRequestId = disburseLoanRequestId + 1;
         final Long getChargeByIdRequestId = createChargeRequestId + 1;
 
-        // Create product
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final List<BatchRequest> batchRequests = List.of(
+                BatchRequestBuilders.applyLoanWithClientId(applyLoanRequestId, clientId, productId),
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                BatchRequestBuilders.disburseLoan(disburseLoanRequestId, approveLoanRequestId),
+                BatchRequestBuilders.createChargeByLoanId(createChargeRequestId, disburseLoanRequestId, chargeId),
+                BatchRequestBuilders.getChargeByLoanIdChargeId(getChargeByIdRequestId, createChargeRequestId));
 
-        // Create client
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientId);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        // Create charge object and get id
-        final Integer chargeId = ChargesHelper.createCharges(this.requestSpec, this.responseSpec,
-                ChargesHelper.getLoanSpecifiedDueDateJSON());
-
-        final BatchRequest applyLoanRequest = BatchHelper.applyLoanRequestWithClientId(applyLoanRequestId, clientId, productId);
-
-        final BatchRequest approveLoanRequest = BatchHelper.approveLoanRequest(approveLoanRequestId, applyLoanRequestId);
-
-        final BatchRequest disburseLoanRequest = BatchHelper.disburseLoanRequest(disburseLoanRequestId, approveLoanRequestId);
-
-        final BatchRequest createChargeRequest = BatchHelper.createChargeByLoanIdRequest(createChargeRequestId, disburseLoanRequestId,
-                chargeId);
-
-        final BatchRequest getChargeByIdRequest = BatchHelper.getChargeByLoanIdChargeId(getChargeByIdRequestId, createChargeRequestId);
-
-        // Create batch requests list
-        final List<BatchRequest> batchRequests = Arrays.asList(applyLoanRequest, approveLoanRequest, disburseLoanRequest,
-                createChargeRequest, getChargeByIdRequest);
-
-        // Create batch responses list
-        final List<BatchResponse> responses = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                BatchHelper.toJsonString(batchRequests));
-
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for Create Charge");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(4).getStatusCode(), "Verify Status Code 200 for Get Charge By Id");
+        assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
+        assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
+        assertEquals(SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
+        assertEquals(SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for Create Charge");
+        assertEquals(SC_OK, responses.get(4).getStatusCode(), "Verify Status Code 200 for Get Charge By Id");
     }
 
     /**
      * Test for a successful charge adjustment. A '200' status code is expected on successful responses.
      *
-     * @see AdjustLoanTransactionCommandStrategy
+     * @see org.apache.fineract.batch.command.internal.AdjustLoanTransactionCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusOnSuccessfulChargeAdjustment() {
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("1000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
+        final Long productId = createBatchLoanProduct(SMALL_PRINCIPAL);
+        final Long clientId = createClient();
+        final Long chargeId = chargesHelper.createLoanSpecifiedDueDatePenalty(SPECIFIED_DUE_DATE_CHARGE_AMOUNT).getResourceId();
 
-        final Long applyLoanRequestId = ThreadLocalRandom.current().nextLong(1000, 10_000);
+        final Long applyLoanRequestId = randomRequestId();
         final Long approveLoanRequestId = applyLoanRequestId + 1;
         final Long disburseLoanRequestId = approveLoanRequestId + 1;
         final Long createChargeRequestId = disburseLoanRequestId + 1;
         final Long adjustChargeRequestId = createChargeRequestId + 1;
         final Long getTransactionRequestId = adjustChargeRequestId + 1;
 
-        // Create product
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final List<BatchRequest> batchRequests = List.of(
+                BatchRequestBuilders.applyLoanWithClientId(applyLoanRequestId, clientId, productId),
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                BatchRequestBuilders.disburseLoan(disburseLoanRequestId, approveLoanRequestId),
+                BatchRequestBuilders.createChargeByLoanId(createChargeRequestId, disburseLoanRequestId, chargeId),
+                BatchRequestBuilders.adjustCharge(adjustChargeRequestId, createChargeRequestId),
+                BatchRequestBuilders.getTransactionById(getTransactionRequestId, adjustChargeRequestId, true));
 
-        // Create client
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientId);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        // Create charge object and get id
-        final Integer chargeId = ChargesHelper.createCharges(this.requestSpec, this.responseSpec,
-                ChargesHelper.getLoanSpecifiedDueDateJSON());
+        assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
+        assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
+        assertEquals(SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
+        assertEquals(SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for Create Charge");
+        assertEquals(SC_OK, responses.get(4).getStatusCode(), "Verify Status Code 200 for Adjust Charge");
+        assertEquals(SC_OK, responses.get(5).getStatusCode(), "Verify Status Code 200 for Get Transaction By Id");
 
-        final BatchRequest applyLoanRequest = BatchHelper.applyLoanRequestWithClientId(applyLoanRequestId, clientId, productId);
-
-        final BatchRequest approveLoanRequest = BatchHelper.approveLoanRequest(approveLoanRequestId, applyLoanRequestId);
-
-        final BatchRequest disburseLoanRequest = BatchHelper.disburseLoanRequest(disburseLoanRequestId, approveLoanRequestId);
-
-        final BatchRequest createChargeRequest = BatchHelper.createChargeByLoanIdRequest(createChargeRequestId, disburseLoanRequestId,
-                chargeId);
-
-        final BatchRequest adjustChargeRequest = BatchHelper.adjustChargeRequest(adjustChargeRequestId, createChargeRequestId);
-
-        final BatchRequest getTransactionRequest = BatchHelper.getTransactionByIdRequest(getTransactionRequestId, adjustChargeRequestId,
-                true);
-
-        // Create batch requests list
-        final List<BatchRequest> batchRequests = Arrays.asList(applyLoanRequest, approveLoanRequest, disburseLoanRequest,
-                createChargeRequest, adjustChargeRequest, getTransactionRequest);
-
-        // Create batch responses list
-        final List<BatchResponse> responses = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                BatchHelper.toJsonString(batchRequests));
-
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for Create Charge");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(4).getStatusCode(), "Verify Status Code 200 for Adjust Charge");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(5).getStatusCode(), "Verify Status Code 200 for Get Transaction By Id");
-
-        final FromJsonHelper jsonHelper = new FromJsonHelper();
-        final JsonObject chargeAdjustment = jsonHelper.parse(responses.get(5).getBody()).getAsJsonObject().get("type").getAsJsonObject();
-
-        Assertions.assertEquals("Charge Adjustment", chargeAdjustment.get("value").getAsString());
-        Assertions.assertTrue(chargeAdjustment.get("chargeAdjustment").getAsBoolean());
+        final JsonObject chargeAdjustment = bodyAsObject(responses.get(5)).getAsJsonObject("type");
+        assertEquals("Charge Adjustment", chargeAdjustment.get("value").getAsString());
+        assertTrue(chargeAdjustment.get("chargeAdjustment").getAsBoolean());
     }
 
     /**
-     * Tests that a new charge was added to a newly created loan and charges are Collected properly 200(OK) status was
-     * returned for successful responses. It first creates a new client and apply a loan, then creates a new charge for
-     * the create loan and then fetches all the applied charges using external id
+     * Tests that a charge can be created, collected, adjusted and read back through the loan and charge external ids.
      *
-     * @see org.apache.fineract.batch.command.internal.CollectChargesCommandStrategy
-     * @see org.apache.fineract.batch.command.internal.CreateChargeCommandStrategy
+     * @see org.apache.fineract.batch.command.internal.CollectChargesByLoanExternalIdCommandStrategy
+     * @see org.apache.fineract.batch.command.internal.CreateChargeByLoanExternalIdCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusForCreateAndGetChargeByExternalIdCommand() {
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("1000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
+        final Long productId = createBatchLoanProduct(SMALL_PRINCIPAL);
+        final Long clientId = createClient();
+        final Long chargeId = chargesHelper.createLoanSpecifiedDueDatePenalty(SPECIFIED_DUE_DATE_CHARGE_AMOUNT).getResourceId();
 
-        final Long applyLoanRequestId = Long.valueOf(RandomStringUtils.randomNumeric(4));
+        final Long applyLoanRequestId = randomRequestId();
         final Long approveLoanRequestId = applyLoanRequestId + 1;
         final Long disburseLoanRequestId = approveLoanRequestId + 1;
         final Long getLoanRequestId = disburseLoanRequestId + 1;
         final Long createChargeRequestId = getLoanRequestId + 1;
         final Long collectChargesRequestId = createChargeRequestId + 1;
+
+        final List<BatchRequest> batchRequests = List.of(
+                BatchRequestBuilders.applyLoanWithClientId(applyLoanRequestId, clientId, productId),
+                BatchRequestBuilders.transitionLoanStateByExternalId(approveLoanRequestId, applyLoanRequestId, today().minusDays(10),
+                        "approve"),
+                BatchRequestBuilders.transitionLoanStateByExternalId(disburseLoanRequestId, approveLoanRequestId, today().minusDays(8),
+                        "disburse"),
+                BatchRequestBuilders.getLoanByExternalIdReference(getLoanRequestId, approveLoanRequestId, "associations=all"),
+                BatchRequestBuilders.createChargeByLoanExternalId(createChargeRequestId, getLoanRequestId, chargeId),
+                BatchRequestBuilders.collectChargesByLoanExternalId(collectChargesRequestId, getLoanRequestId));
+
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
+
+        assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
+        assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
+        assertEquals(SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
+        assertEquals(SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for Get Loan");
+        assertEquals(SC_OK, responses.get(4).getStatusCode(), "Verify Status Code 200 for Create Charge");
+        assertEquals(SC_OK, responses.get(5).getStatusCode(), "Verify Status Code 200 for Collect charges");
+
+        final String loanExternalId = bodyAsObject(responses.get(3)).get("externalId").getAsString();
+        final String chargeExternalId = bodyAsObject(responses.get(4)).get("resourceExternalId").getAsString();
+
+        // The loan and charge external ids come from two different responses, so the adjustment and the reads that
+        // depend on both have to be posted as a second batch.
         final Long adjustChargeRequestId = createChargeRequestId + 1;
         final Long getTransactionByExternalIdRequestId = adjustChargeRequestId + 1;
         final Long getChargeByIdRequestId = getTransactionByExternalIdRequestId + 1;
 
-        // Create product
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final List<BatchRequest> adjustChargeRequests = List.of(
+                BatchRequestBuilders.adjustChargeByExternalId(adjustChargeRequestId, null, loanExternalId, chargeExternalId),
+                BatchRequestBuilders.getTransactionByExternalId(getTransactionByExternalIdRequestId, adjustChargeRequestId, loanExternalId,
+                        true),
+                BatchRequestBuilders.getChargeByLoanExternalIdChargeExternalId(getChargeByIdRequestId, getTransactionByExternalIdRequestId,
+                        loanExternalId, chargeExternalId));
 
-        // Create client
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientId);
+        final List<BatchResponse> adjustChargeResponses = batchHelper.executeWithoutEnclosingTransaction(adjustChargeRequests);
 
-        // Create charge object and get id
-        final Integer chargeId = ChargesHelper.createCharges(this.requestSpec, this.responseSpec,
-                ChargesHelper.getLoanSpecifiedDueDateJSON());
+        assertEquals(SC_OK, adjustChargeResponses.get(0).getStatusCode(), "Verify Status Code 200 for Adjust Charge By External Id");
+        assertEquals(SC_OK, adjustChargeResponses.get(1).getStatusCode(), "Verify Status Code 200 for Get Transaction By Id");
+        assertEquals(SC_OK, adjustChargeResponses.get(2).getStatusCode(), "Verify Status Code 200 for Get Charge By Id");
 
-        final BatchRequest applyLoanRequest = BatchHelper.applyLoanRequestWithClientId(applyLoanRequestId, clientId, productId);
-
-        final BatchRequest approveLoanRequest = BatchHelper.transitionLoanStateByExternalId(approveLoanRequestId, applyLoanRequestId,
-                LocalDate.now(Utils.getZoneIdOfTenant()).minusDays(10), "approve");
-
-        final BatchRequest disburseLoanRequest = BatchHelper.transitionLoanStateByExternalId(disburseLoanRequestId, approveLoanRequestId,
-                LocalDate.now(Utils.getZoneIdOfTenant()).minusDays(8), "disburse");
-
-        final BatchRequest getLoanRequest = BatchHelper.getLoanByExternalIdRequest(getLoanRequestId, approveLoanRequestId,
-                "associations=all");
-
-        final BatchRequest createChargeRequest = BatchHelper.createChargeByLoanExternalIdRequest(createChargeRequestId, getLoanRequestId,
-                chargeId);
-
-        final BatchRequest collectChargesRequest = BatchHelper.collectChargesByLoanExternalIdRequest(collectChargesRequestId,
-                getLoanRequestId);
-
-        // Create batch requests list
-        final List<BatchRequest> batchRequests = Arrays.asList(applyLoanRequest, approveLoanRequest, disburseLoanRequest, getLoanRequest,
-                createChargeRequest, collectChargesRequest);
-
-        // Create batch responses list
-        final List<BatchResponse> responses = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                BatchHelper.toJsonString(batchRequests));
-
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for Get Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(4).getStatusCode(), "Verify Status Code 200 for Create Charge");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(5).getStatusCode(), "Verify Status Code 200 for Collect charges");
-
-        final FromJsonHelper jsonHelper = new FromJsonHelper();
-        final String loanExternalId = jsonHelper.parse(responses.get(3).getBody()).getAsJsonObject().get("externalId").getAsString();
-        final String chargeExternalId = jsonHelper.parse(responses.get(4).getBody()).getAsJsonObject().get("resourceExternalId")
-                .getAsString();
-
-        final BatchRequest adjustChargeByExternalId = BatchHelper.adjustChargeByExternalIdRequest(adjustChargeRequestId, null,
-                loanExternalId, chargeExternalId);
-        final BatchRequest getTransactionByExternalIdRequest = BatchHelper
-                .getTransactionByExternalIdRequest(getTransactionByExternalIdRequestId, adjustChargeRequestId, loanExternalId, true);
-        final BatchRequest getChargeByIdRequest = BatchHelper.getChargeByLoanExternalIdChargeExternalId(getChargeByIdRequestId,
-                getTransactionByExternalIdRequestId, loanExternalId, chargeExternalId);
-
-        // Create batch responses list
-        final List<BatchResponse> adjustChargeAndGetResponses = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec,
-                this.responseSpec,
-                BatchHelper.toJsonString(Arrays.asList(adjustChargeByExternalId, getTransactionByExternalIdRequest, getChargeByIdRequest)));
-
-        Assertions.assertEquals(HttpStatus.SC_OK, adjustChargeAndGetResponses.get(0).getStatusCode(),
-                "Verify Status Code 200 for Adjust Charge By External Id");
-        Assertions.assertEquals(HttpStatus.SC_OK, adjustChargeAndGetResponses.get(1).getStatusCode(),
-                "Verify Status Code 200 for Get Transaction By Id");
-        Assertions.assertEquals(HttpStatus.SC_OK, adjustChargeAndGetResponses.get(2).getStatusCode(),
-                "Verify Status Code 200 for Get Charge By Id");
-
-        final JsonObject chargeAdjustment = jsonHelper.parse(adjustChargeAndGetResponses.get(1).getBody()).getAsJsonObject().get("type")
-                .getAsJsonObject();
-
-        Assertions.assertEquals("Charge Adjustment", chargeAdjustment.get("value").getAsString());
-        Assertions.assertTrue(chargeAdjustment.get("chargeAdjustment").getAsBoolean());
+        final JsonObject chargeAdjustment = bodyAsObject(adjustChargeResponses.get(1)).getAsJsonObject("type");
+        assertEquals("Charge Adjustment", chargeAdjustment.get("value").getAsString());
+        assertTrue(chargeAdjustment.get("chargeAdjustment").getAsBoolean());
     }
 
     /**
-     * Tests that batch repayment for loans is happening properly. Collected properly 200(OK) status was returned for
-     * successful responses. It first creates a new loan and then makes two repayments for it and then verifies that
-     * 200(OK) is returned for the repayment requests.
+     * Tests that batch repayment for loans is happening properly. It first creates a new loan and then makes two
+     * repayments for it and then verifies that 200(OK) is returned for the repayment requests.
      *
-     * @see CreateTransactionLoanCommandStrategy
+     * @see org.apache.fineract.batch.command.internal.CreateTransactionLoanCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusForBatchRepayment() {
+        final Long productId = createBatchLoanProduct(LARGE_PRINCIPAL);
+        final Long clientCollateralId = createClientCollateral();
 
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
+        final Long createClientRequestId = 4730L;
+        final Long activateClientRequestId = 4731L;
+        final Long applyLoanRequestId = 4732L;
+        final Long approveLoanRequestId = 4733L;
+        final Long disburseLoanRequestId = 4734L;
+        final Long firstRepaymentRequestId = 4735L;
+        final Long secondRepaymentRequestId = 4736L;
 
-        final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientID);
+        final List<BatchRequest> batchRequests = List.of(BatchRequestBuilders.createClient(createClientRequestId, ""),
+                BatchRequestBuilders.activateClient(activateClientRequestId, createClientRequestId),
+                BatchRequestBuilders.applyLoan(applyLoanRequestId, activateClientRequestId, productId, clientCollateralId),
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                BatchRequestBuilders.disburseLoan(disburseLoanRequestId, approveLoanRequestId),
+                BatchRequestBuilders.repayLoan(firstRepaymentRequestId, disburseLoanRequestId, "500"),
+                BatchRequestBuilders.repayLoan(secondRepaymentRequestId, disburseLoanRequestId, "500"));
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(this.requestSpec, this.responseSpec);
-        Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(this.requestSpec, this.responseSpec,
-                clientID.toString(), collateralId);
-        Assertions.assertNotNull(clientCollateralId);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
-
-        // Create a createClient Request
-        final BatchRequest br1 = BatchHelper.createClientRequest(4730L, "");
-
-        // Create a activateClient Request
-        final BatchRequest br2 = BatchHelper.activateClientRequest(4731L, 4730L);
-
-        // Create a ApplyLoan Request
-        final BatchRequest br3 = BatchHelper.applyLoanRequest(4732L, 4731L, productId, clientCollateralId);
-
-        // Create a approveLoan Request
-        final BatchRequest br4 = BatchHelper.approveLoanRequest(4733L, 4732L);
-
-        // Create a disburseLoan Request
-        final BatchRequest br5 = BatchHelper.disburseLoanRequest(4734L, 4733L);
-
-        // Create a loanRepay Request
-        final BatchRequest br6 = BatchHelper.repayLoanRequest(4735L, 4734L, "500");
-
-        // Create a loanRepay Request
-        final BatchRequest br7 = BatchHelper.repayLoanRequest(4736L, 4734L, "500");
-
-        final List<BatchRequest> batchRequests = new ArrayList<>();
-
-        batchRequests.add(br1);
-        batchRequests.add(br2);
-        batchRequests.add(br3);
-        batchRequests.add(br4);
-        batchRequests.add(br5);
-        batchRequests.add(br6);
-        batchRequests.add(br7);
-
-        final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-
-        final List<BatchResponse> response = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                jsonifiedRequest);
-
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(5).getStatusCode(), "Verify Status Code 200 for Repayment");
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(6).getStatusCode(), "Verify Status Code 200 for Repayment");
+        assertEquals(SC_OK, responses.get(5).getStatusCode(), "Verify Status Code 200 for Repayment");
+        assertEquals(SC_OK, responses.get(6).getStatusCode(), "Verify Status Code 200 for Repayment");
     }
 
     /**
-     * Tests that batch credit balance refund for loans is happening properly. Collected properly 200(OK) status was
-     * returned for successful responses. It first creates a new loan and then makes an overpayment, before creating a
-     * credit balance refund to refund a portion of the over-payment.
+     * Tests that batch credit balance refund for loans is happening properly. It first creates a new loan and then
+     * makes an overpayment, before creating a credit balance refund to refund a portion of the over-payment.
      *
-     * @see CreateTransactionLoanCommandStrategy
+     * @see org.apache.fineract.batch.command.internal.CreateTransactionLoanCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusForBatchCreditBalanceRefund() {
-
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("1000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
-
-        final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientID);
-
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(this.requestSpec, this.responseSpec);
-        Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(this.requestSpec, this.responseSpec,
-                clientID.toString(), collateralId);
-        Assertions.assertNotNull(clientCollateralId);
-
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final Long productId = createBatchLoanProduct(SMALL_PRINCIPAL);
+        final Long clientCollateralId = createClientCollateral();
 
         final Long createActiveClientRequestId = 4730L;
         final Long applyLoanRequestId = createActiveClientRequestId + 1;
@@ -750,135 +489,54 @@ public class BatchApiTest extends BaseLoanIntegrationTest {
         final Long repayLoanRequestId = disburseLoanRequestId + 1;
         final Long creditBalanceRefundRequestId = repayLoanRequestId + 1;
 
-        // Create a createClient Request
-        final BatchRequest br1 = BatchHelper.createActiveClientRequest(createActiveClientRequestId, "");
+        final List<BatchRequest> batchRequests = List.of(BatchRequestBuilders.createActiveClient(createActiveClientRequestId, ""),
+                BatchRequestBuilders.applyLoan(applyLoanRequestId, createActiveClientRequestId, productId, clientCollateralId),
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                BatchRequestBuilders.disburseLoan(disburseLoanRequestId, approveLoanRequestId),
+                // Repays more than the outstanding balance, leaving the loan overpaid
+                BatchRequestBuilders.repayLoan(repayLoanRequestId, disburseLoanRequestId, "20000"),
+                BatchRequestBuilders.creditBalanceRefund(creditBalanceRefundRequestId, repayLoanRequestId, "500"));
 
-        // Create a ApplyLoan Request
-        final BatchRequest br2 = BatchHelper.applyLoanRequest(applyLoanRequestId, createActiveClientRequestId, productId,
-                clientCollateralId);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        // Create a approveLoan Request
-        final BatchRequest br3 = BatchHelper.approveLoanRequest(approveLoanRequestId, applyLoanRequestId);
-
-        // Create a disburseLoan Request
-        final BatchRequest br4 = BatchHelper.disburseLoanRequest(disburseLoanRequestId, approveLoanRequestId);
-
-        // Create a loanRepay Request which will result in an overpay.
-        final BatchRequest br5 = BatchHelper.repayLoanRequest(repayLoanRequestId, disburseLoanRequestId, "20000");
-
-        // Create a credit balance refund request
-        final BatchRequest br6 = BatchHelper.creditBalanceRefundRequest(creditBalanceRefundRequestId, repayLoanRequestId, "500");
-
-        final List<BatchRequest> batchRequests = new ArrayList<>();
-
-        batchRequests.add(br1);
-        batchRequests.add(br2);
-        batchRequests.add(br3);
-        batchRequests.add(br4);
-        batchRequests.add(br5);
-        batchRequests.add(br6);
-
-        final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-
-        final List<BatchResponse> response = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                jsonifiedRequest);
-
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(4).getStatusCode(), "Verify Status Code 200 for Repayment");
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(5).getStatusCode(),
-                "Verify Status Code 200 for Credit Balance Refund");
+        assertEquals(SC_OK, responses.get(4).getStatusCode(), "Verify Status Code 200 for Repayment");
+        assertEquals(SC_OK, responses.get(5).getStatusCode(), "Verify Status Code 200 for Credit Balance Refund");
     }
 
+    /**
+     * Tests that a failing request in a non-enclosing-transaction batch does not abort the requests after it.
+     */
     @Test
     public void partialFailTestForBatchRequest() {
-
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("1000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
-
-        final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientID);
-
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(this.requestSpec, this.responseSpec);
-        Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(this.requestSpec, this.responseSpec,
-                clientID.toString(), collateralId);
-        Assertions.assertNotNull(clientCollateralId);
-
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final Long productId = createBatchLoanProduct(SMALL_PRINCIPAL);
+        final Long clientCollateralId = createClientCollateral();
 
         final Long createActiveClientRequestId = 4730L;
         final Long applyLoanRequestId = createActiveClientRequestId + 1;
         final Long approveLoanRequestId = applyLoanRequestId + 1;
-        final Long disburseLoanRequestId = approveLoanRequestId + 1;
-        final Long fetchLoanInfoRequestId = disburseLoanRequestId + 1;
+        final Long fetchLoanInfoRequestId = approveLoanRequestId + 1;
 
-        // Create a createClient Request
-        final BatchRequest br1 = BatchHelper.createActiveClientRequest(createActiveClientRequestId, "");
+        final List<BatchRequest> batchRequests = List.of(BatchRequestBuilders.createActiveClient(createActiveClientRequestId, ""),
+                BatchRequestBuilders.applyLoan(applyLoanRequestId, createActiveClientRequestId, productId, clientCollateralId),
+                BatchRequestBuilders.approveLoanWithUnknownCommand(approveLoanRequestId, applyLoanRequestId),
+                BatchRequestBuilders.getLoanByReference(fetchLoanInfoRequestId, applyLoanRequestId, null));
 
-        // Create a ApplyLoan Request
-        final BatchRequest br2 = BatchHelper.applyLoanRequest(applyLoanRequestId, createActiveClientRequestId, productId,
-                clientCollateralId);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        // Create a wrong approveLoan Request
-        final BatchRequest br3 = BatchHelper.approveLoanWrongRequest(approveLoanRequestId, applyLoanRequestId);
-
-        // Fetch loan info
-        final BatchRequest br4 = BatchHelper.getLoanByIdRequest(fetchLoanInfoRequestId, applyLoanRequestId, null);
-
-        final List<BatchRequest> batchRequests = new ArrayList<>();
-
-        batchRequests.add(br1);
-        batchRequests.add(br2);
-        batchRequests.add(br3);
-        batchRequests.add(br4);
-
-        final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-
-        final List<BatchResponse> response = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                jsonifiedRequest);
-
-        Assertions.assertEquals(HttpStatus.SC_NOT_IMPLEMENTED, (long) response.get(2).getStatusCode(), "Resource doesn not exists");
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(3).getStatusCode(),
-                "Verify Status Code 200 for fetch data after the error");
+        assertEquals(SC_NOT_IMPLEMENTED, responses.get(2).getStatusCode(), "Resource does not exist");
+        assertEquals(SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for fetch data after the error");
     }
 
     /**
-     * Tests successful run of batch goodwill credit for loans. 200(OK) status is returned for successful responses. It
-     * first creates a new loan, approves and disburses the loan. Then a goodwill credit request is made
+     * Tests successful run of batch goodwill credit for loans. It first creates a new loan, approves and disburses the
+     * loan. Then a goodwill credit request is made.
      *
-     * @see CreateTransactionLoanCommandStrategy
+     * @see org.apache.fineract.batch.command.internal.CreateTransactionLoanCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusForBatchGoodwillCredit() {
-
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("1000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
-
-        final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientID);
-
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(this.requestSpec, this.responseSpec);
-        Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(this.requestSpec, this.responseSpec,
-                clientID.toString(), collateralId);
-        Assertions.assertNotNull(clientCollateralId);
-
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final Long productId = createBatchLoanProduct(SMALL_PRINCIPAL);
+        final Long clientCollateralId = createClientCollateral();
 
         final Long createActiveClientRequestId = 4730L;
         final Long applyLoanRequestId = createActiveClientRequestId + 1;
@@ -886,658 +544,365 @@ public class BatchApiTest extends BaseLoanIntegrationTest {
         final Long disburseLoanRequestId = approveLoanRequestId + 1;
         final Long goodwillCreditRequestId = disburseLoanRequestId + 1;
 
-        // Create a createClient Request
-        final BatchRequest br1 = BatchHelper.createActiveClientRequest(createActiveClientRequestId, "");
+        final List<BatchRequest> batchRequests = List.of(BatchRequestBuilders.createActiveClient(createActiveClientRequestId, ""),
+                BatchRequestBuilders.applyLoan(applyLoanRequestId, createActiveClientRequestId, productId, clientCollateralId),
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                BatchRequestBuilders.disburseLoan(disburseLoanRequestId, approveLoanRequestId),
+                BatchRequestBuilders.goodwillCredit(goodwillCreditRequestId, disburseLoanRequestId, "500"));
 
-        // Create a ApplyLoan Request
-        final BatchRequest br2 = BatchHelper.applyLoanRequest(applyLoanRequestId, createActiveClientRequestId, productId,
-                clientCollateralId);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        // Create a approveLoan Request
-        final BatchRequest br3 = BatchHelper.approveLoanRequest(approveLoanRequestId, applyLoanRequestId);
-
-        // Create a disburseLoan Request
-        final BatchRequest br4 = BatchHelper.disburseLoanRequest(disburseLoanRequestId, approveLoanRequestId);
-
-        // Create a good will credit request.
-        final BatchRequest br5 = BatchHelper.goodwillCreditRequest(goodwillCreditRequestId, disburseLoanRequestId, "500");
-
-        final List<BatchRequest> batchRequests = new ArrayList<>();
-
-        batchRequests.add(br1);
-        batchRequests.add(br2);
-        batchRequests.add(br3);
-        batchRequests.add(br4);
-        batchRequests.add(br5);
-
-        final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-
-        final List<BatchResponse> response = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                jsonifiedRequest);
-
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(4).getStatusCode(), "Verify Status Code 200 for Goodwill credit");
+        assertEquals(SC_OK, responses.get(4).getStatusCode(), "Verify Status Code 200 for Goodwill credit");
     }
 
     /**
-     * Test for the successful activation of a pending client using 'ActivateClientCommandStrategy'. A '200' status code
-     * is expected on successful activation.
+     * Test for the successful activation of a pending client using 'ActivateClientCommandStrategy'.
      *
      * @see org.apache.fineract.batch.command.internal.ActivateClientCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusOnSuccessfulClientActivation() {
+        final Long createClientRequestId = 4726L;
+        final Long activateClientRequestId = 4727L;
 
-        // Create a createClient Request
-        final BatchRequest br1 = BatchHelper.createClientRequest(4726L, "");
+        final List<BatchRequest> batchRequests = List.of(BatchRequestBuilders.createClient(createClientRequestId, ""),
+                BatchRequestBuilders.activateClient(activateClientRequestId, createClientRequestId));
 
-        // Create an activateClient Request
-        final BatchRequest br2 = BatchHelper.activateClientRequest(4727L, 4726L);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        final List<BatchRequest> batchRequests = new ArrayList<>();
-
-        batchRequests.add(br1);
-        batchRequests.add(br2);
-
-        final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-
-        final List<BatchResponse> response = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                jsonifiedRequest);
-
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(0).getStatusCode(), "Verify Status Code 200 for Create Client");
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(1).getStatusCode(), "Verify Status Code 200 for Activate Client");
+        assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Create Client");
+        assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Activate Client");
     }
 
     /**
-     * Test for the successful approval and disbursal of a loan using 'ApproveLoanCommandStrategy' and
-     * 'DisburseLoanCommandStrategy'. A '200' status code is expected on successful activation.
+     * Test for the successful approval and disbursal of a loan.
      *
      * @see org.apache.fineract.batch.command.internal.ApproveLoanCommandStrategy
      * @see org.apache.fineract.batch.command.internal.DisburseLoanCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusOnSuccessfulLoanApprovalAndDisburse() {
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
+        final Long productId = createBatchLoanProduct(LARGE_PRINCIPAL);
+        final Long clientCollateralId = createClientCollateral();
 
-        final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientID);
+        final Long createClientRequestId = 4730L;
+        final Long activateClientRequestId = 4731L;
+        final Long applyLoanRequestId = 4732L;
+        final Long approveLoanRequestId = 4733L;
+        final Long disburseLoanRequestId = 4734L;
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(this.requestSpec, this.responseSpec);
-        Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(this.requestSpec, this.responseSpec,
-                String.valueOf(clientID), collateralId);
-        Assertions.assertNotNull(clientCollateralId);
+        final List<BatchRequest> batchRequests = List.of(BatchRequestBuilders.createClient(createClientRequestId, ""),
+                BatchRequestBuilders.activateClient(activateClientRequestId, createClientRequestId),
+                BatchRequestBuilders.applyLoan(applyLoanRequestId, activateClientRequestId, productId, clientCollateralId),
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                BatchRequestBuilders.disburseLoan(disburseLoanRequestId, approveLoanRequestId));
 
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        // Create a createClient Request
-        final BatchRequest br1 = BatchHelper.createClientRequest(4730L, "");
-
-        // Create a activateClient Request
-        final BatchRequest br2 = BatchHelper.activateClientRequest(4731L, 4730L);
-
-        // Create an ApplyLoan Request
-        final BatchRequest br3 = BatchHelper.applyLoanRequest(4732L, 4731L, productId, clientCollateralId);
-
-        // Create an approveLoan Request
-        final BatchRequest br4 = BatchHelper.approveLoanRequest(4733L, 4732L);
-
-        // Create an disburseLoan Request
-        final BatchRequest br5 = BatchHelper.disburseLoanRequest(4734L, 4733L);
-
-        final List<BatchRequest> batchRequests = new ArrayList<>();
-
-        batchRequests.add(br1);
-        batchRequests.add(br2);
-        batchRequests.add(br3);
-        batchRequests.add(br4);
-        batchRequests.add(br5);
-
-        final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-
-        final List<BatchResponse> response = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                jsonifiedRequest);
-
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(3).getStatusCode(), "Verify Status Code 200 for Approve Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(4).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
+        assertEquals(SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for Approve Loan");
+        assertEquals(SC_OK, responses.get(4).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
     }
 
     /**
-     * Test for the successful create client, apply loan,approval and disbursal of a loan using Batch API with
-     * enclosingTransaction. A '200' status code is expected on successful activation.
+     * Test for the successful create client, apply loan, approval and disbursal of a loan using Batch API with
+     * enclosingTransaction.
      *
      * @see org.apache.fineract.batch.command.internal.ApproveLoanCommandStrategy
      * @see org.apache.fineract.batch.command.internal.DisburseLoanCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusOnSuccessfulLoanApprovalAndDisburseWithTransaction() {
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
+        final Long productId = createBatchLoanProduct(LARGE_PRINCIPAL);
+        final Long clientCollateralId = createClientCollateral();
 
-        final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientID);
+        final Long createActiveClientRequestId = 4740L;
+        final Long applyLoanRequestId = 4742L;
+        final Long approveLoanRequestId = 4743L;
+        final Long disburseLoanRequestId = 4744L;
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(this.requestSpec, this.responseSpec);
-        Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(this.requestSpec, this.responseSpec,
-                String.valueOf(clientID), collateralId);
-        Assertions.assertNotNull(clientCollateralId);
+        final List<BatchRequest> batchRequests = List.of(BatchRequestBuilders.createActiveClient(createActiveClientRequestId, ""),
+                BatchRequestBuilders.applyLoan(applyLoanRequestId, createActiveClientRequestId, productId, clientCollateralId),
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                BatchRequestBuilders.disburseLoan(disburseLoanRequestId, approveLoanRequestId));
 
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final List<BatchResponse> responses = batchHelper.executeEnclosingTransaction(batchRequests);
 
-        // Create a createClient Request
-        final BatchRequest br1 = BatchHelper.createActiveClientRequest(4740L, "");
-
-        // Create an ApplyLoan Request
-        final BatchRequest br2 = BatchHelper.applyLoanRequest(4742L, 4740L, productId, clientCollateralId);
-
-        // Create an approveLoan Request
-        final BatchRequest br3 = BatchHelper.approveLoanRequest(4743L, 4742L);
-
-        // Create a disburseLoan Request
-        final BatchRequest br4 = BatchHelper.disburseLoanRequest(4744L, 4743L);
-
-        final List<BatchRequest> batchRequests = Arrays.asList(br1, br2, br3, br4);
-
-        final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-
-        final List<BatchResponse> response = BatchHelper.postBatchRequestsWithEnclosingTransaction(this.requestSpec, this.responseSpec,
-                jsonifiedRequest);
-
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(0).getStatusCode(), "Verify Status Code 200 for create client");
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(1).getStatusCode(), "Verify Status Code 200 for apply Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(2).getStatusCode(), "Verify Status Code 200 for approve Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(3).getStatusCode(), "Verify Status Code 200 for disburse Loan");
+        assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for create client");
+        assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for apply Loan");
+        assertEquals(SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for approve Loan");
+        assertEquals(SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for disburse Loan");
     }
 
     /**
-     * Test for the successful disbursement and get loan. A '200' status code is expected on successful responses.
+     * Test for the successful disbursement and get loan transaction.
      *
      * @see org.apache.fineract.batch.command.internal.DisburseLoanCommandStrategy
-     * @see org.apache.fineract.batch.command.internal.GetLoanTransactionByIdCommandStrategy
+     * @see org.apache.fineract.batch.command.internal.GetTransactionByIdCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusOnSuccessfulDisbursementAndGetTransaction() {
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
+        final Long productId = createBatchLoanProduct(LARGE_PRINCIPAL);
+        final Long clientId = createClient();
 
         final Long applyLoanRequestId = 6730L;
         final Long approveLoanRequestId = 6731L;
         final Long disburseLoanRequestId = 6732L;
         final Long getTransactionRequestId = 6733L;
 
-        // Create product
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final List<BatchRequest> batchRequests = List.of(
+                BatchRequestBuilders.applyLoanWithClientId(applyLoanRequestId, clientId, productId),
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                BatchRequestBuilders.disburseLoan(disburseLoanRequestId, approveLoanRequestId),
+                BatchRequestBuilders.getTransactionById(getTransactionRequestId, disburseLoanRequestId, true));
 
-        // Create client
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientId);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        // Create an ApplyLoan Request
-        final BatchRequest batchRequest1 = BatchHelper.applyLoanRequestWithClientId(applyLoanRequestId, clientId, productId);
-
-        // Create an approveLoan Request
-        final BatchRequest batchRequest2 = BatchHelper.approveLoanRequest(approveLoanRequestId, applyLoanRequestId);
-
-        // Create a disbursement Request
-        final BatchRequest batchRequest3 = BatchHelper.disburseLoanRequest(disburseLoanRequestId, approveLoanRequestId);
-
-        // Create a getTransaction Request
-        final BatchRequest batchRequest4 = BatchHelper.getTransactionByIdRequest(getTransactionRequestId, disburseLoanRequestId, true);
-
-        final List<BatchRequest> batchRequests = Arrays.asList(batchRequest1, batchRequest2, batchRequest3, batchRequest4);
-
-        final List<BatchResponse> responses = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                BatchHelper.toJsonString(batchRequests));
-
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for Get Transaction By Id");
+        assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
+        assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
+        assertEquals(SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
+        assertEquals(SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for Get Transaction By Id");
     }
 
     /**
-     * Test for the successful new loan reschedule request and approval for the same. A '200' status code is expected on
-     * successful responses.
+     * Test for the successful new loan reschedule request and approval for the same.
      *
      * @see org.apache.fineract.batch.command.internal.CreateLoanRescheduleRequestCommandStrategy
      * @see org.apache.fineract.batch.command.internal.ApproveLoanRescheduleCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusOnSuccessfulDisbursementAndRescheduleLoan() {
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
+        final Long productId = createBatchLoanProduct(LARGE_PRINCIPAL);
+        final Long clientId = createClient();
+        final Long rescheduleReasonId = codeHelper.retrieveOrCreateCodeValueId(LOAN_RESCHEDULE_REASON_CODE_NAME);
 
-        final Long createActiveClientRequestId = 8462L;
-        final Long applyLoanRequestId = createActiveClientRequestId + 1;
+        final Long applyLoanRequestId = 8463L;
         final Long approveLoanRequestId = applyLoanRequestId + 1;
         final Long disburseLoanRequestId = approveLoanRequestId + 1;
         final Long rescheduleLoanRequestId = disburseLoanRequestId + 1;
         final Long approveRescheduleLoanRequestId = rescheduleLoanRequestId + 1;
 
-        // Create product
-        LOG.info("LoanProduct {}", loanProductJSON);
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final LocalDate disburseLoanDate = today().minusDays(1);
+        final LocalDate adjustedDueDate = today().plusDays(40);
 
-        // Create client
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientId);
+        final List<BatchRequest> batchRequests = List.of(
+                BatchRequestBuilders.applyLoanWithClientId(applyLoanRequestId, clientId, productId),
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                BatchRequestBuilders.disburseLoan(disburseLoanRequestId, approveLoanRequestId, disburseLoanDate),
+                BatchRequestBuilders.createRescheduleLoan(rescheduleLoanRequestId, disburseLoanRequestId, disburseLoanDate.plusMonths(1),
+                        rescheduleReasonId, adjustedDueDate),
+                BatchRequestBuilders.approveRescheduleLoan(approveRescheduleLoanRequestId, rescheduleLoanRequestId));
 
-        /* Retrieve/Create Code Values for the Code "LoanRescheduleReason = 23" */
-        final HashMap<String, Object> codeValue = CodeHelper.retrieveOrCreateCodeValue(23, this.requestSpec, this.responseSpec);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        final Integer codeValueId = (Integer) codeValue.get("id");
-
-        // Create an ApplyLoan request
-        final BatchRequest applyLoanRequestWithClientId = BatchHelper.applyLoanRequestWithClientId(applyLoanRequestId, clientId, productId);
-
-        // Create an approveLoan request
-        final BatchRequest approveLoanRequest = BatchHelper.approveLoanRequest(approveLoanRequestId, applyLoanRequestId);
-
-        // Create a disbursement request
-        final LocalDate disburseLoanDate = LocalDate.now(Utils.getZoneIdOfTenant()).minusDays(1);
-        final BatchRequest disburseLoanRequest = BatchHelper.disburseLoanRequest(disburseLoanRequestId, approveLoanRequestId,
-                disburseLoanDate);
-
-        // Create a reschedule loan request
-        final BatchRequest rescheduleLoanRequest = BatchHelper.createRescheduleLoanRequest(rescheduleLoanRequestId, disburseLoanRequestId,
-                disburseLoanDate.plusMonths(1), codeValueId);
-
-        // Approve reschedule loan request
-        final BatchRequest approveRescheduleLoanRequest = BatchHelper.approveRescheduleLoanRequest(approveRescheduleLoanRequestId,
-                rescheduleLoanRequestId);
-
-        final List<BatchRequest> batchRequests = Arrays.asList(applyLoanRequestWithClientId, approveLoanRequest, disburseLoanRequest,
-                rescheduleLoanRequest, approveRescheduleLoanRequest);
-
-        LOG.info("shouldReturnOkStatusOnSuccessfulDisbursementAndRescheduleLoan Request - {}", BatchHelper.toJsonString(batchRequests));
-        final List<BatchResponse> responses = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                BatchHelper.toJsonString(batchRequests));
-
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(3).getStatusCode(),
-                "Verify Status Code 200 for Create Reschedule Loan request");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(4).getStatusCode(),
-                "Verify Status Code 200 for Approve Reschedule Loan request");
+        assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
+        assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
+        assertEquals(SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
+        assertEquals(SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for Create Reschedule Loan request");
+        assertEquals(SC_OK, responses.get(4).getStatusCode(), "Verify Status Code 200 for Approve Reschedule Loan request");
     }
 
     /**
-     * Test for the successful create client, create, approve and get loan. A '200' status code is expected on
-     * successful responses.
+     * Test for the successful create client, create, approve and get loan.
      *
-     * @see org.apache.fineract.batch.command.internal.CreateClientCommandStrategy
-     * @see org.apache.fineract.batch.command.internal.ApplyLoanCommandStrategy
-     * @see org.apache.fineract.batch.command.internal.ApproveLoanCommandStrategy
      * @see org.apache.fineract.batch.command.internal.GetLoanByIdCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusOnSuccessfulCreateClientCreateApproveAndGetLoan() {
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
+        final Long productId = createBatchLoanProduct(LARGE_PRINCIPAL);
 
         final Long createActiveClientRequestId = 4730L;
         final Long applyLoanRequestId = 4731L;
         final Long approveLoanRequestId = 4732L;
         final Long getLoanByIdRequestId = 4733L;
 
-        // Create product
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final List<BatchRequest> batchRequests = List.of(BatchRequestBuilders.createActiveClient(createActiveClientRequestId, ""),
+                BatchRequestBuilders.applyLoan(applyLoanRequestId, createActiveClientRequestId, productId, null),
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                BatchRequestBuilders.getLoanByReference(getLoanByIdRequestId, applyLoanRequestId, null));
 
-        // Create createClient Request
-        final BatchRequest batchRequest1 = BatchHelper.createActiveClientRequest(createActiveClientRequestId, "");
+        final List<BatchResponse> responses = batchHelper.executeEnclosingTransaction(batchRequests);
 
-        // Create an ApplyLoan Request
-        final BatchRequest batchRequest2 = BatchHelper.applyLoanRequest(applyLoanRequestId, createActiveClientRequestId, productId, null);
+        assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Create Client");
+        assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Apply Loan");
+        assertEquals(SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Approve Loan");
+        assertEquals(SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for Get Loan By Id");
 
-        // Create an approveLoan Request
-        final BatchRequest batchRequest3 = BatchHelper.approveLoanRequest(approveLoanRequestId, applyLoanRequestId);
+        final Long loanId = bodyAsObject(responses.get(1)).get("loanId").getAsLong();
+        final JsonObject getLoanResponse = bodyAsObject(responses.get(3));
+        final JsonObject status = getLoanResponse.getAsJsonObject("status");
 
-        // Get loan by id Request
-        final BatchRequest batchRequest4 = BatchHelper.getLoanByIdRequest(getLoanByIdRequestId, applyLoanRequestId, null);
-
-        final List<BatchRequest> batchRequests = Arrays.asList(batchRequest1, batchRequest2, batchRequest3, batchRequest4);
-
-        final List<BatchResponse> responses = BatchHelper.postBatchRequestsWithEnclosingTransaction(this.requestSpec, this.responseSpec,
-                BatchHelper.toJsonString(batchRequests));
-
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Create Client");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Apply Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Approve Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for Get Loan By Id");
-
-        final FromJsonHelper jsonHelper = new FromJsonHelper();
-        final Long loanId = jsonHelper.extractLongNamed("loanId", jsonHelper.parse(responses.get(1).getBody()).getAsJsonObject());
-        final Long loanIdInGetResponse = jsonHelper.extractLongNamed("id", jsonHelper.parse(responses.get(3).getBody()).getAsJsonObject());
-        final JsonObject statusInGetResponse = jsonHelper.parse(responses.get(3).getBody()).getAsJsonObject().get("status")
-                .getAsJsonObject();
-
-        Assertions.assertEquals(loanId, loanIdInGetResponse);
-        Assertions.assertEquals(LoanStatus.APPROVED.getCode(), jsonHelper.extractStringNamed("code", statusInGetResponse));
-        Assertions.assertEquals("Approved", jsonHelper.extractStringNamed("value", statusInGetResponse));
+        assertEquals(loanId, getLoanResponse.get("id").getAsLong());
+        assertEquals(LoanStatus.APPROVED.getCode(), status.get("code").getAsString());
+        assertEquals("Approved", status.get("value").getAsString());
     }
 
     /**
-     * Test for the successful creat, approve and get loan. A '200' status code is expected on successful responses.
+     * Test for the successful create, approve and get loan, with and without a query parameter.
      *
-     * @see org.apache.fineract.batch.command.internal.ApplyLoanCommandStrategy
-     * @see org.apache.fineract.batch.command.internal.ApproveLoanCommandStrategy
      * @see org.apache.fineract.batch.command.internal.GetLoanByIdCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusOnSuccessfulCreateApproveAndGetLoan() {
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
+        final Long productId = createBatchLoanProduct(LARGE_PRINCIPAL);
+        final Long clientId = createClient();
 
         final Long applyLoanRequestId = 5730L;
         final Long approveLoanRequestId = 5731L;
         final Long getLoanByIdRequestId = 5732L;
         final Long getLoanByIdWithQueryParametersRequestId = 5733L;
 
-        // Create product
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final List<BatchRequest> batchRequests = List.of(
+                BatchRequestBuilders.applyLoanWithClientId(applyLoanRequestId, clientId, productId),
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                BatchRequestBuilders.getLoanByReference(getLoanByIdRequestId, applyLoanRequestId, null),
+                BatchRequestBuilders.getLoanByReference(getLoanByIdWithQueryParametersRequestId, applyLoanRequestId,
+                        "associations=repaymentSchedule,transactions"));
 
-        // Create client
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientId);
+        final List<BatchResponse> responses = batchHelper.executeEnclosingTransaction(batchRequests);
 
-        // Create an ApplyLoan Request
-        final BatchRequest batchRequest1 = BatchHelper.applyLoanRequestWithClientId(applyLoanRequestId, clientId, productId);
+        assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
+        assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
+        assertEquals(SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Get Loan By Id without query parameter");
+        assertEquals(SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for Get Loan By Id with query parameter");
 
-        // Create an approveLoan Request
-        final BatchRequest batchRequest2 = BatchHelper.approveLoanRequest(approveLoanRequestId, applyLoanRequestId);
+        final Long loanId = bodyAsObject(responses.get(0)).get("loanId").getAsLong();
+        final JsonObject getLoanResponse = bodyAsObject(responses.get(2));
+        final JsonObject status = getLoanResponse.getAsJsonObject("status");
 
-        // Get loan by id Request without query param
-        final BatchRequest batchRequest3 = BatchHelper.getLoanByIdRequest(getLoanByIdRequestId, applyLoanRequestId, null);
-
-        // Get loan by id Request with query param
-        final BatchRequest batchRequest4 = BatchHelper.getLoanByIdRequest(getLoanByIdWithQueryParametersRequestId, applyLoanRequestId,
-                "associations=repaymentSchedule,transactions");
-
-        final List<BatchRequest> batchRequests = Arrays.asList(batchRequest1, batchRequest2, batchRequest3, batchRequest4);
-
-        final List<BatchResponse> responses = BatchHelper.postBatchRequestsWithEnclosingTransaction(this.requestSpec, this.responseSpec,
-                BatchHelper.toJsonString(batchRequests));
-
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(2).getStatusCode(),
-                "Verify Status Code 200 for Get Loan By Id without query parameter");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(3).getStatusCode(),
-                "Verify Status Code 200 for Get Loan By Id with query parameter");
-
-        final FromJsonHelper jsonHelper = new FromJsonHelper();
-        final Long loanId = jsonHelper.extractLongNamed("loanId", jsonHelper.parse(responses.get(0).getBody()).getAsJsonObject());
-        final Long loanIdInGetResponse = jsonHelper.extractLongNamed("id", jsonHelper.parse(responses.get(2).getBody()).getAsJsonObject());
-        final JsonObject statusInGetResponse = jsonHelper.parse(responses.get(2).getBody()).getAsJsonObject().get("status")
-                .getAsJsonObject();
-
-        Assertions.assertEquals(loanId, loanIdInGetResponse);
-        Assertions.assertEquals(LoanStatus.APPROVED.getCode(), jsonHelper.extractStringNamed("code", statusInGetResponse));
-        Assertions.assertEquals("Approved", jsonHelper.extractStringNamed("value", statusInGetResponse));
+        assertEquals(loanId, getLoanResponse.get("id").getAsLong());
+        assertEquals(LoanStatus.APPROVED.getCode(), status.get("code").getAsString());
+        assertEquals("Approved", status.get("value").getAsString());
 
         // Repayment schedule will not be available in the response
-        Assertions.assertFalse(responses.get(2).getBody().contains("repaymentSchedule"));
+        assertFalse(responses.get(2).getBody().contains("repaymentSchedule"));
 
         // Repayment schedule information will be available in the response based on the query parameter
-        Assertions.assertTrue(responses.get(3).getBody().contains("repaymentSchedule"));
+        assertTrue(responses.get(3).getBody().contains("repaymentSchedule"));
     }
 
     /**
-     * Test for the successful get loan and get datatable entry. A '200' status code is expected on successful
-     * responses.
+     * Test for the successful get loan and get datatable entry.
      *
-     * @see org.apache.fineract.batch.command.internal.ApplyLoanCommandStrategy
-     * @see org.apache.fineract.batch.command.internal.ApproveLoanCommandStrategy
-     * @see org.apache.fineract.batch.command.internal.GetLoanByIdCommandStrategy
+     * @see org.apache.fineract.batch.command.internal.GetDatatableEntryByAppTableIdCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusOnSuccessfulGetDataTableEntry() {
-        final FromJsonHelper jsonHelper = new FromJsonHelper();
-        final Long loanId = jsonHelper.extractLongNamed("loanId", jsonHelper.parse(setupAccount()).getAsJsonObject());
-        final String datatableName = this.datatableHelper.createDatatable(LOAN_APP_TABLE_NAME, false);
+        final Long loanId = setupLoanAccount();
+        final String datatableName = createLoanDatatable();
         try {
+            final List<BatchRequest> batchRequests = List.of(
+                    BatchRequestBuilders.getLoanByLoanId(GET_LOAN_REQUEST_ID, null, loanId, "associations=repaymentSchedule,transactions"),
+                    BatchRequestBuilders.getDatatableEntries(GET_DATATABLE_ENTRIES_REQUEST_ID, null, datatableName, loanId,
+                            "genericResultSet=true"));
 
-            // Get loan by id Request with query param
-            final BatchRequest getLoanBatchRequest = BatchHelper.getLoanByIdRequest(loanId, "associations=repaymentSchedule,transactions");
+            final List<BatchResponse> responses = batchHelper.executeEnclosingTransaction(batchRequests);
 
-            // Get datatable batch request
-            final BatchRequest getDatatableBatchRequest = BatchHelper.getDatatableByIdRequest(loanId, datatableName,
-                    "genericResultSet=true", null);
+            assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for get loan");
+            assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for datatable");
 
-            final List<BatchRequest> batchRequestsGetLoan = Arrays.asList(getLoanBatchRequest, getDatatableBatchRequest);
+            final String getLoanResponse = responses.get(0).getBody();
+            final String getDatatableResponse = responses.get(1).getBody();
 
-            final List<BatchResponse> responsesGetLoan = BatchHelper.postBatchRequestsWithEnclosingTransaction(this.requestSpec,
-                    this.responseSpec, BatchHelper.toJsonString(batchRequestsGetLoan));
+            assertEquals(loanId, bodyAsObject(responses.get(0)).get("id").getAsLong());
 
-            final String getLoanResponse = responsesGetLoan.get(0).getBody();
-            final String getDatatableResponse = responsesGetLoan.get(1).getBody();
+            // Repayment schedule and transactions are available in the response based on the query parameter
+            assertTrue(getLoanResponse.contains("repaymentSchedule"));
+            assertTrue(getLoanResponse.contains("transactions"));
 
-            Assertions.assertEquals(HttpStatus.SC_OK, responsesGetLoan.get(0).getStatusCode(), "Verify Status Code 200 for get loan");
-            Assertions.assertEquals(HttpStatus.SC_OK, responsesGetLoan.get(1).getStatusCode(), "Verify Status Code 200 for datatable");
-
-            final Long loanIdInGetResponse = jsonHelper.extractLongNamed("id", jsonHelper.parse(getLoanResponse).getAsJsonObject());
-            Assertions.assertEquals(loanId, loanIdInGetResponse);
-
-            // Repayment schedule information will be available in the response based on the query parameter
-            Assertions.assertTrue(getLoanResponse.contains("repaymentSchedule"));
-
-            // Transaction will be available in the response based on the query parameter
-            Assertions.assertTrue(getLoanResponse.contains("transactions"));
-
-            // datatable info will be available in the response based on the query parameter
-            Assertions.assertTrue(getDatatableResponse.contains("columnHeaders"));
-
-            // datatable info will be available in the response based on the query parameter
-            Assertions.assertTrue(getDatatableResponse.contains("data"));
+            // The generic result set carries the column headers along with the data
+            assertTrue(getDatatableResponse.contains("columnHeaders"));
+            assertTrue(getDatatableResponse.contains("data"));
         } finally {
             deleteDatatable(datatableName);
         }
     }
 
     /**
-     * Test for the successful create and update datatable entry. A '200' status code is expected on successful
-     * responses.
+     * Test for the successful create and update datatable entry.
      *
      * @see org.apache.fineract.batch.command.internal.CreateDatatableEntryCommandStrategy
      * @see org.apache.fineract.batch.command.internal.UpdateDatatableEntryOneToManyCommandStrategy
      * @see org.apache.fineract.batch.command.internal.GetDatatableEntryByAppTableIdCommandStrategy
-     * @see GetDatatableEntryByAppTableIdAndDataTableIdCommandStrategy
+     * @see org.apache.fineract.batch.command.internal.GetDatatableEntryByAppTableIdAndDataTableIdCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusOnSuccessfulCreateDataTableEntry() {
-        final FromJsonHelper jsonHelper = new FromJsonHelper();
-        final Long loanId = jsonHelper.extractLongNamed("loanId", jsonHelper.parse(setupAccount()).getAsJsonObject());
-        // creating datatable with m_loan association
-        final Map<String, Object> columnMap = new HashMap<>();
-        final List<HashMap<String, Object>> datatableColumnsList = new ArrayList<>();
+        final Long loanId = setupLoanAccount();
         final String datatableName = Utils.uniqueRandomStringGenerator(LOAN_APP_TABLE_NAME + "_", 5);
         final String columnName1 = Utils.randomStringGenerator("COL1_", 5);
         final String columnName2 = Utils.randomStringGenerator("COL2_", 5);
-        columnMap.put("datatableName", datatableName);
-        columnMap.put("apptableName", LOAN_APP_TABLE_NAME);
-        columnMap.put("entitySubType", "PERSON");
-        columnMap.put("multiRow", true);
-        DatatableHelper.addDatatableColumn(datatableColumnsList, columnName1, "String", true, 10, null);
-        DatatableHelper.addDatatableColumn(datatableColumnsList, columnName2, "String", false, 10, null);
-        columnMap.put("columns", datatableColumnsList);
-        final String datatableRequestJsonString = new Gson().toJson(columnMap);
-        LOG.info("CreateDataTable map : {}", datatableRequestJsonString);
+        createTwoStringColumnDatatable(datatableName, columnName1, columnName2, true, SHORT_COLUMN_LENGTH);
+        try {
+            final Long existingEntryId = createDatatableEntry(datatableName, loanId, columnName1, Utils.randomStringGenerator("VAL1_", 3),
+                    columnName2, Utils.randomStringGenerator("VAL2_", 3));
 
-        this.datatableHelper.createDatatable(datatableRequestJsonString, "");
+            final List<BatchRequest> batchRequests = List.of(
+                    BatchRequestBuilders.createDatatableEntry(CREATE_DATATABLE_ENTRY_REQUEST_ID, datatableName, loanId,
+                            List.of(columnName1, columnName2)),
+                    BatchRequestBuilders.updateDatatableEntryByEntryId(UPDATE_DATATABLE_ENTRY_REQUEST_ID, CREATE_DATATABLE_ENTRY_REQUEST_ID,
+                            datatableName, loanId, existingEntryId, List.of(columnName1)),
+                    BatchRequestBuilders.getDatatableEntries(GET_DATATABLE_ENTRIES_REQUEST_ID, CREATE_DATATABLE_ENTRY_REQUEST_ID,
+                            datatableName, loanId, null),
+                    BatchRequestBuilders.getDatatableEntryByAppTableId(GET_DATATABLE_ENTRY_REQUEST_ID, CREATE_DATATABLE_ENTRY_REQUEST_ID,
+                            datatableName, loanId, "$.resourceId", null));
 
-        // Create a datatable entry so that it can be updated using BatchApi
-        final Map<String, Object> datatableEntryMap = new HashMap<>();
-        datatableEntryMap.put(columnName1, Utils.randomStringGenerator("VAL1_", 3));
-        datatableEntryMap.put(columnName2, Utils.randomStringGenerator("VAL2_", 3));
-        final String datatableEntryRequestJsonString = new Gson().toJson(datatableEntryMap);
-        LOG.info("CreateDataTableEntry map : {}", datatableEntryRequestJsonString);
+            final List<BatchResponse> responses = batchHelper.executeEnclosingTransaction(batchRequests);
 
-        final Map<String, Object> datatableEntryResponse = this.datatableHelper.createDatatableEntry(datatableName, loanId.intValue(),
-                false, datatableEntryRequestJsonString);
-        final Integer datatableEntryResourceId = (Integer) datatableEntryResponse.get("resourceId");
-        assertNotNull(datatableEntryResourceId, "ERROR IN CREATING THE ENTITY DATATABLE RECORD");
+            assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for create datatable entry");
+            assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for update datatable entry");
+            assertEquals(SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for get datatable entries");
+            assertEquals(SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for get datatable entry by id");
 
-        // Create datatable entry batch request
-        final BatchRequest createDatatableEntryRequest = BatchHelper.createDatatableEntryRequest(loanId.toString(), datatableName,
-                Arrays.asList(columnName1, columnName2));
+            final Long createdEntryId = bodyAsObject(responses.get(0)).get("resourceId").getAsLong();
+            final String getDatatableEntriesResponse = responses.get(2).getBody();
+            final JsonArray datatableEntries = JsonParser.parseString(getDatatableEntriesResponse).getAsJsonArray();
+            assertEquals(2, datatableEntries.size());
 
-        // Update datatable entry batch request
-        final BatchRequest updateDatatableEntryByEntryIdRequest = BatchHelper.updateDatatableEntryByEntryIdRequest(loanId, datatableName,
-                Long.valueOf(datatableEntryResourceId), Arrays.asList(columnName1));
-
-        // Get datatable entries batch request
-        final BatchRequest getDatatableEntriesRequest = BatchHelper.getDatatableByIdRequest(loanId, datatableName, null,
-                updateDatatableEntryByEntryIdRequest.getReference());
-
-        // Get datatable entry by app table id batch request
-        final BatchRequest getDatatableEntryByIdRequest = BatchHelper.getDatatableEntryByIdRequest(loanId, datatableName, "$.resourceId",
-                null, updateDatatableEntryByEntryIdRequest.getReference());
-
-        final List<BatchRequest> batchRequestsDatatableEntries = Arrays.asList(createDatatableEntryRequest,
-                updateDatatableEntryByEntryIdRequest, getDatatableEntriesRequest, getDatatableEntryByIdRequest);
-        LOG.info("Batch Request : {}", BatchHelper.toJsonString(batchRequestsDatatableEntries));
-
-        final List<BatchResponse> responseDatatableBatch = BatchHelper.postBatchRequestsWithEnclosingTransaction(this.requestSpec,
-                this.responseSpec, BatchHelper.toJsonString(batchRequestsDatatableEntries));
-
-        LOG.info("Batch Response : {}", new Gson().toJson(responseDatatableBatch));
-
-        final BatchResponse batchResponse1 = responseDatatableBatch.get(0);
-        final BatchResponse batchResponse2 = responseDatatableBatch.get(1);
-        final BatchResponse batchResponse3 = responseDatatableBatch.get(2);
-        final BatchResponse batchResponse4 = responseDatatableBatch.get(3);
-
-        Assertions.assertEquals(HttpStatus.SC_OK, batchResponse1.getStatusCode(), "Verify Status Code 200 for create datatable entry");
-        Assertions.assertEquals(HttpStatus.SC_OK, batchResponse2.getStatusCode(), "Verify Status Code 200 for update datatable entry");
-        Assertions.assertEquals(HttpStatus.SC_OK, batchResponse3.getStatusCode(), "Verify Status Code 200 for get datatable entries");
-        Assertions.assertEquals(HttpStatus.SC_OK, batchResponse4.getStatusCode(), "Verify Status Code 200 for get datatable entry by id");
-
-        final String getDatatableEntriesResponse = batchResponse3.getBody();
-
-        final Long createDatatableEntryId = jsonHelper.extractLongNamed("resourceId",
-                jsonHelper.parse(batchResponse1.getBody()).getAsJsonObject());
-
-        final JsonArray datatableEntries = jsonHelper.parse(getDatatableEntriesResponse).getAsJsonArray();
-        Assertions.assertEquals(2, datatableEntries.size());
-
-        // Ensure both resourceIds are available in response
-        Assertions.assertTrue(getDatatableEntriesResponse.contains(String.format("\"id\": %d", createDatatableEntryId)));
-        Assertions.assertTrue(getDatatableEntriesResponse.contains(String.format("\"id\": %d", datatableEntryResourceId)));
+            // Ensure both resourceIds are available in response
+            assertTrue(getDatatableEntriesResponse.contains("\"id\": %d".formatted(createdEntryId)));
+            assertTrue(getDatatableEntriesResponse.contains("\"id\": %d".formatted(existingEntryId)));
+        } finally {
+            deleteDatatableWithEntriesOf(datatableName, loanId);
+        }
     }
 
     /**
-     * Test for the successful get loan and get datatable entry where get datatable request have no query param. A '200'
-     * status code is expected on successful responses.
+     * Test for the successful get loan and get datatable entry where get datatable request has no query param.
      *
-     * @see org.apache.fineract.batch.command.internal.ApplyLoanCommandStrategy
-     * @see org.apache.fineract.batch.command.internal.ApproveLoanCommandStrategy
-     * @see org.apache.fineract.batch.command.internal.GetLoanByIdCommandStrategy
+     * @see org.apache.fineract.batch.command.internal.GetDatatableEntryByAppTableIdCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusOnSuccessfulGetDatatableEntryWithNoQueryParam() {
-        final FromJsonHelper jsonHelper = new FromJsonHelper();
-        final Long loanId = jsonHelper.extractLongNamed("loanId", jsonHelper.parse(setupAccount()).getAsJsonObject());
-        final String datatableName = this.datatableHelper.createDatatable(LOAN_APP_TABLE_NAME, false);
+        final Long loanId = setupLoanAccount();
+        final String datatableName = createLoanDatatable();
         try {
-            // Get loan by id Request with query param
-            final BatchRequest getLoanBatchRequest = BatchHelper.getLoanByIdRequest(loanId, "associations=repaymentSchedule,transactions");
+            final List<BatchRequest> batchRequests = List.of(
+                    BatchRequestBuilders.getLoanByLoanId(GET_LOAN_REQUEST_ID, null, loanId, "associations=repaymentSchedule,transactions"),
+                    BatchRequestBuilders.getDatatableEntries(GET_DATATABLE_ENTRIES_REQUEST_ID, null, datatableName, loanId, null));
 
-            // Get datatable batch request
-            final BatchRequest getDatatableBatchRequest = BatchHelper.getDatatableByIdRequest(loanId, datatableName, null, null);
+            final List<BatchResponse> responses = batchHelper.executeEnclosingTransaction(batchRequests);
 
-            final List<BatchRequest> batchRequestsGetLoan = Arrays.asList(getLoanBatchRequest, getDatatableBatchRequest);
+            assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Get Loan");
+            assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Get Datatable");
 
-            final List<BatchResponse> responsesGetLoan = BatchHelper.postBatchRequestsWithEnclosingTransaction(this.requestSpec,
-                    this.responseSpec, BatchHelper.toJsonString(batchRequestsGetLoan));
-
-            final String getLoanResponse = responsesGetLoan.get(0).getBody();
-
-            Assertions.assertEquals(HttpStatus.SC_OK, responsesGetLoan.get(0).getStatusCode(), "Verify Status Code 200 for Get Loan");
-            Assertions.assertEquals(HttpStatus.SC_OK, responsesGetLoan.get(1).getStatusCode(), "Verify Status Code 200 for Get Datatable");
-
-            final Long loanIdInGetResponse = jsonHelper.extractLongNamed("id", jsonHelper.parse(getLoanResponse).getAsJsonObject());
-            Assertions.assertEquals(loanId, loanIdInGetResponse);
-
-            Assertions.assertTrue(getLoanResponse.contains("repaymentSchedule"));
-
-            Assertions.assertTrue(getLoanResponse.contains("transactions"));
+            final String getLoanResponse = responses.get(0).getBody();
+            assertEquals(loanId, bodyAsObject(responses.get(0)).get("id").getAsLong());
+            assertTrue(getLoanResponse.contains("repaymentSchedule"));
+            assertTrue(getLoanResponse.contains("transactions"));
         } finally {
             deleteDatatable(datatableName);
         }
-
     }
 
     /**
-     * Test for the successful merchant issued and payout refund transaction. A '200' status code is expected on
-     * successful responses.
+     * Test for the successful merchant issued and payout refund transaction.
      *
-     * @see org.apache.fineract.batch.command.internal.ApplyLoanCommandStrategy
-     * @see org.apache.fineract.batch.command.internal.ApproveLoanCommandStrategy
-     * @see org.apache.fineract.batch.command.internal.DisburseLoanCommandStrategy
      * @see org.apache.fineract.batch.command.internal.CreateTransactionLoanCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusOnSuccessfulTransactionMerchantIssuedAndPayoutRefund() {
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
+        final Long productId = createBatchLoanProduct(LARGE_PRINCIPAL);
+        final Long clientId = createClient();
 
         final Long applyLoanRequestId = 5730L;
         final Long approveLoanRequestId = 5731L;
@@ -1545,65 +910,33 @@ public class BatchApiTest extends BaseLoanIntegrationTest {
         final Long merchantIssuedRefundRequestId = 5733L;
         final Long payoutRefundRequestId = 5734L;
 
-        // Create product
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final List<BatchRequest> batchRequests = List.of(
+                BatchRequestBuilders.applyLoanWithClientId(applyLoanRequestId, clientId, productId),
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                BatchRequestBuilders.disburseLoan(disburseLoanRequestId, approveLoanRequestId, today().minusDays(1)),
+                BatchRequestBuilders.merchantIssuedRefund(merchantIssuedRefundRequestId, applyLoanRequestId, "10"),
+                BatchRequestBuilders.payoutRefund(payoutRefundRequestId, applyLoanRequestId, "10"));
 
-        // Create client
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientId);
+        final List<BatchResponse> responses = batchHelper.executeEnclosingTransaction(batchRequests);
 
-        // Create an ApplyLoan Request
-        final BatchRequest applyLoanRequest = BatchHelper.applyLoanRequestWithClientId(applyLoanRequestId, clientId, productId);
-
-        // Create an approveLoan Request
-        final BatchRequest approveLoanRequest = BatchHelper.approveLoanRequest(approveLoanRequestId, applyLoanRequestId);
-
-        // Create a disbursement request
-        final BatchRequest disburseLoanRequest = BatchHelper.disburseLoanRequest(disburseLoanRequestId, approveLoanRequestId,
-                LocalDate.now(Utils.getZoneIdOfTenant()).minusDays(1));
-
-        // Create a merchant issued refund request
-        final BatchRequest merchantIssuedRefundRequest = BatchHelper.merchantIssuedRefundRequest(merchantIssuedRefundRequestId,
-                applyLoanRequestId, "10");
-
-        // Create a payout refund request
-        final BatchRequest payoutRefundRequest = BatchHelper.payoutRefundRequest(payoutRefundRequestId, applyLoanRequestId, "10");
-
-        final List<BatchRequest> batchRequests = Arrays.asList(applyLoanRequest, approveLoanRequest, disburseLoanRequest,
-                merchantIssuedRefundRequest, payoutRefundRequest);
-
-        final List<BatchResponse> responses = BatchHelper.postBatchRequestsWithEnclosingTransaction(this.requestSpec, this.responseSpec,
-                BatchHelper.toJsonString(batchRequests));
-
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for merchant issued refund");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(4).getStatusCode(), "Verify Status Code 200 for payout refund");
+        assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
+        assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
+        assertEquals(SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse loan");
+        assertEquals(SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for merchant issued refund");
+        assertEquals(SC_OK, responses.get(4).getStatusCode(), "Verify Status Code 200 for payout refund");
     }
 
     /**
-     * Test for the successful repayment reversal transaction. A '200' status code is expected on successful responses.
+     * Test for the successful repayment reversal transaction.
      *
-     * @see AdjustLoanTransactionCommandStrategy
+     * @see org.apache.fineract.batch.command.internal.AdjustLoanTransactionCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusForBatchRepaymentReversal() {
+        final Long productId = createBatchLoanProduct(LARGE_PRINCIPAL);
+        final Long clientId = createClient();
+        final LocalDate reversalDate = today();
 
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
-
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
-
-        final LocalDate date = LocalDate.now(Utils.getZoneIdOfTenant());
         final Long applyLoanRequestId = 5730L;
         final Long approveLoanRequestId = 5731L;
         final Long disburseLoanRequestId = 5732L;
@@ -1611,248 +944,131 @@ public class BatchApiTest extends BaseLoanIntegrationTest {
         final Long repayReversalRequestId = 5734L;
         final Long getLoanRequestId = 5735L;
 
-        // Create client
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientId);
+        final List<BatchRequest> batchRequests = List.of(
+                BatchRequestBuilders.applyLoanWithClientId(applyLoanRequestId, clientId, productId),
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                BatchRequestBuilders.disburseLoan(disburseLoanRequestId, approveLoanRequestId),
+                BatchRequestBuilders.repayLoan(repayLoanRequestId, disburseLoanRequestId, "500"),
+                BatchRequestBuilders.adjustTransaction(repayReversalRequestId, repayLoanRequestId, "0", reversalDate),
+                BatchRequestBuilders.getLoanByReference(getLoanRequestId, applyLoanRequestId, "associations=transactions"));
 
-        // Create an apply loan request
-        final BatchRequest applyLoanRequest = BatchHelper.applyLoanRequestWithClientId(applyLoanRequestId, clientId, productId);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        // Create an approve loan request
-        final BatchRequest approveLoanRequest = BatchHelper.approveLoanRequest(approveLoanRequestId, applyLoanRequestId);
+        assertEquals(SC_OK, responses.get(4).getStatusCode(), "Verify Status Code 200 for repayment reversal");
 
-        // Create a disburse loan request
-        final BatchRequest disburseLoanRequest = BatchHelper.disburseLoanRequest(disburseLoanRequestId, approveLoanRequestId);
-
-        // Create a repayment request.
-        final BatchRequest repaymentRequest = BatchHelper.repayLoanRequest(repayLoanRequestId, disburseLoanRequestId, "500");
-
-        // Create a repayment reversal request
-        final BatchRequest repaymentReversalRequest = BatchHelper.createAdjustTransactionRequest(repayReversalRequestId, repayLoanRequestId,
-                "0", date);
-
-        // Get loan transactions request
-        final BatchRequest getLoanTransactionsRequest = BatchHelper.getLoanByIdRequest(getLoanRequestId, applyLoanRequestId,
-                "associations=transactions");
-
-        final List<BatchRequest> batchRequests = Arrays.asList(applyLoanRequest, approveLoanRequest, disburseLoanRequest, repaymentRequest,
-                repaymentReversalRequest, getLoanTransactionsRequest);
-
-        final List<BatchResponse> responses = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                BatchHelper.toJsonString(batchRequests));
-
-        final FromJsonHelper jsonHelper = new FromJsonHelper();
-        final JsonObject repayment = jsonHelper.parse(responses.get(5).getBody()).getAsJsonObject().get("transactions").getAsJsonArray()
-                .get(1).getAsJsonObject();
-        final JsonArray dateArray = repayment.get("reversedOnDate").getAsJsonArray();
-        final LocalDate reversedOnDate = LocalDate.of(dateArray.get(0).getAsInt(), dateArray.get(1).getAsInt(),
-                dateArray.get(2).getAsInt());
-
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) responses.get(4).getStatusCode(), "Verify Status Code 200 for repayment reversal");
-        Assertions.assertEquals("Repayment", repayment.get("type").getAsJsonObject().get("value").getAsString());
-        Assertions.assertTrue(repayment.get("manuallyReversed").getAsBoolean());
-        Assertions.assertEquals(date, reversedOnDate);
+        final JsonObject repayment = transactionAt(responses.get(5), 1);
+        assertEquals("Repayment", repayment.getAsJsonObject("type").get("value").getAsString());
+        assertTrue(repayment.get("manuallyReversed").getAsBoolean());
+        assertEquals(reversalDate, asLocalDate(repayment.getAsJsonArray("reversedOnDate")));
     }
 
     /**
-     * Test for the successful repayment reversal transaction using loan external id and transaction external id. A
-     * '200' status code is expected on successful responses.
+     * Test for the successful repayment reversal transaction using loan external id and transaction external id.
      *
-     * @see AdjustLoanTransactionCommandStrategy
+     * @see org.apache.fineract.batch.command.internal.AdjustLoanTransactionCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusForBatchRepaymentReversalUsingExternalId() {
+        final Long productId = createBatchLoanProduct(LARGE_PRINCIPAL);
+        final Long clientId = createClient();
+        final LocalDate reversalDate = today();
+        final String loanExternalId = UUID.randomUUID().toString();
 
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
-
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
-
-        final LocalDate date = LocalDate.now(Utils.getZoneIdOfTenant());
-        final Long applyLoanRequestId = ThreadLocalRandom.current().nextLong(1000, 10_000);
+        final Long applyLoanRequestId = randomRequestId();
         final Long approveLoanRequestId = applyLoanRequestId + 1;
         final Long disburseLoanRequestId = approveLoanRequestId + 1;
         final Long getLoanBeforeTxnRequestId = disburseLoanRequestId + 1;
         final Long repayLoanRequestId = getLoanBeforeTxnRequestId + 1;
         final Long getLoanAfterTxnRequestId = repayLoanRequestId + 1;
         final Long repayReversalRequestId = getLoanAfterTxnRequestId + 1;
-        final Long getLoanAfterReversal = repayReversalRequestId + 1;
+        final Long getLoanAfterReversalRequestId = repayReversalRequestId + 1;
 
-        // Create client
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientId);
-        final String loanExternalId = UUID.randomUUID().toString();
-
-        // Create an apply loan request
-        final BatchRequest applyLoanRequest = BatchHelper.applyLoanRequestWithClientIdAndExternalId(applyLoanRequestId, clientId, productId,
-                loanExternalId);
-
-        // Create an approve loan request
-        final BatchRequest approveLoanRequest = BatchHelper.approveLoanRequest(approveLoanRequestId, applyLoanRequestId);
-
-        // Create a disburse loan request
-        final BatchRequest disburseLoanRequest = BatchHelper.disburseLoanRequest(disburseLoanRequestId, approveLoanRequestId);
-
-        // Get loan transactions request
-        final BatchRequest getLoanTransactionsRequestBeforeTxn = BatchHelper.getLoanByIdRequest(getLoanBeforeTxnRequestId,
-                disburseLoanRequestId, "associations=transactions");
-
-        // Create a repayment request by external id
-        final BatchRequest repaymentRequest = BatchHelper.createTransactionRequestByLoanExternalId(repayLoanRequestId,
-                getLoanBeforeTxnRequestId, "repayment", "500", LocalDate.now(Utils.getZoneIdOfTenant()));
-
-        // Get loan transactions request
-        final BatchRequest getLoanTransactionsRequestAfterTxn = BatchHelper.getLoanByIdRequest(getLoanAfterTxnRequestId, repayLoanRequestId,
-                "associations=transactions");
-
-        final List<BatchRequest> batchRequests = Arrays.asList(applyLoanRequest, approveLoanRequest, disburseLoanRequest,
-                getLoanTransactionsRequestBeforeTxn, repaymentRequest, getLoanTransactionsRequestAfterTxn);
+        final List<BatchRequest> batchRequests = List.of(
+                BatchRequestBuilders.applyLoanWithClientIdAndExternalId(applyLoanRequestId, clientId, productId, loanExternalId),
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                BatchRequestBuilders.disburseLoan(disburseLoanRequestId, approveLoanRequestId),
+                BatchRequestBuilders.getLoanByReference(getLoanBeforeTxnRequestId, disburseLoanRequestId, "associations=transactions"),
+                BatchRequestBuilders.createTransactionByLoanExternalId(repayLoanRequestId, getLoanBeforeTxnRequestId, "repayment", "500",
+                        today()),
+                BatchRequestBuilders.getLoanByReference(getLoanAfterTxnRequestId, repayLoanRequestId, "associations=transactions"));
 
         // Because loanExternalId & transactionExternalId are coming from 2 different responses, there is no easy way to
         // use them as reference in 1 batch api call.
         // So we are splitting repayment & reversal into 2 different batch api invocations
-        final List<BatchResponse> responses = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                BatchHelper.toJsonString(batchRequests));
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        final FromJsonHelper jsonHelper = new FromJsonHelper();
-        final String loanExternalIdDisburseLoanResponse = jsonHelper.parse(responses.get(3).getBody()).getAsJsonObject().get("externalId")
-                .getAsString();
-        final Long loanId = jsonHelper.parse(responses.get(3).getBody()).getAsJsonObject().get("id").getAsLong();
-        final String transactionExternalId = jsonHelper.parse(responses.get(4).getBody()).getAsJsonObject().get("resourceExternalId")
-                .getAsString();
-        Assertions.assertNotNull(loanExternalIdDisburseLoanResponse);
-        Assertions.assertEquals(loanExternalId, loanExternalIdDisburseLoanResponse);
-        Assertions.assertNotNull(transactionExternalId);
+        final JsonObject loanBeforeTransaction = bodyAsObject(responses.get(3));
+        final String loanExternalIdInResponse = loanBeforeTransaction.get("externalId").getAsString();
+        final Long loanId = loanBeforeTransaction.get("id").getAsLong();
+        final String transactionExternalId = bodyAsObject(responses.get(4)).get("resourceExternalId").getAsString();
 
-        // Create a repayment reversal request by external id
-        final BatchRequest repaymentReversalRequest = BatchHelper.createAdjustTransactionByExternalIdRequest(repayReversalRequestId, null,
-                loanExternalIdDisburseLoanResponse, transactionExternalId, "0", date);
+        assertEquals(loanExternalId, loanExternalIdInResponse);
+        assertNotNull(transactionExternalId);
 
-        final BatchRequest getLoanByIdWithTransactions = BatchHelper.getLoanByIdRequest(loanId, getLoanAfterReversal,
-                repayReversalRequestId, "associations=transactions");
+        final List<BatchRequest> reversalRequests = List.of(
+                BatchRequestBuilders.adjustTransactionByExternalId(repayReversalRequestId, null, loanExternalIdInResponse,
+                        transactionExternalId, "0", reversalDate),
+                BatchRequestBuilders.getLoanByLoanId(getLoanAfterReversalRequestId, repayReversalRequestId, loanId,
+                        "associations=transactions"));
 
-        final List<BatchRequest> reversalAndGetBatchRequest = Arrays.asList(repaymentReversalRequest, getLoanByIdWithTransactions);
+        final List<BatchResponse> reversalResponses = batchHelper.executeWithoutEnclosingTransaction(reversalRequests);
 
-        final List<BatchResponse> reversalResponses = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec,
-                this.responseSpec, BatchHelper.toJsonString(reversalAndGetBatchRequest));
+        assertEquals(SC_OK, reversalResponses.get(0).getStatusCode(), "Verify Status Code 200 for repayment reversal");
 
-        final JsonObject repayment = jsonHelper.parse(reversalResponses.get(1).getBody()).getAsJsonObject().get("transactions")
-                .getAsJsonArray().get(1).getAsJsonObject();
-
-        final JsonArray dateArray = repayment.get("reversedOnDate").getAsJsonArray();
-        final LocalDate reversedOnDate = LocalDate.of(dateArray.get(0).getAsInt(), dateArray.get(1).getAsInt(),
-                dateArray.get(2).getAsInt());
-
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) reversalResponses.get(0).getStatusCode(),
-                "Verify Status Code 200 for repayment reversal");
-        Assertions.assertEquals("Repayment", repayment.get("type").getAsJsonObject().get("value").getAsString());
-
-        Assertions.assertTrue(repayment.get("manuallyReversed").getAsBoolean());
-        Assertions.assertEquals(date, reversedOnDate);
+        final JsonObject repayment = transactionAt(reversalResponses.get(1), 1);
+        assertEquals("Repayment", repayment.getAsJsonObject("type").get("value").getAsString());
+        assertTrue(repayment.get("manuallyReversed").getAsBoolean());
+        assertEquals(reversalDate, asLocalDate(repayment.getAsJsonArray("reversedOnDate")));
     }
 
     /**
-     * Test for the successful repayment chargeback transaction. A '200' status code is expected on successful
-     * responses.
+     * Test for the successful repayment chargeback transaction.
      *
-     * @see AdjustLoanTransactionCommandStrategy
+     * @see org.apache.fineract.batch.command.internal.AdjustLoanTransactionCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusForBatchRepaymentChargeback() {
-
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
-
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final Long productId = createBatchLoanProduct(LARGE_PRINCIPAL);
+        final Long clientId = createClient();
 
         final Long applyLoanRequestId = 5730L;
         final Long approveLoanRequestId = 5731L;
         final Long disburseLoanRequestId = 5732L;
         final Long repayLoanRequestId = 5733L;
-        final Long repayReversalRequestId = 5734L;
+        final Long chargebackRequestId = 5734L;
         final Long getLoanRequestId = 5735L;
 
-        // Create client
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientId);
+        final List<BatchRequest> batchRequests = List.of(
+                BatchRequestBuilders.applyLoanWithClientId(applyLoanRequestId, clientId, productId),
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                BatchRequestBuilders.disburseLoan(disburseLoanRequestId, approveLoanRequestId),
+                BatchRequestBuilders.repayLoan(repayLoanRequestId, disburseLoanRequestId, "500"),
+                BatchRequestBuilders.chargebackTransaction(chargebackRequestId, repayLoanRequestId, "500"),
+                BatchRequestBuilders.getLoanByReference(getLoanRequestId, applyLoanRequestId, "associations=transactions"));
 
-        // Create an apply loan request
-        final BatchRequest applyLoanRequest = BatchHelper.applyLoanRequestWithClientId(applyLoanRequestId, clientId, productId);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        // Create an approve loan request
-        final BatchRequest approveLoanRequest = BatchHelper.approveLoanRequest(approveLoanRequestId, applyLoanRequestId);
+        assertEquals(SC_OK, responses.get(4).getStatusCode(), "Verify Status Code 200 for repayment chargeback");
 
-        // Create a disburse loan request
-        final BatchRequest disburseLoanRequest = BatchHelper.disburseLoanRequest(disburseLoanRequestId, approveLoanRequestId);
+        final JsonObject repayment = transactionAt(responses.get(5), 1);
+        assertEquals("Repayment", repayment.getAsJsonObject("type").get("value").getAsString());
 
-        // Create a repayment request
-        final BatchRequest repaymentRequest = BatchHelper.repayLoanRequest(repayLoanRequestId, disburseLoanRequestId, "500");
-
-        // Create a repayment chargeback request
-        final BatchRequest repaymentChargebackRequest = BatchHelper.createChargebackTransactionRequest(repayReversalRequestId,
-                repayLoanRequestId, "500");
-
-        // Get loan transactions request
-        final BatchRequest getLoanTransactionsRequest = BatchHelper.getLoanByIdRequest(getLoanRequestId, applyLoanRequestId,
-                "associations=transactions");
-
-        final List<BatchRequest> batchRequests = Arrays.asList(applyLoanRequest, approveLoanRequest, disburseLoanRequest, repaymentRequest,
-                repaymentChargebackRequest, getLoanTransactionsRequest);
-
-        final List<BatchResponse> responses = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                BatchHelper.toJsonString(batchRequests));
-
-        final FromJsonHelper jsonHelper = new FromJsonHelper();
-        final JsonObject repayment = jsonHelper.parse(responses.get(5).getBody()).getAsJsonObject().get("transactions").getAsJsonArray()
-                .get(1).getAsJsonObject();
-
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) responses.get(4).getStatusCode(),
-                "Verify Status Code 200 for repayment chargeback");
-        Assertions.assertEquals("Repayment", repayment.get("type").getAsJsonObject().get("value").getAsString());
-        final JsonArray transactionRelations = repayment.get("transactionRelations").getAsJsonArray();
-        Assertions.assertEquals(1, transactionRelations.size());
-        Assertions.assertEquals("CHARGEBACK", transactionRelations.get(0).getAsJsonObject().get("relationType").getAsString());
+        final JsonArray transactionRelations = repayment.getAsJsonArray("transactionRelations");
+        assertEquals(1, transactionRelations.size());
+        assertEquals("CHARGEBACK", transactionRelations.get(0).getAsJsonObject().get("relationType").getAsString());
     }
 
     /**
-     * Tests successful run of batch goodwill credit reversal for loans. A '200' status code is expected on successful
-     * responses.
+     * Tests successful run of batch goodwill credit reversal for loans.
      *
-     * @see AdjustLoanTransactionCommandStrategy
+     * @see org.apache.fineract.batch.command.internal.AdjustLoanTransactionCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusForBatchGoodwillCreditReversal() {
+        final Long productId = createBatchLoanProduct(SMALL_PRINCIPAL);
+        final Long clientId = createClient();
+        final LocalDate reversalDate = today();
 
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("1000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
-
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
-
-        final LocalDate date = LocalDate.now(Utils.getZoneIdOfTenant());
         final Long applyLoanRequestId = 5730L;
         final Long approveLoanRequestId = 5731L;
         final Long disburseLoanRequestId = 5732L;
@@ -1860,70 +1076,35 @@ public class BatchApiTest extends BaseLoanIntegrationTest {
         final Long goodwillCreditReversalRequestId = 5734L;
         final Long getLoanRequestId = 5735L;
 
-        // Create client
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientId);
+        final List<BatchRequest> batchRequests = List.of(
+                BatchRequestBuilders.applyLoanWithClientId(applyLoanRequestId, clientId, productId),
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                BatchRequestBuilders.disburseLoan(disburseLoanRequestId, approveLoanRequestId),
+                BatchRequestBuilders.goodwillCredit(goodwillCreditRequestId, disburseLoanRequestId, "500"),
+                BatchRequestBuilders.adjustTransaction(goodwillCreditReversalRequestId, goodwillCreditRequestId, "0", reversalDate),
+                BatchRequestBuilders.getLoanByReference(getLoanRequestId, applyLoanRequestId, "associations=transactions"));
 
-        // Create an apply loan request
-        final BatchRequest applyLoanRequest = BatchHelper.applyLoanRequestWithClientId(applyLoanRequestId, clientId, productId);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        // Create an approve loan request
-        final BatchRequest approveLoanRequest = BatchHelper.approveLoanRequest(approveLoanRequestId, applyLoanRequestId);
+        assertEquals(SC_OK, responses.get(4).getStatusCode(), "Verify Status Code 200 for goodwill credit reversal");
 
-        // Create a disburse loan request
-        final BatchRequest disburseLoanRequest = BatchHelper.disburseLoanRequest(disburseLoanRequestId, approveLoanRequestId);
-
-        // Create a good will credit request
-        final BatchRequest goodwillCreditRequest = BatchHelper.goodwillCreditRequest(goodwillCreditRequestId, disburseLoanRequestId, "500");
-
-        // Create a good will credit reversal request
-        final BatchRequest goodwillCreditReversalRequest = BatchHelper.createAdjustTransactionRequest(goodwillCreditReversalRequestId,
-                goodwillCreditRequestId, "0", date);
-
-        // Get loan transactions request
-        final BatchRequest getLoanTransactionsRequest = BatchHelper.getLoanByIdRequest(getLoanRequestId, applyLoanRequestId,
-                "associations=transactions");
-
-        final List<BatchRequest> batchRequests = Arrays.asList(applyLoanRequest, approveLoanRequest, disburseLoanRequest,
-                goodwillCreditRequest, goodwillCreditReversalRequest, getLoanTransactionsRequest);
-
-        final List<BatchResponse> responses = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                BatchHelper.toJsonString(batchRequests));
-
-        final FromJsonHelper jsonHelper = new FromJsonHelper();
-        final JsonObject goodWillCredit = jsonHelper.parse(responses.get(5).getBody()).getAsJsonObject().get("transactions")
-                .getAsJsonArray().get(1).getAsJsonObject();
-        final JsonArray dateArray = goodWillCredit.get("reversedOnDate").getAsJsonArray();
-        final LocalDate reversedOnDate = LocalDate.of(dateArray.get(0).getAsInt(), dateArray.get(1).getAsInt(),
-                dateArray.get(2).getAsInt());
-
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) responses.get(4).getStatusCode(),
-                "Verify Status Code 200 for goodwill credit reversal");
-        Assertions.assertEquals("Goodwill Credit", goodWillCredit.get("type").getAsJsonObject().get("value").getAsString());
-        Assertions.assertTrue(goodWillCredit.get("manuallyReversed").getAsBoolean());
-        Assertions.assertEquals(date, reversedOnDate);
+        final JsonObject goodwillCredit = transactionAt(responses.get(5), 1);
+        assertEquals("Goodwill Credit", goodwillCredit.getAsJsonObject("type").get("value").getAsString());
+        assertTrue(goodwillCredit.get("manuallyReversed").getAsBoolean());
+        assertEquals(reversalDate, asLocalDate(goodwillCredit.getAsJsonArray("reversedOnDate")));
     }
 
     /**
-     * Test for the successful merchant issued refund and payout refund reversal transaction. A '200' status code is
-     * expected on successful responses.
+     * Test for the successful merchant issued refund and payout refund reversal transaction.
      *
-     * @see AdjustLoanTransactionCommandStrategy
+     * @see org.apache.fineract.batch.command.internal.AdjustLoanTransactionCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusOnSuccessfulTransactionMerchantIssuedAndPayoutRefundReversal() {
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
+        final Long productId = createBatchLoanProduct(LARGE_PRINCIPAL);
+        final Long clientId = createClient();
+        final LocalDate reversalDate = today();
 
-        final LocalDate date = LocalDate.now(Utils.getZoneIdOfTenant());
         final Long applyLoanRequestId = 5730L;
         final Long approveLoanRequestId = 5731L;
         final Long disburseLoanRequestId = 5732L;
@@ -1933,818 +1114,563 @@ public class BatchApiTest extends BaseLoanIntegrationTest {
         final Long payoutRefundReversalRequestId = 5736L;
         final Long getLoanRequestId = 5737L;
 
-        // Create product
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final List<BatchRequest> batchRequests = List.of(
+                BatchRequestBuilders.applyLoanWithClientId(applyLoanRequestId, clientId, productId),
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                BatchRequestBuilders.disburseLoan(disburseLoanRequestId, approveLoanRequestId, reversalDate.minusDays(1)),
+                BatchRequestBuilders.merchantIssuedRefund(merchantIssuedRefundRequestId, applyLoanRequestId, "10"),
+                BatchRequestBuilders.payoutRefund(payoutRefundRequestId, applyLoanRequestId, "10"),
+                BatchRequestBuilders.adjustTransaction(merchantIssuedRefundReversalRequestId, merchantIssuedRefundRequestId, "0",
+                        reversalDate),
+                BatchRequestBuilders.adjustTransaction(payoutRefundReversalRequestId, payoutRefundRequestId, "0", reversalDate),
+                BatchRequestBuilders.getLoanByReference(getLoanRequestId, applyLoanRequestId, "associations=transactions"));
 
-        // Create client
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientId);
+        final List<BatchResponse> responses = batchHelper.executeEnclosingTransaction(batchRequests);
 
-        // Create an apply loan request
-        final BatchRequest applyLoanRequest = BatchHelper.applyLoanRequestWithClientId(applyLoanRequestId, clientId, productId);
+        assertEquals(SC_OK, responses.get(5).getStatusCode(), "Verify Status Code 200 for merchant issued refund reversal");
+        assertEquals(SC_OK, responses.get(6).getStatusCode(), "Verify Status Code 200 for payout refund reversal");
 
-        // Create an approve loan request
-        final BatchRequest approveLoanRequest = BatchHelper.approveLoanRequest(approveLoanRequestId, applyLoanRequestId);
+        final JsonObject merchantIssuedRefund = transactionAt(responses.get(7), 1);
+        final JsonObject payoutRefund = transactionAt(responses.get(7), 2);
 
-        // Create a disburse loan request
-        final BatchRequest disburseLoanRequest = BatchHelper.disburseLoanRequest(disburseLoanRequestId, approveLoanRequestId,
-                date.minusDays(1));
-
-        // Create a merchant issued refund request
-        final BatchRequest merchantIssuedRefundRequest = BatchHelper.merchantIssuedRefundRequest(merchantIssuedRefundRequestId,
-                applyLoanRequestId, "10");
-
-        // Create a payout refund request
-        final BatchRequest payoutRefundRequest = BatchHelper.payoutRefundRequest(payoutRefundRequestId, applyLoanRequestId, "10");
-
-        // Create a merchant issued refund reversal request
-        final BatchRequest merchantIssuedRefundReversalRequest = BatchHelper
-                .createAdjustTransactionRequest(merchantIssuedRefundReversalRequestId, merchantIssuedRefundRequestId, "0", date);
-
-        // Create a payout refund reversal request
-        final BatchRequest payoutRefundReversalRequest = BatchHelper.createAdjustTransactionRequest(payoutRefundReversalRequestId,
-                payoutRefundRequestId, "0", date);
-
-        // Get loan transactions request
-        final BatchRequest getLoanTransactionsRequest = BatchHelper.getLoanByIdRequest(getLoanRequestId, applyLoanRequestId,
-                "associations=transactions");
-
-        final List<BatchRequest> batchRequests = Arrays.asList(applyLoanRequest, approveLoanRequest, disburseLoanRequest,
-                merchantIssuedRefundRequest, payoutRefundRequest, merchantIssuedRefundReversalRequest, payoutRefundReversalRequest,
-                getLoanTransactionsRequest);
-
-        final List<BatchResponse> responses = BatchHelper.postBatchRequestsWithEnclosingTransaction(this.requestSpec, this.responseSpec,
-                BatchHelper.toJsonString(batchRequests));
-
-        final FromJsonHelper jsonHelper = new FromJsonHelper();
-        final JsonObject merchantIssuedRefund = jsonHelper.parse(responses.get(7).getBody()).getAsJsonObject().get("transactions")
-                .getAsJsonArray().get(1).getAsJsonObject();
-        final JsonObject payoutRefund = jsonHelper.parse(responses.get(7).getBody()).getAsJsonObject().get("transactions").getAsJsonArray()
-                .get(2).getAsJsonObject();
-        final JsonArray merchantIssuedDateArray = merchantIssuedRefund.get("reversedOnDate").getAsJsonArray();
-        final LocalDate merchantIssuedDate = LocalDate.of(merchantIssuedDateArray.get(0).getAsInt(),
-                merchantIssuedDateArray.get(1).getAsInt(), merchantIssuedDateArray.get(2).getAsInt());
-        final JsonArray payoutRefundDateArray = payoutRefund.getAsJsonObject().get("reversedOnDate").getAsJsonArray();
-        final LocalDate payoutRefundDate = LocalDate.of(payoutRefundDateArray.get(0).getAsInt(), payoutRefundDateArray.get(1).getAsInt(),
-                payoutRefundDateArray.get(2).getAsInt());
-
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(5).getStatusCode(),
-                "Verify Status Code 200 for merchant issued refund reversal");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(6).getStatusCode(), "Verify Status Code 200 for payout refund reversal");
-        Assertions.assertEquals("Merchant Issued Refund", merchantIssuedRefund.get("type").getAsJsonObject().get("value").getAsString());
-        Assertions.assertEquals("Payout Refund", payoutRefund.get("type").getAsJsonObject().get("value").getAsString());
-        Assertions.assertTrue(merchantIssuedRefund.get("manuallyReversed").getAsBoolean());
-        Assertions.assertTrue(payoutRefund.get("manuallyReversed").getAsBoolean());
-        Assertions.assertEquals(date, merchantIssuedDate);
-        Assertions.assertEquals(date, payoutRefundDate);
+        assertEquals("Merchant Issued Refund", merchantIssuedRefund.getAsJsonObject("type").get("value").getAsString());
+        assertEquals("Payout Refund", payoutRefund.getAsJsonObject("type").get("value").getAsString());
+        assertTrue(merchantIssuedRefund.get("manuallyReversed").getAsBoolean());
+        assertTrue(payoutRefund.get("manuallyReversed").getAsBoolean());
+        assertEquals(reversalDate, asLocalDate(merchantIssuedRefund.getAsJsonArray("reversedOnDate")));
+        assertEquals(reversalDate, asLocalDate(payoutRefund.getAsJsonArray("reversedOnDate")));
     }
 
     @Test
     public void shouldReturnOkStatusOnModifyingSavingAccount() {
         final String startDate = "10 April 2022";
-        final SavingsProductHelper savingsProductHelper = new SavingsProductHelper();
-        final SavingsAccountHelper savingsAccountHelper = new SavingsAccountHelper(this.requestSpec, this.responseSpec);
-        final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec, startDate);
-        Assertions.assertNotNull(clientID);
-        final String savingsProductJSON = savingsProductHelper.withInterestCompoundingPeriodTypeAsDaily()
-                .withInterestPostingPeriodTypeAsDaily().withInterestCalculationPeriodTypeAsDailyBalance().build();
-        final Integer savingsProductID = SavingsProductHelper.createSavingsProduct(savingsProductJSON, requestSpec, responseSpec);
-        Assertions.assertNotNull(savingsProductID);
-        final Integer savingsId = savingsAccountHelper.applyForSavingsApplicationOnDate(clientID, savingsProductID, "INDIVIDUAL",
-                startDate);
-        Assertions.assertNotNull(savingsId);
-        HashMap savingsStatusHashMap = savingsAccountHelper.approveSavingsOnDate(savingsId, startDate);
-        SavingsStatusChecker.verifySavingsIsApproved(savingsStatusHashMap);
-        savingsStatusHashMap = savingsAccountHelper.activateSavingsAccount(savingsId, startDate);
-        SavingsStatusChecker.verifySavingsIsActive(savingsStatusHashMap);
+        final Long clientId = createClient(startDate);
+        final Long savingsId = createActiveSavingsAccount(clientId, startDate, startDate, startDate);
 
-        final BatchRequest getSavingAccountRequest = BatchHelper.getSavingAccount(1L, Long.valueOf(savingsId), "chargeStatus=all", null);
-        final BatchRequest depositSavingAccountRequest = BatchHelper.depositSavingAccount(2L, 1L, 100F);
-        final BatchRequest holdAmountOnSavingAccountRequest = BatchHelper.holdAmountOnSavingAccount(3L, 1L, 10F);
+        final Long getSavingsAccountRequestId = 1L;
+        final Long depositRequestId = 2L;
+        final Long holdAmountRequestId = 3L;
 
-        final List<BatchRequest> batchRequests1 = Arrays.asList(getSavingAccountRequest, depositSavingAccountRequest,
-                holdAmountOnSavingAccountRequest);
-        final List<BatchResponse> responses1 = BatchHelper.postBatchRequestsWithEnclosingTransaction(this.requestSpec, this.responseSpec,
-                BatchHelper.toJsonString(batchRequests1));
+        final BatchRequest getSavingsAccountRequest = BatchRequestBuilders.getSavingsAccount(getSavingsAccountRequestId, null, savingsId,
+                "chargeStatus=all");
 
-        Assertions.assertEquals(HttpStatus.SC_OK, responses1.get(1).getStatusCode(), "Verify Status Code 200 for deposit saving account");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses1.get(2).getStatusCode(),
-                "Verify Status Code 200 for hold amount on saving account");
-        final FromJsonHelper jsonHelper = new FromJsonHelper();
-        final Long holdAmountTransactionId = jsonHelper.parse(responses1.get(2).getBody()).getAsJsonObject().get("resourceId").getAsLong();
+        final List<BatchRequest> depositRequests = List.of(getSavingsAccountRequest,
+                BatchRequestBuilders.depositSavingsAccount(depositRequestId, getSavingsAccountRequestId, 100F),
+                BatchRequestBuilders.holdAmountOnSavingsAccount(holdAmountRequestId, getSavingsAccountRequestId, 10F));
 
-        final BatchRequest releaseAmountOnSavingAccountRequest = BatchHelper.releaseAmountOnSavingAccount(2L, 1L, holdAmountTransactionId);
-        final BatchRequest withdrawSavingAccountRequest = BatchHelper.withdrawSavingAccount(3L, 1L, 80F);
+        final List<BatchResponse> depositResponses = batchHelper.executeEnclosingTransaction(depositRequests);
 
-        final List<BatchRequest> batchRequests2 = Arrays.asList(getSavingAccountRequest, releaseAmountOnSavingAccountRequest,
-                withdrawSavingAccountRequest);
-        final List<BatchResponse> responses2 = BatchHelper.postBatchRequestsWithEnclosingTransaction(this.requestSpec, this.responseSpec,
-                BatchHelper.toJsonString(batchRequests2));
+        assertEquals(SC_OK, depositResponses.get(1).getStatusCode(), "Verify Status Code 200 for deposit saving account");
+        assertEquals(SC_OK, depositResponses.get(2).getStatusCode(), "Verify Status Code 200 for hold amount on saving account");
 
-        Assertions.assertEquals(HttpStatus.SC_OK, responses2.get(1).getStatusCode(),
-                "Verify Status Code 200 for release amount on saving account");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses2.get(2).getStatusCode(), "Verify Status Code 200 for withdraw saving account");
+        final Long holdAmountTransactionId = bodyAsObject(depositResponses.get(2)).get("resourceId").getAsLong();
+
+        final Long releaseAmountRequestId = 2L;
+        final Long withdrawRequestId = 3L;
+
+        final List<BatchRequest> withdrawRequests = List.of(getSavingsAccountRequest,
+                BatchRequestBuilders.releaseAmountOnSavingsAccount(releaseAmountRequestId, getSavingsAccountRequestId,
+                        holdAmountTransactionId),
+                BatchRequestBuilders.withdrawSavingsAccount(withdrawRequestId, getSavingsAccountRequestId, 80F));
+
+        final List<BatchResponse> withdrawResponses = batchHelper.executeEnclosingTransaction(withdrawRequests);
+
+        assertEquals(SC_OK, withdrawResponses.get(1).getStatusCode(), "Verify Status Code 200 for release amount on saving account");
+        assertEquals(SC_OK, withdrawResponses.get(2).getStatusCode(), "Verify Status Code 200 for withdraw saving account");
     }
 
     /**
-     * Test for finding datatable entry by the query API and update its value
+     * Test for finding a one-to-one datatable entry by the query API and updating one of its columns.
      */
     @Test
     public void shouldFindOneToOneDatatableEntryByQueryAPIAndUpdateOneOfItsColumn() {
+        final Long loanId = setupLoanAccount();
         final String datatableName = Utils.uniqueRandomStringGenerator(LOAN_APP_TABLE_NAME + "_", 5).toLowerCase();
-
-        final FromJsonHelper jsonHelper = new FromJsonHelper();
-        final Long loanId = jsonHelper.extractLongNamed("loanId", jsonHelper.parse(setupAccount()).getAsJsonObject());
-        // creating datatable with m_loan association
-        final Map<String, Object> columnMap = new HashMap<>();
-        final List<HashMap<String, Object>> datatableColumnsList = new ArrayList<>();
-
         final String columnName1 = Utils.randomStringGenerator("COL1_", 5).toLowerCase();
         final String columnName2 = Utils.randomStringGenerator("COL2_", 5).toLowerCase();
-        columnMap.put("datatableName", datatableName);
-        columnMap.put("apptableName", LOAN_APP_TABLE_NAME);
-        columnMap.put("entitySubType", "PERSON");
-        columnMap.put("multiRow", false);
-        DatatableHelper.addDatatableColumn(datatableColumnsList, columnName1, "String", true, 10, null);
-        DatatableHelper.addDatatableColumn(datatableColumnsList, columnName2, "String", false, 10, null);
-        columnMap.put("columns", datatableColumnsList);
-        final String datatableRequestJsonString = new Gson().toJson(columnMap);
-        LOG.info("CreateDataTable map : {}", datatableRequestJsonString);
+        createTwoStringColumnDatatable(datatableName, columnName1, columnName2, false, SHORT_COLUMN_LENGTH);
+        try {
+            final String columnValue1 = Utils.randomStringGenerator("VAL1_", 3);
+            final String columnValue2 = Utils.randomStringGenerator("VAL2_", 3);
+            createDatatableEntry(datatableName, loanId, columnName1, columnValue1, columnName2, columnValue2);
 
-        this.datatableHelper.createDatatable(datatableRequestJsonString, "");
+            final String updatedColumnValue2 = columnValue2 + "1";
+            final List<BatchRequest> batchRequests = List.of(
+                    BatchRequestBuilders.queryDatatableEntries(QUERY_DATATABLE_ENTRIES_REQUEST_ID, datatableName, columnName1, columnValue1,
+                            "loan_id"),
+                    BatchRequestBuilders.updateDatatableEntry(UPDATE_QUERIED_DATATABLE_ENTRY_REQUEST_ID, QUERY_DATATABLE_ENTRIES_REQUEST_ID,
+                            datatableName, "$.[0].loan_id", columnName2, updatedColumnValue2));
 
-        // Create a datatable entry so that it can be updated using BatchApi
-        final Map<String, Object> datatableEntryMap = new HashMap<>();
-        String columnValue1 = Utils.randomStringGenerator("VAL1_", 3);
-        String columnValue2 = Utils.randomStringGenerator("VAL2_", 3);
-        datatableEntryMap.put(columnName1, columnValue1);
-        datatableEntryMap.put(columnName2, columnValue2);
-        final String datatableEntryRequestJsonString = new Gson().toJson(datatableEntryMap);
-        LOG.info("CreateDataTableEntry map : {}", datatableEntryRequestJsonString);
+            final List<BatchResponse> responses = batchHelper.executeEnclosingTransaction(batchRequests);
 
-        final Map<String, Object> datatableEntryResponse = this.datatableHelper.createDatatableEntry(datatableName, loanId.intValue(),
-                false, datatableEntryRequestJsonString);
-        final Integer datatableEntryResourceId = (Integer) datatableEntryResponse.get("resourceId");
-        assertNotNull(datatableEntryResourceId, "ERROR IN CREATING THE ENTITY DATATABLE RECORD");
+            assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for query datatable entries");
+            assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for update datatable entry");
 
-        final BatchRequest queryDatatableEntriesRequest = BatchHelper.queryDatatableEntries(datatableName, columnName1, columnValue1,
-                "loan_id");
-        final BatchRequest updateDatatableEntry = BatchHelper.updateDatatableEntry(datatableName, "$.[0].loan_id", columnName2,
-                columnValue2 + "1");
-
-        final List<BatchRequest> batchRequestsToQueryAndUpdateDatatableEntries = Arrays.asList(queryDatatableEntriesRequest,
-                updateDatatableEntry);
-        LOG.info("Batch Request : {}", BatchHelper.toJsonString(batchRequestsToQueryAndUpdateDatatableEntries));
-
-        final List<BatchResponse> responseOfQuertAndUpdateDatatableBatch = BatchHelper.postBatchRequestsWithEnclosingTransaction(
-                this.requestSpec, this.responseSpec, BatchHelper.toJsonString(batchRequestsToQueryAndUpdateDatatableEntries));
-
-        LOG.info("Batch Response : {}", new Gson().toJson(responseOfQuertAndUpdateDatatableBatch));
-
-        final BatchResponse batchQueryAndUpdateResponse1 = responseOfQuertAndUpdateDatatableBatch.get(0);
-        final BatchResponse batchQueryAndUpdateResponse2 = responseOfQuertAndUpdateDatatableBatch.get(1);
-        Assertions.assertEquals(HttpStatus.SC_OK, batchQueryAndUpdateResponse1.getStatusCode(),
-                "Verify Status Code 200 for create datatable entry");
-        Assertions.assertEquals(HttpStatus.SC_OK, batchQueryAndUpdateResponse2.getStatusCode(),
-                "Verify Status Code 200 for update datatable entry");
-
-        final JsonObject changes = jsonHelper.parse(batchQueryAndUpdateResponse2.getBody()).getAsJsonObject().get("changes")
-                .getAsJsonObject();
-        Assertions.assertEquals(changes.get(columnName2).getAsString(), columnValue2 + "1");
+            final JsonObject changes = bodyAsObject(responses.get(1)).getAsJsonObject("changes");
+            assertEquals(updatedColumnValue2, changes.get(columnName2).getAsString());
+        } finally {
+            deleteDatatableWithEntriesOf(datatableName, loanId);
+        }
     }
 
     /**
-     * Test when datatable entry was not found by the query API, and the update fails
+     * Test when a datatable entry was not found by the query API, and the update consequently fails.
      */
     @Test
     public void shouldNotFindAnyDatatableEntryByQueryAPIAndFailsToUpdateItsColumn() {
         final String datatableName = Utils.uniqueRandomStringGenerator(LOAN_APP_TABLE_NAME + "_", 5).toLowerCase();
-
-        // creating datatable with m_loan association
-        final Map<String, Object> columnMap = new HashMap<>();
-        final List<HashMap<String, Object>> datatableColumnsList = new ArrayList<>();
-
         final String columnName1 = Utils.randomStringGenerator("COL1_", 5).toLowerCase();
         final String columnName2 = Utils.randomStringGenerator("COL2_", 5).toLowerCase();
-        columnMap.put("datatableName", datatableName);
-        columnMap.put("apptableName", LOAN_APP_TABLE_NAME);
-        columnMap.put("entitySubType", "PERSON");
-        columnMap.put("multiRow", false);
-        DatatableHelper.addDatatableColumn(datatableColumnsList, columnName1, "String", true, 15, null);
-        DatatableHelper.addDatatableColumn(datatableColumnsList, columnName2, "String", false, 15, null);
-        columnMap.put("columns", datatableColumnsList);
-        final String datatableRequestJsonString = new Gson().toJson(columnMap);
-        LOG.info("CreateDataTable map : {}", datatableRequestJsonString);
+        createTwoStringColumnDatatable(datatableName, columnName1, columnName2, false, LONG_COLUMN_LENGTH);
+        try {
+            final List<BatchRequest> batchRequests = List.of(
+                    BatchRequestBuilders.queryDatatableEntries(QUERY_DATATABLE_ENTRIES_REQUEST_ID, datatableName, columnName1,
+                            "columnValue1", "loan_id"),
+                    BatchRequestBuilders.updateDatatableEntry(UPDATE_QUERIED_DATATABLE_ENTRY_REQUEST_ID, QUERY_DATATABLE_ENTRIES_REQUEST_ID,
+                            datatableName, "$.[0].loan_id", columnName2, "columnValue2"));
 
-        this.datatableHelper.createDatatable(datatableRequestJsonString, "");
+            final List<BatchResponse> responses = batchHelper.executeEnclosingTransaction(batchRequests);
 
-        final BatchRequest queryDatatableEntriesRequest = BatchHelper.queryDatatableEntries(datatableName, columnName1, "columnValue1",
-                "loan_id");
-        final BatchRequest updateDatatableEntry = BatchHelper.updateDatatableEntry(datatableName, "$.[0].loan_id", columnName2,
-                "columnValue2");
-
-        final List<BatchRequest> batchRequestsToQueryAndUpdateDatatableEntries = Arrays.asList(queryDatatableEntriesRequest,
-                updateDatatableEntry);
-        LOG.info("Batch Request : {}", BatchHelper.toJsonString(batchRequestsToQueryAndUpdateDatatableEntries));
-
-        final List<BatchResponse> responseOfQueryAndUpdateDatatableBatch = BatchHelper.postBatchRequestsWithEnclosingTransaction(
-                this.requestSpec, this.responseSpec, BatchHelper.toJsonString(batchRequestsToQueryAndUpdateDatatableEntries));
-
-        LOG.info("Batch Response : {}", new Gson().toJson(responseOfQueryAndUpdateDatatableBatch));
-
-        final BatchResponse updateResponse = responseOfQueryAndUpdateDatatableBatch.get(0);
-
-        Assertions.assertEquals(2L, updateResponse.getRequestId());
-        Assertions.assertEquals(HttpStatus.SC_BAD_REQUEST, updateResponse.getStatusCode(),
-                "Verify Status Code 400 for update datatable entry");
-        MatcherAssert.assertThat(updateResponse.getBody(), containsString("The referenced JSON path is invalid"));
+            final BatchResponse updateResponse = responses.get(0);
+            assertEquals(UPDATE_QUERIED_DATATABLE_ENTRY_REQUEST_ID, updateResponse.getRequestId());
+            assertEquals(SC_BAD_REQUEST, updateResponse.getStatusCode(), "Verify Status Code 400 for update datatable entry");
+            assertTrue(updateResponse.getBody().contains("The referenced JSON path is invalid"),
+                    "Expected an invalid JSON path error but was: " + updateResponse.getBody());
+        } finally {
+            deleteDatatable(datatableName);
+        }
     }
 
     /**
-     * Test for finding datatable entry by the query API and update its value
+     * Test for finding a one-to-many datatable entry by the query API and updating one of its columns.
      */
     @Test
     public void shouldFindOneToManyDatatableEntryByQueryAPIAndUpdateOneOfItsColumn() {
+        final Long loanId = setupLoanAccount();
         final String datatableName = Utils.uniqueRandomStringGenerator(LOAN_APP_TABLE_NAME + "_", 5).toLowerCase();
-
-        final FromJsonHelper jsonHelper = new FromJsonHelper();
-        final Long loanId = jsonHelper.extractLongNamed("loanId", jsonHelper.parse(setupAccount()).getAsJsonObject());
-        // creating datatable with m_loan association
-        final Map<String, Object> columnMap = new HashMap<>();
-        final List<HashMap<String, Object>> datatableColumnsList = new ArrayList<>();
-
         final String columnName1 = Utils.randomStringGenerator("COL1_", 5).toLowerCase();
         final String columnName2 = Utils.randomStringGenerator("COL2_", 5).toLowerCase();
-        columnMap.put("datatableName", datatableName);
-        columnMap.put("apptableName", LOAN_APP_TABLE_NAME);
-        columnMap.put("entitySubType", "PERSON");
-        columnMap.put("multiRow", true);
-        DatatableHelper.addDatatableColumn(datatableColumnsList, columnName1, "String", true, 10, null);
-        DatatableHelper.addDatatableColumn(datatableColumnsList, columnName2, "String", false, 10, null);
-        columnMap.put("columns", datatableColumnsList);
-        final String datatableRequestJsonString = new Gson().toJson(columnMap);
-        LOG.info("CreateDataTable map : {}", datatableRequestJsonString);
+        createTwoStringColumnDatatable(datatableName, columnName1, columnName2, true, SHORT_COLUMN_LENGTH);
+        try {
+            final String columnValue1 = Utils.randomStringGenerator("VAL1_", 3);
+            final String columnValue2 = Utils.randomStringGenerator("VAL2_", 3);
+            final Long existingEntryId = createDatatableEntry(datatableName, loanId, columnName1, columnValue1, columnName2, columnValue2);
 
-        this.datatableHelper.createDatatable(datatableRequestJsonString, "");
+            final List<BatchRequest> createAndReadRequests = List.of(
+                    BatchRequestBuilders.createDatatableEntry(CREATE_DATATABLE_ENTRY_REQUEST_ID, datatableName, loanId,
+                            List.of(columnName1, columnName2)),
+                    BatchRequestBuilders.getDatatableEntries(GET_DATATABLE_ENTRIES_REQUEST_ID, CREATE_DATATABLE_ENTRY_REQUEST_ID,
+                            datatableName, loanId, null));
 
-        // Create a datatable entry so that it can be updated using BatchApi
-        final Map<String, Object> datatableEntryMap = new HashMap<>();
-        String columnValue1 = Utils.randomStringGenerator("VAL1_", 3);
-        String columnValue2 = Utils.randomStringGenerator("VAL2_", 3);
-        datatableEntryMap.put(columnName1, columnValue1);
-        datatableEntryMap.put(columnName2, columnValue2);
-        final String datatableEntryRequestJsonString = new Gson().toJson(datatableEntryMap);
-        LOG.info("CreateDataTableEntry map : {}", datatableEntryRequestJsonString);
+            final List<BatchResponse> createAndReadResponses = batchHelper.executeEnclosingTransaction(createAndReadRequests);
 
-        final Map<String, Object> datatableEntryResponse = this.datatableHelper.createDatatableEntry(datatableName, loanId.intValue(),
-                false, datatableEntryRequestJsonString);
-        final Integer datatableEntryResourceId = (Integer) datatableEntryResponse.get("resourceId");
-        assertNotNull(datatableEntryResourceId, "ERROR IN CREATING THE ENTITY DATATABLE RECORD");
+            assertEquals(SC_OK, createAndReadResponses.get(0).getStatusCode(), "Verify Status Code 200 for create datatable entry");
+            assertEquals(SC_OK, createAndReadResponses.get(1).getStatusCode(), "Verify Status Code 200 for get datatable entries");
 
-        // Create datatable entry batch request
-        final BatchRequest createDatatableEntryRequest = BatchHelper.createDatatableEntryRequest(loanId.toString(), datatableName,
-                Arrays.asList(columnName1, columnName2));
+            final Long createdEntryId = bodyAsObject(createAndReadResponses.get(0)).get("resourceId").getAsLong();
+            final String getDatatableEntriesResponse = createAndReadResponses.get(1).getBody();
+            final JsonArray datatableEntries = JsonParser.parseString(getDatatableEntriesResponse).getAsJsonArray();
+            assertEquals(2, datatableEntries.size());
 
-        // Get datatable entries batch request
-        final BatchRequest getDatatableEntriesRequest = BatchHelper.getDatatableByIdRequest(loanId, datatableName, null,
-                createDatatableEntryRequest.getReference());
+            // Ensure both resourceIds are available in response
+            assertTrue(getDatatableEntriesResponse.contains("\"id\": %d".formatted(createdEntryId)));
+            assertTrue(getDatatableEntriesResponse.contains("\"id\": %d".formatted(existingEntryId)));
 
-        final List<BatchRequest> batchRequestsDatatableEntries = Arrays.asList(createDatatableEntryRequest, getDatatableEntriesRequest);
-        LOG.info("Batch Request : {}", BatchHelper.toJsonString(batchRequestsDatatableEntries));
+            final String updatedColumnValue2 = columnValue2 + "1";
+            final List<BatchRequest> queryAndUpdateRequests = List.of(
+                    BatchRequestBuilders.queryDatatableEntries(QUERY_DATATABLE_ENTRIES_REQUEST_ID, datatableName, columnName1, columnValue1,
+                            "id,loan_id"),
+                    BatchRequestBuilders.updateDatatableEntry(UPDATE_QUERIED_DATATABLE_ENTRY_REQUEST_ID, QUERY_DATATABLE_ENTRIES_REQUEST_ID,
+                            datatableName, "$.[0].loan_id", "$.[0].id", columnName2, updatedColumnValue2));
 
-        final List<BatchResponse> responseDatatableBatch = BatchHelper.postBatchRequestsWithEnclosingTransaction(this.requestSpec,
-                this.responseSpec, BatchHelper.toJsonString(batchRequestsDatatableEntries));
+            final List<BatchResponse> queryAndUpdateResponses = batchHelper.executeEnclosingTransaction(queryAndUpdateRequests);
 
-        LOG.info("Batch Response : {}", new Gson().toJson(responseDatatableBatch));
+            assertEquals(SC_OK, queryAndUpdateResponses.get(0).getStatusCode(), "Verify Status Code 200 for query datatable entries");
+            assertEquals(SC_OK, queryAndUpdateResponses.get(1).getStatusCode(), "Verify Status Code 200 for update datatable entry");
 
-        final BatchResponse batchResponse1 = responseDatatableBatch.get(0);
-        final BatchResponse batchResponse2 = responseDatatableBatch.get(1);
-        Assertions.assertEquals(HttpStatus.SC_OK, batchResponse1.getStatusCode(), "Verify Status Code 200 for create datatable entry");
-        Assertions.assertEquals(HttpStatus.SC_OK, batchResponse2.getStatusCode(), "Verify Status Code 200 for update datatable entry");
-
-        final String getDatatableEntriesResponse = batchResponse2.getBody();
-
-        final Long createDatatableEntryId = jsonHelper.extractLongNamed("resourceId",
-                jsonHelper.parse(batchResponse1.getBody()).getAsJsonObject());
-
-        final JsonArray datatableEntries = jsonHelper.parse(getDatatableEntriesResponse).getAsJsonArray();
-        Assertions.assertEquals(2, datatableEntries.size());
-
-        // Ensure both resourceIds are available in response
-        Assertions.assertTrue(getDatatableEntriesResponse.contains(String.format("\"id\": %d", createDatatableEntryId)));
-        Assertions.assertTrue(getDatatableEntriesResponse.contains(String.format("\"id\": %d", datatableEntryResourceId)));
-
-        final BatchRequest queryDatatableEntriesRequest = BatchHelper.queryDatatableEntries(datatableName, columnName1, columnValue1,
-                "id,loan_id");
-        final BatchRequest updateDatatableEntry = BatchHelper.updateDatatableEntry(datatableName, "$.[0].loan_id", "$.[0].id", columnName2,
-                columnValue2 + "1");
-
-        final List<BatchRequest> batchRequestsToQueryAndUpdateDatatableEntries = Arrays.asList(queryDatatableEntriesRequest,
-                updateDatatableEntry);
-        LOG.info("Batch Request : {}", BatchHelper.toJsonString(batchRequestsToQueryAndUpdateDatatableEntries));
-
-        final List<BatchResponse> responseOfQuertAndUpdateDatatableBatch = BatchHelper.postBatchRequestsWithEnclosingTransaction(
-                this.requestSpec, this.responseSpec, BatchHelper.toJsonString(batchRequestsToQueryAndUpdateDatatableEntries));
-
-        LOG.info("Batch Response : {}", new Gson().toJson(responseOfQuertAndUpdateDatatableBatch));
-
-        final BatchResponse batchQueryAndUpdateResponse1 = responseOfQuertAndUpdateDatatableBatch.get(0);
-        final BatchResponse batchQueryAndUpdateResponse2 = responseOfQuertAndUpdateDatatableBatch.get(1);
-        Assertions.assertEquals(HttpStatus.SC_OK, batchQueryAndUpdateResponse1.getStatusCode(),
-                "Verify Status Code 200 for create datatable entry");
-        Assertions.assertEquals(HttpStatus.SC_OK, batchQueryAndUpdateResponse2.getStatusCode(),
-                "Verify Status Code 200 for update datatable entry");
-
-        final JsonObject changes = jsonHelper.parse(batchQueryAndUpdateResponse2.getBody()).getAsJsonObject().get("changes")
-                .getAsJsonObject();
-        Assertions.assertEquals(changes.get(columnName2).getAsString(), columnValue2 + "1");
+            final JsonObject changes = bodyAsObject(queryAndUpdateResponses.get(1)).getAsJsonObject("changes");
+            assertEquals(updatedColumnValue2, changes.get(columnName2).getAsString());
+        } finally {
+            deleteDatatableWithEntriesOf(datatableName, loanId);
+        }
     }
 
     /**
-     * Tests that a loan information was successfully updated through updateLoanCommand. A 'changes' parameter is
-     * returned as part of response after successful update of loan information. In this test, we are marking an active
-     * loan account as fraud.
+     * Tests that a loan information was successfully updated through updateLoanCommand. In this test, we are marking an
+     * active loan account as fraud.
      *
      * @see org.apache.fineract.batch.command.internal.ModifyLoanApplicationCommandStrategy
      */
     @Test
     public void shouldReflectChangesOnLoanUpdate() {
+        final Long productId = createBatchLoanProduct(SMALL_PRINCIPAL);
+        final Long clientId = createClient();
 
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("1000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
-
-        final Long applyLoanRequestId = ThreadLocalRandom.current().nextLong(100, 1000);
+        final Long applyLoanRequestId = randomRequestId();
         final Long approveLoanRequestId = applyLoanRequestId + 1;
         final Long disburseLoanRequestId = approveLoanRequestId + 1;
         final Long updateLoanRequestId = disburseLoanRequestId + 1;
 
-        // Create product
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final List<BatchRequest> batchRequests = List.of(
+                BatchRequestBuilders.applyLoanWithClientId(applyLoanRequestId, clientId, productId),
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                BatchRequestBuilders.disburseLoan(disburseLoanRequestId, approveLoanRequestId),
+                BatchRequestBuilders.markLoanAsFraud(updateLoanRequestId, disburseLoanRequestId));
 
-        // Create client
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientId);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        final BatchRequest applyLoanRequest = BatchHelper.applyLoanRequestWithClientId(applyLoanRequestId, clientId, productId);
+        assertEquals(SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for update loan application");
 
-        final BatchRequest approveLoanRequest = BatchHelper.approveLoanRequest(approveLoanRequestId, applyLoanRequestId);
-
-        final BatchRequest disburseLoanRequest = BatchHelper.disburseLoanRequest(disburseLoanRequestId, approveLoanRequestId);
-
-        final BatchRequest updateLoanRequest = BatchHelper.createLoanRequestMarkAsFraud(updateLoanRequestId, disburseLoanRequestId);
-
-        // Create batch requests list
-        final List<BatchRequest> batchRequests = Arrays.asList(applyLoanRequest, approveLoanRequest, disburseLoanRequest,
-                updateLoanRequest);
-
-        final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-
-        final List<BatchResponse> response = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                jsonifiedRequest);
-
-        // Get the changes parameter from updateLoan Response
-        final JsonObject changes = new FromJsonHelper().parse(response.get(3).getBody()).getAsJsonObject().get("changes").getAsJsonObject();
-
-        Assertions.assertEquals(HttpStatus.SC_OK, response.get(3).getStatusCode(), "Verify Status Code 200 for update loan application");
-        Assertions.assertEquals("true", changes.get("fraud").getAsString());
+        final JsonObject changes = bodyAsObject(responses.get(3)).getAsJsonObject("changes");
+        assertTrue(changes.get("fraud").getAsBoolean());
     }
 
     /**
-     * Tests that a loan information was successfully updated through updateLoanCommand using external id. A 'changes'
-     * parameter is returned as part of response after successful update of loan information. In this test, we are
-     * marking an active loan account as fraud.
+     * Tests that a loan information was successfully updated through updateLoanCommand using external id. In this test,
+     * we are marking an active loan account as fraud.
      *
      * @see org.apache.fineract.batch.command.internal.ModifyLoanApplicationByExternalIdCommandStrategy
      */
     @Test
     public void shouldReflectChangesOnLoanUpdateByExternalId() {
+        final Long productId = createBatchLoanProduct(SMALL_PRINCIPAL);
+        final Long clientId = createClient();
 
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("1000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
-
-        final long applyLoanRequestId = ThreadLocalRandom.current().nextLong(100, 1000);
+        final Long applyLoanRequestId = randomRequestId();
         final Long approveLoanRequestId = applyLoanRequestId + 1;
         final Long disburseLoanRequestId = approveLoanRequestId + 1;
         final Long updateLoanRequestId = disburseLoanRequestId + 1;
         final Long getLoanRequestId = updateLoanRequestId + 1;
 
-        // Create product
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final List<BatchRequest> batchRequests = List.of(
+                BatchRequestBuilders.applyLoanWithClientId(applyLoanRequestId, clientId, productId),
+                BatchRequestBuilders.transitionLoanStateByExternalId(approveLoanRequestId, applyLoanRequestId, today().minusDays(10),
+                        "approve"),
+                BatchRequestBuilders.transitionLoanStateByExternalId(disburseLoanRequestId, approveLoanRequestId, today().minusDays(8),
+                        "disburse"),
+                BatchRequestBuilders.markLoanAsFraudByExternalId(updateLoanRequestId, approveLoanRequestId),
+                BatchRequestBuilders.getLoanByExternalIdReference(getLoanRequestId, approveLoanRequestId, "associations=all"));
 
-        // Create client
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientId);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        final BatchRequest applyLoanRequest = BatchHelper.applyLoanRequestWithClientId(applyLoanRequestId, clientId, productId);
+        assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
+        assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
+        assertEquals(SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
+        assertEquals(SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for update loan application");
+        assertEquals(SC_OK, responses.get(4).getStatusCode(), "Verify Status Code 200 for Get Loan");
 
-        final BatchRequest approveLoanRequest = BatchHelper.transitionLoanStateByExternalId(approveLoanRequestId, applyLoanRequestId,
-                LocalDate.now(Utils.getZoneIdOfTenant()).minusDays(10), "approve");
-
-        final BatchRequest disburseLoanRequest = BatchHelper.transitionLoanStateByExternalId(disburseLoanRequestId, approveLoanRequestId,
-                LocalDate.now(Utils.getZoneIdOfTenant()).minusDays(8), "disburse");
-
-        final BatchRequest updateLoanRequest = BatchHelper.modifyLoanByExternalIdRequest(updateLoanRequestId, approveLoanRequestId);
-
-        final BatchRequest getLoanRequest = BatchHelper.getLoanByExternalIdRequest(getLoanRequestId, approveLoanRequestId,
-                "associations=all");
-
-        // Create batch requests list
-        final List<BatchRequest> batchRequests = Arrays.asList(applyLoanRequest, approveLoanRequest, disburseLoanRequest, updateLoanRequest,
-                getLoanRequest);
-
-        final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-
-        final List<BatchResponse> responses = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                jsonifiedRequest);
-
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for update loan application");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(4).getStatusCode(), "Verify Status Code 200 for Get Loan");
-
-        // Get the changes parameter from updateLoan Response
-        final JsonObject changes = new FromJsonHelper().parse(responses.get(3).getBody()).getAsJsonObject().get("changes")
-                .getAsJsonObject();
-        Assertions.assertEquals("true", changes.get("fraud").getAsString());
+        final JsonObject changes = bodyAsObject(responses.get(3)).getAsJsonObject("changes");
+        assertTrue(changes.get("fraud").getAsBoolean());
     }
 
     /**
-     * Tests that a loan is hard locked and if a repayment triggered in as a batch request, it returns the proper error
-     *
-     * @see org.apache.fineract.batch.command.internal.ModifyLoanApplicationByExternalIdCommandStrategy
+     * Tests that a repayment posted as a batch request against a locked loan is rejected with a 409, when the batch is
+     * submitted through the legacy un-versioned {@code loans/...} relative URL.
      */
     @Test
     public void shoulRetrieveTheProperErrorDuringLockedLoan_OldRelativePath() {
-        ResponseSpecification responseSpec = new ResponseSpecBuilder().expectStatusCode(202).build();
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("1000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
-
-        final long applyLoanRequestId = ThreadLocalRandom.current().nextLong(100, 1000);
-        final Long approveLoanRequestId = applyLoanRequestId + 1;
-        final Long disburseLoanRequestId = approveLoanRequestId + 1;
-        final Long getLoanRequestId = disburseLoanRequestId + 1;
-
-        // Create product
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
-
-        // Create client
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientId);
-
-        final BatchRequest applyLoanRequest = BatchHelper.applyLoanRequestWithClientId(applyLoanRequestId, clientId, productId);
-
-        final BatchRequest approveLoanRequest = BatchHelper.transitionLoanStateByExternalId(approveLoanRequestId, applyLoanRequestId,
-                LocalDate.now(Utils.getZoneIdOfTenant()).minusDays(10), "approve");
-
-        final BatchRequest disburseLoanRequest = BatchHelper.transitionLoanStateByExternalId(disburseLoanRequestId, approveLoanRequestId,
-                LocalDate.now(Utils.getZoneIdOfTenant()).minusDays(8), "disburse");
-
-        final BatchRequest getLoanRequest = BatchHelper.getLoanByExternalIdRequest(getLoanRequestId, approveLoanRequestId,
-                "associations=all");
-
-        // Create batch requests list
-        final List<BatchRequest> batchRequests = Arrays.asList(applyLoanRequest, approveLoanRequest, disburseLoanRequest, getLoanRequest);
-
-        final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-
-        final List<BatchResponse> responses = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                jsonifiedRequest);
-
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for Get Loan");
-
-        final Long loanId = new FromJsonHelper().parse(responses.get(2).getBody()).getAsJsonObject().get("resourceId").getAsLong();
-
-        LoanAccountLockHelper.placeSoftLockOnLoanAccount(loanId, "LOAN_COB_CHUNK_PROCESSING");
-
-        RequestSpecification requestSpec = UserHelper.getSimpleUserWithoutBypassPermission(this.requestSpec, this.responseSpec);
-
-        // Create a repayment Request
-        final BatchRequest br = new BatchRequest();
-
-        br.setRequestId(1L);
-        br.setRelativeUrl(String.format("loans/" + loanId + "/transactions?command=repayment"));
-        br.setMethod("POST");
-        String dateString = LocalDate.now(Utils.getZoneIdOfTenant()).format(DateTimeFormatter.ofPattern("dd MMMM yyyy"));
-        br.setBody(String.format(
-                "{\"locale\": \"en\", \"dateFormat\": \"dd MMMM yyyy\", " + "\"transactionDate\": \"%s\",  \"transactionAmount\": \"500\"}",
-                dateString));
-
-        final String jsonifiedRepaymentRequest = BatchHelper.toJsonString(List.of(br));
-
-        // verify HTTP 409
-        ResponseSpecification conflictResponseSpec = new ResponseSpecBuilder().expectStatusCode(409).build();
-        ErrorResponse errorResponse = BatchHelper.postBatchRequestsWithoutEnclosingTransactionError(requestSpec, conflictResponseSpec,
-                jsonifiedRepaymentRequest);
-        assertEquals(409, errorResponse.getHttpStatusCode());
+        assertLockedLoanRepaymentIsRejected(false);
     }
 
     /**
-     * Tests that a loan is hard locked and if a repayment triggered in as a batch request, it returns the proper error
-     *
-     * @see org.apache.fineract.batch.command.internal.ModifyLoanApplicationByExternalIdCommandStrategy
+     * Tests that a repayment posted as a batch request against a locked loan is rejected with a 409, when the batch is
+     * submitted through the current {@code v1/loans/...} relative URL.
      */
     @Test
     public void shoulRetrieveTheProperErrorDuringLockedLoan() {
-        ResponseSpecification responseSpec = new ResponseSpecBuilder().expectStatusCode(202).build();
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("1000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
-
-        final Long applyLoanRequestId = ThreadLocalRandom.current().nextLong(100, 1000);
-        final Long approveLoanRequestId = applyLoanRequestId + 1;
-        final Long disburseLoanRequestId = approveLoanRequestId + 1;
-        final Long getLoanRequestId = disburseLoanRequestId + 1;
-
-        // Create product
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
-
-        // Create client
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientId);
-
-        final BatchRequest applyLoanRequest = BatchHelper.applyLoanRequestWithClientId(applyLoanRequestId, clientId, productId);
-
-        final BatchRequest approveLoanRequest = BatchHelper.transitionLoanStateByExternalId(approveLoanRequestId, applyLoanRequestId,
-                LocalDate.now(Utils.getZoneIdOfTenant()).minusDays(10), "approve");
-
-        final BatchRequest disburseLoanRequest = BatchHelper.transitionLoanStateByExternalId(disburseLoanRequestId, approveLoanRequestId,
-                LocalDate.now(Utils.getZoneIdOfTenant()).minusDays(8), "disburse");
-
-        final BatchRequest getLoanRequest = BatchHelper.getLoanByExternalIdRequest(getLoanRequestId, approveLoanRequestId,
-                "associations=all");
-
-        // Create batch requests list
-        final List<BatchRequest> batchRequests = Arrays.asList(applyLoanRequest, approveLoanRequest, disburseLoanRequest, getLoanRequest);
-
-        final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-
-        final List<BatchResponse> responses = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                jsonifiedRequest);
-
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for Get Loan");
-
-        final Long loanId = new FromJsonHelper().parse(responses.get(2).getBody()).getAsJsonObject().get("resourceId").getAsLong();
-
-        LoanAccountLockHelper.placeSoftLockOnLoanAccount(loanId, "LOAN_COB_CHUNK_PROCESSING");
-
-        RequestSpecification requestSpec = UserHelper.getSimpleUserWithoutBypassPermission(this.requestSpec, this.responseSpec);
-
-        // Create a repayment Request
-        final BatchRequest br = new BatchRequest();
-
-        br.setRequestId(1L);
-        br.setRelativeUrl(String.format("v1/loans/" + loanId + "/transactions?command=repayment"));
-        br.setMethod("POST");
-        String dateString = LocalDate.now(Utils.getZoneIdOfTenant()).format(DateTimeFormatter.ofPattern("dd MMMM yyyy"));
-        br.setBody(String.format(
-                "{\"locale\": \"en\", \"dateFormat\": \"dd MMMM yyyy\", " + "\"transactionDate\": \"%s\",  \"transactionAmount\": \"500\"}",
-                dateString));
-
-        final String jsonifiedRepaymentRequest = BatchHelper.toJsonString(List.of(br));
-
-        // verify HTTP 409
-        ResponseSpecification conflictResponseSpec = new ResponseSpecBuilder().expectStatusCode(409).build();
-        ErrorResponse errorResponse = BatchHelper.postBatchRequestsWithoutEnclosingTransactionError(requestSpec, conflictResponseSpec,
-                jsonifiedRepaymentRequest);
-        assertEquals(409, errorResponse.getHttpStatusCode());
+        assertLockedLoanRepaymentIsRejected(true);
     }
 
     @Test
     public void verifyCalculatingRunningBalanceAfterBatchWithReleaseAmount() {
-        final SavingsProductHelper savingsProductHelper = new SavingsProductHelper();
-        final SavingsAccountHelper savingsAccountHelper = new SavingsAccountHelper(this.requestSpec, this.responseSpec);
-        final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec);
-        Assertions.assertNotNull(clientID);
-        final String savingsProductJSON = savingsProductHelper.withInterestCompoundingPeriodTypeAsDaily()
-                .withInterestPostingPeriodTypeAsDaily().withInterestCalculationPeriodTypeAsDailyBalance().build();
-        final Integer savingsProductID = SavingsProductHelper.createSavingsProduct(savingsProductJSON, requestSpec, responseSpec);
-        Assertions.assertNotNull(savingsProductID);
-        final Integer savingsId = savingsAccountHelper.applyForSavingsApplication(clientID, savingsProductID,
-                ClientSavingsIntegrationTest.ACCOUNT_TYPE_INDIVIDUAL);
-        Assertions.assertNotNull(savingsId);
-        HashMap savingsStatusHashMap = savingsAccountHelper.approveSavings(savingsId);
-        SavingsStatusChecker.verifySavingsIsApproved(savingsStatusHashMap);
-        savingsStatusHashMap = savingsAccountHelper.activateSavings(savingsId);
-        SavingsStatusChecker.verifySavingsIsActive(savingsStatusHashMap);
+        final Long clientId = createClient();
+        final Long savingsId = createActiveSavingsAccount(clientId, SAVINGS_SUBMITTED_ON_DATE, SAVINGS_APPROVED_ON_DATE,
+                SAVINGS_ACTIVATED_ON_DATE);
 
         final float holdAmount = 10F;
         final float withdrawalAmount = 80F;
-        final BatchRequest getSavingAccountRequest = BatchHelper.getSavingAccount(1L, Long.valueOf(savingsId), "chargeStatus=all", null);
-        final BatchRequest depositSavingAccountRequest = BatchHelper.depositSavingAccount(2L, 1L, 300F);
-        final BatchRequest holdAmountOnSavingAccountRequest = BatchHelper.holdAmountOnSavingAccount(3L, 1L, holdAmount);
 
-        final List<BatchRequest> batchRequests1 = Arrays.asList(getSavingAccountRequest, depositSavingAccountRequest,
-                holdAmountOnSavingAccountRequest);
-        final List<BatchResponse> responses1 = BatchHelper.postBatchRequestsWithEnclosingTransaction(this.requestSpec, this.responseSpec,
-                BatchHelper.toJsonString(batchRequests1));
+        final Long getSavingsAccountRequestId = 1L;
+        final Long depositRequestId = 2L;
+        final Long holdAmountRequestId = 3L;
 
-        Assertions.assertEquals(HttpStatus.SC_OK, responses1.get(1).getStatusCode(), "Verify Status Code 200 for deposit saving account");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses1.get(2).getStatusCode(),
-                "Verify Status Code 200 for hold amount on saving account");
-        final FromJsonHelper jsonHelper = new FromJsonHelper();
-        final Long holdAmountTransactionId = jsonHelper.parse(responses1.get(2).getBody()).getAsJsonObject().get("resourceId").getAsLong();
+        final BatchRequest getSavingsAccountRequest = BatchRequestBuilders.getSavingsAccount(getSavingsAccountRequestId, null, savingsId,
+                "chargeStatus=all");
 
-        HashMap accountDetails = savingsAccountHelper.getSavingsDetails(savingsId);
-        ArrayList<HashMap<String, Object>> transactions = (ArrayList<HashMap<String, Object>>) accountDetails.get("transactions");
-        final float runningBalanceBeforeBatch = (float) transactions.get(0).get("runningBalance");
+        final List<BatchRequest> depositRequests = List.of(getSavingsAccountRequest,
+                BatchRequestBuilders.depositSavingsAccount(depositRequestId, getSavingsAccountRequestId, 300F),
+                BatchRequestBuilders.holdAmountOnSavingsAccount(holdAmountRequestId, getSavingsAccountRequestId, holdAmount));
 
-        final BatchRequest releaseAmountOnSavingAccountRequest = BatchHelper.releaseAmountOnSavingAccount(2L, 1L, holdAmountTransactionId);
-        final BatchRequest withdrawSavingAccountRequest1 = BatchHelper.withdrawSavingAccount(3L, 1L, withdrawalAmount);
-        final BatchRequest withdrawSavingAccountRequest2 = BatchHelper.withdrawSavingAccount(4L, 1L, withdrawalAmount);
+        final List<BatchResponse> depositResponses = batchHelper.executeEnclosingTransaction(depositRequests);
 
-        final List<BatchRequest> batchRequests2 = Arrays.asList(getSavingAccountRequest, releaseAmountOnSavingAccountRequest,
-                withdrawSavingAccountRequest1, withdrawSavingAccountRequest2);
-        final List<BatchResponse> responses2 = BatchHelper.postBatchRequestsWithEnclosingTransaction(this.requestSpec, this.responseSpec,
-                BatchHelper.toJsonString(batchRequests2));
+        assertEquals(SC_OK, depositResponses.get(1).getStatusCode(), "Verify Status Code 200 for deposit saving account");
+        assertEquals(SC_OK, depositResponses.get(2).getStatusCode(), "Verify Status Code 200 for hold amount on saving account");
 
-        Assertions.assertEquals(HttpStatus.SC_OK, responses2.get(0).getStatusCode(),
-                "Verify Status Code 200 for release amount on saving account");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses2.get(1).getStatusCode(), "Verify Status Code 200 for withdraw saving account");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses2.get(2).getStatusCode(), "Verify Status Code 200 for withdraw saving account");
+        final Long holdAmountTransactionId = bodyAsObject(depositResponses.get(2)).get("resourceId").getAsLong();
 
-        accountDetails = savingsAccountHelper.getSavingsDetails(savingsId);
-        transactions = (ArrayList<HashMap<String, Object>>) accountDetails.get("transactions");
+        final BigDecimal runningBalanceBeforeBatch = savingsHelper.getSavingsDetails(savingsId).getTransactions().get(0)
+                .getRunningBalance();
 
-        final HashMap<String, Object> transactionRelease = transactions.get(2);
-        final HashMap<String, Object> transactionWithdrawal1 = transactions.get(1);
-        final HashMap<String, Object> transactionWithdrawal2 = transactions.get(0);
+        final Long releaseAmountRequestId = 2L;
+        final Long firstWithdrawRequestId = 3L;
+        final Long secondWithdrawRequestId = 4L;
 
-        assertEquals(runningBalanceBeforeBatch + holdAmount, transactionRelease.get("runningBalance"),
-                "Verify running balance after release amount");
-        assertEquals(runningBalanceBeforeBatch + holdAmount - withdrawalAmount, transactionWithdrawal1.get("runningBalance"),
+        final List<BatchRequest> withdrawRequests = List.of(getSavingsAccountRequest,
+                BatchRequestBuilders.releaseAmountOnSavingsAccount(releaseAmountRequestId, getSavingsAccountRequestId,
+                        holdAmountTransactionId),
+                BatchRequestBuilders.withdrawSavingsAccount(firstWithdrawRequestId, getSavingsAccountRequestId, withdrawalAmount),
+                BatchRequestBuilders.withdrawSavingsAccount(secondWithdrawRequestId, getSavingsAccountRequestId, withdrawalAmount));
+
+        final List<BatchResponse> withdrawResponses = batchHelper.executeEnclosingTransaction(withdrawRequests);
+
+        assertEquals(SC_OK, withdrawResponses.get(0).getStatusCode(), "Verify Status Code 200 for get saving account");
+        assertEquals(SC_OK, withdrawResponses.get(1).getStatusCode(), "Verify Status Code 200 for release amount on saving account");
+        assertEquals(SC_OK, withdrawResponses.get(2).getStatusCode(), "Verify Status Code 200 for withdraw saving account");
+
+        final List<SavingsAccountTransactionData> transactions = savingsHelper.getSavingsDetails(savingsId).getTransactions();
+        final BigDecimal releaseRunningBalance = transactions.get(2).getRunningBalance();
+        final BigDecimal firstWithdrawalRunningBalance = transactions.get(1).getRunningBalance();
+        final BigDecimal secondWithdrawalRunningBalance = transactions.get(0).getRunningBalance();
+
+        final BigDecimal expectedAfterRelease = runningBalanceBeforeBatch.add(BigDecimal.valueOf(holdAmount));
+        assertEquals(0, expectedAfterRelease.compareTo(releaseRunningBalance), "Verify running balance after release amount");
+        assertEquals(0, expectedAfterRelease.subtract(BigDecimal.valueOf(withdrawalAmount)).compareTo(firstWithdrawalRunningBalance),
                 "Verify running balance after first withdrawal");
-        assertEquals(runningBalanceBeforeBatch + holdAmount - withdrawalAmount - withdrawalAmount,
-                transactionWithdrawal2.get("runningBalance"), "Verify running balance after second withdrawal");
+        assertEquals(0, expectedAfterRelease.subtract(BigDecimal.valueOf(withdrawalAmount)).subtract(BigDecimal.valueOf(withdrawalAmount))
+                .compareTo(secondWithdrawalRunningBalance), "Verify running balance after second withdrawal");
     }
 
     @Test
     public void shouldReturnOkStatusForBatchChargeOff() {
+        final Long productId = createBatchLoanProduct(LARGE_PRINCIPAL);
+        final Long clientCollateralId = createClientCollateral();
 
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
+        final Long createClientRequestId = 4730L;
+        final Long activateClientRequestId = 4731L;
+        final Long applyLoanRequestId = 4732L;
+        final Long approveLoanRequestId = 4733L;
+        final Long disburseLoanRequestId = 4734L;
+        final Long firstRepaymentRequestId = 4735L;
+        final Long secondRepaymentRequestId = 4736L;
+        final Long chargeOffRequestId = 4737L;
 
-        final Integer clientID = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientID);
+        final List<BatchRequest> batchRequests = List.of(BatchRequestBuilders.createClient(createClientRequestId, ""),
+                BatchRequestBuilders.activateClient(activateClientRequestId, createClientRequestId),
+                BatchRequestBuilders.applyLoan(applyLoanRequestId, activateClientRequestId, productId, clientCollateralId),
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                BatchRequestBuilders.disburseLoan(disburseLoanRequestId, approveLoanRequestId),
+                BatchRequestBuilders.repayLoan(firstRepaymentRequestId, disburseLoanRequestId, "500"),
+                BatchRequestBuilders.repayLoan(secondRepaymentRequestId, disburseLoanRequestId, "500"),
+                BatchRequestBuilders.chargeOff(chargeOffRequestId, secondRepaymentRequestId));
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(this.requestSpec, this.responseSpec);
-        Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(this.requestSpec, this.responseSpec,
-                clientID.toString(), collateralId);
-        Assertions.assertNotNull(clientCollateralId);
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
-
-        // Create a createClient Request
-        final BatchRequest br1 = BatchHelper.createClientRequest(4730L, "");
-
-        // Create a activateClient Request
-        final BatchRequest br2 = BatchHelper.activateClientRequest(4731L, 4730L);
-
-        // Create a ApplyLoan Request
-        final BatchRequest br3 = BatchHelper.applyLoanRequest(4732L, 4731L, productId, clientCollateralId);
-
-        // Create a approveLoan Request
-        final BatchRequest br4 = BatchHelper.approveLoanRequest(4733L, 4732L);
-
-        // Create a disburseLoan Request
-        final BatchRequest br5 = BatchHelper.disburseLoanRequest(4734L, 4733L);
-
-        // Create a loanRepay Request
-        final BatchRequest br6 = BatchHelper.repayLoanRequest(4735L, 4734L, "500");
-
-        // Create a loanRepay Request
-        final BatchRequest br7 = BatchHelper.repayLoanRequest(4736L, 4734L, "500");
-
-        final BatchRequest br8 = BatchHelper.chargeOffRequest(4737L, 4736L);
-
-        final List<BatchRequest> batchRequests = new ArrayList<>();
-
-        batchRequests.add(br1);
-        batchRequests.add(br2);
-        batchRequests.add(br3);
-        batchRequests.add(br4);
-        batchRequests.add(br5);
-        batchRequests.add(br6);
-        batchRequests.add(br7);
-        batchRequests.add(br8);
-
-        final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-
-        final List<BatchResponse> response = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec, this.responseSpec,
-                jsonifiedRequest);
-
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(7).getStatusCode(), "Verify Status Code 200 for ChargeOff");
+        assertEquals(SC_OK, responses.get(7).getStatusCode(), "Verify Status Code 200 for ChargeOff");
     }
 
     /**
-     * Delete datatable
-     *
-     * @param datatableName
-     *            the datatable name
+     * Disburses a loan, hard-locks it, and asserts that a batch repayment posted by a user without the loan-checker
+     * bypass permission is answered with a 409.
      */
+    private void assertLockedLoanRepaymentIsRejected(final boolean apiVersionPrefixedRelativeUrl) {
+        final Long productId = createBatchLoanProduct(SMALL_PRINCIPAL);
+        final Long clientId = createClient();
+
+        final Long applyLoanRequestId = randomRequestId();
+        final Long approveLoanRequestId = applyLoanRequestId + 1;
+        final Long disburseLoanRequestId = approveLoanRequestId + 1;
+
+        final List<BatchRequest> batchRequests = List.of(
+                BatchRequestBuilders.applyLoanWithClientId(applyLoanRequestId, clientId, productId),
+                BatchRequestBuilders.transitionLoanStateByExternalId(approveLoanRequestId, applyLoanRequestId, today().minusDays(10),
+                        "approve"),
+                BatchRequestBuilders.transitionLoanStateByExternalId(disburseLoanRequestId, approveLoanRequestId, today().minusDays(8),
+                        "disburse"));
+
+        final List<BatchResponse> responses = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
+
+        assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
+        assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
+        assertEquals(SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
+
+        final Long loanId = bodyAsObject(responses.get(2)).get("resourceId").getAsLong();
+        placeHardLockOnLoan(loanId);
+
+        final FeignBatchHelper nonByPassBatchHelper = new FeignBatchHelper(FeignUserHelper.getSimpleUserWithoutBypassPermissionClient());
+        final BatchRequest repaymentRequest = BatchRequestBuilders.repayLoanByLoanId(1L, loanId, "500", apiVersionPrefixedRelativeUrl);
+
+        final ErrorResponse errorResponse = nonByPassBatchHelper
+                .executeWithoutEnclosingTransactionExpectingError(List.of(repaymentRequest));
+        assertEquals(SC_CONFLICT, errorResponse.getHttpStatusCode());
+    }
+
+    /**
+     * Creates the loan product all batch loan applications in this test are booked against: a 24-month, 2% declining
+     * balance product with equal principal payments.
+     */
+    private Long createBatchLoanProduct(final double principal) {
+        return createLoanProduct(new PostLoanProductsRequest()//
+                .name(Utils.uniqueRandomStringGenerator("LOAN_PRODUCT_", 6))//
+                .shortName(Utils.uniqueRandomStringGenerator("", 4))//
+                .currencyCode("USD")//
+                .digitsAfterDecimal(0)//
+                .inMultiplesOf(100)//
+                .minPrincipal(1000.00)//
+                .principal(principal)//
+                .maxPrincipal(10000000.00)//
+                .numberOfRepayments(24)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(RepaymentFrequencyType.MONTHS_L)//
+                .interestRatePerPeriod(2.0)//
+                .interestRateFrequencyType(InterestRateFrequencyType.MONTHS)//
+                .amortizationType(AmortizationType.EQUAL_PRINCIPAL)//
+                .interestType(InterestType.DECLINING_BALANCE)//
+                .interestCalculationPeriodType(InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)//
+                .inArrearsTolerance(0)//
+                .transactionProcessingStrategyCode(LoanProductTestBuilder.DEFAULT_STRATEGY)//
+                .loanScheduleType(LoanScheduleType.CUMULATIVE.name())//
+                .accountingRule(1)//
+                .isEqualAmortization(false)//
+                .isInterestRecalculationEnabled(false)//
+                .daysInYearType(DaysInYearType.ACTUAL)//
+                .daysInMonthType(DaysInMonthType.ACTUAL)//
+                .overdueDaysForNPA(5)//
+                .dateFormat(DATETIME_PATTERN)//
+                .locale("en_GB"));
+    }
+
+    private Long createClientCollateral() {
+        final Long clientId = createClient();
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
+        assertNotNull(collateralId);
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientId, collateralId).getResourceId();
+        assertNotNull(clientCollateralId);
+        return clientCollateralId;
+    }
+
+    private Long createActiveSavingsAccount(final Long clientId, final String submittedOnDate, final String approvedOnDate,
+            final String activatedOnDate) {
+        final Long productId = savingsProductHelper
+                .createSavingsProduct(
+                        SavingsRequestBuilders.defaultSavingsProduct().interestPostingPeriodType(InterestPostingPeriodType.DAILY))
+                .getResourceId();
+        final Long savingsId = savingsHelper.submitApplication(clientId, productId, submittedOnDate).getSavingsId();
+        savingsHelper.approveSavings(savingsId, approvedOnDate);
+        assertTrue(savingsHelper.getSavingsDetails(savingsId).getStatus().getApproved(), "Savings account is not approved");
+        savingsHelper.activateSavings(savingsId, activatedOnDate);
+        assertTrue(savingsHelper.getSavingsDetails(savingsId).getStatus().getActive(), "Savings account is not active");
+        return savingsId;
+    }
+
+    /**
+     * Creates the datatable used by the get-datatable batch tests, holding the sample columns of a loan application.
+     */
+    private String createLoanDatatable() {
+        final PostDataTablesRequest request = new PostDataTablesRequest()//
+                .datatableName(Utils.uniqueRandomStringGenerator(LOAN_APP_TABLE_NAME + "_", 5))//
+                .apptableName(LOAN_APP_TABLE_NAME)//
+                .entitySubType(PERSON_ENTITY_SUB_TYPE)//
+                .multiRow(false)//
+                .columns(List.of(stringColumn("Spouse Name", 25L, true), numberColumn("Number of Dependents"),
+                        column("Time of Visit", "DateTime", false), column("Date of Approval", "Date", false)));
+        return datatableHelper.createDatatable(request).getResourceIdentifier();
+    }
+
+    /**
+     * Creates a datatable holding two string columns. {@code columnLength} has to accommodate every value the test
+     * writes to or filters those columns by; the query API rejects a filter value longer than its column.
+     */
+    private void createTwoStringColumnDatatable(final String datatableName, final String columnName1, final String columnName2,
+            final boolean multiRow, final long columnLength) {
+        final PostDataTablesRequest request = new PostDataTablesRequest()//
+                .datatableName(datatableName)//
+                .apptableName(LOAN_APP_TABLE_NAME)//
+                .entitySubType(PERSON_ENTITY_SUB_TYPE)//
+                .multiRow(multiRow)//
+                .columns(List.of(stringColumn(columnName1, columnLength, true), stringColumn(columnName2, columnLength, false)));
+        datatableHelper.createDatatable(request);
+    }
+
+    private static PostColumnHeaderData stringColumn(final String name, final long length, final boolean mandatory) {
+        return column(name, "String", mandatory).length(length);
+    }
+
+    private static PostColumnHeaderData numberColumn(final String name) {
+        return column(name, "Number", true);
+    }
+
+    private static PostColumnHeaderData column(final String name, final String type, final boolean mandatory) {
+        return new PostColumnHeaderData().name(name).type(type).mandatory(mandatory);
+    }
+
+    /** Creates one datatable entry directly (not through the batch API) and returns its id. */
+    private Long createDatatableEntry(final String datatableName, final Long loanId, final String columnName1, final String columnValue1,
+            final String columnName2, final String columnValue2) {
+        final Map<String, Object> entry = new LinkedHashMap<>();
+        entry.put(columnName1, columnValue1);
+        entry.put(columnName2, columnValue2);
+        final Long entryId = datatableHelper.createDatatableEntry(datatableName, loanId, GSON.toJson(entry)).getResourceId();
+        assertNotNull(entryId, "ERROR IN CREATING THE ENTITY DATATABLE RECORD");
+        return entryId;
+    }
+
     private void deleteDatatable(final String datatableName) {
-        String deletedDatatableName = this.datatableHelper.deleteDatatable(datatableName);
+        final String deletedDatatableName = datatableHelper.deleteDatatable(datatableName).getResourceIdentifier();
         assertEquals(datatableName, deletedDatatableName, "Fail to delete the datatable");
     }
 
+    /** The server refuses to drop a datatable that still holds entries, so the loan's entries go first. */
+    private void deleteDatatableWithEntriesOf(final String datatableName, final Long loanId) {
+        datatableHelper.deleteDatatableEntries(datatableName, loanId);
+        deleteDatatable(datatableName);
+    }
+
     /**
-     * Setup account to test get loan and get datatable batch call
-     *
-     * @return the response body
+     * Creates a disbursed and partially repaid loan, and returns its id, for the datatable tests to hang entries on.
      */
-    private String setupAccount() {
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails("0", "100").build(null);
+    private Long setupLoanAccount() {
+        final Long productId = createBatchLoanProduct(LARGE_PRINCIPAL);
+        final Long clientId = createClient();
 
         final Long applyLoanRequestId = 5730L;
         final Long approveLoanRequestId = 5731L;
         final Long disburseLoanRequestId = 5734L;
         final Long repayLoanRequestId = 5735L;
 
-        // Create product
-        final Integer productId = new LoanTransactionHelper(this.requestSpec, this.responseSpec).getLoanProductId(loanProductJSON);
+        final List<BatchRequest> batchRequests = List.of(
+                BatchRequestBuilders.applyLoanWithClientId(applyLoanRequestId, clientId, productId),
+                BatchRequestBuilders.approveLoan(approveLoanRequestId, applyLoanRequestId),
+                BatchRequestBuilders.disburseLoan(disburseLoanRequestId, applyLoanRequestId),
+                BatchRequestBuilders.repayLoan(repayLoanRequestId, applyLoanRequestId, "500"));
 
-        // Create client
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, clientId);
+        final List<BatchResponse> responses = batchHelper.executeEnclosingTransaction(batchRequests);
 
-        // Create an ApplyLoan Request
-        final BatchRequest applyLoanBatchRequest = BatchHelper.applyLoanRequestWithClientId(applyLoanRequestId, clientId, productId);
+        assertEquals(SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
+        assertEquals(SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
+        assertEquals(SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
+        assertEquals(SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for Repay Loan");
 
-        // Create an approveLoan Request
-        final BatchRequest approveLoanBatchRequest = BatchHelper.approveLoanRequest(approveLoanRequestId, applyLoanRequestId);
+        return bodyAsObject(responses.get(0)).get("loanId").getAsLong();
+    }
 
-        // Create a disburseLoan Request
-        final BatchRequest disburseLoanBatchRequest = BatchHelper.disburseLoanRequest(disburseLoanRequestId, applyLoanRequestId);
+    private static Long randomRequestId() {
+        return ThreadLocalRandom.current().nextLong(1000, 10_000);
+    }
 
-        // Create a repayment Request
-        final BatchRequest repaymentBatchRequest = BatchHelper.repayLoanRequest(repayLoanRequestId, applyLoanRequestId, "500");
+    private static LocalDate today() {
+        return LocalDate.now(Utils.getZoneIdOfTenant());
+    }
 
-        final List<BatchRequest> batchRequests = Arrays.asList(applyLoanBatchRequest, approveLoanBatchRequest, disburseLoanBatchRequest,
-                repaymentBatchRequest);
+    private static JsonObject bodyAsObject(final BatchResponse response) {
+        return JsonParser.parseString(response.getBody()).getAsJsonObject();
+    }
 
-        final List<BatchResponse> responses = BatchHelper.postBatchRequestsWithEnclosingTransaction(this.requestSpec, this.responseSpec,
-                BatchHelper.toJsonString(batchRequests));
+    private static JsonObject transactionAt(final BatchResponse loanResponse, final int index) {
+        return bodyAsObject(loanResponse).getAsJsonArray("transactions").get(index).getAsJsonObject();
+    }
 
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(0).getStatusCode(), "Verify Status Code 200 for Apply Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(1).getStatusCode(), "Verify Status Code 200 for Approve Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(2).getStatusCode(), "Verify Status Code 200 for Disburse Loan");
-        Assertions.assertEquals(HttpStatus.SC_OK, responses.get(3).getStatusCode(), "Verify Status Code 200 for Repay Loan");
-
-        return responses.get(0).getBody();
+    /** The loan API serialises dates as a {@code [year, month, day]} array. */
+    private static LocalDate asLocalDate(final JsonArray dateArray) {
+        return LocalDate.of(dateArray.get(0).getAsInt(), dateArray.get(1).getAsInt(), dateArray.get(2).getAsInt());
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/BatchLoanIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/BatchLoanIntegrationTest.java
@@ -18,64 +18,27 @@
  */
 package org.apache.fineract.integrationtests;
 
-import io.restassured.builder.ResponseSpecBuilder;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
-import org.apache.fineract.batch.domain.BatchResponse;
+import org.apache.fineract.client.models.BatchResponse;
 import org.apache.fineract.client.models.PostLoanProductsRequest;
-import org.apache.fineract.client.models.PostLoanProductsResponse;
-import org.apache.fineract.client.models.PostLoansLoanIdResponse;
 import org.apache.fineract.client.models.PostLoansRequest;
-import org.apache.fineract.client.models.PostLoansResponse;
-import org.apache.fineract.integrationtests.common.ClientHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.RepaymentFrequencyType;
 import org.apache.fineract.integrationtests.common.error.ErrorResponse;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class BatchLoanIntegrationTest extends BaseLoanIntegrationTest {
+public class BatchLoanIntegrationTest extends FeignLoanTestBase {
 
     @Test
     public void test_InlineLoanCOB_ShouldExecute_WhenLoanIsBehind_And_RescheduleIsRequestedViaBatchApi() {
         AtomicLong createdLoanId = new AtomicLong();
 
         runAt("01 January 2023", () -> {
-            // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
-
-            int numberOfRepayments = 24;
-            int repaymentEvery = 1;
-
-            // Create Loan Product
-            PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct() //
-                    .numberOfRepayments(numberOfRepayments) //
-                    .repaymentEvery(repaymentEvery) //
-                    .repaymentFrequencyType(RepaymentFrequencyType.MONTHS.longValue()); //
-
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-            Long loanProductId = loanProductResponse.getResourceId();
-
-            // Apply and Approve Loan
-            double amount = 1250.0;
-
-            PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "01 January 2023", amount, numberOfRepayments)//
-                    .repaymentEvery(repaymentEvery)//
-                    .loanTermFrequency(numberOfRepayments)//
-                    .repaymentFrequencyType(RepaymentFrequencyType.MONTHS)//
-                    .loanTermFrequencyType(RepaymentFrequencyType.MONTHS);
-
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applicationRequest);
-
-            PostLoansLoanIdResponse approvedLoanResult = loanTransactionHelper.approveLoan(postLoansResponse.getResourceId(),
-                    approveLoanRequest(amount, "01 January 2023"));
-
-            Long loanId = approvedLoanResult.getLoanId();
-
-            // disburse Loan
-            disburseLoan(loanId, BigDecimal.valueOf(1250.0), "01 January 2023");
-
-            createdLoanId.set(loanId);
+            createdLoanId.set(createBehindLoan());
         });
 
         runAt("02 January 2023", () -> {
@@ -106,41 +69,7 @@ public class BatchLoanIntegrationTest extends BaseLoanIntegrationTest {
         AtomicLong createdLoanId = new AtomicLong();
 
         runAt("01 January 2023", () -> {
-            // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
-
-            int numberOfRepayments = 24;
-            int repaymentEvery = 1;
-
-            // Create Loan Product
-            PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct() //
-                    .numberOfRepayments(numberOfRepayments) //
-                    .repaymentEvery(repaymentEvery) //
-                    .repaymentFrequencyType(RepaymentFrequencyType.MONTHS.longValue()); //
-
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-            Long loanProductId = loanProductResponse.getResourceId();
-
-            // Apply and Approve Loan
-            double amount = 1250.0;
-
-            PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "01 January 2023", amount, numberOfRepayments)//
-                    .repaymentEvery(repaymentEvery)//
-                    .loanTermFrequency(numberOfRepayments)//
-                    .repaymentFrequencyType(RepaymentFrequencyType.MONTHS)//
-                    .loanTermFrequencyType(RepaymentFrequencyType.MONTHS);
-
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applicationRequest);
-
-            PostLoansLoanIdResponse approvedLoanResult = loanTransactionHelper.approveLoan(postLoansResponse.getResourceId(),
-                    approveLoanRequest(amount, "01 January 2023"));
-
-            Long loanId = approvedLoanResult.getLoanId();
-
-            // disburse Loan
-            disburseLoan(loanId, BigDecimal.valueOf(1250.0), "01 January 2023");
-
-            createdLoanId.set(loanId);
+            createdLoanId.set(createBehindLoan());
         });
 
         runAt("02 January 2023", () -> {
@@ -155,10 +84,42 @@ public class BatchLoanIntegrationTest extends BaseLoanIntegrationTest {
                 ErrorResponse response = batchRequest() //
                         .rescheduleLoan(1L, loanId, "01 January 2023", "01 February 2023", "01 March 2023") //
                         .approveRescheduleLoan(2L, 1L, "01 January 2023") //
-                        .executeEnclosingTransactionError(new ResponseSpecBuilder().expectStatusCode(409).build()); //
+                        .executeEnclosingTransactionError(); //
 
                 Assertions.assertEquals(HttpStatus.SC_CONFLICT, response.getHttpStatusCode());
             });
         });
+    }
+
+    private Long createBehindLoan() {
+        // Create Client
+        Long clientId = createClient();
+
+        int numberOfRepayments = 24;
+        int repaymentEvery = 1;
+
+        PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct() //
+                .numberOfRepayments(numberOfRepayments) //
+                .repaymentEvery(repaymentEvery) //
+                .repaymentFrequencyType(RepaymentFrequencyType.MONTHS_L); //
+
+        // Create Loan Product
+        Long loanProductId = createLoanProduct(product);
+
+        double amount = 1250.0;
+
+        PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "01 January 2023", amount, numberOfRepayments)//
+                .repaymentEvery(repaymentEvery)//
+                .loanTermFrequency(numberOfRepayments)//
+                .repaymentFrequencyType(RepaymentFrequencyType.MONTHS)//
+                .loanTermFrequencyType(RepaymentFrequencyType.MONTHS);
+
+        Long loanId = applyForLoan(applicationRequest);
+
+        approveLoan(loanId, approveLoanRequest(amount, "01 January 2023"));
+
+        disburseLoan(loanId, BigDecimal.valueOf(1250.0), "01 January 2023");
+
+        return loanId;
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/BatchLoanIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/BatchLoanIntegrationTest.java
@@ -18,64 +18,27 @@
  */
 package org.apache.fineract.integrationtests;
 
-import io.restassured.builder.ResponseSpecBuilder;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
-import org.apache.fineract.batch.domain.BatchResponse;
+import org.apache.fineract.client.models.BatchResponse;
 import org.apache.fineract.client.models.PostLoanProductsRequest;
-import org.apache.fineract.client.models.PostLoanProductsResponse;
-import org.apache.fineract.client.models.PostLoansLoanIdResponse;
 import org.apache.fineract.client.models.PostLoansRequest;
-import org.apache.fineract.client.models.PostLoansResponse;
-import org.apache.fineract.integrationtests.common.ClientHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.RepaymentFrequencyType;
 import org.apache.fineract.integrationtests.common.error.ErrorResponse;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class BatchLoanIntegrationTest extends BaseLoanIntegrationTest {
+public class BatchLoanIntegrationTest extends FeignLoanTestBase {
 
     @Test
     public void test_InlineLoanCOB_ShouldExecute_WhenLoanIsBehind_And_RescheduleIsRequestedViaBatchApi() {
         AtomicLong createdLoanId = new AtomicLong();
 
         runAt("01 January 2023", () -> {
-            // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
-
-            int numberOfRepayments = 24;
-            int repaymentEvery = 1;
-
-            // Create Loan Product
-            PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct() //
-                    .numberOfRepayments(numberOfRepayments) //
-                    .repaymentEvery(repaymentEvery) //
-                    .repaymentFrequencyType(RepaymentFrequencyType.MONTHS.longValue()); //
-
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-            Long loanProductId = loanProductResponse.getResourceId();
-
-            // Apply and Approve Loan
-            double amount = 1250.0;
-
-            PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "01 January 2023", amount, numberOfRepayments)//
-                    .repaymentEvery(repaymentEvery)//
-                    .loanTermFrequency(numberOfRepayments)//
-                    .repaymentFrequencyType(RepaymentFrequencyType.MONTHS)//
-                    .loanTermFrequencyType(RepaymentFrequencyType.MONTHS);
-
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applicationRequest);
-
-            PostLoansLoanIdResponse approvedLoanResult = loanTransactionHelper.approveLoan(postLoansResponse.getResourceId(),
-                    approveLoanRequest(amount, "01 January 2023"));
-
-            Long loanId = approvedLoanResult.getLoanId();
-
-            // disburse Loan
-            disburseLoan(loanId, BigDecimal.valueOf(1250.0), "01 January 2023");
-
-            createdLoanId.set(loanId);
+            createdLoanId.set(createBehindLoan());
         });
 
         runAt("02 January 2023", () -> {
@@ -106,41 +69,7 @@ public class BatchLoanIntegrationTest extends BaseLoanIntegrationTest {
         AtomicLong createdLoanId = new AtomicLong();
 
         runAt("01 January 2023", () -> {
-            // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
-
-            int numberOfRepayments = 24;
-            int repaymentEvery = 1;
-
-            // Create Loan Product
-            PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct() //
-                    .numberOfRepayments(numberOfRepayments) //
-                    .repaymentEvery(repaymentEvery) //
-                    .repaymentFrequencyType(RepaymentFrequencyType.MONTHS.longValue()); //
-
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-            Long loanProductId = loanProductResponse.getResourceId();
-
-            // Apply and Approve Loan
-            double amount = 1250.0;
-
-            PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "01 January 2023", amount, numberOfRepayments)//
-                    .repaymentEvery(repaymentEvery)//
-                    .loanTermFrequency(numberOfRepayments)//
-                    .repaymentFrequencyType(RepaymentFrequencyType.MONTHS)//
-                    .loanTermFrequencyType(RepaymentFrequencyType.MONTHS);
-
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applicationRequest);
-
-            PostLoansLoanIdResponse approvedLoanResult = loanTransactionHelper.approveLoan(postLoansResponse.getResourceId(),
-                    approveLoanRequest(amount, "01 January 2023"));
-
-            Long loanId = approvedLoanResult.getLoanId();
-
-            // disburse Loan
-            disburseLoan(loanId, BigDecimal.valueOf(1250.0), "01 January 2023");
-
-            createdLoanId.set(loanId);
+            createdLoanId.set(createBehindLoan());
         });
 
         runAt("02 January 2023", () -> {
@@ -155,10 +84,40 @@ public class BatchLoanIntegrationTest extends BaseLoanIntegrationTest {
                 ErrorResponse response = batchRequest() //
                         .rescheduleLoan(1L, loanId, "01 January 2023", "01 February 2023", "01 March 2023") //
                         .approveRescheduleLoan(2L, 1L, "01 January 2023") //
-                        .executeEnclosingTransactionError(new ResponseSpecBuilder().expectStatusCode(409).build()); //
+                        .executeEnclosingTransactionError(); //
 
                 Assertions.assertEquals(HttpStatus.SC_CONFLICT, response.getHttpStatusCode());
             });
         });
+    }
+
+    private Long createBehindLoan() {
+        Long clientId = createClient();
+
+        int numberOfRepayments = 24;
+        int repaymentEvery = 1;
+
+        PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct() //
+                .numberOfRepayments(numberOfRepayments) //
+                .repaymentEvery(repaymentEvery) //
+                .repaymentFrequencyType(RepaymentFrequencyType.MONTHS_L); //
+
+        Long loanProductId = createLoanProduct(product);
+
+        double amount = 1250.0;
+
+        PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "01 January 2023", amount, numberOfRepayments)//
+                .repaymentEvery(repaymentEvery)//
+                .loanTermFrequency(numberOfRepayments)//
+                .repaymentFrequencyType(RepaymentFrequencyType.MONTHS)//
+                .loanTermFrequencyType(RepaymentFrequencyType.MONTHS);
+
+        Long loanId = applyForLoan(applicationRequest);
+
+        approveLoan(loanId, approveLoanRequest(amount, "01 January 2023"));
+
+        disburseLoan(loanId, BigDecimal.valueOf(1250.0), "01 January 2023");
+
+        return loanId;
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/ClientChargeRoundingTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/ClientChargeRoundingTest.java
@@ -18,53 +18,50 @@
  */
 package org.apache.fineract.integrationtests;
 
-import static io.restassured.RestAssured.given;
-import static org.apache.fineract.integrationtests.common.ClientHelper.addChargesForClient;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.restassured.response.Response;
-import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
 import org.apache.fineract.client.models.ChargeRequest;
 import org.apache.fineract.client.models.CurrencyConfigurationData;
 import org.apache.fineract.client.models.CurrencyUpdateRequest;
 import org.apache.fineract.client.models.GetClientsChargesPageItems;
 import org.apache.fineract.client.models.GetClientsClientIdChargesResponse;
 import org.apache.fineract.client.models.PostChargesResponse;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.FineractClientHelper;
-import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
+import org.apache.fineract.client.models.PostClientsClientIdChargesRequest;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 @Slf4j
-public class ClientChargeRoundingTest extends BaseLoanIntegrationTest {
+public class ClientChargeRoundingTest extends FeignLoanTestBase {
 
     private Long clientId;
-    private ChargesHelper chargesHelper;
     private static final String DATE = "01 January 2026";
 
     @BeforeEach
-    public void setup() throws Exception {
+    public void setup() {
         enableRequiredCurrencies();
-        clientId = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
-        chargesHelper = new ChargesHelper();
+        clientId = createClient();
     }
 
     @Test
-    public void shouldRoundUsdClientChargeTo_TwoDecimalPlaces() throws Exception {
+    public void shouldRoundUsdClientChargeTo_TwoDecimalPlaces() {
         PostChargesResponse chargesResponse = createFlatClientCharge(19.876, "USD");
 
-        Integer appliedChargeId = applyChargeToClient(clientId, chargesResponse.getResourceId(), new BigDecimal("19.876"));
+        applyChargeToClient(clientId, chargesResponse.getResourceId(), new BigDecimal("19.876"));
 
-        GetClientsChargesPageItems charge = getClientCharge(clientId, appliedChargeId.longValue());
+        GetClientsChargesPageItems charge = getSingleClientCharge(clientId);
 
         assertNotNull(charge);
         BigDecimal actualChargeAmount = charge.getAmount();
@@ -73,12 +70,12 @@ public class ClientChargeRoundingTest extends BaseLoanIntegrationTest {
     }
 
     @Test
-    public void shouldRoundJpyClientChargeTo_ZeroDecimalPlaces() throws Exception {
+    public void shouldRoundJpyClientChargeTo_ZeroDecimalPlaces() {
         PostChargesResponse chargesResponse = createFlatClientCharge(19.8, "JPY");
 
-        Integer appliedChargeId = applyChargeToClient(clientId, chargesResponse.getResourceId(), new BigDecimal("19.8"));
+        applyChargeToClient(clientId, chargesResponse.getResourceId(), new BigDecimal("19.8"));
 
-        GetClientsChargesPageItems charge = getClientCharge(clientId, appliedChargeId.longValue());
+        GetClientsChargesPageItems charge = getSingleClientCharge(clientId);
 
         assertNotNull(charge);
         BigDecimal actualChargeAmount = charge.getAmount();
@@ -87,12 +84,12 @@ public class ClientChargeRoundingTest extends BaseLoanIntegrationTest {
     }
 
     @Test
-    public void shouldRoundUpJpyClientCharge_whenValueIsAboveHalfTo_ZeroDecimalPlaces() throws Exception {
+    public void shouldRoundUpJpyClientCharge_whenValueIsAboveHalfTo_ZeroDecimalPlaces() {
         PostChargesResponse chargesResponse = createFlatClientCharge(0.55, "JPY");
 
-        Integer appliedChargeId = applyChargeToClient(clientId, chargesResponse.getResourceId(), new BigDecimal("0.55"));
+        applyChargeToClient(clientId, chargesResponse.getResourceId(), new BigDecimal("0.55"));
 
-        GetClientsChargesPageItems charge = getClientCharge(clientId, appliedChargeId.longValue());
+        GetClientsChargesPageItems charge = getSingleClientCharge(clientId);
 
         assertNotNull(charge);
         BigDecimal actualChargeAmount = charge.getAmount();
@@ -101,14 +98,14 @@ public class ClientChargeRoundingTest extends BaseLoanIntegrationTest {
     }
 
     @Test
-    public void shouldFailToAddJpyClientCharge_whenRoundedToZero() throws Exception {
+    public void shouldFailToAddJpyClientCharge_whenRoundedToZero() {
         PostChargesResponse chargesResponse = createFlatClientCharge(0.5, "JPY");
 
-        Response response = applyChargeToClientRaw(clientId, chargesResponse.getResourceId(), new BigDecimal("0.5"));
+        CallFailedRuntimeException exception = applyChargeToClientExpectingError(clientId, chargesResponse.getResourceId(),
+                new BigDecimal("0.5"));
 
-        assertEquals(400, response.statusCode());
-        String errorBody = response.asString();
-        assertTrue(errorBody.contains("error.msg.client.charge.amount.rounded.to.zero"));
+        assertEquals(400, exception.getStatus());
+        assertTrue(exception.getResponseBody().contains("error.msg.client.charge.amount.rounded.to.zero"));
         assertFalse(hasAnyClientCharges(clientId), "Expected no client charge to be created when rounded amount becomes 0");
     }
 
@@ -118,51 +115,40 @@ public class ClientChargeRoundingTest extends BaseLoanIntegrationTest {
 
     private PostChargesResponse createFlatClientCharge(double amount, String currencyCode) {
         String uniqueChargeName = "Client Charge Flat " + UUID.randomUUID().toString().replace("-", "");
-        return chargesHelper.createCharges(new ChargeRequest().name(uniqueChargeName).chargeAppliesTo(3) // CLIENT
+        return chargesHelper.createCharge(new ChargeRequest().name(uniqueChargeName).chargeAppliesTo(3) // CLIENT
                 .chargeTimeType(2).chargeCalculationType(1) // FLAT
                 .amount(amount).currencyCode(currencyCode).locale("en").active(true).penalty(false));
     }
 
-    private Integer applyChargeToClient(Long clientId, Long chargeId, BigDecimal amount) {
-        String request = """
-                {
-                  "chargeId": %d,
-                  "amount": %s,
-                  "locale": "en",
-                  "dateFormat": "dd MMMM yyyy",
-                  "dueDate": "%s"
-                }
-                """.formatted(chargeId, amount.toPlainString(), DATE);
-
-        return addChargesForClient(requestSpec, responseSpec, clientId.intValue(), request);
+    private void applyChargeToClient(Long clientId, Long chargeId, BigDecimal amount) {
+        chargesHelper.addClientCharge(clientId, clientChargeRequest(chargeId, amount));
     }
 
-    private Response applyChargeToClientRaw(Long clientId, Long chargeId, BigDecimal amount) {
-
-        String request = """
-                {
-                  "chargeId": %d,
-                  "amount": %s,
-                  "locale": "en",
-                  "dateFormat": "dd MMMM yyyy",
-                  "dueDate": "%s"
-                }
-                """.formatted(chargeId, amount.toPlainString(), DATE);
-
-        String url = "/fineract-provider/api/v1/clients/" + clientId + "/charges?" + Utils.TENANT_IDENTIFIER;
-
-        return given().spec(requestSpec).body(request).when().post(url);
+    private CallFailedRuntimeException applyChargeToClientExpectingError(Long clientId, Long chargeId, BigDecimal amount) {
+        return assertThrows(CallFailedRuntimeException.class,
+                () -> chargesHelper.addClientCharge(clientId, clientChargeRequest(chargeId, amount)));
     }
 
-    private GetClientsChargesPageItems getClientCharge(Long clientId, Long chargeId) throws IOException {
-        return FineractClientHelper.getFineractClient().clientCharges.retrieveOneClientCharge(clientId, chargeId).execute().body();
+    private PostClientsClientIdChargesRequest clientChargeRequest(Long chargeId, BigDecimal amount) {
+        return new PostClientsClientIdChargesRequest()//
+                .chargeId(chargeId)//
+                .amount(amount)//
+                .locale(LoanTestData.LOCALE)//
+                .dateFormat(DATETIME_PATTERN)//
+                .dueDate(DATE);
     }
 
-    private boolean hasAnyClientCharges(Long clientId) throws IOException {
+    private GetClientsChargesPageItems getSingleClientCharge(Long clientId) {
+        GetClientsClientIdChargesResponse response = chargesHelper.getClientCharges(clientId);
+        assertNotNull(response);
+        Set<GetClientsChargesPageItems> pageItems = response.getPageItems();
+        assertNotNull(pageItems);
+        assertEquals(1, pageItems.size());
+        return pageItems.iterator().next();
+    }
 
-        GetClientsClientIdChargesResponse response = FineractClientHelper.getFineractClient().clientCharges
-                .retrieveAllClientCharges(clientId, "all", null, null, null).execute().body();
-
+    private boolean hasAnyClientCharges(Long clientId) {
+        GetClientsClientIdChargesResponse response = chargesHelper.getClientCharges(clientId);
         return response != null && response.getPageItems() != null && !response.getPageItems().isEmpty();
     }
 
@@ -174,12 +160,12 @@ public class ClientChargeRoundingTest extends BaseLoanIntegrationTest {
      * Currencies used by these tests must be explicitly enabled in the currency configuration. Otherwise, charge
      * creation and persistence may succeed while retrieval APIs do not return the charges.
      */
-    private void enableRequiredCurrencies() throws Exception {
+    private void enableRequiredCurrencies() {
         CurrencyUpdateRequest request = new CurrencyUpdateRequest().currencies(List.of("USD", "JPY"));
 
-        FineractClientHelper.getFineractClient().currencies.updateCurrencies(request).execute();
+        FineractFeignClientHelper.getFineractFeignClient().currency().updateCurrencies(request);
 
-        CurrencyConfigurationData data = FineractClientHelper.getFineractClient().currencies.retrieveCurrencies().execute().body();
+        CurrencyConfigurationData data = FineractFeignClientHelper.getFineractFeignClient().currency().retrieveCurrencies();
 
         assertNotNull(data);
         assertNotNull(data.getSelectedCurrencyOptions());

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/ClientChargeRoundingTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/ClientChargeRoundingTest.java
@@ -18,53 +18,50 @@
  */
 package org.apache.fineract.integrationtests;
 
-import static io.restassured.RestAssured.given;
-import static org.apache.fineract.integrationtests.common.ClientHelper.addChargesForClient;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.restassured.response.Response;
-import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
 import org.apache.fineract.client.models.ChargeRequest;
 import org.apache.fineract.client.models.CurrencyConfigurationData;
 import org.apache.fineract.client.models.CurrencyUpdateRequest;
 import org.apache.fineract.client.models.GetClientsChargesPageItems;
 import org.apache.fineract.client.models.GetClientsClientIdChargesResponse;
 import org.apache.fineract.client.models.PostChargesResponse;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.FineractClientHelper;
-import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.ClientChargeCommandsApi;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 @Slf4j
-public class ClientChargeRoundingTest extends BaseLoanIntegrationTest {
+public class ClientChargeRoundingTest extends FeignLoanTestBase {
 
     private Long clientId;
-    private ChargesHelper chargesHelper;
     private static final String DATE = "01 January 2026";
 
     @BeforeEach
-    public void setup() throws Exception {
+    public void setup() {
         enableRequiredCurrencies();
-        clientId = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
-        chargesHelper = new ChargesHelper();
+        clientId = createClient();
     }
 
     @Test
-    public void shouldRoundUsdClientChargeTo_TwoDecimalPlaces() throws Exception {
+    public void shouldRoundUsdClientChargeTo_TwoDecimalPlaces() {
         PostChargesResponse chargesResponse = createFlatClientCharge(19.876, "USD");
 
-        Integer appliedChargeId = applyChargeToClient(clientId, chargesResponse.getResourceId(), new BigDecimal("19.876"));
+        applyChargeToClient(clientId, chargesResponse.getResourceId(), new BigDecimal("19.876"));
 
-        GetClientsChargesPageItems charge = getClientCharge(clientId, appliedChargeId.longValue());
+        GetClientsChargesPageItems charge = getSingleClientCharge(clientId);
 
         assertNotNull(charge);
         BigDecimal actualChargeAmount = charge.getAmount();
@@ -73,12 +70,12 @@ public class ClientChargeRoundingTest extends BaseLoanIntegrationTest {
     }
 
     @Test
-    public void shouldRoundJpyClientChargeTo_ZeroDecimalPlaces() throws Exception {
+    public void shouldRoundJpyClientChargeTo_ZeroDecimalPlaces() {
         PostChargesResponse chargesResponse = createFlatClientCharge(19.8, "JPY");
 
-        Integer appliedChargeId = applyChargeToClient(clientId, chargesResponse.getResourceId(), new BigDecimal("19.8"));
+        applyChargeToClient(clientId, chargesResponse.getResourceId(), new BigDecimal("19.8"));
 
-        GetClientsChargesPageItems charge = getClientCharge(clientId, appliedChargeId.longValue());
+        GetClientsChargesPageItems charge = getSingleClientCharge(clientId);
 
         assertNotNull(charge);
         BigDecimal actualChargeAmount = charge.getAmount();
@@ -87,12 +84,12 @@ public class ClientChargeRoundingTest extends BaseLoanIntegrationTest {
     }
 
     @Test
-    public void shouldRoundUpJpyClientCharge_whenValueIsAboveHalfTo_ZeroDecimalPlaces() throws Exception {
+    public void shouldRoundUpJpyClientCharge_whenValueIsAboveHalfTo_ZeroDecimalPlaces() {
         PostChargesResponse chargesResponse = createFlatClientCharge(0.55, "JPY");
 
-        Integer appliedChargeId = applyChargeToClient(clientId, chargesResponse.getResourceId(), new BigDecimal("0.55"));
+        applyChargeToClient(clientId, chargesResponse.getResourceId(), new BigDecimal("0.55"));
 
-        GetClientsChargesPageItems charge = getClientCharge(clientId, appliedChargeId.longValue());
+        GetClientsChargesPageItems charge = getSingleClientCharge(clientId);
 
         assertNotNull(charge);
         BigDecimal actualChargeAmount = charge.getAmount();
@@ -101,14 +98,14 @@ public class ClientChargeRoundingTest extends BaseLoanIntegrationTest {
     }
 
     @Test
-    public void shouldFailToAddJpyClientCharge_whenRoundedToZero() throws Exception {
+    public void shouldFailToAddJpyClientCharge_whenRoundedToZero() {
         PostChargesResponse chargesResponse = createFlatClientCharge(0.5, "JPY");
 
-        Response response = applyChargeToClientRaw(clientId, chargesResponse.getResourceId(), new BigDecimal("0.5"));
+        CallFailedRuntimeException exception = applyChargeToClientExpectingError(clientId, chargesResponse.getResourceId(),
+                new BigDecimal("0.5"));
 
-        assertEquals(400, response.statusCode());
-        String errorBody = response.asString();
-        assertTrue(errorBody.contains("error.msg.client.charge.amount.rounded.to.zero"));
+        assertEquals(400, exception.getStatus());
+        assertTrue(exception.getResponseBody().contains("error.msg.client.charge.amount.rounded.to.zero"));
         assertFalse(hasAnyClientCharges(clientId), "Expected no client charge to be created when rounded amount becomes 0");
     }
 
@@ -118,51 +115,44 @@ public class ClientChargeRoundingTest extends BaseLoanIntegrationTest {
 
     private PostChargesResponse createFlatClientCharge(double amount, String currencyCode) {
         String uniqueChargeName = "Client Charge Flat " + UUID.randomUUID().toString().replace("-", "");
-        return chargesHelper.createCharges(new ChargeRequest().name(uniqueChargeName).chargeAppliesTo(3) // CLIENT
+        return chargesHelper.createCharge(new ChargeRequest().name(uniqueChargeName).chargeAppliesTo(3) // CLIENT
                 .chargeTimeType(2).chargeCalculationType(1) // FLAT
                 .amount(amount).currencyCode(currencyCode).locale("en").active(true).penalty(false));
     }
 
-    private Integer applyChargeToClient(Long clientId, Long chargeId, BigDecimal amount) {
-        String request = """
-                {
-                  "chargeId": %d,
-                  "amount": %s,
-                  "locale": "en",
-                  "dateFormat": "dd MMMM yyyy",
-                  "dueDate": "%s"
-                }
-                """.formatted(chargeId, amount.toPlainString(), DATE);
-
-        return addChargesForClient(requestSpec, responseSpec, clientId.intValue(), request);
+    private void applyChargeToClient(Long clientId, Long chargeId, BigDecimal amount) {
+        chargesHelper.addClientChargeWithDecimalAmount(clientId, clientChargeRequest(chargeId, amount));
     }
 
-    private Response applyChargeToClientRaw(Long clientId, Long chargeId, BigDecimal amount) {
-
-        String request = """
-                {
-                  "chargeId": %d,
-                  "amount": %s,
-                  "locale": "en",
-                  "dateFormat": "dd MMMM yyyy",
-                  "dueDate": "%s"
-                }
-                """.formatted(chargeId, amount.toPlainString(), DATE);
-
-        String url = "/fineract-provider/api/v1/clients/" + clientId + "/charges?" + Utils.TENANT_IDENTIFIER;
-
-        return given().spec(requestSpec).body(request).when().post(url);
+    private CallFailedRuntimeException applyChargeToClientExpectingError(Long clientId, Long chargeId, BigDecimal amount) {
+        return assertThrows(CallFailedRuntimeException.class,
+                () -> chargesHelper.addClientChargeWithDecimalAmount(clientId, clientChargeRequest(chargeId, amount)));
     }
 
-    private GetClientsChargesPageItems getClientCharge(Long clientId, Long chargeId) throws IOException {
-        return FineractClientHelper.getFineractClient().clientCharges.retrieveOneClientCharge(clientId, chargeId).execute().body();
+    /**
+     * The generated {@code PostClientsClientIdChargesRequest} declares {@code amount} as an {@code Integer}, so these
+     * fractional amounts - the whole point of this class - go through {@link ClientChargeCommandsApi} instead.
+     */
+    private ClientChargeCommandsApi.DecimalAmountClientChargeRequest clientChargeRequest(Long chargeId, BigDecimal amount) {
+        return new ClientChargeCommandsApi.DecimalAmountClientChargeRequest()//
+                .chargeId(chargeId)//
+                .amount(amount)//
+                .locale(LoanTestData.LOCALE)//
+                .dateFormat(DATETIME_PATTERN)//
+                .dueDate(DATE);
     }
 
-    private boolean hasAnyClientCharges(Long clientId) throws IOException {
+    private GetClientsChargesPageItems getSingleClientCharge(Long clientId) {
+        GetClientsClientIdChargesResponse response = chargesHelper.getClientCharges(clientId);
+        assertNotNull(response);
+        Set<GetClientsChargesPageItems> pageItems = response.getPageItems();
+        assertNotNull(pageItems);
+        assertEquals(1, pageItems.size());
+        return pageItems.iterator().next();
+    }
 
-        GetClientsClientIdChargesResponse response = FineractClientHelper.getFineractClient().clientCharges
-                .retrieveAllClientCharges(clientId, "all", null, null, null).execute().body();
-
+    private boolean hasAnyClientCharges(Long clientId) {
+        GetClientsClientIdChargesResponse response = chargesHelper.getClientCharges(clientId);
         return response != null && response.getPageItems() != null && !response.getPageItems().isEmpty();
     }
 
@@ -174,12 +164,12 @@ public class ClientChargeRoundingTest extends BaseLoanIntegrationTest {
      * Currencies used by these tests must be explicitly enabled in the currency configuration. Otherwise, charge
      * creation and persistence may succeed while retrieval APIs do not return the charges.
      */
-    private void enableRequiredCurrencies() throws Exception {
+    private void enableRequiredCurrencies() {
         CurrencyUpdateRequest request = new CurrencyUpdateRequest().currencies(List.of("USD", "JPY"));
 
-        FineractClientHelper.getFineractClient().currencies.updateCurrencies(request).execute();
+        FineractFeignClientHelper.getFineractFeignClient().currency().updateCurrencies(request);
 
-        CurrencyConfigurationData data = FineractClientHelper.getFineractClient().currencies.retrieveCurrencies().execute().body();
+        CurrencyConfigurationData data = FineractFeignClientHelper.getFineractFeignClient().currency().retrieveCurrencies();
 
         assertNotNull(data);
         assertNotNull(data.getSelectedCurrencyOptions());

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/ClientLoanChargeExternalIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/ClientLoanChargeExternalIntegrationTest.java
@@ -52,7 +52,7 @@ public class ClientLoanChargeExternalIntegrationTest extends FeignLoanTestBase {
         approveLoan(loanId, approveLoanRequest(12000.0, "20 September 2011"));
         disburseLoanWithNetDisbursalAmount(loanId, "20 September 2011", "12,000.00");
 
-        final Long chargeDefId = chargesHelper.createLoanSpecifiedDueDatePercentageAmountAndInterestFee(1.0).getResourceId();
+        final Long chargeDefId = chargesHelper.createLoanSpecifiedDueDatePercentageOfInterestFee(1.0).getResourceId();
 
         final String externalId = "extId" + loanId.toString();
         PostLoansLoanIdChargesResponse chargeResponse = addLoanCharge(loanId, new PostLoansLoanIdChargesRequest().chargeId(chargeDefId)
@@ -74,7 +74,7 @@ public class ClientLoanChargeExternalIntegrationTest extends FeignLoanTestBase {
         approveLoan(loanId, approveLoanRequest(12000.0, "20 September 2011"));
         disburseLoanWithNetDisbursalAmount(loanId, "20 September 2011", "12,000.00");
 
-        final Long chargeDefId = chargesHelper.createLoanSpecifiedDueDatePercentageAmountAndInterestFee(1.0).getResourceId();
+        final Long chargeDefId = chargesHelper.createLoanSpecifiedDueDatePercentageOfInterestFee(1.0).getResourceId();
 
         final String externalId = "extId" + loanId.toString();
         PostLoansLoanIdChargesResponse chargeResponse = addLoanCharge(loanId, new PostLoansLoanIdChargesRequest().chargeId(chargeDefId)

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/ClientLoanIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/ClientLoanIntegrationTest.java
@@ -25,53 +25,47 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.path.json.JsonPath;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
 import java.math.BigDecimal;
 import java.text.DateFormat;
 import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import org.apache.fineract.accounting.common.AccountingRuleType;
 import org.apache.fineract.accounting.glaccount.domain.GLAccountType;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
 import org.apache.fineract.client.models.AllowAttributeOverrides;
-import org.apache.fineract.client.models.BusinessDateUpdateRequest;
 import org.apache.fineract.client.models.ChargeRequest;
+import org.apache.fineract.client.models.DisbursementDetail;
 import org.apache.fineract.client.models.GetJournalEntriesTransactionIdResponse;
+import org.apache.fineract.client.models.GetLoanProductsProductIdResponse;
 import org.apache.fineract.client.models.GetLoanTransactionRelation;
+import org.apache.fineract.client.models.GetLoansLoanIdChargesChargeIdResponse;
+import org.apache.fineract.client.models.GetLoansLoanIdCollateralData;
 import org.apache.fineract.client.models.GetLoansLoanIdLoanTransactionRelation;
 import org.apache.fineract.client.models.GetLoansLoanIdRepaymentPeriod;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
+import org.apache.fineract.client.models.GetLoansLoanIdStatus;
 import org.apache.fineract.client.models.GetLoansLoanIdSummary;
 import org.apache.fineract.client.models.GetLoansLoanIdTransactions;
+import org.apache.fineract.client.models.GetLoansLoanIdTransactionsTemplateResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdTransactionsTransactionIdResponse;
 import org.apache.fineract.client.models.JournalEntryTransactionItem;
+import org.apache.fineract.client.models.LoanProductChargeData;
+import org.apache.fineract.client.models.LoanProductChargeToGLAccountMapper;
 import org.apache.fineract.client.models.PostChargesResponse;
-import org.apache.fineract.client.models.PostClientsRequest;
-import org.apache.fineract.client.models.PostClientsResponse;
 import org.apache.fineract.client.models.PostGLAccountsRequest;
 import org.apache.fineract.client.models.PostGLAccountsResponse;
 import org.apache.fineract.client.models.PostLoanProductsRequest;
-import org.apache.fineract.client.models.PostLoanProductsResponse;
+import org.apache.fineract.client.models.PostLoansDisbursementData;
 import org.apache.fineract.client.models.PostLoansLoanIdChargesChargeIdRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdChargesChargeIdResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdChargesRequest;
@@ -82,37 +76,42 @@ import org.apache.fineract.client.models.PostLoansLoanIdTransactionsRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsTransactionIdRequest;
 import org.apache.fineract.client.models.PostLoansRequest;
+import org.apache.fineract.client.models.PostLoansRequestChargeData;
+import org.apache.fineract.client.models.PostLoansRequestCollateralData;
 import org.apache.fineract.client.models.PostLoansResponse;
 import org.apache.fineract.client.models.PutChargeTransactionChangesRequest;
 import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
-import org.apache.fineract.client.util.CallFailedRuntimeException;
+import org.apache.fineract.client.models.PutLoansLoanIdChargeData;
+import org.apache.fineract.client.models.PutLoansLoanIdChargesChargeIdRequest;
+import org.apache.fineract.client.models.PutLoansLoanIdCollateral;
+import org.apache.fineract.client.models.PutLoansLoanIdRequest;
+import org.apache.fineract.client.models.PutSavingsAccountsAccountIdRequest;
+import org.apache.fineract.client.models.PutSavingsAccountsAccountIdResponse;
+import org.apache.fineract.client.models.SavingsAccountSummaryData;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
 import org.apache.fineract.infrastructure.core.service.DateUtils;
-import org.apache.fineract.integrationtests.common.BusinessDateHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.CollateralManagementHelper;
-import org.apache.fineract.integrationtests.common.SchedulerJobHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignAccountTransferHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignCollateralHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignSavingsHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignSavingsProductHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.LoanChargeCommandsApi;
+import org.apache.fineract.integrationtests.client.feign.modules.ChargeRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
+import org.apache.fineract.integrationtests.client.feign.modules.SavingsRequestBuilders;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.common.accounting.Account;
-import org.apache.fineract.integrationtests.common.accounting.AccountHelper;
 import org.apache.fineract.integrationtests.common.accounting.JournalEntry;
-import org.apache.fineract.integrationtests.common.accounting.JournalEntryHelper;
-import org.apache.fineract.integrationtests.common.accounting.PeriodicAccrualAccountingHelper;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
-import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanProductHelper;
-import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanStatusChecker;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.apache.fineract.integrationtests.common.savings.AccountTransferHelper;
-import org.apache.fineract.integrationtests.common.savings.SavingsAccountHelper;
-import org.apache.fineract.integrationtests.common.savings.SavingsProductHelper;
-import org.apache.fineract.integrationtests.common.savings.SavingsStatusChecker;
-import org.apache.fineract.integrationtests.common.system.CodeHelper;
 import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
 import org.apache.fineract.portfolio.charge.domain.ChargePaymentMode;
 import org.apache.fineract.portfolio.charge.domain.ChargeTimeType;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanStatus;
+import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleProcessingType;
+import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleType;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.commons.util.StringUtils;
@@ -123,561 +122,544 @@ import org.slf4j.LoggerFactory;
  * Client Loan Integration Test for checking Loan Application Repayments Schedule, loan charges, penalties, loan
  * repayments and verifying accounting transactions
  */
-@SuppressWarnings({ "rawtypes", "unchecked" })
 @Order(2)
-public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
-
-    static {
-        Utils.initializeRESTAssured();
-    }
+public class ClientLoanIntegrationTest extends FeignLoanTestBase {
 
     private static final String MINIMUM_OPENING_BALANCE = "1000.0";
-    private static final String ACCOUNT_TYPE_INDIVIDUAL = "INDIVIDUAL";
     private static final Logger LOG = LoggerFactory.getLogger(ClientLoanIntegrationTest.class);
-    private static final String NONE = "1";
-    private static final String CASH_BASED = "2";
-    private static final String ACCRUAL_PERIODIC = "3";
-    private static final String ACCRUAL_UPFRONT = "4";
 
-    private static final ResponseSpecification RESPONSE_SPEC = createResponseSpecification(200);
-    private static final RequestSpecification REQUEST_SPEC = createRequestSpecification();
-    private static final LoanTransactionHelper LOAN_TRANSACTION_HELPER = new LoanTransactionHelper(REQUEST_SPEC, RESPONSE_SPEC);
-    private static final JournalEntryHelper JOURNAL_ENTRY_HELPER = new JournalEntryHelper(REQUEST_SPEC, RESPONSE_SPEC);
-    private static final AccountHelper ACCOUNT_HELPER = new AccountHelper(REQUEST_SPEC, RESPONSE_SPEC);
+    private static final Integer NONE = AccountingRuleType.NONE.getValue();
+    private static final Integer CASH_BASED = AccountingRuleType.CASH_BASED.getValue();
+    private static final Integer ACCRUAL_PERIODIC = AccountingRuleType.ACCRUAL_PERIODIC.getValue();
+    private static final Integer ACCRUAL_UPFRONT = AccountingRuleType.ACCRUAL_UPFRONT.getValue();
+
+    /** The loan/product JSON builders this test replaced used {@code en_GB}; keep it so number parsing is unchanged. */
+    private static final String LOCALE = "en_GB";
+    private static final String OVERRIDE_MESSAGE = "Loan overrode the product's %s";
+    /** The interoperation repayment body was built with plain {@code en}, unlike the {@code en_GB} used elsewhere. */
+    private static final String INTEROP_LOCALE = "en";
+
+    /** Mirrors the legacy {@code SavingsAccountHelper} date constants. */
+    private static final String SAVINGS_TRANSACTION_DATE = "01 March 2013";
+    private static final String SAVINGS_CREATED_DATE = "08 January 2013";
+    private static final String SAVINGS_CREATED_DATE_PLUS_ONE = "09 January 2013";
+
+    private static final String DEFAULT_STRATEGY = "mifos-standard-strategy";
+    private static final String RBI_INDIA_STRATEGY = "rbi-india-strategy";
+    private static final String INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY = "interest-principal-penalties-fees-order-strategy";
+    private static final String DUE_PENALTY_FEE_INTEREST_PRINCIPAL_IN_ADVANCE_PRINCIPAL_PENALTY_FEE_INTEREST_STRATEGY = "due-penalty-fee-interest-principal-in-advance-principal-penalty-fee-interest-strategy";
+    private static final String DUE_PENALTY_INTEREST_PRINCIPAL_FEE_IN_ADVANCE_PENALTY_INTEREST_PRINCIPAL_FEE_STRATEGY = "due-penalty-interest-principal-fee-in-advance-penalty-interest-principal-fee-strategy";
+
+    /**
+     * GL accounts and helpers are created in {@link #setupClientLoanTest()} rather than in field initializers, because
+     * the inherited Feign helpers are only assigned in the base class {@code @BeforeAll}, which runs after this class
+     * is initialized.
+     */
     // asset
-    private static final Account LOANS_RECEIVABLE_ACCOUNT = ACCOUNT_HELPER.createAssetAccount();
-    private static final Account INTEREST_FEE_RECEIVABLE_ACCOUNT = ACCOUNT_HELPER.createAssetAccount();
-    private static final Account SUSPENSE_ACCOUNT = ACCOUNT_HELPER.createAssetAccount();
+    private static Account loansReceivableAccount;
+    private static Account interestFeeReceivableAccount;
+    private static Account suspenseAccount;
     // liability
-    private static final Account SUSPENSE_CLEARING_ACCOUNT = ACCOUNT_HELPER.createLiabilityAccount();
-    private static final Account OVERPAYMENT_ACCOUNT = ACCOUNT_HELPER.createLiabilityAccount();
+    private static Account suspenseClearingAccount;
+    private static Account overpaymentAccount;
     // income
-    private static final Account INTEREST_INCOME_ACCOUNT = ACCOUNT_HELPER.createIncomeAccount();
-    private static final Account FEE_INCOME_ACCOUNT = ACCOUNT_HELPER.createIncomeAccount();
-    private static final Account FEE_CHARGE_OFF_ACCOUNT = ACCOUNT_HELPER.createIncomeAccount();
-    private static final Account RECOVERIES_ACCOUNT = ACCOUNT_HELPER.createIncomeAccount();
-    private static final Account INTEREST_INCOME_CHARGE_OFF_ACCOUNT = ACCOUNT_HELPER.createIncomeAccount();
+    private static Account interestIncomeAccount;
+    private static Account feeIncomeAccount;
+    private static Account feeChargeOffAccount;
+    private static Account recoveriesAccount;
+    private static Account interestIncomeChargeOffAccount;
     // expense
-    private static final Account CREDIT_LOSS_BAD_DEBT_ACCOUNT = ACCOUNT_HELPER.createExpenseAccount();
-    private static final Account CREDIT_LOSS_BAD_DEBT_FRAUD_ACCOUNT = ACCOUNT_HELPER.createExpenseAccount();
-    private static final Account WRITTEN_OFF_ACCOUNT = ACCOUNT_HELPER.createExpenseAccount();
-    private static final Account GOODWILL_EXPENSE_ACCOUNT = ACCOUNT_HELPER.createExpenseAccount();
-    private static final SavingsAccountHelper SAVINGS_ACCOUNT_HELPER = new SavingsAccountHelper(REQUEST_SPEC, RESPONSE_SPEC);
-    private static final AccountTransferHelper ACCOUNT_TRANSFER_HELPER = new AccountTransferHelper(REQUEST_SPEC, RESPONSE_SPEC);
-    private static final LoanProductHelper LOAN_PRODUCT_HELPER = new LoanProductHelper();
-    private static final String DATETIME_PATTERN = "dd MMMM yyyy";
-    private static final DateTimeFormatter DATE_TIME_FORMATTER = new DateTimeFormatterBuilder().appendPattern(DATETIME_PATTERN)
-            .toFormatter();
-    private static final BusinessDateHelper BUSINESS_DATE_HELPER = new BusinessDateHelper();
-    private static final ChargesHelper CHARGES_HELPER = new ChargesHelper();
-    private static final ClientHelper CLIENT_HELPER = new ClientHelper(REQUEST_SPEC, RESPONSE_SPEC);
+    private static Account creditLossBadDebtAccount;
+    private static Account creditLossBadDebtFraudAccount;
+    private static Account writtenOffAccount;
+    private static Account goodwillExpenseAccount;
 
-    private static RequestSpecification createRequestSpecification() {
-        RequestSpecification request = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
+    private static FeignCollateralHelper collateralHelper;
+    private static FeignSavingsHelper savingsHelper;
+    private static FeignSavingsProductHelper savingsProductHelper;
+    private static FeignAccountTransferHelper accountTransferHelper;
 
-        request.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        request.header("Fineract-Platform-TenantId", "default");
-        return request;
-    }
+    @BeforeAll
+    public static void setupClientLoanTest() {
+        loansReceivableAccount = accountHelper.createAssetAccount();
+        interestFeeReceivableAccount = accountHelper.createAssetAccount();
+        suspenseAccount = accountHelper.createAssetAccount();
 
-    private static ResponseSpecification createResponseSpecification(int statusCode) {
-        return new ResponseSpecBuilder().expectStatusCode(statusCode).build();
+        suspenseClearingAccount = accountHelper.createLiabilityAccount();
+        overpaymentAccount = accountHelper.createLiabilityAccount();
+
+        interestIncomeAccount = accountHelper.createIncomeAccount();
+        feeIncomeAccount = accountHelper.createIncomeAccount();
+        feeChargeOffAccount = accountHelper.createIncomeAccount();
+        recoveriesAccount = accountHelper.createIncomeAccount();
+        interestIncomeChargeOffAccount = accountHelper.createIncomeAccount();
+
+        creditLossBadDebtAccount = accountHelper.createExpenseAccount();
+        creditLossBadDebtFraudAccount = accountHelper.createExpenseAccount();
+        writtenOffAccount = accountHelper.createExpenseAccount();
+        goodwillExpenseAccount = accountHelper.createExpenseAccount();
+
+        collateralHelper = new FeignCollateralHelper(FineractFeignClientHelper.getFineractFeignClient());
+        savingsHelper = new FeignSavingsHelper(FineractFeignClientHelper.getFineractFeignClient());
+        savingsProductHelper = new FeignSavingsProductHelper(FineractFeignClientHelper.getFineractFeignClient());
+        accountTransferHelper = new FeignAccountTransferHelper(FineractFeignClientHelper.getFineractFeignClient());
     }
 
     @Test
     public void checkClientLoanCreateAndDisburseFlow() {
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
-        List<HashMap> collaterals = new ArrayList<>();
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long clientID = createClient();
 
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+        verifyClientCreatedOnServer(clientID);
 
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanProductID = createLoanProduct(false, NONE);
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, null, null, "12,000.00", collaterals);
-        final ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        final Long loanProductID = createLoanProduct(false, NONE);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID, null, null, "12,000.00", collaterals);
+        final List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
         verifyLoanRepaymentSchedule(loanSchedule);
     }
 
     @Test
     public void validateClientLoanWithUniqueExternalId() {
         // Given
-        final ResponseSpecification responseSpec403 = new ResponseSpecBuilder().expectStatusCode(403).build();
-
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        final Integer loanProductID = createLoanProduct(false, NONE);
+        final Long clientID = createClient();
+        final Long loanProductID = createLoanProduct(false, NONE);
 
         final String externalId = UUID.randomUUID().toString();
 
         // When
-        final Integer loanID = applyForLoanApplicationWithExternalId(REQUEST_SPEC, RESPONSE_SPEC, clientID, loanProductID, "12,000.00",
-                externalId);
+        final Long loanID = applyForLoanApplicationWithExternalId(clientID, loanProductID, "12,000.00", externalId);
 
         // Then
         assertNotNull(loanID);
-        applyForLoanApplicationWithExternalId(REQUEST_SPEC, responseSpec403, clientID, loanProductID, "12,000.00", externalId);
+        CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
+                () -> applyForLoanApplicationWithExternalId(clientID, loanProductID, "12,000.00", externalId));
+        assertEquals(403, exception.getStatus());
     }
 
     @Test
     public void testAddingLoanChargeIncludesLoanIdInTheResponse() {
         // given
-        Integer clientId = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        Integer loanProductId = createLoanProduct(false, NONE);
-        Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
-        Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientId), collateralId);
-        List<HashMap> collaterals = List.of(collaterals(clientCollateralId, BigDecimal.ONE));
+        Long clientId = createClient();
+        Long loanProductId = createLoanProduct(false, NONE);
+        Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
+        Long clientCollateralId = collateralHelper.createClientCollateral(clientId, collateralId).getResourceId();
+        List<PostLoansRequestCollateralData> collaterals = List.of(collateral(clientCollateralId, BigDecimal.ONE));
 
-        Integer chargeId = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanDisbursementJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1"));
-        List<HashMap> charges = List.of(charges(chargeId, "1", null));
+        Long chargeId = chargesHelper.createLoanDisbursementCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0).getResourceId();
+        List<PostLoansRequestChargeData> charges = List.of(charge(chargeId, 1.0, null));
         // when
-        Integer loanId = applyForLoanApplication(clientId, loanProductId, charges, null, "12,000.00", collaterals);
+        Long loanId = applyForLoanApplication(clientId, loanProductId, charges, null, "12,000.00", collaterals);
         // then
-        List<HashMap> loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanId);
-        Integer loanChargeId = (Integer) loanCharges.get(0).get("id");
-        HashMap loanChargeDetail = LOAN_TRANSACTION_HELPER.getLoanCharge(loanId, loanChargeId);
-        assertEquals(loanId, loanChargeDetail.get("loanId"));
+        List<GetLoansLoanIdChargesChargeIdResponse> loanCharges = getLoanCharges(loanId);
+        Long loanChargeId = loanCharges.get(0).getId();
+        GetLoansLoanIdChargesChargeIdResponse loanChargeDetail = getLoanCharge(loanId, loanChargeId);
+        assertEquals(loanId, loanChargeDetail.getLoanId());
     }
 
     @Test
     public void testLoanCharges_DISBURSEMENT_FEE() {
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProduct(false, NONE);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Long loanProductID = createLoanProduct(false, NONE);
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
         Assertions.assertNotNull(collateralId);
-        List<HashMap> collaterals = new ArrayList<>();
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
         Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        List<HashMap> charges = new ArrayList<>();
-        Integer flatDisbursement = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC, ChargesHelper.getLoanDisbursementJSON());
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
+        Long flatDisbursement = chargesHelper.createLoanDisbursementCharge(ChargeCalculationType.FLAT, 100.0).getResourceId();
 
-        Integer amountPercentage = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanDisbursementJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1"));
-        addCharges(charges, amountPercentage, "1", null);
-        Integer amountPlusInterestPercentage = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanDisbursementJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT_AND_INTEREST, "1"));
-        addCharges(charges, amountPlusInterestPercentage, "1", null);
-        Integer interestPercentage = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanDisbursementJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_INTEREST, "1"));
-        addCharges(charges, interestPercentage, "1", null);
+        Long amountPercentage = chargesHelper.createLoanDisbursementCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0).getResourceId();
+        addCharges(charges, amountPercentage, 1.0, null);
+        Long amountPlusInterestPercentage = chargesHelper
+                .createLoanDisbursementCharge(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST, 1.0).getResourceId();
+        addCharges(charges, amountPlusInterestPercentage, 1.0, null);
+        Long interestPercentage = chargesHelper.createLoanDisbursementCharge(ChargeCalculationType.PERCENT_OF_INTEREST, 1.0)
+                .getResourceId();
+        addCharges(charges, interestPercentage, 1.0, null);
 
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
         Assertions.assertNotNull(loanID);
 
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap disbursementDetail = loanSchedule.get(0);
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod disbursementDetail = loanSchedule.get(0);
 
-        List<HashMap> loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        List<GetLoansLoanIdChargesChargeIdResponse> loanCharges = getLoanCharges(loanID);
 
         validateCharge(amountPercentage, loanCharges, "1.0", "120.0", "0.0", "0.0");
         validateCharge(interestPercentage, loanCharges, "1.0", "6.06", "0.0", "0.0");
         validateCharge(amountPlusInterestPercentage, loanCharges, "1.0", "126.06", "0.0", "0.0");
 
-        validateNumberForEqual("252.12", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        validateNumberForEqual("252.12", String.valueOf(disbursementDetail.getFeeChargesDue()));
 
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID,
-                LoanTransactionHelper.getDisbursementChargesForLoanAsJSON(String.valueOf(flatDisbursement)));
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        addDisbursementCharge(loanID, flatDisbursement, 100.0);
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         disbursementDetail = loanSchedule.get(0);
 
         validateCharge(flatDisbursement, loanCharges, "100.0", "100.0", "0.0", "0.0");
-        validateNumberForEqual("352.12", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        validateNumberForEqual("352.12", String.valueOf(disbursementDetail.getFeeChargesDue()));
 
-        LOAN_TRANSACTION_HELPER.updateChargesForLoan(loanID, (Integer) getloanCharge(amountPercentage, loanCharges).get("id"),
-                LoanTransactionHelper.getUpdateChargesForLoanAsJSON("2"));
-        LOAN_TRANSACTION_HELPER.updateChargesForLoan(loanID, (Integer) getloanCharge(interestPercentage, loanCharges).get("id"),
-                LoanTransactionHelper.getUpdateChargesForLoanAsJSON("2"));
-        LOAN_TRANSACTION_HELPER.updateChargesForLoan(loanID, (Integer) getloanCharge(amountPlusInterestPercentage, loanCharges).get("id"),
-                LoanTransactionHelper.getUpdateChargesForLoanAsJSON("2"));
-        LOAN_TRANSACTION_HELPER.updateChargesForLoan(loanID, (Integer) getloanCharge(flatDisbursement, loanCharges).get("id"),
-                LoanTransactionHelper.getUpdateChargesForLoanAsJSON("150"));
+        updateLoanCharge(loanID, getloanCharge(amountPercentage, loanCharges).getId(),
+                new PutLoansLoanIdChargesChargeIdRequest().amount(2.0).locale(LOCALE).dateFormat(DATETIME_PATTERN));
+        updateLoanCharge(loanID, getloanCharge(interestPercentage, loanCharges).getId(),
+                new PutLoansLoanIdChargesChargeIdRequest().amount(2.0).locale(LOCALE).dateFormat(DATETIME_PATTERN));
+        updateLoanCharge(loanID, getloanCharge(amountPlusInterestPercentage, loanCharges).getId(),
+                new PutLoansLoanIdChargesChargeIdRequest().amount(2.0).locale(LOCALE).dateFormat(DATETIME_PATTERN));
+        updateLoanCharge(loanID, getloanCharge(flatDisbursement, loanCharges).getId(),
+                new PutLoansLoanIdChargesChargeIdRequest().amount(150.0).locale(LOCALE).dateFormat(DATETIME_PATTERN));
 
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         disbursementDetail = loanSchedule.get(0);
         validateCharge(amountPercentage, loanCharges, "2.0", "240.0", "0.0", "0.0");
         validateCharge(interestPercentage, loanCharges, "2.0", "12.12", "0.0", "0.0");
         validateCharge(amountPlusInterestPercentage, loanCharges, "2.0", "252.12", "0.0", "0.0");
         validateCharge(flatDisbursement, loanCharges, "150.0", "150.0", "0.0", "0.0");
-        validateNumberForEqual("654.24", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        validateNumberForEqual("654.24", String.valueOf(disbursementDetail.getFeeChargesDue()));
 
-        LOAN_TRANSACTION_HELPER.updateLoan(loanID,
-                updateLoanJson(clientID, loanProductID, copyChargesForUpdate(loanCharges, null, null), null, collaterals));
+        modifyLoanApplication(loanID, null,
+                updateLoanRequest(clientID, loanProductID, copyChargesForUpdate(loanCharges, null, null), null, collaterals));
 
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         disbursementDetail = loanSchedule.get(0);
         validateCharge(amountPercentage, loanCharges, "2.0", "200.0", "0.0", "0.0");
         validateCharge(interestPercentage, loanCharges, "2.0", "10.1", "0.0", "0.0");
         validateCharge(amountPlusInterestPercentage, loanCharges, "2.0", "210.1", "0.0", "0.0");
         validateCharge(flatDisbursement, loanCharges, "150.0", "150.0", "0.0", "0.0");
-        validateNumberForEqual("570.2", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        validateNumberForEqual("570.2", String.valueOf(disbursementDetail.getFeeChargesDue()));
 
-        LOAN_TRANSACTION_HELPER.updateLoan(loanID,
-                updateLoanJson(clientID, loanProductID, copyChargesForUpdate(loanCharges, flatDisbursement, "1"), null, collaterals));
+        modifyLoanApplication(loanID, null,
+                updateLoanRequest(clientID, loanProductID, copyChargesForUpdate(loanCharges, flatDisbursement, 1.0), null, collaterals));
 
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         disbursementDetail = loanSchedule.get(0);
         validateCharge(amountPercentage, loanCharges, "1.0", "100.0", "0.0", "0.0");
         validateCharge(interestPercentage, loanCharges, "1.0", "5.05", "0.0", "0.0");
         validateCharge(amountPlusInterestPercentage, loanCharges, "1.0", "105.05", "0.0", "0.0");
-        validateNumberForEqual("210.1", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        validateNumberForEqual("210.1", String.valueOf(disbursementDetail.getFeeChargesDue()));
 
         charges.clear();
-        addCharges(charges, flatDisbursement, "100", null);
-        LOAN_TRANSACTION_HELPER.updateLoan(loanID, updateLoanJson(clientID, loanProductID, charges, null, collaterals));
+        addCharges(charges, flatDisbursement, 100.0, null);
+        modifyLoanApplication(loanID, null, updateLoanRequest(clientID, loanProductID, toUpdateCharges(charges), null, collaterals));
 
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         disbursementDetail = loanSchedule.get(0);
         validateCharge(flatDisbursement, loanCharges, "100.0", "100.0", "0.0", "0.0");
-        validateNumberForEqual("100.0", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        validateNumberForEqual("100.0", String.valueOf(disbursementDetail.getFeeChargesDue()));
 
-        LOAN_TRANSACTION_HELPER.deleteChargesForLoan(loanID, (Integer) getloanCharge(flatDisbursement, loanCharges).get("id"));
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        deleteLoanCharge(loanID, getloanCharge(flatDisbursement, loanCharges).getId());
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         disbursementDetail = loanSchedule.get(0);
         Assertions.assertEquals(0, loanCharges.size());
-        validateNumberForEqual("0.0", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        validateNumberForEqual("0.0", String.valueOf(disbursementDetail.getFeeChargesDue()));
 
     }
 
     @Test
     public void testLoanCharges_DISBURSEMENT_FEE_WITH_AMOUNT_CHANGE() {
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProduct(false, NONE);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Long loanProductID = createLoanProduct(false, NONE);
 
-        List<HashMap> charges = new ArrayList<>();
-        Integer amountPercentage = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanDisbursementJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1"));
-        addCharges(charges, amountPercentage, "1", null);
-        Integer amountPlusInterestPercentage = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanDisbursementJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT_AND_INTEREST, "1"));
-        addCharges(charges, amountPlusInterestPercentage, "1", null);
-        Integer interestPercentage = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanDisbursementJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_INTEREST, "1"));
-        addCharges(charges, interestPercentage, "1", null);
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
+        Long amountPercentage = chargesHelper.createLoanDisbursementCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0).getResourceId();
+        addCharges(charges, amountPercentage, 1.0, null);
+        Long amountPlusInterestPercentage = chargesHelper
+                .createLoanDisbursementCharge(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST, 1.0).getResourceId();
+        addCharges(charges, amountPlusInterestPercentage, 1.0, null);
+        Long interestPercentage = chargesHelper.createLoanDisbursementCharge(ChargeCalculationType.PERCENT_OF_INTEREST, 1.0)
+                .getResourceId();
+        addCharges(charges, interestPercentage, 1.0, null);
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
         Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
         Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
         Assertions.assertNotNull(loanID);
 
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap disbursementDetail = loanSchedule.get(0);
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod disbursementDetail = loanSchedule.get(0);
 
-        List<HashMap> loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        List<GetLoansLoanIdChargesChargeIdResponse> loanCharges = getLoanCharges(loanID);
 
         validateCharge(amountPercentage, loanCharges, "1.0", "120.0", "0.0", "0.0");
         validateCharge(interestPercentage, loanCharges, "1.0", "6.06", "0.0", "0.0");
         validateCharge(amountPlusInterestPercentage, loanCharges, "1.0", "126.06", "0.0", "0.0");
-        validateNumberForEqual("252.12", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        validateNumberForEqual("252.12", String.valueOf(disbursementDetail.getFeeChargesDue()));
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("20 September 2011", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("20 September 2011", loanID));
 
         // DISBURSE
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("20 September 2011", loanID, "10000",
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LOG.info("DISBURSE {}", loanStatusHashMap.toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount("20 September 2011", loanID, "10000"));
 
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         disbursementDetail = loanSchedule.get(0);
 
         validateCharge(amountPercentage, loanCharges, "1.0", "0.0", "100.0", "0.0");
         validateCharge(interestPercentage, loanCharges, "1.0", "0.0", "5.05", "0.0");
         validateCharge(amountPlusInterestPercentage, loanCharges, "1.0", "0.0", "105.05", "0.0");
-        validateNumberForEqual("210.1", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        validateNumberForEqual("210.1", String.valueOf(disbursementDetail.getFeeChargesDue()));
 
     }
 
     @Test
     public void testLoanDisbursedTodayIsRetrieved() {
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProduct(false, NONE);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Long loanProductID = createLoanProduct(false, NONE);
 
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, "5", null);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID, 5, null);
         Assertions.assertNotNull(loanID);
 
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
         DateFormat dateFormat = new SimpleDateFormat(DATETIME_PATTERN, Locale.US);
         Calendar todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         final String LOAN_DISBURSEMENT_DATE = "2 June 2014";
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(LOAN_DISBURSEMENT_DATE, loanID));
 
         // DISBURSE on todays date so that loan can't be in arrears
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID, "10000",
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LOG.info("DISBURSE {}", loanStatusHashMap.toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-        loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID, "10000"));
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanID);
         // Test added because loans created without arrears were failing to be retrieved (associations=all) due to inner
         // join on m_loan_arrears_aging (now left join)
         Assertions.assertNotNull(loanDetails, "Empty Loan Details");
-        Assertions.assertNotNull(JsonPath.from(loanDetails).get("id"), "No id Found");
+        Assertions.assertNotNull(loanDetails.getId(), "No id Found");
 
     }
 
     @Test
     public void testLoanCharges_SPECIFIED_DUE_DATE_FEE() {
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProduct(false, NONE);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Long loanProductID = createLoanProduct(false, NONE);
 
-        List<HashMap> charges = new ArrayList<>();
-        Integer flat = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "100", false));
-        Integer flatAccTransfer = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateWithAccountTransferJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "100", false));
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
+        Long flat = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.FLAT, 100.0, false).getResourceId();
+        Long flatAccTransfer = chargesHelper.createLoanSpecifiedDueDateAccountTransferCharge(ChargeCalculationType.FLAT, 100.0, false)
+                .getResourceId();
 
-        Integer amountPercentage = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1", false));
-        addCharges(charges, amountPercentage, "1", "29 September 2011");
-        Integer amountPlusInterestPercentage = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC, ChargesHelper
-                .getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT_AND_INTEREST, "1", false));
-        addCharges(charges, amountPlusInterestPercentage, "1", "29 September 2011");
-        Integer interestPercentage = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_INTEREST, "1", false));
-        addCharges(charges, interestPercentage, "1", "29 September 2011");
+        Long amountPercentage = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0, false)
+                .getResourceId();
+        addCharges(charges, amountPercentage, 1.0, "29 September 2011");
+        Long amountPlusInterestPercentage = chargesHelper
+                .createLoanSpecifiedDueDateCharge(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST, 1.0, false).getResourceId();
+        addCharges(charges, amountPlusInterestPercentage, 1.0, "29 September 2011");
+        Long interestPercentage = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.PERCENT_OF_INTEREST, 1.0, false)
+                .getResourceId();
+        addCharges(charges, interestPercentage, 1.0, "29 September 2011");
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
         Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                clientID.toString(), collateralId);
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
         Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
         Assertions.assertNotNull(loanID);
 
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap firstInstallment = loanSchedule.get(1);
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod firstInstallment = loanSchedule.get(1);
 
-        List<HashMap> loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        List<GetLoansLoanIdChargesChargeIdResponse> loanCharges = getLoanCharges(loanID);
 
         validateCharge(amountPercentage, loanCharges, "1.0", "120.0", "0.0", "0.0");
         validateCharge(interestPercentage, loanCharges, "1.0", "6.06", "0.0", "0.0");
         validateCharge(amountPlusInterestPercentage, loanCharges, "1.0", "126.06", "0.0", "0.0");
 
-        validateNumberForEqual("252.12", String.valueOf(firstInstallment.get("feeChargesDue")));
+        validateNumberForEqual("252.12", String.valueOf(firstInstallment.getFeeChargesDue()));
 
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID,
-                LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flat), "29 September 2011", "100"));
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        addLoanCharge(loanID, flat, "29 September 2011", 100.0);
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         firstInstallment = loanSchedule.get(1);
 
         validateCharge(flat, loanCharges, "100.0", "100.0", "0.0", "0.0");
-        validateNumberForEqual("352.12", String.valueOf(firstInstallment.get("feeChargesDue")));
+        validateNumberForEqual("352.12", String.valueOf(firstInstallment.getFeeChargesDue()));
 
-        LOAN_TRANSACTION_HELPER.updateChargesForLoan(loanID, (Integer) getloanCharge(amountPercentage, loanCharges).get("id"),
-                LoanTransactionHelper.getUpdateChargesForLoanAsJSON("2"));
-        LOAN_TRANSACTION_HELPER.updateChargesForLoan(loanID, (Integer) getloanCharge(interestPercentage, loanCharges).get("id"),
-                LoanTransactionHelper.getUpdateChargesForLoanAsJSON("2"));
-        LOAN_TRANSACTION_HELPER.updateChargesForLoan(loanID, (Integer) getloanCharge(amountPlusInterestPercentage, loanCharges).get("id"),
-                LoanTransactionHelper.getUpdateChargesForLoanAsJSON("2"));
-        LOAN_TRANSACTION_HELPER.updateChargesForLoan(loanID, (Integer) getloanCharge(flat, loanCharges).get("id"),
-                LoanTransactionHelper.getUpdateChargesForLoanAsJSON("150"));
+        updateLoanCharge(loanID, getloanCharge(amountPercentage, loanCharges).getId(),
+                new PutLoansLoanIdChargesChargeIdRequest().amount(2.0).locale(LOCALE).dateFormat(DATETIME_PATTERN));
+        updateLoanCharge(loanID, getloanCharge(interestPercentage, loanCharges).getId(),
+                new PutLoansLoanIdChargesChargeIdRequest().amount(2.0).locale(LOCALE).dateFormat(DATETIME_PATTERN));
+        updateLoanCharge(loanID, getloanCharge(amountPlusInterestPercentage, loanCharges).getId(),
+                new PutLoansLoanIdChargesChargeIdRequest().amount(2.0).locale(LOCALE).dateFormat(DATETIME_PATTERN));
+        updateLoanCharge(loanID, getloanCharge(flat, loanCharges).getId(),
+                new PutLoansLoanIdChargesChargeIdRequest().amount(150.0).locale(LOCALE).dateFormat(DATETIME_PATTERN));
 
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         firstInstallment = loanSchedule.get(1);
         validateCharge(amountPercentage, loanCharges, "2.0", "240.0", "0.0", "0.0");
         validateCharge(interestPercentage, loanCharges, "2.0", "12.12", "0.0", "0.0");
         validateCharge(amountPlusInterestPercentage, loanCharges, "2.0", "252.12", "0.0", "0.0");
         validateCharge(flat, loanCharges, "150.0", "150.0", "0.0", "0.0");
-        validateNumberForEqual("654.24", String.valueOf(firstInstallment.get("feeChargesDue")));
+        validateNumberForEqual("654.24", String.valueOf(firstInstallment.getFeeChargesDue()));
 
-        final Integer savingsId = SavingsAccountHelper.openSavingsAccount(REQUEST_SPEC, RESPONSE_SPEC, clientID, MINIMUM_OPENING_BALANCE);
-        LOAN_TRANSACTION_HELPER.updateLoan(loanID, updateLoanJson(clientID, loanProductID, copyChargesForUpdate(loanCharges, null, null),
-                String.valueOf(savingsId), collaterals));
+        final Long savingsId = openSavingsAccountActivatedOnTransactionDate(clientID, MINIMUM_OPENING_BALANCE);
+        modifyLoanApplication(loanID, null,
+                updateLoanRequest(clientID, loanProductID, copyChargesForUpdate(loanCharges, null, null), savingsId, collaterals));
 
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         firstInstallment = loanSchedule.get(1);
         validateCharge(amountPercentage, loanCharges, "2.0", "200.0", "0.0", "0.0");
         validateCharge(interestPercentage, loanCharges, "2.0", "10.1", "0.0", "0.0");
         validateCharge(amountPlusInterestPercentage, loanCharges, "2.0", "210.1", "0.0", "0.0");
         validateCharge(flat, loanCharges, "150.0", "150.0", "0.0", "0.0");
-        validateNumberForEqual("570.2", String.valueOf(firstInstallment.get("feeChargesDue")));
+        validateNumberForEqual("570.2", String.valueOf(firstInstallment.getFeeChargesDue()));
 
-        LOAN_TRANSACTION_HELPER.updateLoan(loanID,
-                updateLoanJson(clientID, loanProductID, copyChargesForUpdate(loanCharges, flat, "1"), null, collaterals));
+        modifyLoanApplication(loanID, null,
+                updateLoanRequest(clientID, loanProductID, copyChargesForUpdate(loanCharges, flat, 1.0), null, collaterals));
 
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         firstInstallment = loanSchedule.get(1);
         validateCharge(amountPercentage, loanCharges, "1.0", "100.0", "0.0", "0.0");
         validateCharge(interestPercentage, loanCharges, "1.0", "5.05", "0.0", "0.0");
         validateCharge(amountPlusInterestPercentage, loanCharges, "1.0", "105.05", "0.0", "0.0");
-        validateNumberForEqual("210.1", String.valueOf(firstInstallment.get("feeChargesDue")));
+        validateNumberForEqual("210.1", String.valueOf(firstInstallment.getFeeChargesDue()));
 
         charges.clear();
-        addCharges(charges, flat, "100", "29 September 2011");
-        LOAN_TRANSACTION_HELPER.updateLoan(loanID, updateLoanJson(clientID, loanProductID, charges, null, collaterals));
+        addCharges(charges, flat, 100.0, "29 September 2011");
+        modifyLoanApplication(loanID, null, updateLoanRequest(clientID, loanProductID, toUpdateCharges(charges), null, collaterals));
 
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         firstInstallment = loanSchedule.get(1);
         validateCharge(flat, loanCharges, "100.0", "100.0", "0.0", "0.0");
-        validateNumberForEqual("100.0", String.valueOf(firstInstallment.get("feeChargesDue")));
+        validateNumberForEqual("100.0", String.valueOf(firstInstallment.getFeeChargesDue()));
 
-        LOAN_TRANSACTION_HELPER.deleteChargesForLoan(loanID, (Integer) getloanCharge(flat, loanCharges).get("id"));
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        deleteLoanCharge(loanID, getloanCharge(flat, loanCharges).getId());
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         firstInstallment = loanSchedule.get(1);
         Assertions.assertEquals(0, loanCharges.size());
-        validateNumberForEqual("0", String.valueOf(firstInstallment.get("feeChargesDue")));
+        validateNumberForEqual("0", String.valueOf(firstInstallment.getFeeChargesDue()));
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("20 September 2011", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("20 September 2011", loanID));
 
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID,
-                LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flatAccTransfer), "29 September 2011", "100"));
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        addLoanCharge(loanID, flatAccTransfer, "29 September 2011", 100.0);
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         firstInstallment = loanSchedule.get(1);
         validateCharge(flatAccTransfer, loanCharges, "100.0", "100.0", "0.0", "0.0");
-        validateNumberForEqual("100.0", String.valueOf(firstInstallment.get("feeChargesDue")));
+        validateNumberForEqual("100.0", String.valueOf(firstInstallment.getFeeChargesDue()));
 
         // DISBURSE
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("20 September 2011", loanID, "10000",
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LOG.info("DISBURSE {}", loanStatusHashMap.toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount("20 September 2011", loanID, "10000"));
 
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID,
-                LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(amountPercentage), "29 September 2011", "1"));
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        addLoanCharge(loanID, amountPercentage, "29 September 2011", 1.0);
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         firstInstallment = loanSchedule.get(1);
         validateCharge(amountPercentage, loanCharges, "1.0", "100.0", "0.0", "0.0");
         validateCharge(flatAccTransfer, loanCharges, "100.0", "100.0", "0.0", "0.0");
-        validateNumberForEqual("200.0", String.valueOf(firstInstallment.get("feeChargesDue")));
+        validateNumberForEqual("200.0", String.valueOf(firstInstallment.getFeeChargesDue()));
 
-        LOAN_TRANSACTION_HELPER.waiveChargesForLoan(loanID, (Integer) getloanCharge(amountPercentage, loanCharges).get("id"), "");
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        waiveWholeLoanCharge(loanID, getloanCharge(amountPercentage, loanCharges).getId());
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         firstInstallment = loanSchedule.get(1);
         validateCharge(amountPercentage, loanCharges, "1.0", "0.0", "0.0", "100.0");
         validateCharge(flatAccTransfer, loanCharges, "100.0", "100.0", "0.0", "0.0");
-        validateNumberForEqual("200.0", String.valueOf(firstInstallment.get("feeChargesDue")));
-        validateNumberForEqual("100.0", String.valueOf(firstInstallment.get("feeChargesOutstanding")));
-        validateNumberForEqual("100.0", String.valueOf(firstInstallment.get("feeChargesWaived")));
+        validateNumberForEqual("200.0", String.valueOf(firstInstallment.getFeeChargesDue()));
+        validateNumberForEqual("100.0", String.valueOf(firstInstallment.getFeeChargesOutstanding()));
+        validateNumberForEqual("100.0", String.valueOf(firstInstallment.getFeeChargesWaived()));
 
-        LOAN_TRANSACTION_HELPER.payChargesForLoan(loanID, (Integer) getloanCharge(flatAccTransfer, loanCharges).get("id"),
-                LoanTransactionHelper.getPayChargeJSON(SavingsAccountHelper.TRANSACTION_DATE, null));
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        payLoanCharge(loanID, getloanCharge(flatAccTransfer, loanCharges).getId(), new PostLoansLoanIdChargesChargeIdRequest()
+                .transactionDate(SAVINGS_TRANSACTION_DATE).locale(LOCALE).dateFormat(DATETIME_PATTERN));
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         firstInstallment = loanSchedule.get(1);
         validateCharge(amountPercentage, loanCharges, "1.0", "0.0", "0.0", "100.0");
         validateCharge(flatAccTransfer, loanCharges, "100.0", "0.0", "100.0", "0.0");
-        validateNumberForEqual("200.0", String.valueOf(firstInstallment.get("feeChargesDue")));
-        validateNumberForEqual("100.0", String.valueOf(firstInstallment.get("feeChargesWaived")));
-        validateNumberForEqual("100.0", String.valueOf(firstInstallment.get("feeChargesPaid")));
-        validateNumberForEqual("0.0", String.valueOf(firstInstallment.get("feeChargesOutstanding")));
+        validateNumberForEqual("200.0", String.valueOf(firstInstallment.getFeeChargesDue()));
+        validateNumberForEqual("100.0", String.valueOf(firstInstallment.getFeeChargesWaived()));
+        validateNumberForEqual("100.0", String.valueOf(firstInstallment.getFeeChargesPaid()));
+        validateNumberForEqual("0.0", String.valueOf(firstInstallment.getFeeChargesOutstanding()));
     }
 
     @Test
     public void testLoanCharges_INSTALMENT_FEE() {
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProduct(false, NONE);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Long loanProductID = createLoanProduct(false, NONE);
 
-        List<HashMap> charges = new ArrayList<>();
-        Integer flat = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "50", false));
-        Integer flatAccTransfer = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanInstallmentWithAccountTransferJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "50", false));
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
+        Long flat = chargesHelper.createLoanInstallmentCharge(ChargeCalculationType.FLAT, 50.0, false).getResourceId();
+        Long flatAccTransfer = chargesHelper.createLoanInstallmentAccountTransferCharge(ChargeCalculationType.FLAT, 50.0, false)
+                .getResourceId();
 
-        Integer amountPercentage = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1", false));
-        addCharges(charges, amountPercentage, "1", "29 September 2011");
-        Integer amountPlusInterestPercentage = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT_AND_INTEREST, "1", false));
-        addCharges(charges, amountPlusInterestPercentage, "1", "29 September 2011");
-        Integer interestPercentage = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_INTEREST, "1", false));
-        addCharges(charges, interestPercentage, "1", "29 September 2011");
+        Long amountPercentage = chargesHelper.createLoanInstallmentCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0, false)
+                .getResourceId();
+        addCharges(charges, amountPercentage, 1.0, "29 September 2011");
+        Long amountPlusInterestPercentage = chargesHelper
+                .createLoanInstallmentCharge(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST, 1.0, false).getResourceId();
+        addCharges(charges, amountPlusInterestPercentage, 1.0, "29 September 2011");
+        Long interestPercentage = chargesHelper.createLoanInstallmentCharge(ChargeCalculationType.PERCENT_OF_INTEREST, 1.0, false)
+                .getResourceId();
+        addCharges(charges, interestPercentage, 1.0, "29 September 2011");
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
 
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
         Assertions.assertNotNull(loanID);
 
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
         loanSchedule.remove(0);
-        List<HashMap> loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        List<GetLoansLoanIdChargesChargeIdResponse> loanCharges = getLoanCharges(loanID);
 
         Float totalPerOfAmout = 0F;
         Float totalPerOfAmoutPlusInt = 0F;
         Float totalPerOfint = 0F;
-        for (HashMap installment : loanSchedule) {
-            Float principalDue = (Float) installment.get("principalDue");
-            Float interestDue = (Float) installment.get("interestDue");
+        for (GetLoansLoanIdRepaymentPeriod installment : loanSchedule) {
+            Float principalDue = installment.getPrincipalDue().floatValue();
+            Float interestDue = installment.getInterestDue().floatValue();
             Float principalFee = principalDue / 100;
             Float interestFee = interestDue / 100;
             Float totalInstallmentFee = (principalFee * 2) + (interestFee * 2);
-            validateNumberForEqualExcludePrecission(String.valueOf(totalInstallmentFee), String.valueOf(installment.get("feeChargesDue")));
+            validateNumberForEqualExcludePrecission(String.valueOf(totalInstallmentFee), String.valueOf(installment.getFeeChargesDue()));
             totalPerOfAmout = totalPerOfAmout + principalFee;
             totalPerOfAmoutPlusInt = totalPerOfAmoutPlusInt + principalFee + interestFee;
             totalPerOfint = totalPerOfint + interestFee;
@@ -688,21 +670,20 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         validateChargeExcludePrecission(amountPlusInterestPercentage, loanCharges, "1.0", String.valueOf(totalPerOfAmoutPlusInt), "0.0",
                 "0.0");
 
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID,
-                LoanTransactionHelper.getInstallmentChargesForLoanAsJSON(String.valueOf(flat), "50"));
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        addLoanCharge(loanID, new PostLoansLoanIdChargesRequest().chargeId(flat).amount(50.0).locale(LOCALE).dateFormat(DATETIME_PATTERN));
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         loanSchedule.remove(0);
         totalPerOfAmout = 0F;
         totalPerOfAmoutPlusInt = 0F;
         totalPerOfint = 0F;
-        for (HashMap installment : loanSchedule) {
-            Float principalDue = (Float) installment.get("principalDue");
-            Float interestDue = (Float) installment.get("interestDue");
+        for (GetLoansLoanIdRepaymentPeriod installment : loanSchedule) {
+            Float principalDue = installment.getPrincipalDue().floatValue();
+            Float interestDue = installment.getInterestDue().floatValue();
             Float principalFee = principalDue / 100;
             Float interestFee = interestDue / 100;
             Float totalInstallmentFee = (principalFee * 2) + (interestFee * 2) + 50;
-            validateNumberForEqualExcludePrecission(String.valueOf(totalInstallmentFee), String.valueOf(installment.get("feeChargesDue")));
+            validateNumberForEqualExcludePrecission(String.valueOf(totalInstallmentFee), String.valueOf(installment.getFeeChargesDue()));
             totalPerOfAmout = totalPerOfAmout + principalFee;
             totalPerOfAmoutPlusInt = totalPerOfAmoutPlusInt + principalFee + interestFee;
             totalPerOfint = totalPerOfint + interestFee;
@@ -714,28 +695,28 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
                 "0.0");
         validateChargeExcludePrecission(flat, loanCharges, "50.0", "200", "0.0", "0.0");
 
-        LOAN_TRANSACTION_HELPER.updateChargesForLoan(loanID, (Integer) getloanCharge(amountPercentage, loanCharges).get("id"),
-                LoanTransactionHelper.getUpdateChargesForLoanAsJSON("2"));
-        LOAN_TRANSACTION_HELPER.updateChargesForLoan(loanID, (Integer) getloanCharge(interestPercentage, loanCharges).get("id"),
-                LoanTransactionHelper.getUpdateChargesForLoanAsJSON("2"));
-        LOAN_TRANSACTION_HELPER.updateChargesForLoan(loanID, (Integer) getloanCharge(amountPlusInterestPercentage, loanCharges).get("id"),
-                LoanTransactionHelper.getUpdateChargesForLoanAsJSON("2"));
-        LOAN_TRANSACTION_HELPER.updateChargesForLoan(loanID, (Integer) getloanCharge(flat, loanCharges).get("id"),
-                LoanTransactionHelper.getUpdateChargesForLoanAsJSON("100"));
+        updateLoanCharge(loanID, getloanCharge(amountPercentage, loanCharges).getId(),
+                new PutLoansLoanIdChargesChargeIdRequest().amount(2.0).locale(LOCALE).dateFormat(DATETIME_PATTERN));
+        updateLoanCharge(loanID, getloanCharge(interestPercentage, loanCharges).getId(),
+                new PutLoansLoanIdChargesChargeIdRequest().amount(2.0).locale(LOCALE).dateFormat(DATETIME_PATTERN));
+        updateLoanCharge(loanID, getloanCharge(amountPlusInterestPercentage, loanCharges).getId(),
+                new PutLoansLoanIdChargesChargeIdRequest().amount(2.0).locale(LOCALE).dateFormat(DATETIME_PATTERN));
+        updateLoanCharge(loanID, getloanCharge(flat, loanCharges).getId(),
+                new PutLoansLoanIdChargesChargeIdRequest().amount(100.0).locale(LOCALE).dateFormat(DATETIME_PATTERN));
 
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         loanSchedule.remove(0);
         totalPerOfAmout = 0F;
         totalPerOfAmoutPlusInt = 0F;
         totalPerOfint = 0F;
-        for (HashMap installment : loanSchedule) {
-            Float principalDue = (Float) installment.get("principalDue");
-            Float interestDue = (Float) installment.get("interestDue");
+        for (GetLoansLoanIdRepaymentPeriod installment : loanSchedule) {
+            Float principalDue = installment.getPrincipalDue().floatValue();
+            Float interestDue = installment.getInterestDue().floatValue();
             Float principalFee = principalDue * 2 / 100;
             Float interestFee = interestDue * 2 / 100;
             Float totalInstallmentFee = (principalFee * 2) + (interestFee * 2) + 100;
-            validateNumberForEqualExcludePrecission(String.valueOf(totalInstallmentFee), String.valueOf(installment.get("feeChargesDue")));
+            validateNumberForEqualExcludePrecission(String.valueOf(totalInstallmentFee), String.valueOf(installment.getFeeChargesDue()));
             totalPerOfAmout = totalPerOfAmout + principalFee;
             totalPerOfAmoutPlusInt = totalPerOfAmoutPlusInt + principalFee + interestFee;
             totalPerOfint = totalPerOfint + interestFee;
@@ -747,23 +728,23 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
                 "0.0");
         validateChargeExcludePrecission(flat, loanCharges, "100.0", "400", "0.0", "0.0");
 
-        final Integer savingsId = SavingsAccountHelper.openSavingsAccount(REQUEST_SPEC, RESPONSE_SPEC, clientID, MINIMUM_OPENING_BALANCE);
-        LOAN_TRANSACTION_HELPER.updateLoan(loanID, updateLoanJson(clientID, loanProductID, copyChargesForUpdate(loanCharges, null, null),
-                String.valueOf(savingsId), collaterals));
+        final Long savingsId = openSavingsAccountActivatedOnTransactionDate(clientID, MINIMUM_OPENING_BALANCE);
+        modifyLoanApplication(loanID, null,
+                updateLoanRequest(clientID, loanProductID, copyChargesForUpdate(loanCharges, null, null), savingsId, collaterals));
 
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         loanSchedule.remove(0);
         totalPerOfAmout = 0F;
         totalPerOfAmoutPlusInt = 0F;
         totalPerOfint = 0F;
-        for (HashMap installment : loanSchedule) {
-            Float principalDue = (Float) installment.get("principalDue");
-            Float interestDue = (Float) installment.get("interestDue");
+        for (GetLoansLoanIdRepaymentPeriod installment : loanSchedule) {
+            Float principalDue = installment.getPrincipalDue().floatValue();
+            Float interestDue = installment.getInterestDue().floatValue();
             Float principalFee = principalDue * 2 / 100;
             Float interestFee = interestDue * 2 / 100;
             Float totalInstallmentFee = (principalFee * 2) + (interestFee * 2) + 100;
-            validateNumberForEqualExcludePrecission(String.valueOf(totalInstallmentFee), String.valueOf(installment.get("feeChargesDue")));
+            validateNumberForEqualExcludePrecission(String.valueOf(totalInstallmentFee), String.valueOf(installment.getFeeChargesDue()));
             totalPerOfAmout = totalPerOfAmout + principalFee;
             totalPerOfAmoutPlusInt = totalPerOfAmoutPlusInt + principalFee + interestFee;
             totalPerOfint = totalPerOfint + interestFee;
@@ -775,22 +756,22 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
                 "0.0");
         validateChargeExcludePrecission(flat, loanCharges, "100.0", "400", "0.0", "0.0");
 
-        LOAN_TRANSACTION_HELPER.updateLoan(loanID,
-                updateLoanJson(clientID, loanProductID, copyChargesForUpdate(loanCharges, flat, "1"), null, collaterals));
+        modifyLoanApplication(loanID, null,
+                updateLoanRequest(clientID, loanProductID, copyChargesForUpdate(loanCharges, flat, 1.0), null, collaterals));
 
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         loanSchedule.remove(0);
         totalPerOfAmout = 0F;
         totalPerOfAmoutPlusInt = 0F;
         totalPerOfint = 0F;
-        for (HashMap installment : loanSchedule) {
-            Float principalDue = (Float) installment.get("principalDue");
-            Float interestDue = (Float) installment.get("interestDue");
+        for (GetLoansLoanIdRepaymentPeriod installment : loanSchedule) {
+            Float principalDue = installment.getPrincipalDue().floatValue();
+            Float interestDue = installment.getInterestDue().floatValue();
             Float principalFee = principalDue / 100;
             Float interestFee = interestDue / 100;
             Float totalInstallmentFee = (principalFee * 2) + (interestFee * 2);
-            validateNumberForEqualExcludePrecission(String.valueOf(totalInstallmentFee), String.valueOf(installment.get("feeChargesDue")));
+            validateNumberForEqualExcludePrecission(String.valueOf(totalInstallmentFee), String.valueOf(installment.getFeeChargesDue()));
             totalPerOfAmout = totalPerOfAmout + principalFee;
             totalPerOfAmoutPlusInt = totalPerOfAmoutPlusInt + principalFee + interestFee;
             totalPerOfint = totalPerOfint + interestFee;
@@ -802,84 +783,70 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
                 "0.0");
 
         charges.clear();
-        addCharges(charges, flat, "50", "29 September 2011");
-        LOAN_TRANSACTION_HELPER.updateLoan(loanID, updateLoanJson(clientID, loanProductID, charges, null, collaterals));
+        addCharges(charges, flat, 50.0, "29 September 2011");
+        modifyLoanApplication(loanID, null, updateLoanRequest(clientID, loanProductID, toUpdateCharges(charges), null, collaterals));
 
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         loanSchedule.remove(0);
-        for (HashMap installment : loanSchedule) {
-            validateNumberForEqualExcludePrecission("50", String.valueOf(installment.get("feeChargesDue")));
+        for (GetLoansLoanIdRepaymentPeriod installment : loanSchedule) {
+            validateNumberForEqualExcludePrecission("50", String.valueOf(installment.getFeeChargesDue()));
         }
         validateChargeExcludePrecission(flat, loanCharges, "50.0", "200", "0.0", "0.0");
 
-        LOAN_TRANSACTION_HELPER.deleteChargesForLoan(loanID, (Integer) getloanCharge(flat, loanCharges).get("id"));
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        deleteLoanCharge(loanID, getloanCharge(flat, loanCharges).getId());
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         loanSchedule.remove(0);
-        for (HashMap installment : loanSchedule) {
-            validateNumberForEqualExcludePrecission("0", String.valueOf(installment.get("feeChargesDue")));
+        for (GetLoansLoanIdRepaymentPeriod installment : loanSchedule) {
+            validateNumberForEqualExcludePrecission("0", String.valueOf(installment.getFeeChargesDue()));
         }
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("20 September 2011", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("20 September 2011", loanID));
 
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID,
-                LoanTransactionHelper.getInstallmentChargesForLoanAsJSON(String.valueOf(flatAccTransfer), "100"));
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        addLoanCharge(loanID,
+                new PostLoansLoanIdChargesRequest().chargeId(flatAccTransfer).amount(100.0).locale(LOCALE).dateFormat(DATETIME_PATTERN));
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         loanSchedule.remove(0);
-        for (HashMap installment : loanSchedule) {
-            validateNumberForEqualExcludePrecission("100", String.valueOf(installment.get("feeChargesDue")));
+        for (GetLoansLoanIdRepaymentPeriod installment : loanSchedule) {
+            validateNumberForEqualExcludePrecission("100", String.valueOf(installment.getFeeChargesDue()));
         }
         validateChargeExcludePrecission(flatAccTransfer, loanCharges, "100.0", "400", "0.0", "0.0");
 
         // DISBURSE
-        String loanDetail = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("20 September 2011", loanID, "10000",
-                JsonPath.from(loanDetail).get("netDisbursalAmount").toString());
+        GetLoansLoanIdResponse loanStatusHashMap = disburseLoanWithNetDisbursalAmount("20 September 2011", loanID, "10000");
         LOG.info("DISBURSE {}", loanStatusHashMap.toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(loanStatusHashMap);
 
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID,
-                LoanTransactionHelper.getInstallmentChargesForLoanAsJSON(String.valueOf(flat), "50"));
+        addLoanCharge(loanID, new PostLoansLoanIdChargesRequest().chargeId(flat).amount(50.0).locale(LOCALE).dateFormat(DATETIME_PATTERN));
 
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         loanSchedule.remove(0);
-        for (HashMap installment : loanSchedule) {
-            validateNumberForEqualExcludePrecission("150", String.valueOf(installment.get("feeChargesDue")));
+        for (GetLoansLoanIdRepaymentPeriod installment : loanSchedule) {
+            validateNumberForEqualExcludePrecission("150", String.valueOf(installment.getFeeChargesDue()));
         }
         validateChargeExcludePrecission(flatAccTransfer, loanCharges, "100.0", "400", "0.0", "0.0");
         validateChargeExcludePrecission(flat, loanCharges, "50.0", "200", "0.0", "0.0");
 
-        Integer waivePeriodnum = 1;
-        final Integer waivedChargeId = LOAN_TRANSACTION_HELPER.waiveChargesForLoan(loanID,
-                (Integer) getloanCharge(flat, loanCharges).get("id"),
-                LoanTransactionHelper.getWaiveChargeJSON(String.valueOf(waivePeriodnum)));
+        Long waivePeriodnum = 1L;
+        final Long waivedChargeId = waiveLoanCharge(loanID, getloanCharge(flat, loanCharges).getId(),
+                new PostLoansLoanIdChargesChargeIdRequest().installmentNumber(waivePeriodnum).locale(LOCALE)).getResourceId();
 
         // Get loan transaction details
-        ArrayList<HashMap> loanDetails = LOAN_TRANSACTION_HELPER.getLoanTransactionDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        Assertions.assertNotNull(loanDetails, "Empty Loan Details");
-        Gson gson = new Gson();
-        Integer transId = null;
-        Integer chargeId = null;
-        for (HashMap detail : loanDetails) {
-            String resultObject = gson.toJson(detail);
-            JsonObject reportObject = JsonParser.parseString(resultObject).getAsJsonObject();
-            JsonObject type = reportObject.getAsJsonObject("type");
-            final Integer transTypeId = type.get("id").getAsInt();
-            Assertions.assertNotNull(transTypeId);
-            if (Integer.valueOf(9).compareTo(transTypeId) == 0) {
-                transId = reportObject.get("id").getAsInt();
+        List<GetLoansLoanIdTransactions> loanTransactions = getLoanDetails(loanID).getTransactions();
+        Assertions.assertNotNull(loanTransactions, "Empty Loan Details");
+        Long transId = null;
+        Long chargeId = null;
+        for (GetLoansLoanIdTransactions transaction : loanTransactions) {
+            Assertions.assertNotNull(transaction.getType().getId());
+            if (Boolean.TRUE.equals(transaction.getType().getWaiveCharges())) {
+                transId = transaction.getId();
                 Assertions.assertNotNull(transId);
-                final HashMap<String, String> map = new HashMap<>();
-                map.put("id", transId.toString());
-                map.put("loanId", loanID.toString());
-                final String putBody = gson.toJson(map);
-                chargeId = LOAN_TRANSACTION_HELPER.undoWaiveChargesForLoanReturnResourceId(loanID, transId, putBody);
+                chargeId = undoWaiveLoanCharge(loanID, transId, new PutChargeTransactionChangesRequest().id(transId).loanId(loanID))
+                        .getResourceId();
                 break;
             }
         }
@@ -887,19 +854,14 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         Assertions.assertEquals(waivedChargeId, chargeId);
 
         // Validate the undo process
-        ArrayList<HashMap> loanTransactionDetails = LOAN_TRANSACTION_HELPER.getLoanTransactionDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        List<GetLoansLoanIdTransactions> loanTransactionDetails = getLoanDetails(loanID).getTransactions();
         Assertions.assertNotNull(loanTransactionDetails, "Empty Loan Transaction Details");
         for (int i = 0; i < loanTransactionDetails.size(); i++) {
-            String resultObject = gson.toJson(loanTransactionDetails.get(i));
-            JsonObject reportObject = JsonParser.parseString(resultObject).getAsJsonObject();
-            final Boolean isReversed = reportObject.get("manuallyReversed").getAsBoolean();
-            final Integer id = reportObject.get("id").getAsInt();
+            final Boolean isReversed = loanTransactionDetails.get(i).getManuallyReversed();
+            final Long id = loanTransactionDetails.get(i).getId();
 
             if (transId.compareTo(id) == 0) {
-                final HashMap chargeDetails = LOAN_TRANSACTION_HELPER.getLoanCharge(loanID, waivedChargeId);
-                String resultChargeObject = gson.toJson(chargeDetails);
-                JsonObject reportChargeObject = JsonParser.parseString(resultChargeObject).getAsJsonObject();
-                BigDecimal waiveAmount = reportChargeObject.get("amountWaived").getAsBigDecimal();
+                BigDecimal waiveAmount = BigDecimal.valueOf(getLoanCharge(loanID, waivedChargeId).getAmountWaived());
 
                 Assertions.assertEquals(true, isReversed);
                 Assertions.assertEquals(Double.valueOf(0), waiveAmount.doubleValue());
@@ -910,42 +872,42 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         }
 
         // Re-waive charge
-        LOAN_TRANSACTION_HELPER.waiveChargesForLoan(loanID, waivedChargeId,
-                LoanTransactionHelper.getWaiveChargeJSON(String.valueOf(waivePeriodnum)));
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        waiveLoanCharge(loanID, waivedChargeId,
+                new PostLoansLoanIdChargesChargeIdRequest().installmentNumber(waivePeriodnum).locale(LOCALE));
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         loanSchedule.remove(0);
-        for (HashMap installment : loanSchedule) {
-            validateNumberForEqualExcludePrecission("150", String.valueOf(installment.get("feeChargesDue")));
-            if (waivePeriodnum.equals(installment.get("period"))) {
-                validateNumberForEqualExcludePrecission("100.0", String.valueOf(installment.get("feeChargesOutstanding")));
-                validateNumberForEqualExcludePrecission("50.0", String.valueOf(installment.get("feeChargesWaived")));
+        for (GetLoansLoanIdRepaymentPeriod installment : loanSchedule) {
+            validateNumberForEqualExcludePrecission("150", String.valueOf(installment.getFeeChargesDue()));
+            if (isPeriod(installment, waivePeriodnum)) {
+                validateNumberForEqualExcludePrecission("100.0", String.valueOf(installment.getFeeChargesOutstanding()));
+                validateNumberForEqualExcludePrecission("50.0", String.valueOf(installment.getFeeChargesWaived()));
             } else {
-                validateNumberForEqualExcludePrecission("150.0", String.valueOf(installment.get("feeChargesOutstanding")));
-                validateNumberForEqualExcludePrecission("0.0", String.valueOf(installment.get("feeChargesWaived")));
+                validateNumberForEqualExcludePrecission("150.0", String.valueOf(installment.getFeeChargesOutstanding()));
+                validateNumberForEqualExcludePrecission("0.0", String.valueOf(installment.getFeeChargesWaived()));
 
             }
         }
         validateChargeExcludePrecission(flatAccTransfer, loanCharges, "100.0", "400", "0.0", "0.0");
         validateChargeExcludePrecission(flat, loanCharges, "50.0", "150", "0.0", "50.0");
 
-        Integer payPeriodnum = 2;
-        LOAN_TRANSACTION_HELPER.payChargesForLoan(loanID, (Integer) getloanCharge(flatAccTransfer, loanCharges).get("id"),
-                LoanTransactionHelper.getPayChargeJSON(SavingsAccountHelper.TRANSACTION_DATE, String.valueOf(payPeriodnum)));
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        Long payPeriodnum = 2L;
+        payLoanCharge(loanID, getloanCharge(flatAccTransfer, loanCharges).getId(), new PostLoansLoanIdChargesChargeIdRequest()
+                .transactionDate(SAVINGS_TRANSACTION_DATE).installmentNumber(payPeriodnum).locale(LOCALE).dateFormat(DATETIME_PATTERN));
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         loanSchedule.remove(0);
-        for (HashMap installment : loanSchedule) {
-            validateNumberForEqualExcludePrecission("150", String.valueOf(installment.get("feeChargesDue")));
-            if (payPeriodnum.equals(installment.get("period"))) {
-                validateNumberForEqualExcludePrecission("50.0", String.valueOf(installment.get("feeChargesOutstanding")));
-                validateNumberForEqualExcludePrecission("100.0", String.valueOf(installment.get("feeChargesPaid")));
-            } else if (waivePeriodnum.equals(installment.get("period"))) {
-                validateNumberForEqualExcludePrecission("100.0", String.valueOf(installment.get("feeChargesOutstanding")));
-                validateNumberForEqualExcludePrecission("50.0", String.valueOf(installment.get("feeChargesWaived")));
+        for (GetLoansLoanIdRepaymentPeriod installment : loanSchedule) {
+            validateNumberForEqualExcludePrecission("150", String.valueOf(installment.getFeeChargesDue()));
+            if (isPeriod(installment, payPeriodnum)) {
+                validateNumberForEqualExcludePrecission("50.0", String.valueOf(installment.getFeeChargesOutstanding()));
+                validateNumberForEqualExcludePrecission("100.0", String.valueOf(installment.getFeeChargesPaid()));
+            } else if (isPeriod(installment, waivePeriodnum)) {
+                validateNumberForEqualExcludePrecission("100.0", String.valueOf(installment.getFeeChargesOutstanding()));
+                validateNumberForEqualExcludePrecission("50.0", String.valueOf(installment.getFeeChargesWaived()));
             } else {
-                validateNumberForEqualExcludePrecission("150.0", String.valueOf(installment.get("feeChargesOutstanding")));
-                validateNumberForEqualExcludePrecission("0.0", String.valueOf(installment.get("feeChargesPaid")));
+                validateNumberForEqualExcludePrecission("150.0", String.valueOf(installment.getFeeChargesOutstanding()));
+                validateNumberForEqualExcludePrecission("0.0", String.valueOf(installment.getFeeChargesPaid()));
 
             }
         }
@@ -953,90 +915,81 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         validateChargeExcludePrecission(flat, loanCharges, "50.0", "150", "0.0", "50.0");
 
         // Loan Charges with US Locale using the amount as a number in the JSON body
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID,
-                LoanTransactionHelper.getInstallmentChargesForLoanAsJSON(String.valueOf(flat), 50.05, Locale.US));
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        addInstallmentChargeWithLocale(loanID, flat, 50.05, Locale.US);
+        loanCharges = getLoanCharges(loanID);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         loanSchedule.remove(0);
-        for (HashMap installment : loanSchedule) {
-            validateNumberForEqualExcludePrecission("200.05", String.valueOf(installment.get("feeChargesDue")));
+        for (GetLoansLoanIdRepaymentPeriod installment : loanSchedule) {
+            validateNumberForEqualExcludePrecission("200.05", String.valueOf(installment.getFeeChargesDue()));
         }
 
         // Loan Charges with other Locale using comma (,) as decimal delimiter
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID,
-                LoanTransactionHelper.getInstallmentChargesForLoanAsJSON(String.valueOf(flat), "50,05", Locale.GERMAN));
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        addInstallmentChargeWithLocaleFormattedAmount(loanID, flat, "50,05", Locale.GERMAN);
+        loanCharges = getLoanCharges(loanID);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         loanSchedule.remove(0);
-        for (HashMap installment : loanSchedule) {
-            validateNumberForEqualExcludePrecission("250.10", String.valueOf(installment.get("feeChargesDue")));
+        for (GetLoansLoanIdRepaymentPeriod installment : loanSchedule) {
+            validateNumberForEqualExcludePrecission("250.10", String.valueOf(installment.getFeeChargesDue()));
         }
 
         // Loan Charges with German Locale (where the comma is the decimal delimiter) using the amount as a number in
         // the JSON body
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID,
-                LoanTransactionHelper.getInstallmentChargesForLoanAsJSON(String.valueOf(flat), 50.05, Locale.GERMAN));
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        addInstallmentChargeWithLocale(loanID, flat, 50.05, Locale.GERMAN);
+        loanCharges = getLoanCharges(loanID);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         loanSchedule.remove(0);
-        for (HashMap installment : loanSchedule) {
-            validateNumberForEqualExcludePrecission("300.15", String.valueOf(installment.get("feeChargesDue")));
+        for (GetLoansLoanIdRepaymentPeriod installment : loanSchedule) {
+            validateNumberForEqualExcludePrecission("300.15", String.valueOf(installment.getFeeChargesDue()));
         }
     }
 
     @Test
     public void testLoanCharges_DISBURSEMENT_TO_SAVINGS() {
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProduct(false, NONE);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Long loanProductID = createLoanProduct(false, NONE);
 
-        final Integer savingsId = SavingsAccountHelper.openSavingsAccount(REQUEST_SPEC, RESPONSE_SPEC, clientID, MINIMUM_OPENING_BALANCE);
+        final Long savingsId = openSavingsAccountActivatedOnTransactionDate(clientID, MINIMUM_OPENING_BALANCE);
 
-        List<HashMap> collaterals = new ArrayList<>();
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
         Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
         Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, null, savingsId.toString(), "12,000.00", collaterals);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID, null, savingsId, "12,000.00", collaterals);
         Assertions.assertNotNull(loanID);
 
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("20 September 2011", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("20 September 2011", loanID));
 
-        HashMap summary = SAVINGS_ACCOUNT_HELPER.getSavingsSummary(savingsId);
+        SavingsAccountSummaryData summary = savingsHelper.getSavingsSummary(savingsId);
         float balance = Float.parseFloat(MINIMUM_OPENING_BALANCE);
-        assertEquals(balance, summary.get("accountBalance"), "Verifying opening Balance");
+        assertEquals(balance, summary.getAccountBalance().floatValue(), "Verifying opening Balance");
 
         // DISBURSE
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanToSavings(SavingsAccountHelper.TRANSACTION_DATE, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
+        GetLoansLoanIdResponse loanStatusHashMap = disburseToSavingsWithNetDisbursalAmount(SAVINGS_TRANSACTION_DATE, loanID);
         LOG.info("DISBURSE {}", loanStatusHashMap.toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(loanStatusHashMap);
 
-        summary = SAVINGS_ACCOUNT_HELPER.getSavingsSummary(savingsId);
+        summary = savingsHelper.getSavingsSummary(savingsId);
         balance = Float.parseFloat(MINIMUM_OPENING_BALANCE) + Float.parseFloat("12000");
-        assertEquals(balance, summary.get("accountBalance"), "Verifying opening Balance");
+        assertEquals(balance, summary.getAccountBalance().floatValue(), "Verifying opening Balance");
 
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.undoDisbursal(loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        undoDisbursement(loanID);
+        loanStatusHashMap = getLoanDetails(loanID);
+        verifyLoanIsApprovedAndWaitingForDisbursal(loanStatusHashMap);
 
-        summary = SAVINGS_ACCOUNT_HELPER.getSavingsSummary(savingsId);
+        summary = savingsHelper.getSavingsSummary(savingsId);
         balance = Float.parseFloat(MINIMUM_OPENING_BALANCE);
-        assertEquals(balance, summary.get("accountBalance"), "Verifying opening Balance");
+        assertEquals(balance, summary.getAccountBalance().floatValue(), "Verifying opening Balance");
 
     }
 
@@ -1050,148 +1003,133 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         }
 
         String fourMonthsfromNow = Utils.convertDateToURLFormat(fourMonthsfromNowCalendar);
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProduct(false, NONE);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Long loanProductID = createLoanProduct(false, NONE);
 
-        List<HashMap> charges = new ArrayList<>();
-        Integer disbursementFee = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanDisbursementJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_INTEREST, "5"));
-        addCharges(charges, disbursementFee, "5", null);
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
+        Long disbursementFee = chargesHelper.createLoanDisbursementCharge(ChargeCalculationType.PERCENT_OF_INTEREST, 5.0).getResourceId();
+        addCharges(charges, disbursementFee, 5.0, null);
 
-        List<HashMap> collaterals = new ArrayList<>();
-        final Integer loanID = applyForLoanApplicationWithPaymentStrategyAndPastMonth(clientID, loanProductID, charges, null, "1000",
-                LoanApplicationTestBuilder.DEFAULT_STRATEGY, fourMonthsfromNow, collaterals);
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
+        final Long loanID = applyForLoanApplicationWithPaymentStrategyAndPastMonth(clientID, loanProductID, charges, null, "1000",
+                DEFAULT_STRATEGY, fourMonthsfromNow, collaterals);
         Assertions.assertNotNull(loanID);
 
-        LOAN_TRANSACTION_HELPER.approveLoan(fourMonthsfromNow, loanID);
+        approveLoan(fourMonthsfromNow, loanID);
 
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(fourMonthsfromNow, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanID);
+        disburseLoanWithNetDisbursalAmount(fourMonthsfromNow, loanID);
 
         // check for disbursement fee: Principal 1,000 with 24% Annual Rate for 6 Months we have Total Interest of:
         // 120.00
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap disbursementDetail = loanSchedule.get(0);
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod disbursementDetail = loanSchedule.get(0);
         // Disbursement Fee: 5% of 120.00 = 6.00
-        validateNumberForEqual("6.00", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        validateNumberForEqual("6.00", String.valueOf(disbursementDetail.getFeeChargesDue()));
     }
 
     @Test
     public void testLoanCharges_DISBURSEMENT_WITH_TRANCHES() {
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProduct(true, NONE);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Long loanProductID = createLoanProduct(true, NONE);
 
-        List<HashMap> tranches = new ArrayList<>();
+        List<PostLoansDisbursementData> tranches = new ArrayList<>();
         tranches.add(createTrancheDetail("01 March 2014", "25000"));
         tranches.add(createTrancheDetail("23 April 2014", "20000"));
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
         Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                clientID.toString(), collateralId);
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
         Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanID = applyForLoanApplicationWithTranches(clientID, loanProductID, null, null, "45,000.00", tranches, collaterals);
+        final Long loanID = applyForLoanApplicationWithTranches(clientID, loanProductID, null, null, "45,000.00", tranches, collaterals);
         Assertions.assertNotNull(loanID);
 
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("01 March 2014", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("01 March 2014", loanID));
 
         // DISBURSE first Tranche
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("20 March 2014", loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanID);
+        GetLoansLoanIdResponse loanStatusHashMap = disburseLoanWithNetDisbursalAmount("20 March 2014", loanID);
         LOG.info("DISBURSE {}", loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(loanStatusHashMap);
 
         // DISBURSE Second Tranche
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("23 April 2014", loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
+        loanStatusHashMap = disburseLoanWithNetDisbursalAmount("23 April 2014", loanID);
         LOG.info("DISBURSE {}", loanStatusHashMap.toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(loanStatusHashMap);
 
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.undoDisbursal(loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        undoDisbursement(loanID);
+        loanStatusHashMap = getLoanDetails(loanID);
+        verifyLoanIsApprovedAndWaitingForDisbursal(loanStatusHashMap);
 
     }
 
     @Test
     public void testLoanCharges_DISBURSEMENT_TO_SAVINGS_WITH_TRANCHES() {
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProduct(true, NONE);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Long loanProductID = createLoanProduct(true, NONE);
 
-        final Integer savingsId = SavingsAccountHelper.openSavingsAccount(REQUEST_SPEC, RESPONSE_SPEC, clientID, MINIMUM_OPENING_BALANCE);
+        final Long savingsId = openSavingsAccountActivatedOnTransactionDate(clientID, MINIMUM_OPENING_BALANCE);
 
-        List<HashMap> tranches = new ArrayList<>();
+        List<PostLoansDisbursementData> tranches = new ArrayList<>();
         tranches.add(createTrancheDetail("01 March 2014", "25000"));
         tranches.add(createTrancheDetail("23 April 2014", "20000"));
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
         Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
         Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanID = applyForLoanApplicationWithTranches(clientID, loanProductID, null, savingsId.toString(), "45,000.00",
-                tranches, collaterals);
+        final Long loanID = applyForLoanApplicationWithTranches(clientID, loanProductID, null, savingsId, "45,000.00", tranches,
+                collaterals);
         Assertions.assertNotNull(loanID);
 
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("01 March 2014", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("01 March 2014", loanID));
 
-        HashMap summary = SAVINGS_ACCOUNT_HELPER.getSavingsSummary(savingsId);
+        SavingsAccountSummaryData summary = savingsHelper.getSavingsSummary(savingsId);
         float balance = Float.parseFloat(MINIMUM_OPENING_BALANCE);
-        assertEquals(balance, summary.get("accountBalance"), "Verifying opening Balance");
+        assertEquals(balance, summary.getAccountBalance().floatValue(), "Verifying opening Balance");
 
         // DISBURSE first Tranche
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanToSavings("01 March 2014", loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
+        GetLoansLoanIdResponse loanStatusHashMap = disburseToSavingsWithNetDisbursalAmount("01 March 2014", loanID);
         LOG.info("DISBURSE {}", loanStatusHashMap.toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(loanStatusHashMap);
 
-        summary = SAVINGS_ACCOUNT_HELPER.getSavingsSummary(savingsId);
+        summary = savingsHelper.getSavingsSummary(savingsId);
         balance = Float.parseFloat(MINIMUM_OPENING_BALANCE) + Float.parseFloat("25000");
-        assertEquals(balance, summary.get("accountBalance"), "Verifying opening Balance");
+        assertEquals(balance, summary.getAccountBalance().floatValue(), "Verifying opening Balance");
 
         // DISBURSE Second Tranche
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanToSavings("23 April 2014", loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
+        loanStatusHashMap = disburseToSavingsWithNetDisbursalAmount("23 April 2014", loanID);
         LOG.info("DISBURSE {}", loanStatusHashMap.toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(loanStatusHashMap);
 
-        summary = SAVINGS_ACCOUNT_HELPER.getSavingsSummary(savingsId);
+        summary = savingsHelper.getSavingsSummary(savingsId);
         balance = Float.parseFloat(MINIMUM_OPENING_BALANCE) + Float.parseFloat("25000") + Float.parseFloat("20000");
-        assertEquals(balance, summary.get("accountBalance"), "Verifying opening Balance");
+        assertEquals(balance, summary.getAccountBalance().floatValue(), "Verifying opening Balance");
 
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.undoDisbursal(loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        undoDisbursement(loanID);
+        loanStatusHashMap = getLoanDetails(loanID);
+        verifyLoanIsApprovedAndWaitingForDisbursal(loanStatusHashMap);
 
-        summary = SAVINGS_ACCOUNT_HELPER.getSavingsSummary(savingsId);
+        summary = savingsHelper.getSavingsSummary(savingsId);
         balance = Float.parseFloat(MINIMUM_OPENING_BALANCE);
-        assertEquals(balance, summary.get("accountBalance"), "Verifying opening Balance");
+        assertEquals(balance, summary.getAccountBalance().floatValue(), "Verifying opening Balance");
 
     }
 
@@ -1201,184 +1139,174 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void loanWithFlatCahargesAndCashBasedAccountingEnabled() {
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
 
         // Add charges with payment mode regular
-        List<HashMap> charges = new ArrayList<>();
-        Integer flatDisbursement = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC, ChargesHelper.getLoanDisbursementJSON());
-        addCharges(charges, flatDisbursement, "100", null);
-        Integer flatSpecifiedDueDate = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "100", false));
-        addCharges(charges, flatSpecifiedDueDate, "100", "29 September 2011");
-        Integer flatInstallmentFee = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "50", false));
-        addCharges(charges, flatInstallmentFee, "50", null);
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
+        Long flatDisbursement = chargesHelper.createLoanDisbursementCharge(ChargeCalculationType.FLAT, 100.0).getResourceId();
+        addCharges(charges, flatDisbursement, 100.0, null);
+        Long flatSpecifiedDueDate = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.FLAT, 100.0, false)
+                .getResourceId();
+        addCharges(charges, flatSpecifiedDueDate, 100.0, "29 September 2011");
+        Long flatInstallmentFee = chargesHelper.createLoanInstallmentCharge(ChargeCalculationType.FLAT, 50.0, false).getResourceId();
+        addCharges(charges, flatInstallmentFee, 50.0, null);
 
-        final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-        final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-        final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-        final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+        final Account assetAccount = accountHelper.createAssetAccount();
+        final Account incomeAccount = accountHelper.createIncomeAccount();
+        final Account expenseAccount = accountHelper.createExpenseAccount();
+        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
 
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanProductID = createLoanProduct(false, CASH_BASED, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
+        final Long loanProductID = createLoanProduct(false, CASH_BASED, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
 
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
         verifyLoanRepaymentSchedule(loanSchedule);
 
-        List<HashMap> loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        List<GetLoansLoanIdChargesChargeIdResponse> loanCharges = getLoanCharges(loanID);
         validateCharge(flatDisbursement, loanCharges, "100", "100.00", "0.0", "0.0");
         validateCharge(flatSpecifiedDueDate, loanCharges, "100", "100.00", "0.0", "0.0");
         validateCharge(flatInstallmentFee, loanCharges, "50", "200.00", "0.0", "0.0");
 
         // check for disbursement fee
-        HashMap disbursementDetail = loanSchedule.get(0);
-        validateNumberForEqual("100.00", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod disbursementDetail = loanSchedule.get(0);
+        validateNumberForEqual("100.00", String.valueOf(disbursementDetail.getFeeChargesDue()));
 
         // check for charge at specified date and installment fee
-        HashMap firstInstallment = loanSchedule.get(1);
-        validateNumberForEqual("150.00", String.valueOf(firstInstallment.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod firstInstallment = loanSchedule.get(1);
+        validateNumberForEqual("150.00", String.valueOf(firstInstallment.getFeeChargesDue()));
 
         // check for installment fee
-        HashMap secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("50.00", String.valueOf(secondInstallment.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod secondInstallment = loanSchedule.get(2);
+        validateNumberForEqual("50.00", String.valueOf(secondInstallment.getFeeChargesDue()));
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("20 September 2011", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("20 September 2011", loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("20 September 2011", loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount("20 September 2011", loanID));
 
-        final JournalEntry[] assetAccountInitialEntry = { new JournalEntry(Float.parseFloat("100.00"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.DEBIT) };
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", assetAccountInitialEntry);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 September 2011",
-                new JournalEntry(Float.parseFloat("100.00"), JournalEntry.TransactionType.CREDIT));
+        final LoanTestData.Journal[] assetAccountInitialEntry = {
+                journalEntry(Float.parseFloat("100.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()) };
+        checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", assetAccountInitialEntry);
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 September 2011",
+                journalEntry(Float.parseFloat("100.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(flatDisbursement, loanCharges, "100", "0.00", "100.0", "0.0");
 
         LOG.info("-------------Make repayment 1-----------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 October 2011", Float.parseFloat("3301.49"), loanID);
+        makeRepayment("20 October 2011", Float.parseFloat("3301.49"), loanID);
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(flatDisbursement, loanCharges, "100", "0.00", "100.0", "0.0");
         validateCharge(flatSpecifiedDueDate, loanCharges, "100", "0.00", "100.0", "0.0");
         validateCharge(flatInstallmentFee, loanCharges, "50", "150.00", "50.0", "0.0");
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("3301.49"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("2911.49"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("150.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("240.00"), JournalEntry.TransactionType.CREDIT));
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flatSpecifiedDueDate), "29 October 2011", "100"));
+        checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("3301.49"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("2911.49"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("150.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("240.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
+        addLoanCharge(loanID, flatSpecifiedDueDate, "29 October 2011", 100.0);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
 
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("150.00", String.valueOf(secondInstallment.get("feeChargesDue")));
-        LOAN_TRANSACTION_HELPER.waiveChargesForLoan(loanID, (Integer) getloanCharge(flatInstallmentFee, loanCharges).get("id"),
-                LoanTransactionHelper.getWaiveChargeJSON(String.valueOf(2)));
+        validateNumberForEqual("150.00", String.valueOf(secondInstallment.getFeeChargesDue()));
+        waiveLoanCharge(loanID, getloanCharge(flatInstallmentFee, loanCharges).getId(),
+                new PostLoansLoanIdChargesChargeIdRequest().installmentNumber(2L).locale(LOCALE));
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(flatInstallmentFee, loanCharges, "50", "100.00", "50.0", "50.0");
 
         LOG.info("----------Make repayment 2------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3251.49"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("3251.49"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("2969.72"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("100.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("181.77"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 November 2011", Float.parseFloat("3251.49"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("3251.49"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("2969.72"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("100.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("181.77"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("0", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("--------------Waive interest---------------");
-        LOAN_TRANSACTION_HELPER.waiveInterest("20 December 2011", String.valueOf(61.79), loanID);
+        waiveInterestOnLoan(loanID, "20 December 2011", 61.79);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap thirdInstallment = loanSchedule.get(3);
-        validateNumberForEqual("60.59", String.valueOf(thirdInstallment.get("interestOutstanding")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod thirdInstallment = loanSchedule.get(3);
+        validateNumberForEqual("60.59", String.valueOf(thirdInstallment.getInterestOutstanding()));
 
-        Integer flatPenaltySpecifiedDueDate = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "100", true));
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flatPenaltySpecifiedDueDate), "29 September 2011", "100"));
+        Long flatPenaltySpecifiedDueDate = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.FLAT, 100.0, true)
+                .getResourceId();
+        addLoanCharge(loanID, flatPenaltySpecifiedDueDate, "29 September 2011", 100.0);
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(flatPenaltySpecifiedDueDate, loanCharges, "100", "0.00", "100.0", "0.0");
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("100", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("100", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("3301.49"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("2811.49"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("100.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("150.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("240"), JournalEntry.TransactionType.CREDIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("3301.49"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("2811.49"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("100.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("150.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("240"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         LOG.info("----------Make repayment 3 advance------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3301.49"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("3301.49"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3129.11"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("50.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("122.38"), JournalEntry.TransactionType.CREDIT));
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flatPenaltySpecifiedDueDate), "10 January 2012", "100"));
+        makeRepayment("20 November 2011", Float.parseFloat("3301.49"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("3301.49"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3129.11"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("50.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("122.38"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
+        addLoanCharge(loanID, flatPenaltySpecifiedDueDate, "10 January 2012", 100.0);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("100", String.valueOf(fourthInstallment.get("penaltyChargesOutstanding")));
-        validateNumberForEqual("3239.68", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod fourthInstallment = loanSchedule.get(4);
+        validateNumberForEqual("100", String.valueOf(fourthInstallment.getPenaltyChargesOutstanding()));
+        validateNumberForEqual("3239.68", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("----------Pay applied penalty ------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("100"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("100"), JournalEntry.TransactionType.DEBIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("100.00"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 January 2012", Float.parseFloat("100"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("100"), assetAccount, JournalEntry.TransactionType.DEBIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("100.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("0", String.valueOf(fourthInstallment.get("penaltyChargesOutstanding")));
-        validateNumberForEqual("3139.68", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0", String.valueOf(fourthInstallment.getPenaltyChargesOutstanding()));
+        validateNumberForEqual("3139.68", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("----------Make repayment 4 ------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("3139.68"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("3139.68"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3089.68"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("50.00"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 January 2012", Float.parseFloat("3139.68"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("3139.68"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3089.68"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("50.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
     }
 
     /***
@@ -1388,187 +1316,178 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void loanWithChargesOfTypeAmountPercentageAndCashBasedAccountingEnabled() {
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
 
         // Add charges with payment mode regular
-        List<HashMap> charges = new ArrayList<>();
-        Integer percentageDisbursementCharge = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanDisbursementJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1"));
-        addCharges(charges, percentageDisbursementCharge, "1", null);
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
+        Long percentageDisbursementCharge = chargesHelper.createLoanDisbursementCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0)
+                .getResourceId();
+        addCharges(charges, percentageDisbursementCharge, 1.0, null);
 
-        Integer percentageSpecifiedDueDateCharge = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1", false));
-        addCharges(charges, percentageSpecifiedDueDateCharge, "1", "29 September 2011");
+        Long percentageSpecifiedDueDateCharge = chargesHelper
+                .createLoanSpecifiedDueDateCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0, false).getResourceId();
+        addCharges(charges, percentageSpecifiedDueDateCharge, 1.0, "29 September 2011");
 
-        Integer percentageInstallmentFee = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1", false));
-        addCharges(charges, percentageInstallmentFee, "1", "29 September 2011");
+        Long percentageInstallmentFee = chargesHelper.createLoanInstallmentCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0, false)
+                .getResourceId();
+        addCharges(charges, percentageInstallmentFee, 1.0, "29 September 2011");
 
-        final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-        final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-        final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-        final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+        final Account assetAccount = accountHelper.createAssetAccount();
+        final Account incomeAccount = accountHelper.createIncomeAccount();
+        final Account expenseAccount = accountHelper.createExpenseAccount();
+        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
         Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                clientID.toString(), collateralId);
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
         Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanProductID = createLoanProduct(false, CASH_BASED, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
+        final Long loanProductID = createLoanProduct(false, CASH_BASED, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
         verifyLoanRepaymentSchedule(loanSchedule);
 
-        List<HashMap> loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        List<GetLoansLoanIdChargesChargeIdResponse> loanCharges = getLoanCharges(loanID);
         validateCharge(percentageDisbursementCharge, loanCharges, "1", "120.00", "0.0", "0.0");
         validateCharge(percentageSpecifiedDueDateCharge, loanCharges, "1", "120.00", "0.0", "0.0");
         validateCharge(percentageInstallmentFee, loanCharges, "1", "120.00", "0.0", "0.0");
 
         // check for disbursement fee
-        HashMap disbursementDetail = loanSchedule.get(0);
-        validateNumberForEqual("120.00", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod disbursementDetail = loanSchedule.get(0);
+        validateNumberForEqual("120.00", String.valueOf(disbursementDetail.getFeeChargesDue()));
 
         // check for charge at specified date and installment fee
-        HashMap firstInstallment = loanSchedule.get(1);
-        validateNumberForEqual("149.11", String.valueOf(firstInstallment.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod firstInstallment = loanSchedule.get(1);
+        validateNumberForEqual("149.11", String.valueOf(firstInstallment.getFeeChargesDue()));
 
         // check for installment fee
-        HashMap secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("29.70", String.valueOf(secondInstallment.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod secondInstallment = loanSchedule.get(2);
+        validateNumberForEqual("29.70", String.valueOf(secondInstallment.getFeeChargesDue()));
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("20 September 2011", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("20 September 2011", loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("20 September 2011", loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount("20 September 2011", loanID));
 
-        final JournalEntry[] assetAccountInitialEntry = { new JournalEntry(Float.parseFloat("120.00"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.DEBIT) };
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", assetAccountInitialEntry);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 September 2011",
-                new JournalEntry(Float.parseFloat("120.00"), JournalEntry.TransactionType.CREDIT));
+        final LoanTestData.Journal[] assetAccountInitialEntry = {
+                journalEntry(Float.parseFloat("120.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()) };
+        checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", assetAccountInitialEntry);
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 September 2011",
+                journalEntry(Float.parseFloat("120.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(percentageDisbursementCharge, loanCharges, "1", "0.0", "120.00", "0.0");
 
         LOG.info("-------------Make repayment 1-----------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 October 2011", Float.parseFloat("3300.60"), loanID);
+        makeRepayment("20 October 2011", Float.parseFloat("3300.60"), loanID);
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(percentageDisbursementCharge, loanCharges, "1", "0.00", "120.00", "0.0");
         validateCharge(percentageSpecifiedDueDateCharge, loanCharges, "1", "0.00", "120.0", "0.0");
         validateCharge(percentageInstallmentFee, loanCharges, "1", "90.89", "29.11", "0.0");
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("3300.60"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("2911.49"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("149.11"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("240.00"), JournalEntry.TransactionType.CREDIT));
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(percentageSpecifiedDueDateCharge), "29 October 2011", "1"));
+        checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("3300.60"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("2911.49"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("149.11"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("240.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
+        addLoanCharge(loanID, percentageSpecifiedDueDateCharge, "29 October 2011", 1.0);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
 
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("149.70", String.valueOf(secondInstallment.get("feeChargesDue")));
-        LOAN_TRANSACTION_HELPER.waiveChargesForLoan(loanID, (Integer) getloanCharge(percentageInstallmentFee, loanCharges).get("id"),
-                LoanTransactionHelper.getWaiveChargeJSON(String.valueOf(2)));
+        validateNumberForEqual("149.70", String.valueOf(secondInstallment.getFeeChargesDue()));
+        waiveLoanCharge(loanID, getloanCharge(percentageInstallmentFee, loanCharges).getId(),
+                new PostLoansLoanIdChargesChargeIdRequest().installmentNumber(2L).locale(LOCALE));
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(percentageInstallmentFee, loanCharges, "1", "61.19", "29.11", "29.70");
 
         LOG.info("----------Make repayment 2------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3271.49"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("3271.49"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("2969.72"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("120.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("181.77"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 November 2011", Float.parseFloat("3271.49"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("3271.49"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("2969.72"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("120.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("181.77"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("0", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("--------------Waive interest---------------");
-        LOAN_TRANSACTION_HELPER.waiveInterest("20 December 2011", String.valueOf(61.79), loanID);
+        waiveInterestOnLoan(loanID, "20 December 2011", 61.79);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap thirdInstallment = loanSchedule.get(3);
-        validateNumberForEqual("60.59", String.valueOf(thirdInstallment.get("interestOutstanding")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod thirdInstallment = loanSchedule.get(3);
+        validateNumberForEqual("60.59", String.valueOf(thirdInstallment.getInterestOutstanding()));
 
-        Integer percentagePenaltySpecifiedDueDate = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1", true));
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(percentagePenaltySpecifiedDueDate), "29 September 2011", "1"));
+        Long percentagePenaltySpecifiedDueDate = chargesHelper
+                .createLoanSpecifiedDueDateCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0, true).getResourceId();
+        addLoanCharge(loanID, percentagePenaltySpecifiedDueDate, "29 September 2011", 1.0);
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(percentagePenaltySpecifiedDueDate, loanCharges, "1", "0.00", "120.0", "0.0");
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("120", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("120", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("3300.60"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("2791.49"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("120.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("149.11"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("240"), JournalEntry.TransactionType.CREDIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("3300.60"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("2791.49"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("120.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("149.11"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("240"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         LOG.info("----------Make repayment 3 advance------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3301.78"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("3301.78"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3149.11"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("30.29"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("122.38"), JournalEntry.TransactionType.CREDIT));
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(percentagePenaltySpecifiedDueDate), "10 January 2012", "1"));
+        makeRepayment("20 November 2011", Float.parseFloat("3301.78"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("3301.78"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3149.11"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("30.29"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("122.38"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
+        addLoanCharge(loanID, percentagePenaltySpecifiedDueDate, "10 January 2012", 1.0);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("120", String.valueOf(fourthInstallment.get("penaltyChargesOutstanding")));
-        validateNumberForEqual("3240.58", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod fourthInstallment = loanSchedule.get(4);
+        validateNumberForEqual("120", String.valueOf(fourthInstallment.getPenaltyChargesOutstanding()));
+        validateNumberForEqual("3240.58", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("----------Pay applied penalty ------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("120"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("120"), JournalEntry.TransactionType.DEBIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("120.00"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 January 2012", Float.parseFloat("120"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("120"), assetAccount, JournalEntry.TransactionType.DEBIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("120.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("0", String.valueOf(fourthInstallment.get("penaltyChargesOutstanding")));
-        validateNumberForEqual("3120.58", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0", String.valueOf(fourthInstallment.getPenaltyChargesOutstanding()));
+        validateNumberForEqual("3120.58", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("----------Make repayment 4 ------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("3120.58"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("3120.58"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3089.68"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("30.90"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 January 2012", Float.parseFloat("3120.58"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("3120.58"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3089.68"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("30.90"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
     }
 
     /***
@@ -1578,189 +1497,179 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void loanWithChargesOfTypeAmountPlusInterestPercentageAndCashBasedAccountingEnabled() {
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
 
         // Add charges with payment mode regular
-        List<HashMap> charges = new ArrayList<>();
-        Integer amountPlusInterestPercentageDisbursementCharge = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanDisbursementJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT_AND_INTEREST, "1"));
-        addCharges(charges, amountPlusInterestPercentageDisbursementCharge, "1", null);
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
+        Long amountPlusInterestPercentageDisbursementCharge = chargesHelper
+                .createLoanDisbursementCharge(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST, 1.0).getResourceId();
+        addCharges(charges, amountPlusInterestPercentageDisbursementCharge, 1.0, null);
 
-        Integer amountPlusInterestPercentageSpecifiedDueDateCharge = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC, ChargesHelper
-                .getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT_AND_INTEREST, "1", false));
-        addCharges(charges, amountPlusInterestPercentageSpecifiedDueDateCharge, "1", "29 September 2011");
+        Long amountPlusInterestPercentageSpecifiedDueDateCharge = chargesHelper
+                .createLoanSpecifiedDueDateCharge(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST, 1.0, false).getResourceId();
+        addCharges(charges, amountPlusInterestPercentageSpecifiedDueDateCharge, 1.0, "29 September 2011");
 
-        Integer amountPlusInterestPercentageInstallmentFee = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT_AND_INTEREST, "1", false));
-        addCharges(charges, amountPlusInterestPercentageInstallmentFee, "1", "29 September 2011");
+        Long amountPlusInterestPercentageInstallmentFee = chargesHelper
+                .createLoanInstallmentCharge(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST, 1.0, false).getResourceId();
+        addCharges(charges, amountPlusInterestPercentageInstallmentFee, 1.0, "29 September 2011");
 
-        final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-        final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-        final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-        final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+        final Account assetAccount = accountHelper.createAssetAccount();
+        final Account incomeAccount = accountHelper.createIncomeAccount();
+        final Account expenseAccount = accountHelper.createExpenseAccount();
+        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
 
         Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                clientID.toString(), collateralId);
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
         Assertions.assertNotNull(collateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanProductID = createLoanProduct(false, CASH_BASED, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
+        final Long loanProductID = createLoanProduct(false, CASH_BASED, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
         verifyLoanRepaymentSchedule(loanSchedule);
 
-        List<HashMap> loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        List<GetLoansLoanIdChargesChargeIdResponse> loanCharges = getLoanCharges(loanID);
         validateCharge(amountPlusInterestPercentageDisbursementCharge, loanCharges, "1", "126.06", "0.0", "0.0");
         validateCharge(amountPlusInterestPercentageSpecifiedDueDateCharge, loanCharges, "1", "126.06", "0.0", "0.0");
         validateCharge(amountPlusInterestPercentageInstallmentFee, loanCharges, "1", "126.04", "0.0", "0.0");
 
         // check for disbursement fee
-        HashMap disbursementDetail = loanSchedule.get(0);
-        validateNumberForEqual("126.06", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod disbursementDetail = loanSchedule.get(0);
+        validateNumberForEqual("126.06", String.valueOf(disbursementDetail.getFeeChargesDue()));
 
         // check for charge at specified date and installment fee
-        HashMap firstInstallment = loanSchedule.get(1);
-        validateNumberForEqual("157.57", String.valueOf(firstInstallment.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod firstInstallment = loanSchedule.get(1);
+        validateNumberForEqual("157.57", String.valueOf(firstInstallment.getFeeChargesDue()));
 
         // check for installment fee
-        HashMap secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("31.51", String.valueOf(secondInstallment.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod secondInstallment = loanSchedule.get(2);
+        validateNumberForEqual("31.51", String.valueOf(secondInstallment.getFeeChargesDue()));
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("20 September 2011", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("20 September 2011", loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("20 September 2011", loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount("20 September 2011", loanID));
 
-        final JournalEntry[] assetAccountInitialEntry = { new JournalEntry(Float.parseFloat("126.06"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.DEBIT) };
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", assetAccountInitialEntry);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 September 2011",
-                new JournalEntry(Float.parseFloat("126.06"), JournalEntry.TransactionType.CREDIT));
+        final LoanTestData.Journal[] assetAccountInitialEntry = {
+                journalEntry(Float.parseFloat("126.06"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()) };
+        checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", assetAccountInitialEntry);
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 September 2011",
+                journalEntry(Float.parseFloat("126.06"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(amountPlusInterestPercentageDisbursementCharge, loanCharges, "1", "0.0", "126.06", "0.0");
 
         LOG.info("-------------Make repayment 1-----------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 October 2011", Float.parseFloat("3309.06"), loanID);
+        makeRepayment("20 October 2011", Float.parseFloat("3309.06"), loanID);
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(amountPlusInterestPercentageDisbursementCharge, loanCharges, "1", "0.00", "126.06", "0.0");
         validateCharge(amountPlusInterestPercentageSpecifiedDueDateCharge, loanCharges, "1", "0.00", "126.06", "0.0");
         validateCharge(amountPlusInterestPercentageInstallmentFee, loanCharges, "1", "94.53", "31.51", "0.0");
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("3309.06"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("2911.49"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("157.57"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("240.00"), JournalEntry.TransactionType.CREDIT));
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(
-                String.valueOf(amountPlusInterestPercentageSpecifiedDueDateCharge), "29 October 2011", "1"));
+        checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("3309.06"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("2911.49"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("157.57"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("240.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
+        addLoanCharge(loanID, amountPlusInterestPercentageSpecifiedDueDateCharge, "29 October 2011", 1.0);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
 
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("157.57", String.valueOf(secondInstallment.get("feeChargesDue")));
-        LOAN_TRANSACTION_HELPER.waiveChargesForLoan(loanID,
-                (Integer) getloanCharge(amountPlusInterestPercentageInstallmentFee, loanCharges).get("id"),
-                LoanTransactionHelper.getWaiveChargeJSON(String.valueOf(2)));
+        validateNumberForEqual("157.57", String.valueOf(secondInstallment.getFeeChargesDue()));
+        waiveLoanCharge(loanID, getloanCharge(amountPlusInterestPercentageInstallmentFee, loanCharges).getId(),
+                new PostLoansLoanIdChargesChargeIdRequest().installmentNumber(2L).locale(LOCALE));
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(amountPlusInterestPercentageInstallmentFee, loanCharges, "1", "63.02", "31.51", "31.51");
 
         LOG.info("----------Make repayment 2------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3277.55"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("3277.55"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("2969.72"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("126.06"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("181.77"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 November 2011", Float.parseFloat("3277.55"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("3277.55"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("2969.72"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("126.06"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("181.77"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("0", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("--------------Waive interest---------------");
-        LOAN_TRANSACTION_HELPER.waiveInterest("20 December 2011", String.valueOf(61.79), loanID);
+        waiveInterestOnLoan(loanID, "20 December 2011", 61.79);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap thirdInstallment = loanSchedule.get(3);
-        validateNumberForEqual("60.59", String.valueOf(thirdInstallment.get("interestOutstanding")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod thirdInstallment = loanSchedule.get(3);
+        validateNumberForEqual("60.59", String.valueOf(thirdInstallment.getInterestOutstanding()));
 
-        Integer amountPlusInterestPercentagePenaltySpecifiedDueDate = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1", true));
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(
-                String.valueOf(amountPlusInterestPercentagePenaltySpecifiedDueDate), "29 September 2011", "1"));
+        Long amountPlusInterestPercentagePenaltySpecifiedDueDate = chargesHelper
+                .createLoanSpecifiedDueDateCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0, true).getResourceId();
+        addLoanCharge(loanID, amountPlusInterestPercentagePenaltySpecifiedDueDate, "29 September 2011", 1.0);
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(amountPlusInterestPercentagePenaltySpecifiedDueDate, loanCharges, "1", "0.0", "120.0", "0.0");
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("120", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("120", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("3309.06"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("2791.49"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("120.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("157.57"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("240"), JournalEntry.TransactionType.CREDIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("3309.06"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("2791.49"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("120.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("157.57"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("240"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         LOG.info("----------Make repayment 3 advance------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3303"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("3303"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3149.11"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("31.51"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("122.38"), JournalEntry.TransactionType.CREDIT));
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(
-                String.valueOf(amountPlusInterestPercentagePenaltySpecifiedDueDate), "10 January 2012", "1"));
+        makeRepayment("20 November 2011", Float.parseFloat("3303"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("3303"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3149.11"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("31.51"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("122.38"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
+        addLoanCharge(loanID, amountPlusInterestPercentagePenaltySpecifiedDueDate, "10 January 2012", 1.0);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("120", String.valueOf(fourthInstallment.get("penaltyChargesOutstanding")));
-        validateNumberForEqual("3241.19", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod fourthInstallment = loanSchedule.get(4);
+        validateNumberForEqual("120", String.valueOf(fourthInstallment.getPenaltyChargesOutstanding()));
+        validateNumberForEqual("3241.19", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("----------Pay applied penalty ------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("120"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("120"), JournalEntry.TransactionType.DEBIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("120.00"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 January 2012", Float.parseFloat("120"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("120"), assetAccount, JournalEntry.TransactionType.DEBIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("120.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("0", String.valueOf(fourthInstallment.get("penaltyChargesOutstanding")));
-        validateNumberForEqual("3121.19", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0", String.valueOf(fourthInstallment.getPenaltyChargesOutstanding()));
+        validateNumberForEqual("3121.19", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("----------Make repayment 4 ------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("3121.19"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("3121.19"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3089.68"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("31.51"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 January 2012", Float.parseFloat("3121.19"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("3121.19"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3089.68"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("31.51"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
     }
 
     /***
@@ -1769,201 +1678,190 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void loanWithFlatCahargesAndUpfrontAccrualAccountingEnabled() {
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
 
         // Add charges with payment mode regular
-        List<HashMap> charges = new ArrayList<>();
-        Integer flatDisbursement = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC, ChargesHelper.getLoanDisbursementJSON());
-        addCharges(charges, flatDisbursement, "100", null);
-        Integer flatSpecifiedDueDate = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "100", false));
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
+        Long flatDisbursement = chargesHelper.createLoanDisbursementCharge(ChargeCalculationType.FLAT, 100.0).getResourceId();
+        addCharges(charges, flatDisbursement, 100.0, null);
+        Long flatSpecifiedDueDate = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.FLAT, 100.0, false)
+                .getResourceId();
 
-        Integer flatInstallmentFee = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "50", false));
-        addCharges(charges, flatInstallmentFee, "50", null);
+        Long flatInstallmentFee = chargesHelper.createLoanInstallmentCharge(ChargeCalculationType.FLAT, 50.0, false).getResourceId();
+        addCharges(charges, flatInstallmentFee, 50.0, null);
 
-        final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-        final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-        final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-        final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+        final Account assetAccount = accountHelper.createAssetAccount();
+        final Account incomeAccount = accountHelper.createIncomeAccount();
+        final Account expenseAccount = accountHelper.createExpenseAccount();
+        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
         Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
         Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanProductID = createLoanProduct(false, ACCRUAL_UPFRONT, assetAccount, incomeAccount, expenseAccount,
+        final Long loanProductID = createLoanProduct(false, ACCRUAL_UPFRONT, assetAccount, incomeAccount, expenseAccount,
                 overpaymentAccount);
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
         verifyLoanRepaymentSchedule(loanSchedule);
 
-        List<HashMap> loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        List<GetLoansLoanIdChargesChargeIdResponse> loanCharges = getLoanCharges(loanID);
         validateCharge(flatDisbursement, loanCharges, "100", "100.00", "0.0", "0.0");
         validateCharge(flatInstallmentFee, loanCharges, "50", "200.00", "0.0", "0.0");
 
         // check for disbursement fee
-        HashMap disbursementDetail = loanSchedule.get(0);
-        validateNumberForEqual("100.00", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod disbursementDetail = loanSchedule.get(0);
+        validateNumberForEqual("100.00", String.valueOf(disbursementDetail.getFeeChargesDue()));
 
         // check for charge at specified date and installment fee
-        HashMap firstInstallment = loanSchedule.get(1);
-        validateNumberForEqual("50.00", String.valueOf(firstInstallment.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod firstInstallment = loanSchedule.get(1);
+        validateNumberForEqual("50.00", String.valueOf(firstInstallment.getFeeChargesDue()));
 
         // check for installment fee
-        HashMap secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("50.00", String.valueOf(secondInstallment.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod secondInstallment = loanSchedule.get(2);
+        validateNumberForEqual("50.00", String.valueOf(secondInstallment.getFeeChargesDue()));
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("20 September 2011", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("20 September 2011", loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("20 September 2011", loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount("20 September 2011", loanID));
 
-        final JournalEntry[] assetAccountInitialEntry = { new JournalEntry(Float.parseFloat("605.94"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("100.00"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("200.00"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.DEBIT) };
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", assetAccountInitialEntry);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 September 2011",
-                new JournalEntry(Float.parseFloat("605.94"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("100.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("200.00"), JournalEntry.TransactionType.CREDIT));
+        final LoanTestData.Journal[] assetAccountInitialEntry = {
+                journalEntry(Float.parseFloat("605.94"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("100.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("200.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()) };
+        checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", assetAccountInitialEntry);
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 September 2011",
+                journalEntry(Float.parseFloat("605.94"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("100.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("200.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
 
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flatSpecifiedDueDate), "29 September 2011", "100"));
+        addLoanCharge(loanID, flatSpecifiedDueDate, "29 September 2011", 100.0);
 
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(flatDisbursement, loanCharges, "100", "0.00", "100.0", "0.0");
         validateCharge(flatSpecifiedDueDate, loanCharges, "100", "100.00", "0.0", "0.0");
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "29 September 2011",
-                new JournalEntry(Float.parseFloat("100.00"), JournalEntry.TransactionType.DEBIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "29 September 2011",
-                new JournalEntry(Float.parseFloat("100.00"), JournalEntry.TransactionType.CREDIT));
+        checkJournalEntryForAssetAccount(assetAccount, "29 September 2011",
+                journalEntry(Float.parseFloat("100.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "29 September 2011",
+                journalEntry(Float.parseFloat("100.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         LOG.info("-------------Make repayment 1-----------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 October 2011", Float.parseFloat("3301.49"), loanID);
+        makeRepayment("20 October 2011", Float.parseFloat("3301.49"), loanID);
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(flatDisbursement, loanCharges, "100", "0.00", "100.0", "0.0");
         validateCharge(flatSpecifiedDueDate, loanCharges, "100", "0.00", "100.0", "0.0");
         validateCharge(flatInstallmentFee, loanCharges, "50", "150.00", "50.0", "0.0");
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("3301.49"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3301.49"), JournalEntry.TransactionType.CREDIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("3301.49"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3301.49"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flatSpecifiedDueDate), "29 October 2011", "100"));
+        addLoanCharge(loanID, flatSpecifiedDueDate, "29 October 2011", 100.0);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
 
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("150.00", String.valueOf(secondInstallment.get("feeChargesDue")));
+        validateNumberForEqual("150.00", String.valueOf(secondInstallment.getFeeChargesDue()));
         LOG.info("----------- Waive installment charge for 2nd installment ---------");
-        LOAN_TRANSACTION_HELPER.waiveChargesForLoan(loanID, (Integer) getloanCharge(flatInstallmentFee, loanCharges).get("id"),
-                LoanTransactionHelper.getWaiveChargeJSON(String.valueOf(2)));
+        waiveLoanCharge(loanID, getloanCharge(flatInstallmentFee, loanCharges).getId(),
+                new PostLoansLoanIdChargesChargeIdRequest().installmentNumber(2L).locale(LOCALE));
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(flatInstallmentFee, loanCharges, "50", "100.00", "50.0", "50.0");
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("50.0"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForExpenseAccount(expenseAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("50.0"), JournalEntry.TransactionType.DEBIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("50.0"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForExpenseAccount(expenseAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("50.0"), expenseAccount, JournalEntry.TransactionType.DEBIT.name()));
 
         LOG.info("----------Make repayment 2------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3251.49"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("3251.49"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3251.49"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 November 2011", Float.parseFloat("3251.49"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("3251.49"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3251.49"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("0", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("--------------Waive interest---------------");
-        LOAN_TRANSACTION_HELPER.waiveInterest("20 December 2011", String.valueOf(61.79), loanID);
+        waiveInterestOnLoan(loanID, "20 December 2011", 61.79);
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap thirdInstallment = loanSchedule.get(3);
-        validateNumberForEqual("60.59", String.valueOf(thirdInstallment.get("interestOutstanding")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod thirdInstallment = loanSchedule.get(3);
+        validateNumberForEqual("60.59", String.valueOf(thirdInstallment.getInterestOutstanding()));
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 December 2011",
-                new JournalEntry(Float.parseFloat("61.79"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForExpenseAccount(expenseAccount, "20 December 2011",
-                new JournalEntry(Float.parseFloat("61.79"), JournalEntry.TransactionType.DEBIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 December 2011",
+                journalEntry(Float.parseFloat("61.79"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForExpenseAccount(expenseAccount, "20 December 2011",
+                journalEntry(Float.parseFloat("61.79"), expenseAccount, JournalEntry.TransactionType.DEBIT.name()));
 
-        Integer flatPenaltySpecifiedDueDate = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "100", true));
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flatPenaltySpecifiedDueDate), "29 September 2011", "100"));
+        Long flatPenaltySpecifiedDueDate = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.FLAT, 100.0, true)
+                .getResourceId();
+        addLoanCharge(loanID, flatPenaltySpecifiedDueDate, "29 September 2011", 100.0);
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(flatPenaltySpecifiedDueDate, loanCharges, "100", "0.00", "100.0", "0.0");
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("100", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("100", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
         // checking the journal entry as applied penalty has been collected
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("3301.49"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3301.49"), JournalEntry.TransactionType.CREDIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("3301.49"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3301.49"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         LOG.info("----------Make repayment 3 advance------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3301.49"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("3301.49"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3301.49"), JournalEntry.TransactionType.CREDIT));
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flatPenaltySpecifiedDueDate), "10 January 2012", "100"));
+        makeRepayment("20 November 2011", Float.parseFloat("3301.49"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("3301.49"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3301.49"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        addLoanCharge(loanID, flatPenaltySpecifiedDueDate, "10 January 2012", 100.0);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("100", String.valueOf(fourthInstallment.get("penaltyChargesOutstanding")));
-        validateNumberForEqual("3239.68", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod fourthInstallment = loanSchedule.get(4);
+        validateNumberForEqual("100", String.valueOf(fourthInstallment.getPenaltyChargesOutstanding()));
+        validateNumberForEqual("3239.68", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("----------Pay applied penalty ------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("100"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("100"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("100"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 January 2012", Float.parseFloat("100"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("100"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("100"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("0", String.valueOf(fourthInstallment.get("penaltyChargesOutstanding")));
-        validateNumberForEqual("3139.68", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0", String.valueOf(fourthInstallment.getPenaltyChargesOutstanding()));
+        validateNumberForEqual("3139.68", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("----------Make over payment for repayment 4 ------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("3220.60"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("3220.60"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3139.68"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForLiabilityAccount(overpaymentAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("80.92"), JournalEntry.TransactionType.CREDIT));
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "status");
-        LoanStatusChecker.verifyLoanAccountIsOverPaid(loanStatusHashMap);
+        makeRepayment("20 January 2012", Float.parseFloat("3220.60"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("3220.60"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3139.68"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForLiabilityAccount(overpaymentAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("80.92"), overpaymentAccount, JournalEntry.TransactionType.CREDIT.name()));
+        GetLoansLoanIdResponse loanStatusHashMap = getLoanDetails(loanID);
+        verifyLoanStatus(loanStatusHashMap, GetLoansLoanIdStatus::getOverpaid);
     }
 
     /***
@@ -1973,197 +1871,188 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void loanWithCahargesAndUpfrontAccrualAccountingEnabled() {
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
 
         // Add charges with payment mode regular
-        List<HashMap> charges = new ArrayList<>();
-        Integer percentageDisbursementCharge = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanDisbursementJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1"));
-        addCharges(charges, percentageDisbursementCharge, "1", null);
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
+        Long percentageDisbursementCharge = chargesHelper.createLoanDisbursementCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0)
+                .getResourceId();
+        addCharges(charges, percentageDisbursementCharge, 1.0, null);
 
-        Integer percentageSpecifiedDueDateCharge = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1", false));
-        addCharges(charges, percentageSpecifiedDueDateCharge, "1", "29 September 2011");
+        Long percentageSpecifiedDueDateCharge = chargesHelper
+                .createLoanSpecifiedDueDateCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0, false).getResourceId();
+        addCharges(charges, percentageSpecifiedDueDateCharge, 1.0, "29 September 2011");
 
-        Integer percentageInstallmentFee = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1", false));
-        addCharges(charges, percentageInstallmentFee, "1", "29 September 2011");
+        Long percentageInstallmentFee = chargesHelper.createLoanInstallmentCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0, false)
+                .getResourceId();
+        addCharges(charges, percentageInstallmentFee, 1.0, "29 September 2011");
 
-        final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-        final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-        final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-        final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+        final Account assetAccount = accountHelper.createAssetAccount();
+        final Account incomeAccount = accountHelper.createIncomeAccount();
+        final Account expenseAccount = accountHelper.createExpenseAccount();
+        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
         Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
         Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanProductID = createLoanProduct(false, ACCRUAL_UPFRONT, assetAccount, incomeAccount, expenseAccount,
+        final Long loanProductID = createLoanProduct(false, ACCRUAL_UPFRONT, assetAccount, incomeAccount, expenseAccount,
                 overpaymentAccount);
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
         verifyLoanRepaymentSchedule(loanSchedule);
 
-        List<HashMap> loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        List<GetLoansLoanIdChargesChargeIdResponse> loanCharges = getLoanCharges(loanID);
         validateCharge(percentageDisbursementCharge, loanCharges, "1", "120.00", "0.0", "0.0");
         validateCharge(percentageSpecifiedDueDateCharge, loanCharges, "1", "120.00", "0.0", "0.0");
         validateCharge(percentageInstallmentFee, loanCharges, "1", "120.00", "0.0", "0.0");
 
         // check for disbursement fee
-        HashMap disbursementDetail = loanSchedule.get(0);
-        validateNumberForEqual("120.00", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod disbursementDetail = loanSchedule.get(0);
+        validateNumberForEqual("120.00", String.valueOf(disbursementDetail.getFeeChargesDue()));
 
         // check for charge at specified date and installment fee
-        HashMap firstInstallment = loanSchedule.get(1);
-        validateNumberForEqual("149.11", String.valueOf(firstInstallment.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod firstInstallment = loanSchedule.get(1);
+        validateNumberForEqual("149.11", String.valueOf(firstInstallment.getFeeChargesDue()));
 
         // check for installment fee
-        HashMap secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("29.70", String.valueOf(secondInstallment.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod secondInstallment = loanSchedule.get(2);
+        validateNumberForEqual("29.70", String.valueOf(secondInstallment.getFeeChargesDue()));
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("20 September 2011", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("20 September 2011", loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("20 September 2011", loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount("20 September 2011", loanID));
 
-        final JournalEntry[] assetAccountInitialEntry = { new JournalEntry(Float.parseFloat("605.94"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("120.00"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("120.00"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("120.00"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.DEBIT) };
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", assetAccountInitialEntry);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 September 2011",
-                new JournalEntry(Float.parseFloat("605.94"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("120.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("120.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("120.00"), JournalEntry.TransactionType.CREDIT));
+        final LoanTestData.Journal[] assetAccountInitialEntry = {
+                journalEntry(Float.parseFloat("605.94"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("120.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("120.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("120.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()) };
+        checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", assetAccountInitialEntry);
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 September 2011",
+                journalEntry(Float.parseFloat("605.94"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("120.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("120.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("120.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(percentageDisbursementCharge, loanCharges, "1", "0.0", "120.00", "0.0");
 
         LOG.info("-------------Make repayment 1-----------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 October 2011", Float.parseFloat("3300.60"), loanID);
+        makeRepayment("20 October 2011", Float.parseFloat("3300.60"), loanID);
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(percentageDisbursementCharge, loanCharges, "1", "0.00", "120.00", "0.0");
         validateCharge(percentageSpecifiedDueDateCharge, loanCharges, "1", "0.00", "120.0", "0.0");
         validateCharge(percentageInstallmentFee, loanCharges, "1", "90.89", "29.11", "0.0");
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("3300.60"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3300.60"), JournalEntry.TransactionType.CREDIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("3300.60"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3300.60"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(percentageSpecifiedDueDateCharge), "29 October 2011", "1"));
+        addLoanCharge(loanID, percentageSpecifiedDueDateCharge, "29 October 2011", 1.0);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
 
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("149.70", String.valueOf(secondInstallment.get("feeChargesDue")));
+        validateNumberForEqual("149.70", String.valueOf(secondInstallment.getFeeChargesDue()));
         LOG.info("----------- Waive installment charge for 2nd installment ---------");
-        LOAN_TRANSACTION_HELPER.waiveChargesForLoan(loanID, (Integer) getloanCharge(percentageInstallmentFee, loanCharges).get("id"),
-                LoanTransactionHelper.getWaiveChargeJSON(String.valueOf(2)));
+        waiveLoanCharge(loanID, getloanCharge(percentageInstallmentFee, loanCharges).getId(),
+                new PostLoansLoanIdChargesChargeIdRequest().installmentNumber(2L).locale(LOCALE));
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(percentageInstallmentFee, loanCharges, "1", "61.19", "29.11", "29.70");
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("29.7"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForExpenseAccount(expenseAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("29.7"), JournalEntry.TransactionType.DEBIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("29.7"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForExpenseAccount(expenseAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("29.7"), expenseAccount, JournalEntry.TransactionType.DEBIT.name()));
 
         LOG.info("----------Make repayment 2------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3271.49"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("3271.49"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3271.49"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 November 2011", Float.parseFloat("3271.49"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("3271.49"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3271.49"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("0", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("--------------Waive interest---------------");
-        LOAN_TRANSACTION_HELPER.waiveInterest("20 December 2011", String.valueOf(61.79), loanID);
+        waiveInterestOnLoan(loanID, "20 December 2011", 61.79);
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap thirdInstallment = loanSchedule.get(3);
-        validateNumberForEqual("60.59", String.valueOf(thirdInstallment.get("interestOutstanding")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod thirdInstallment = loanSchedule.get(3);
+        validateNumberForEqual("60.59", String.valueOf(thirdInstallment.getInterestOutstanding()));
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 December 2011",
-                new JournalEntry(Float.parseFloat("61.79"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForExpenseAccount(expenseAccount, "20 December 2011",
-                new JournalEntry(Float.parseFloat("61.79"), JournalEntry.TransactionType.DEBIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 December 2011",
+                journalEntry(Float.parseFloat("61.79"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForExpenseAccount(expenseAccount, "20 December 2011",
+                journalEntry(Float.parseFloat("61.79"), expenseAccount, JournalEntry.TransactionType.DEBIT.name()));
 
-        Integer percentagePenaltySpecifiedDueDate = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1", true));
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(percentagePenaltySpecifiedDueDate), "29 September 2011", "1"));
+        Long percentagePenaltySpecifiedDueDate = chargesHelper
+                .createLoanSpecifiedDueDateCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0, true).getResourceId();
+        addLoanCharge(loanID, percentagePenaltySpecifiedDueDate, "29 September 2011", 1.0);
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(percentagePenaltySpecifiedDueDate, loanCharges, "1", "0.00", "120.0", "0.0");
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("120", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("120", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
         // checking the journal entry as applied penalty has been collected
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("3300.60"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3300.60"), JournalEntry.TransactionType.CREDIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("3300.60"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3300.60"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         LOG.info("----------Make repayment 3 advance------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3301.78"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("3301.78"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3301.78"), JournalEntry.TransactionType.CREDIT));
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(percentagePenaltySpecifiedDueDate), "10 January 2012", "1"));
+        makeRepayment("20 November 2011", Float.parseFloat("3301.78"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("3301.78"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3301.78"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        addLoanCharge(loanID, percentagePenaltySpecifiedDueDate, "10 January 2012", 1.0);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("120", String.valueOf(fourthInstallment.get("penaltyChargesOutstanding")));
-        validateNumberForEqual("3240.58", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod fourthInstallment = loanSchedule.get(4);
+        validateNumberForEqual("120", String.valueOf(fourthInstallment.getPenaltyChargesOutstanding()));
+        validateNumberForEqual("3240.58", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("----------Pay applied penalty ------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("120"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("120"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("120"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 January 2012", Float.parseFloat("120"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("120"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("120"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("0", String.valueOf(fourthInstallment.get("penaltyChargesOutstanding")));
-        validateNumberForEqual("3120.58", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0", String.valueOf(fourthInstallment.getPenaltyChargesOutstanding()));
+        validateNumberForEqual("3120.58", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("----------Make over payment for repayment 4 ------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("3220.58"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("3220.58"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3120.58"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForLiabilityAccount(overpaymentAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("100.00"), JournalEntry.TransactionType.CREDIT));
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "status");
-        LoanStatusChecker.verifyLoanAccountIsOverPaid(loanStatusHashMap);
+        makeRepayment("20 January 2012", Float.parseFloat("3220.58"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("3220.58"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3120.58"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForLiabilityAccount(overpaymentAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("100.00"), overpaymentAccount, JournalEntry.TransactionType.CREDIT.name()));
+        GetLoansLoanIdResponse loanStatusHashMap = getLoanDetails(loanID);
+        verifyLoanStatus(loanStatusHashMap, GetLoansLoanIdStatus::getOverpaid);
     }
 
     /***
@@ -2173,203 +2062,192 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void loanWithCahargesOfTypeAmountPlusInterestPercentageAndUpfrontAccrualAccountingEnabled() {
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
 
         // Add charges with payment mode regular
-        List<HashMap> charges = new ArrayList<>();
-        Integer amountPlusInterestPercentageDisbursementCharge = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanDisbursementJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT_AND_INTEREST, "1"));
-        addCharges(charges, amountPlusInterestPercentageDisbursementCharge, "1", null);
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
+        Long amountPlusInterestPercentageDisbursementCharge = chargesHelper
+                .createLoanDisbursementCharge(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST, 1.0).getResourceId();
+        addCharges(charges, amountPlusInterestPercentageDisbursementCharge, 1.0, null);
 
-        Integer amountPlusInterestPercentageSpecifiedDueDateCharge = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC, ChargesHelper
-                .getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT_AND_INTEREST, "1", false));
+        Long amountPlusInterestPercentageSpecifiedDueDateCharge = chargesHelper
+                .createLoanSpecifiedDueDateCharge(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST, 1.0, false).getResourceId();
 
-        Integer amountPlusInterestPercentageInstallmentFee = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT_AND_INTEREST, "1", false));
-        addCharges(charges, amountPlusInterestPercentageInstallmentFee, "1", "29 September 2011");
+        Long amountPlusInterestPercentageInstallmentFee = chargesHelper
+                .createLoanInstallmentCharge(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST, 1.0, false).getResourceId();
+        addCharges(charges, amountPlusInterestPercentageInstallmentFee, 1.0, "29 September 2011");
 
-        final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-        final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-        final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-        final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+        final Account assetAccount = accountHelper.createAssetAccount();
+        final Account incomeAccount = accountHelper.createIncomeAccount();
+        final Account expenseAccount = accountHelper.createExpenseAccount();
+        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
 
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanProductID = createLoanProduct(false, ACCRUAL_UPFRONT, assetAccount, incomeAccount, expenseAccount,
+        final Long loanProductID = createLoanProduct(false, ACCRUAL_UPFRONT, assetAccount, incomeAccount, expenseAccount,
                 overpaymentAccount);
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
         verifyLoanRepaymentSchedule(loanSchedule);
 
-        List<HashMap> loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        List<GetLoansLoanIdChargesChargeIdResponse> loanCharges = getLoanCharges(loanID);
         validateCharge(amountPlusInterestPercentageDisbursementCharge, loanCharges, "1", "126.06", "0.0", "0.0");
         validateCharge(amountPlusInterestPercentageInstallmentFee, loanCharges, "1", "126.04", "0.0", "0.0");
 
         // check for disbursement fee
-        HashMap disbursementDetail = loanSchedule.get(0);
-        validateNumberForEqual("126.06", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod disbursementDetail = loanSchedule.get(0);
+        validateNumberForEqual("126.06", String.valueOf(disbursementDetail.getFeeChargesDue()));
 
         // check for charge at specified date and installment fee
-        HashMap firstInstallment = loanSchedule.get(1);
-        validateNumberForEqual("31.51", String.valueOf(firstInstallment.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod firstInstallment = loanSchedule.get(1);
+        validateNumberForEqual("31.51", String.valueOf(firstInstallment.getFeeChargesDue()));
 
         // check for installment fee
-        HashMap secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("31.51", String.valueOf(secondInstallment.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod secondInstallment = loanSchedule.get(2);
+        validateNumberForEqual("31.51", String.valueOf(secondInstallment.getFeeChargesDue()));
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("20 September 2011", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("20 September 2011", loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("20 September 2011", loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount("20 September 2011", loanID));
 
-        final JournalEntry[] assetAccountInitialEntry = { new JournalEntry(Float.parseFloat("605.94"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("126.06"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("126.04"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.DEBIT) };
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", assetAccountInitialEntry);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 September 2011",
-                new JournalEntry(Float.parseFloat("605.94"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("126.06"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("126.04"), JournalEntry.TransactionType.CREDIT));
+        final LoanTestData.Journal[] assetAccountInitialEntry = {
+                journalEntry(Float.parseFloat("605.94"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("126.06"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("126.04"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()) };
+        checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", assetAccountInitialEntry);
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 September 2011",
+                journalEntry(Float.parseFloat("605.94"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("126.06"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("126.04"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
 
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(
-                String.valueOf(amountPlusInterestPercentageSpecifiedDueDateCharge), "29 September 2011", "1"));
+        addLoanCharge(loanID, amountPlusInterestPercentageSpecifiedDueDateCharge, "29 September 2011", 1.0);
 
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(amountPlusInterestPercentageDisbursementCharge, loanCharges, "1", "0.0", "126.06", "0.0");
         validateCharge(amountPlusInterestPercentageSpecifiedDueDateCharge, loanCharges, "1", "126.06", "0.0", "0.0");
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "29 September 2011",
-                new JournalEntry(Float.parseFloat("126.06"), JournalEntry.TransactionType.DEBIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "29 September 2011",
-                new JournalEntry(Float.parseFloat("126.06"), JournalEntry.TransactionType.CREDIT));
+        checkJournalEntryForAssetAccount(assetAccount, "29 September 2011",
+                journalEntry(Float.parseFloat("126.06"), assetAccount, JournalEntry.TransactionType.DEBIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "29 September 2011",
+                journalEntry(Float.parseFloat("126.06"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         LOG.info("-------------Make repayment 1-----------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 October 2011", Float.parseFloat("3309.06"), loanID);
+        makeRepayment("20 October 2011", Float.parseFloat("3309.06"), loanID);
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(amountPlusInterestPercentageDisbursementCharge, loanCharges, "1", "0.00", "126.06", "0.0");
         validateCharge(amountPlusInterestPercentageSpecifiedDueDateCharge, loanCharges, "1", "0.00", "126.06", "0.0");
         validateCharge(amountPlusInterestPercentageInstallmentFee, loanCharges, "1", "94.53", "31.51", "0.0");
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("3309.06"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3309.06"), JournalEntry.TransactionType.CREDIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("3309.06"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3309.06"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(
-                String.valueOf(amountPlusInterestPercentageSpecifiedDueDateCharge), "29 October 2011", "1"));
+        addLoanCharge(loanID, amountPlusInterestPercentageSpecifiedDueDateCharge, "29 October 2011", 1.0);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
 
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("157.57", String.valueOf(secondInstallment.get("feeChargesDue")));
+        validateNumberForEqual("157.57", String.valueOf(secondInstallment.getFeeChargesDue()));
         LOG.info("----------- Waive installment charge for 2nd installment ---------");
-        LOAN_TRANSACTION_HELPER.waiveChargesForLoan(loanID,
-                (Integer) getloanCharge(amountPlusInterestPercentageInstallmentFee, loanCharges).get("id"),
-                LoanTransactionHelper.getWaiveChargeJSON(String.valueOf(2)));
+        waiveLoanCharge(loanID, getloanCharge(amountPlusInterestPercentageInstallmentFee, loanCharges).getId(),
+                new PostLoansLoanIdChargesChargeIdRequest().installmentNumber(2L).locale(LOCALE));
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(amountPlusInterestPercentageInstallmentFee, loanCharges, "1", "63.02", "31.51", "31.51");
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("31.51"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForExpenseAccount(expenseAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("31.51"), JournalEntry.TransactionType.DEBIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("31.51"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForExpenseAccount(expenseAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("31.51"), expenseAccount, JournalEntry.TransactionType.DEBIT.name()));
 
         LOG.info("----------Make repayment 2------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3277.55"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("3277.55"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3277.55"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 November 2011", Float.parseFloat("3277.55"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("3277.55"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3277.55"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("0", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("--------------Waive interest---------------");
-        LOAN_TRANSACTION_HELPER.waiveInterest("20 December 2011", String.valueOf(61.79), loanID);
+        waiveInterestOnLoan(loanID, "20 December 2011", 61.79);
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap thirdInstallment = loanSchedule.get(3);
-        validateNumberForEqual("60.59", String.valueOf(thirdInstallment.get("interestOutstanding")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod thirdInstallment = loanSchedule.get(3);
+        validateNumberForEqual("60.59", String.valueOf(thirdInstallment.getInterestOutstanding()));
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 December 2011",
-                new JournalEntry(Float.parseFloat("61.79"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForExpenseAccount(expenseAccount, "20 December 2011",
-                new JournalEntry(Float.parseFloat("61.79"), JournalEntry.TransactionType.DEBIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 December 2011",
+                journalEntry(Float.parseFloat("61.79"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForExpenseAccount(expenseAccount, "20 December 2011",
+                journalEntry(Float.parseFloat("61.79"), expenseAccount, JournalEntry.TransactionType.DEBIT.name()));
 
-        Integer amountPlusInterestPercentagePenaltySpecifiedDueDate = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1", true));
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(
-                String.valueOf(amountPlusInterestPercentagePenaltySpecifiedDueDate), "29 September 2011", "1"));
+        Long amountPlusInterestPercentagePenaltySpecifiedDueDate = chargesHelper
+                .createLoanSpecifiedDueDateCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0, true).getResourceId();
+        addLoanCharge(loanID, amountPlusInterestPercentagePenaltySpecifiedDueDate, "29 September 2011", 1.0);
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(amountPlusInterestPercentagePenaltySpecifiedDueDate, loanCharges, "1", "0.0", "120.0", "0.0");
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("120", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("120", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
         // checking the journal entry as applied penalty has been collected
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("3309.06"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3309.06"), JournalEntry.TransactionType.CREDIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("3309.06"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3309.06"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         LOG.info("----------Make repayment 3 advance------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3303"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("3303"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3303"), JournalEntry.TransactionType.CREDIT));
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(
-                String.valueOf(amountPlusInterestPercentagePenaltySpecifiedDueDate), "10 January 2012", "1"));
+        makeRepayment("20 November 2011", Float.parseFloat("3303"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("3303"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3303"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        addLoanCharge(loanID, amountPlusInterestPercentagePenaltySpecifiedDueDate, "10 January 2012", 1.0);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("120", String.valueOf(fourthInstallment.get("penaltyChargesOutstanding")));
-        validateNumberForEqual("3241.19", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod fourthInstallment = loanSchedule.get(4);
+        validateNumberForEqual("120", String.valueOf(fourthInstallment.getPenaltyChargesOutstanding()));
+        validateNumberForEqual("3241.19", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("----------Pay applied penalty ------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("120"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("120"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("120"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 January 2012", Float.parseFloat("120"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("120"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("120"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("0", String.valueOf(fourthInstallment.get("penaltyChargesOutstanding")));
-        validateNumberForEqual("3121.19", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0", String.valueOf(fourthInstallment.getPenaltyChargesOutstanding()));
+        validateNumberForEqual("3121.19", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("----------Make over payment for repayment 4 ------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("3221.61"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("3221.61"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3121.19"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForLiabilityAccount(overpaymentAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("100.42"), JournalEntry.TransactionType.CREDIT));
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "status");
-        LoanStatusChecker.verifyLoanAccountIsOverPaid(loanStatusHashMap);
+        makeRepayment("20 January 2012", Float.parseFloat("3221.61"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("3221.61"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3121.19"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForLiabilityAccount(overpaymentAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("100.42"), overpaymentAccount, JournalEntry.TransactionType.CREDIT.name()));
+        GetLoansLoanIdResponse loanStatusHashMap = getLoanDetails(loanID);
+        verifyLoanStatus(loanStatusHashMap, GetLoansLoanIdStatus::getOverpaid);
     }
 
     /***
@@ -2378,195 +2256,185 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void loanWithFlatChargesAndPeriodicAccrualAccountingEnabled() throws InterruptedException {
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
 
         // Add charges with payment mode regular
-        List<HashMap> charges = new ArrayList<>();
-        Integer flatDisbursement = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC, ChargesHelper.getLoanDisbursementJSON());
-        addCharges(charges, flatDisbursement, "100", null);
-        Integer flatSpecifiedDueDate = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "100", false));
-        addCharges(charges, flatSpecifiedDueDate, "100", "29 September 2011");
-        Integer flatInstallmentFee = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "50", false));
-        addCharges(charges, flatInstallmentFee, "50", null);
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
+        Long flatDisbursement = chargesHelper.createLoanDisbursementCharge(ChargeCalculationType.FLAT, 100.0).getResourceId();
+        addCharges(charges, flatDisbursement, 100.0, null);
+        Long flatSpecifiedDueDate = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.FLAT, 100.0, false)
+                .getResourceId();
+        addCharges(charges, flatSpecifiedDueDate, 100.0, "29 September 2011");
+        Long flatInstallmentFee = chargesHelper.createLoanInstallmentCharge(ChargeCalculationType.FLAT, 50.0, false).getResourceId();
+        addCharges(charges, flatInstallmentFee, 50.0, null);
 
-        final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-        final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-        final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-        final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+        final Account assetAccount = accountHelper.createAssetAccount();
+        final Account incomeAccount = accountHelper.createIncomeAccount();
+        final Account expenseAccount = accountHelper.createExpenseAccount();
+        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
 
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanProductID = createLoanProduct(false, ACCRUAL_PERIODIC, assetAccount, incomeAccount, expenseAccount,
+        final Long loanProductID = createLoanProduct(false, ACCRUAL_PERIODIC, assetAccount, incomeAccount, expenseAccount,
                 overpaymentAccount);
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
         verifyLoanRepaymentSchedule(loanSchedule);
 
-        List<HashMap> loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        List<GetLoansLoanIdChargesChargeIdResponse> loanCharges = getLoanCharges(loanID);
         validateCharge(flatDisbursement, loanCharges, "100", "100.00", "0.0", "0.0");
         validateCharge(flatSpecifiedDueDate, loanCharges, "100", "100.00", "0.0", "0.0");
         validateCharge(flatInstallmentFee, loanCharges, "50", "200.00", "0.0", "0.0");
 
         // check for disbursement fee
-        HashMap disbursementDetail = loanSchedule.get(0);
-        validateNumberForEqual("100.00", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod disbursementDetail = loanSchedule.get(0);
+        validateNumberForEqual("100.00", String.valueOf(disbursementDetail.getFeeChargesDue()));
 
         // check for charge at specified date and installment fee
-        HashMap firstInstallment = loanSchedule.get(1);
-        validateNumberForEqual("150.00", String.valueOf(firstInstallment.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod firstInstallment = loanSchedule.get(1);
+        validateNumberForEqual("150.00", String.valueOf(firstInstallment.getFeeChargesDue()));
 
         // check for installment fee
-        HashMap secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("50.00", String.valueOf(secondInstallment.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod secondInstallment = loanSchedule.get(2);
+        validateNumberForEqual("50.00", String.valueOf(secondInstallment.getFeeChargesDue()));
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("20 September 2011", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("20 September 2011", loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("20 September 2011", loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount("20 September 2011", loanID));
 
-        final JournalEntry[] assetAccountInitialEntry = { new JournalEntry(Float.parseFloat("100.00"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.DEBIT) };
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", assetAccountInitialEntry);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 September 2011",
-                new JournalEntry(Float.parseFloat("100.00"), JournalEntry.TransactionType.CREDIT));
+        final LoanTestData.Journal[] assetAccountInitialEntry = {
+                journalEntry(Float.parseFloat("100.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()) };
+        checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", assetAccountInitialEntry);
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 September 2011",
+                journalEntry(Float.parseFloat("100.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(flatDisbursement, loanCharges, "100", "0.00", "100.0", "0.0");
 
         LOG.info("-------------Make repayment 1-----------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 October 2011", Float.parseFloat("3301.49"), loanID);
+        makeRepayment("20 October 2011", Float.parseFloat("3301.49"), loanID);
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(flatDisbursement, loanCharges, "100", "0.00", "100.0", "0.0");
         validateCharge(flatSpecifiedDueDate, loanCharges, "100", "0.00", "100.0", "0.0");
         validateCharge(flatInstallmentFee, loanCharges, "50", "150.00", "50.0", "0.0");
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("3301.49"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3301.49"), JournalEntry.TransactionType.CREDIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("3301.49"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3301.49"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flatSpecifiedDueDate), "29 October 2011", "100"));
+        addLoanCharge(loanID, flatSpecifiedDueDate, "29 October 2011", 100.0);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
 
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("150.00", String.valueOf(secondInstallment.get("feeChargesDue")));
+        validateNumberForEqual("150.00", String.valueOf(secondInstallment.getFeeChargesDue()));
         LOG.info("----------- Waive installment charge for 2nd installment ---------");
-        LOAN_TRANSACTION_HELPER.waiveChargesForLoan(loanID, (Integer) getloanCharge(flatInstallmentFee, loanCharges).get("id"),
-                LoanTransactionHelper.getWaiveChargeJSON(String.valueOf(2)));
+        waiveLoanCharge(loanID, getloanCharge(flatInstallmentFee, loanCharges).getId(),
+                new PostLoansLoanIdChargesChargeIdRequest().installmentNumber(2L).locale(LOCALE));
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(flatInstallmentFee, loanCharges, "50", "100.00", "50.0", "50.0");
 
         /*
-         * JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount( assetAccount, "20 September 2011", new
+         * checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", new
          * JournalEntry(Float.parseFloat("50.0"), JournalEntry.TransactionType.CREDIT));
-         * JOURNAL_ENTRY_HELPER.checkJournalEntryForExpenseAccount (expenseAccount, "20 September 2011", new
+         * journalHelper.checkJournalEntryForExpenseAccount (expenseAccount, "20 September 2011", new
          * JournalEntry(Float.parseFloat("50.0"), JournalEntry.TransactionType.DEBIT));
          */
         final String jobName = "Add Accrual Transactions";
 
-        SchedulerJobHelper.executeAndAwaitJob(jobName);
+        schedulerHelper.executeAndAwaitJob(jobName);
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         checkAccrualTransactions(loanSchedule, loanID);
 
         LOG.info("----------Make repayment 2------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3251.49"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("3251.49"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3251.49"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 November 2011", Float.parseFloat("3251.49"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("3251.49"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3251.49"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("0", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("--------------Waive interest---------------");
-        LOAN_TRANSACTION_HELPER.waiveInterest("20 December 2011", String.valueOf(61.79), loanID);
+        waiveInterestOnLoan(loanID, "20 December 2011", 61.79);
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap thirdInstallment = loanSchedule.get(3);
-        validateNumberForEqual("60.59", String.valueOf(thirdInstallment.get("interestOutstanding")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod thirdInstallment = loanSchedule.get(3);
+        validateNumberForEqual("60.59", String.valueOf(thirdInstallment.getInterestOutstanding()));
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 December 2011",
-                new JournalEntry(Float.parseFloat("61.79"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForExpenseAccount(expenseAccount, "20 December 2011",
-                new JournalEntry(Float.parseFloat("61.79"), JournalEntry.TransactionType.DEBIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 December 2011",
+                journalEntry(Float.parseFloat("61.79"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForExpenseAccount(expenseAccount, "20 December 2011",
+                journalEntry(Float.parseFloat("61.79"), expenseAccount, JournalEntry.TransactionType.DEBIT.name()));
 
-        Integer flatPenaltySpecifiedDueDate = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "100", true));
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flatPenaltySpecifiedDueDate), "29 September 2011", "100"));
+        Long flatPenaltySpecifiedDueDate = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.FLAT, 100.0, true)
+                .getResourceId();
+        addLoanCharge(loanID, flatPenaltySpecifiedDueDate, "29 September 2011", 100.0);
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(flatPenaltySpecifiedDueDate, loanCharges, "100", "0.00", "100.0", "0.0");
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("100", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("100", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
         // checking the journal entry as applied penalty has been collected
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("3301.49"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3301.49"), JournalEntry.TransactionType.CREDIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("3301.49"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3301.49"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         LOG.info("----------Make repayment 3 advance------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3301.49"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("3301.49"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3301.49"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 November 2011", Float.parseFloat("3301.49"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("3301.49"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3301.49"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flatPenaltySpecifiedDueDate), "10 January 2012", "100"));
+        addLoanCharge(loanID, flatPenaltySpecifiedDueDate, "10 January 2012", 100.0);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("100", String.valueOf(fourthInstallment.get("penaltyChargesOutstanding")));
-        validateNumberForEqual("3239.68", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod fourthInstallment = loanSchedule.get(4);
+        validateNumberForEqual("100", String.valueOf(fourthInstallment.getPenaltyChargesOutstanding()));
+        validateNumberForEqual("3239.68", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("----------Pay applied penalty ------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("100"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("100"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("100"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 January 2012", Float.parseFloat("100"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("100"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("100"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("0", String.valueOf(fourthInstallment.get("penaltyChargesOutstanding")));
-        validateNumberForEqual("3139.68", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0", String.valueOf(fourthInstallment.getPenaltyChargesOutstanding()));
+        validateNumberForEqual("3139.68", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("----------Make repayment 4 ------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("3139.68"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("3139.68"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3139.68"), JournalEntry.TransactionType.CREDIT));
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "status");
-        LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
+        makeRepayment("20 January 2012", Float.parseFloat("3139.68"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("3139.68"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3139.68"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        GetLoansLoanIdResponse loanStatusHashMap = getLoanDetails(loanID);
+        verifyLoanStatus(loanStatusHashMap, GetLoansLoanIdStatus::getClosed);
     }
 
     /**
@@ -2577,202 +2445,191 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
     public void loanWithChargesOfTypeAmountPercentageAndPeriodicAccrualAccountingEnabled() throws InterruptedException {
         try {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-            ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+            final Long clientID = createClient();
+            verifyClientCreatedOnServer(clientID);
 
             // Add charges with payment mode regular
-            List<HashMap> charges = new ArrayList<>();
-            Integer percentageDisbursementCharge = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                    ChargesHelper.getLoanDisbursementJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1"));
-            addCharges(charges, percentageDisbursementCharge, "1", null);
+            List<PostLoansRequestChargeData> charges = new ArrayList<>();
+            Long percentageDisbursementCharge = chargesHelper.createLoanDisbursementCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0)
+                    .getResourceId();
+            addCharges(charges, percentageDisbursementCharge, 1.0, null);
 
-            Integer percentageSpecifiedDueDateCharge = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1", false));
-            addCharges(charges, percentageSpecifiedDueDateCharge, "1", "29 September 2011");
+            Long percentageSpecifiedDueDateCharge = chargesHelper
+                    .createLoanSpecifiedDueDateCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0, false).getResourceId();
+            addCharges(charges, percentageSpecifiedDueDateCharge, 1.0, "29 September 2011");
 
-            Integer percentageInstallmentFee = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                    ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1", false));
-            addCharges(charges, percentageInstallmentFee, "1", "29 September 2011");
+            Long percentageInstallmentFee = chargesHelper.createLoanInstallmentCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0, false)
+                    .getResourceId();
+            addCharges(charges, percentageInstallmentFee, 1.0, "29 September 2011");
 
-            final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-            final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-            final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-            final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+            final Account assetAccount = accountHelper.createAssetAccount();
+            final Account incomeAccount = accountHelper.createIncomeAccount();
+            final Account expenseAccount = accountHelper.createExpenseAccount();
+            final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-            List<HashMap> collaterals = new ArrayList<>();
+            List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-            final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+            final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
 
-            final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                    String.valueOf(clientID), collateralId);
-            addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+            final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
+            collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-            final Integer loanProductID = createLoanProduct(false, ACCRUAL_PERIODIC, assetAccount, incomeAccount, expenseAccount,
+            final Long loanProductID = createLoanProduct(false, ACCRUAL_PERIODIC, assetAccount, incomeAccount, expenseAccount,
                     overpaymentAccount);
-            final Integer loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
+            final Long loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
             Assertions.assertNotNull(loanID);
-            HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+            verifyLoanIsPending(loanID);
 
-            ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+            List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
             verifyLoanRepaymentSchedule(loanSchedule);
 
-            List<HashMap> loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+            List<GetLoansLoanIdChargesChargeIdResponse> loanCharges = getLoanCharges(loanID);
             validateCharge(percentageDisbursementCharge, loanCharges, "1", "120.00", "0.0", "0.0");
             validateCharge(percentageSpecifiedDueDateCharge, loanCharges, "1", "120.00", "0.0", "0.0");
             validateCharge(percentageInstallmentFee, loanCharges, "1", "120.00", "0.0", "0.0");
 
             // check for disbursement fee
-            HashMap disbursementDetail = loanSchedule.get(0);
-            validateNumberForEqual("120.00", String.valueOf(disbursementDetail.get("feeChargesDue")));
+            GetLoansLoanIdRepaymentPeriod disbursementDetail = loanSchedule.get(0);
+            validateNumberForEqual("120.00", String.valueOf(disbursementDetail.getFeeChargesDue()));
 
             // check for charge at specified date and installment fee
-            HashMap firstInstallment = loanSchedule.get(1);
-            validateNumberForEqual("149.11", String.valueOf(firstInstallment.get("feeChargesDue")));
+            GetLoansLoanIdRepaymentPeriod firstInstallment = loanSchedule.get(1);
+            validateNumberForEqual("149.11", String.valueOf(firstInstallment.getFeeChargesDue()));
 
             // check for installment fee
-            HashMap secondInstallment = loanSchedule.get(2);
-            validateNumberForEqual("29.70", String.valueOf(secondInstallment.get("feeChargesDue")));
+            GetLoansLoanIdRepaymentPeriod secondInstallment = loanSchedule.get(2);
+            validateNumberForEqual("29.70", String.valueOf(secondInstallment.getFeeChargesDue()));
 
             LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("20 September 2011", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-            LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+            verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("20 September 2011", loanID));
 
             LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-            String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("20 September 2011", loanID,
-                    JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+            verifyLoanIsActive(disburseLoanWithNetDisbursalAmount("20 September 2011", loanID));
 
-            ArrayList<HashMap> loanTransactionDetails = LOAN_TRANSACTION_HELPER.getLoanTransactionDetails(REQUEST_SPEC, RESPONSE_SPEC,
-                    loanID);
-            final JournalEntry[] assetAccountInitialEntry = {
-                    new JournalEntry(Float.parseFloat("120.00"), JournalEntry.TransactionType.DEBIT),
-                    new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.CREDIT),
-                    new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.DEBIT) };
-            JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", assetAccountInitialEntry);
-            JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 September 2011",
-                    new JournalEntry(Float.parseFloat("120.00"), JournalEntry.TransactionType.CREDIT));
+            List<GetLoansLoanIdTransactions> loanTransactionDetails = getLoanDetails(loanID).getTransactions();
+            final LoanTestData.Journal[] assetAccountInitialEntry = {
+                    journalEntry(Float.parseFloat("120.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                    journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                    journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()) };
+            checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", assetAccountInitialEntry);
+            checkJournalEntryForIncomeAccount(incomeAccount, "20 September 2011",
+                    journalEntry(Float.parseFloat("120.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
             loanCharges.clear();
-            loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+            loanCharges = getLoanCharges(loanID);
             validateCharge(percentageDisbursementCharge, loanCharges, "1", "0.0", "120.00", "0.0");
 
             LOG.info("-------------Make repayment 1-----------");
-            LOAN_TRANSACTION_HELPER.makeRepayment("20 October 2011", Float.parseFloat("3300.60"), loanID);
+            makeRepayment("20 October 2011", Float.parseFloat("3300.60"), loanID);
             loanCharges.clear();
-            loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+            loanCharges = getLoanCharges(loanID);
             validateCharge(percentageDisbursementCharge, loanCharges, "1", "0.00", "120.00", "0.0");
             validateCharge(percentageSpecifiedDueDateCharge, loanCharges, "1", "0.00", "120.0", "0.0");
             validateCharge(percentageInstallmentFee, loanCharges, "1", "90.89", "29.11", "0.0");
 
-            JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
-                    new JournalEntry(Float.parseFloat("3300.60"), JournalEntry.TransactionType.DEBIT),
-                    new JournalEntry(Float.parseFloat("3300.60"), JournalEntry.TransactionType.CREDIT));
+            checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
+                    journalEntry(Float.parseFloat("3300.60"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                    journalEntry(Float.parseFloat("3300.60"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
-            LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                    .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(percentageSpecifiedDueDateCharge), "29 October 2011", "1"));
+            addLoanCharge(loanID, percentageSpecifiedDueDateCharge, "29 October 2011", 1.0);
             loanSchedule.clear();
-            loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+            loanSchedule = getLoanRepaymentSchedule(loanID);
 
             secondInstallment = loanSchedule.get(2);
-            validateNumberForEqual("149.70", String.valueOf(secondInstallment.get("feeChargesDue")));
+            validateNumberForEqual("149.70", String.valueOf(secondInstallment.getFeeChargesDue()));
             LOG.info("----------- Waive installment charge for 2nd installment ---------");
-            LOAN_TRANSACTION_HELPER.waiveChargesForLoan(loanID, (Integer) getloanCharge(percentageInstallmentFee, loanCharges).get("id"),
-                    LoanTransactionHelper.getWaiveChargeJSON(String.valueOf(2)));
+            waiveLoanCharge(loanID, getloanCharge(percentageInstallmentFee, loanCharges).getId(),
+                    new PostLoansLoanIdChargesChargeIdRequest().installmentNumber(2L).locale(LOCALE));
             loanCharges.clear();
-            loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+            loanCharges = getLoanCharges(loanID);
             validateCharge(percentageInstallmentFee, loanCharges, "1", "61.19", "29.11", "29.70");
 
             /*
-             * JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount( assetAccount, "20 September 2011", new
+             * checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", new
              * JournalEntry(Float.parseFloat("29.7"), JournalEntry.TransactionType.CREDIT));
-             * JOURNAL_ENTRY_HELPER.checkJournalEntryForExpenseAccount (expenseAccount, "20 September 2011", new
+             * journalHelper.checkJournalEntryForExpenseAccount (expenseAccount, "20 September 2011", new
              * JournalEntry(Float.parseFloat("29.7"), JournalEntry.TransactionType.DEBIT));
              */
 
             final String jobName = "Add Accrual Transactions";
 
-            SchedulerJobHelper.executeAndAwaitJob(jobName);
+            schedulerHelper.executeAndAwaitJob(jobName);
 
             loanSchedule.clear();
-            loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+            loanSchedule = getLoanRepaymentSchedule(loanID);
             checkAccrualTransactions(loanSchedule, loanID);
 
             LOG.info("----------Make repayment 2------------");
-            LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3271.49"), loanID);
-            JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                    new JournalEntry(Float.parseFloat("3271.49"), JournalEntry.TransactionType.DEBIT),
-                    new JournalEntry(Float.parseFloat("3271.49"), JournalEntry.TransactionType.CREDIT));
+            makeRepayment("20 November 2011", Float.parseFloat("3271.49"), loanID);
+            checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                    journalEntry(Float.parseFloat("3271.49"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                    journalEntry(Float.parseFloat("3271.49"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
             loanSchedule.clear();
-            loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+            loanSchedule = getLoanRepaymentSchedule(loanID);
             secondInstallment = loanSchedule.get(2);
-            validateNumberForEqual("0", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+            validateNumberForEqual("0", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
             LOG.info("--------------Waive interest---------------");
-            LOAN_TRANSACTION_HELPER.waiveInterest("20 December 2011", String.valueOf(61.79), loanID);
+            waiveInterestOnLoan(loanID, "20 December 2011", 61.79);
 
             loanSchedule.clear();
-            loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            HashMap thirdInstallment = loanSchedule.get(3);
-            validateNumberForEqual("60.59", String.valueOf(thirdInstallment.get("interestOutstanding")));
+            loanSchedule = getLoanRepaymentSchedule(loanID);
+            GetLoansLoanIdRepaymentPeriod thirdInstallment = loanSchedule.get(3);
+            validateNumberForEqual("60.59", String.valueOf(thirdInstallment.getInterestOutstanding()));
 
-            JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 December 2011",
-                    new JournalEntry(Float.parseFloat("61.79"), JournalEntry.TransactionType.CREDIT));
-            JOURNAL_ENTRY_HELPER.checkJournalEntryForExpenseAccount(expenseAccount, "20 December 2011",
-                    new JournalEntry(Float.parseFloat("61.79"), JournalEntry.TransactionType.DEBIT));
+            checkJournalEntryForAssetAccount(assetAccount, "20 December 2011",
+                    journalEntry(Float.parseFloat("61.79"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+            checkJournalEntryForExpenseAccount(expenseAccount, "20 December 2011",
+                    journalEntry(Float.parseFloat("61.79"), expenseAccount, JournalEntry.TransactionType.DEBIT.name()));
 
-            Integer percentagePenaltySpecifiedDueDate = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1", true));
-            LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                    .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(percentagePenaltySpecifiedDueDate), "29 September 2011", "1"));
+            Long percentagePenaltySpecifiedDueDate = chargesHelper
+                    .createLoanSpecifiedDueDateCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0, true).getResourceId();
+            addLoanCharge(loanID, percentagePenaltySpecifiedDueDate, "29 September 2011", 1.0);
             loanCharges.clear();
-            loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+            loanCharges = getLoanCharges(loanID);
             validateCharge(percentagePenaltySpecifiedDueDate, loanCharges, "1", "0.00", "120.0", "0.0");
 
             loanSchedule.clear();
-            loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+            loanSchedule = getLoanRepaymentSchedule(loanID);
             secondInstallment = loanSchedule.get(2);
-            validateNumberForEqual("120", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+            validateNumberForEqual("120", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
             // checking the journal entry as applied penalty has been collected
-            JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
-                    new JournalEntry(Float.parseFloat("3300.60"), JournalEntry.TransactionType.DEBIT),
-                    new JournalEntry(Float.parseFloat("3300.60"), JournalEntry.TransactionType.CREDIT));
+            checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
+                    journalEntry(Float.parseFloat("3300.60"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                    journalEntry(Float.parseFloat("3300.60"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
             LOG.info("----------Make repayment 3 advance------------");
-            LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3301.78"), loanID);
-            JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                    new JournalEntry(Float.parseFloat("3301.78"), JournalEntry.TransactionType.DEBIT),
-                    new JournalEntry(Float.parseFloat("3301.78"), JournalEntry.TransactionType.CREDIT));
+            makeRepayment("20 November 2011", Float.parseFloat("3301.78"), loanID);
+            checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                    journalEntry(Float.parseFloat("3301.78"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                    journalEntry(Float.parseFloat("3301.78"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
-            LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                    .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(percentagePenaltySpecifiedDueDate), "10 January 2012", "1"));
+            addLoanCharge(loanID, percentagePenaltySpecifiedDueDate, "10 January 2012", 1.0);
             loanSchedule.clear();
-            loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            HashMap fourthInstallment = loanSchedule.get(4);
-            validateNumberForEqual("120", String.valueOf(fourthInstallment.get("penaltyChargesOutstanding")));
-            validateNumberForEqual("3240.58", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
+            loanSchedule = getLoanRepaymentSchedule(loanID);
+            GetLoansLoanIdRepaymentPeriod fourthInstallment = loanSchedule.get(4);
+            validateNumberForEqual("120", String.valueOf(fourthInstallment.getPenaltyChargesOutstanding()));
+            validateNumberForEqual("3240.58", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
 
             LOG.info("----------Pay applied penalty ------------");
-            LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("120"), loanID);
-            JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
-                    new JournalEntry(Float.parseFloat("120"), JournalEntry.TransactionType.DEBIT),
-                    new JournalEntry(Float.parseFloat("120"), JournalEntry.TransactionType.CREDIT));
+            makeRepayment("20 January 2012", Float.parseFloat("120"), loanID);
+            checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
+                    journalEntry(Float.parseFloat("120"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                    journalEntry(Float.parseFloat("120"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
             loanSchedule.clear();
-            loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+            loanSchedule = getLoanRepaymentSchedule(loanID);
             fourthInstallment = loanSchedule.get(4);
-            validateNumberForEqual("0", String.valueOf(fourthInstallment.get("penaltyChargesOutstanding")));
-            validateNumberForEqual("3120.58", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
+            validateNumberForEqual("0", String.valueOf(fourthInstallment.getPenaltyChargesOutstanding()));
+            validateNumberForEqual("3120.58", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
 
             LOG.info("----------Make repayment 4 ------------");
-            LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("3120.58"), loanID);
-            JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
-                    new JournalEntry(Float.parseFloat("3120.58"), JournalEntry.TransactionType.DEBIT),
-                    new JournalEntry(Float.parseFloat("3120.58"), JournalEntry.TransactionType.CREDIT));
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "status");
-            LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
+            makeRepayment("20 January 2012", Float.parseFloat("3120.58"), loanID);
+            checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
+                    journalEntry(Float.parseFloat("3120.58"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                    journalEntry(Float.parseFloat("3120.58"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+            GetLoansLoanIdResponse loanStatusHashMap = getLoanDetails(loanID);
+            verifyLoanStatus(loanStatusHashMap, GetLoansLoanIdStatus::getClosed);
         } finally {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, false);
         }
@@ -2785,220 +2642,209 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void loanWithChargesOfTypeAmountPlusInterestPercentageAndPeriodicAccrualAccountingEnabled() throws InterruptedException {
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
 
         // Add charges with payment mode regular
-        List<HashMap> charges = new ArrayList<>();
-        Integer amountPlusInterestPercentageDisbursementCharge = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanDisbursementJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT_AND_INTEREST, "1"));
-        addCharges(charges, amountPlusInterestPercentageDisbursementCharge, "1", null);
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
+        Long amountPlusInterestPercentageDisbursementCharge = chargesHelper
+                .createLoanDisbursementCharge(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST, 1.0).getResourceId();
+        addCharges(charges, amountPlusInterestPercentageDisbursementCharge, 1.0, null);
 
-        Integer amountPlusInterestPercentageSpecifiedDueDateCharge = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC, ChargesHelper
-                .getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT_AND_INTEREST, "1", false));
-        addCharges(charges, amountPlusInterestPercentageSpecifiedDueDateCharge, "1", "29 September 2011");
+        Long amountPlusInterestPercentageSpecifiedDueDateCharge = chargesHelper
+                .createLoanSpecifiedDueDateCharge(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST, 1.0, false).getResourceId();
+        addCharges(charges, amountPlusInterestPercentageSpecifiedDueDateCharge, 1.0, "29 September 2011");
 
-        Integer amountPlusInterestPercentageInstallmentFee = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT_AND_INTEREST, "1", false));
-        addCharges(charges, amountPlusInterestPercentageInstallmentFee, "1", "29 September 2011");
+        Long amountPlusInterestPercentageInstallmentFee = chargesHelper
+                .createLoanInstallmentCharge(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST, 1.0, false).getResourceId();
+        addCharges(charges, amountPlusInterestPercentageInstallmentFee, 1.0, "29 September 2011");
 
-        final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-        final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-        final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-        final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+        final Account assetAccount = accountHelper.createAssetAccount();
+        final Account incomeAccount = accountHelper.createIncomeAccount();
+        final Account expenseAccount = accountHelper.createExpenseAccount();
+        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
         Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
         Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanProductID = createLoanProduct(false, ACCRUAL_PERIODIC, assetAccount, incomeAccount, expenseAccount,
+        final Long loanProductID = createLoanProduct(false, ACCRUAL_PERIODIC, assetAccount, incomeAccount, expenseAccount,
                 overpaymentAccount);
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
         verifyLoanRepaymentSchedule(loanSchedule);
 
-        List<HashMap> loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        List<GetLoansLoanIdChargesChargeIdResponse> loanCharges = getLoanCharges(loanID);
         validateCharge(amountPlusInterestPercentageDisbursementCharge, loanCharges, "1", "126.06", "0.0", "0.0");
         validateCharge(amountPlusInterestPercentageSpecifiedDueDateCharge, loanCharges, "1", "126.06", "0.0", "0.0");
         validateCharge(amountPlusInterestPercentageInstallmentFee, loanCharges, "1", "126.04", "0.0", "0.0");
 
         // check for disbursement fee
-        HashMap disbursementDetail = loanSchedule.get(0);
-        validateNumberForEqual("126.06", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod disbursementDetail = loanSchedule.get(0);
+        validateNumberForEqual("126.06", String.valueOf(disbursementDetail.getFeeChargesDue()));
 
         // check for charge at specified date and installment fee
-        HashMap firstInstallment = loanSchedule.get(1);
-        validateNumberForEqual("157.57", String.valueOf(firstInstallment.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod firstInstallment = loanSchedule.get(1);
+        validateNumberForEqual("157.57", String.valueOf(firstInstallment.getFeeChargesDue()));
 
         // check for installment fee
-        HashMap secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("31.51", String.valueOf(secondInstallment.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod secondInstallment = loanSchedule.get(2);
+        validateNumberForEqual("31.51", String.valueOf(secondInstallment.getFeeChargesDue()));
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("20 September 2011", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("20 September 2011", loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("20 September 2011", loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount("20 September 2011", loanID));
 
-        final JournalEntry[] assetAccountInitialEntry = { new JournalEntry(Float.parseFloat("126.06"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.DEBIT) };
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", assetAccountInitialEntry);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 September 2011",
-                new JournalEntry(Float.parseFloat("126.06"), JournalEntry.TransactionType.CREDIT));
+        final LoanTestData.Journal[] assetAccountInitialEntry = {
+                journalEntry(Float.parseFloat("126.06"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()) };
+        checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", assetAccountInitialEntry);
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 September 2011",
+                journalEntry(Float.parseFloat("126.06"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(amountPlusInterestPercentageDisbursementCharge, loanCharges, "1", "0.0", "126.06", "0.0");
 
         LOG.info("-------------Make repayment 1-----------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 October 2011", Float.parseFloat("3309.06"), loanID);
+        makeRepayment("20 October 2011", Float.parseFloat("3309.06"), loanID);
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(amountPlusInterestPercentageDisbursementCharge, loanCharges, "1", "0.00", "126.06", "0.0");
         validateCharge(amountPlusInterestPercentageSpecifiedDueDateCharge, loanCharges, "1", "0.00", "126.06", "0.0");
         validateCharge(amountPlusInterestPercentageInstallmentFee, loanCharges, "1", "94.53", "31.51", "0.0");
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("3309.06"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3309.06"), JournalEntry.TransactionType.CREDIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("3309.06"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3309.06"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(
-                String.valueOf(amountPlusInterestPercentageSpecifiedDueDateCharge), "29 October 2011", "1"));
+        addLoanCharge(loanID, amountPlusInterestPercentageSpecifiedDueDateCharge, "29 October 2011", 1.0);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
 
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("157.57", String.valueOf(secondInstallment.get("feeChargesDue")));
+        validateNumberForEqual("157.57", String.valueOf(secondInstallment.getFeeChargesDue()));
         LOG.info("----------- Waive installment charge for 2nd installment ---------");
-        LOAN_TRANSACTION_HELPER.waiveChargesForLoan(loanID,
-                (Integer) getloanCharge(amountPlusInterestPercentageInstallmentFee, loanCharges).get("id"),
-                LoanTransactionHelper.getWaiveChargeJSON(String.valueOf(2)));
+        waiveLoanCharge(loanID, getloanCharge(amountPlusInterestPercentageInstallmentFee, loanCharges).getId(),
+                new PostLoansLoanIdChargesChargeIdRequest().installmentNumber(2L).locale(LOCALE));
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(amountPlusInterestPercentageInstallmentFee, loanCharges, "1", "63.02", "31.51", "31.51");
 
         /*
-         * JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount( assetAccount, "20 September 2011", new JournalEntry(
-         * Float.parseFloat("31.51"), JournalEntry.TransactionType.CREDIT));
-         * JOURNAL_ENTRY_HELPER.checkJournalEntryForExpenseAccount (expenseAccount, "20 September 2011", new
-         * JournalEntry(Float.parseFloat("31.51"), JournalEntry.TransactionType.DEBIT));
+         * checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", journalEntry(* Float.parseFloat("31.51"),
+         * assetAccount, JournalEntry.TransactionType.CREDIT.name())); journalHelper.checkJournalEntryForExpenseAccount
+         * (expenseAccount, "20 September 2011", new JournalEntry(Float.parseFloat("31.51"),
+         * JournalEntry.TransactionType.DEBIT));
          */
 
         final String jobName = "Add Accrual Transactions";
 
-        SchedulerJobHelper.executeAndAwaitJob(jobName);
+        schedulerHelper.executeAndAwaitJob(jobName);
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         checkAccrualTransactions(loanSchedule, loanID);
 
         LOG.info("----------Make repayment 2------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3277.55"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("3277.55"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3277.55"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 November 2011", Float.parseFloat("3277.55"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("3277.55"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3277.55"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("0", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("--------------Waive interest---------------");
-        LOAN_TRANSACTION_HELPER.waiveInterest("20 December 2011", String.valueOf(61.79), loanID);
+        waiveInterestOnLoan(loanID, "20 December 2011", 61.79);
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap thirdInstallment = loanSchedule.get(3);
-        validateNumberForEqual("60.59", String.valueOf(thirdInstallment.get("interestOutstanding")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod thirdInstallment = loanSchedule.get(3);
+        validateNumberForEqual("60.59", String.valueOf(thirdInstallment.getInterestOutstanding()));
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 December 2011",
-                new JournalEntry(Float.parseFloat("61.79"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForExpenseAccount(expenseAccount, "20 December 2011",
-                new JournalEntry(Float.parseFloat("61.79"), JournalEntry.TransactionType.DEBIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 December 2011",
+                journalEntry(Float.parseFloat("61.79"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForExpenseAccount(expenseAccount, "20 December 2011",
+                journalEntry(Float.parseFloat("61.79"), expenseAccount, JournalEntry.TransactionType.DEBIT.name()));
 
-        Integer amountPlusInterestPercentagePenaltySpecifiedDueDate = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1", true));
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(
-                String.valueOf(amountPlusInterestPercentagePenaltySpecifiedDueDate), "29 September 2011", "1"));
+        Long amountPlusInterestPercentagePenaltySpecifiedDueDate = chargesHelper
+                .createLoanSpecifiedDueDateCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0, true).getResourceId();
+        addLoanCharge(loanID, amountPlusInterestPercentagePenaltySpecifiedDueDate, "29 September 2011", 1.0);
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(amountPlusInterestPercentagePenaltySpecifiedDueDate, loanCharges, "1", "0.0", "120.0", "0.0");
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("120", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("120", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
         // checking the journal entry as applied penalty has been collected
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("3309.06"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3309.06"), JournalEntry.TransactionType.CREDIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("3309.06"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3309.06"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         LOG.info("----------Make repayment 3 advance------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3303"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("3303"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3303"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 November 2011", Float.parseFloat("3303"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("3303"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3303"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(
-                String.valueOf(amountPlusInterestPercentagePenaltySpecifiedDueDate), "10 January 2012", "1"));
+        addLoanCharge(loanID, amountPlusInterestPercentagePenaltySpecifiedDueDate, "10 January 2012", 1.0);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("120", String.valueOf(fourthInstallment.get("penaltyChargesOutstanding")));
-        validateNumberForEqual("3241.19", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod fourthInstallment = loanSchedule.get(4);
+        validateNumberForEqual("120", String.valueOf(fourthInstallment.getPenaltyChargesOutstanding()));
+        validateNumberForEqual("3241.19", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("----------Pay applied penalty ------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("120"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("120"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("120"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 January 2012", Float.parseFloat("120"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("120"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("120"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("0", String.valueOf(fourthInstallment.get("penaltyChargesOutstanding")));
-        validateNumberForEqual("3121.19", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0", String.valueOf(fourthInstallment.getPenaltyChargesOutstanding()));
+        validateNumberForEqual("3121.19", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("----------Make repayment 4 ------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("3121.19"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("3121.19"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3121.19"), JournalEntry.TransactionType.CREDIT));
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "status");
-        LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
+        makeRepayment("20 January 2012", Float.parseFloat("3121.19"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("3121.19"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3121.19"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        GetLoansLoanIdResponse loanStatusHashMap = getLoanDetails(loanID);
+        verifyLoanStatus(loanStatusHashMap, GetLoansLoanIdStatus::getClosed);
     }
 
     @Test
     public void testClientLoanScheduleWithCurrencyDetails() {
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
 
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanProductID = createLoanProduct("100", "0", LoanProductTestBuilder.DEFAULT_STRATEGY);
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, null, collaterals);
-        final ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        final Long loanProductID = createLoanProduct(100, 0, DEFAULT_STRATEGY);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID, null, collaterals);
+        final List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
         verifyLoanRepaymentScheduleForEqualPrincipal(loanSchedule);
 
     }
@@ -3006,20 +2852,19 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void testClientLoanScheduleWithCurrencyDetails_with_grace() {
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
 
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanProductID = createLoanProduct("100", "0", LoanProductTestBuilder.DEFAULT_STRATEGY);
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, "5", collaterals);
-        final ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        final Long loanProductID = createLoanProduct(100, 0, DEFAULT_STRATEGY);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID, 5, collaterals);
+        final List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
         verifyLoanRepaymentScheduleForEqualPrincipalWithGrace(loanSchedule);
 
     }
@@ -3030,82 +2875,75 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void testRBIPaymentStrategy() {
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
 
         /***
          * Create loan product with RBI strategy
          */
-        final Integer loanProductID = createLoanProduct("100", "0", LoanProductTestBuilder.RBI_INDIA_STRATEGY);
+        final Long loanProductID = createLoanProduct(100, 0, RBI_INDIA_STRATEGY);
         Assertions.assertNotNull(loanProductID);
 
         /***
          * Apply for loan application and verify loan status
          */
-        final String savingsId = null;
+        final Long savingsId = null;
         final String principal = "12,000.00";
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
 
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanID = applyForLoanApplicationWithPaymentStrategy(clientID, loanProductID, null, savingsId, principal,
-                LoanApplicationTestBuilder.RBI_INDIA_STRATEGY, collaterals);
+        final Long loanID = applyForLoanApplicationWithPaymentStrategy(clientID, loanProductID, null, savingsId, principal,
+                RBI_INDIA_STRATEGY, collaterals);
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("20 September 2011", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("20 September 2011", loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("20 September 2011", loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount("20 September 2011", loanID));
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap firstInstallment = loanSchedule.get(1);
-        validateNumberForEqual("3200", String.valueOf(firstInstallment.get("totalOutstandingForPeriod")));
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod firstInstallment = loanSchedule.get(1);
+        validateNumberForEqual("3200", String.valueOf(firstInstallment.getTotalOutstandingForPeriod()));
 
         /***
          * Make payment for installment #1
          */
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 October 2011", Float.parseFloat("3200"), loanID);
+        makeRepayment("20 October 2011", Float.parseFloat("3200"), loanID);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         firstInstallment = loanSchedule.get(1);
-        validateNumberForEqual("0.00", String.valueOf(firstInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0.00", String.valueOf(firstInstallment.getTotalOutstandingForPeriod()));
 
         /***
          * Verify 2nd and 3rd repayments dues before making excess payment for installment no 2
          */
-        HashMap secondInstallment = loanSchedule.get(2);
-        HashMap thirdInstallment = loanSchedule.get(3);
+        GetLoansLoanIdRepaymentPeriod secondInstallment = loanSchedule.get(2);
+        GetLoansLoanIdRepaymentPeriod thirdInstallment = loanSchedule.get(3);
 
-        validateNumberForEqual("3200", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
-        validateNumberForEqual("3200", String.valueOf(thirdInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("3200", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
+        validateNumberForEqual("3200", String.valueOf(thirdInstallment.getTotalOutstandingForPeriod()));
 
-        validateNumberForEqual("3000", String.valueOf(secondInstallment.get("principalOutstanding")));
-        validateNumberForEqual("3100", String.valueOf(thirdInstallment.get("principalOutstanding")));
+        validateNumberForEqual("3000", String.valueOf(secondInstallment.getPrincipalOutstanding()));
+        validateNumberForEqual("3100", String.valueOf(thirdInstallment.getPrincipalOutstanding()));
 
         /***
          * Make payment for installment #2
          */
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3200"), loanID);
+        makeRepayment("20 November 2011", Float.parseFloat("3200"), loanID);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         /***
          * Verify 2nd and 3rd repayments after making excess payment for installment no 2
          */
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("0.00", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0.00", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
         /***
          * According to RBI Excess payment should go to principal portion of next installment, but as interest
@@ -3113,95 +2951,87 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
          * payment, so excess payments will behave the same as regular payment with the excess amount
          */
         thirdInstallment = loanSchedule.get(3);
-        validateNumberForEqual("3200", String.valueOf(thirdInstallment.get("totalOutstandingForPeriod")));
-        validateNumberForEqual("3100", String.valueOf(thirdInstallment.get("principalOutstanding")));
-        validateNumberForEqual("0", String.valueOf(thirdInstallment.get("principalPaid")));
-        validateNumberForEqual("0", String.valueOf(thirdInstallment.get("interestPaid")));
-        validateNumberForEqual("100.00", String.valueOf(thirdInstallment.get("interestOutstanding")));
+        validateNumberForEqual("3200", String.valueOf(thirdInstallment.getTotalOutstandingForPeriod()));
+        validateNumberForEqual("3100", String.valueOf(thirdInstallment.getPrincipalOutstanding()));
+        validateNumberForEqual("0", String.valueOf(thirdInstallment.getPrincipalPaid()));
+        validateNumberForEqual("0", String.valueOf(thirdInstallment.getInterestPaid()));
+        validateNumberForEqual("100.00", String.valueOf(thirdInstallment.getInterestOutstanding()));
 
         /***
          * Make payment with due amount of 3rd installment on 4th installment date
          */
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("3200"), loanID);
+        makeRepayment("20 January 2012", Float.parseFloat("3200"), loanID);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
 
         /***
          * Verify overdue interests are deducted first and then remaining amount for interest portion of due installment
          */
         thirdInstallment = loanSchedule.get(3);
-        HashMap fourthInstallment = loanSchedule.get(4);
+        GetLoansLoanIdRepaymentPeriod fourthInstallment = loanSchedule.get(4);
 
-        validateNumberForEqual("100", String.valueOf(thirdInstallment.get("totalOutstandingForPeriod")));
-        validateNumberForEqual("100", String.valueOf(thirdInstallment.get("principalOutstanding")));
+        validateNumberForEqual("100", String.valueOf(thirdInstallment.getTotalOutstandingForPeriod()));
+        validateNumberForEqual("100", String.valueOf(thirdInstallment.getPrincipalOutstanding()));
 
-        validateNumberForEqual("2900", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
-        validateNumberForEqual("100", String.valueOf(fourthInstallment.get("interestPaid")));
-        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.get("interestOutstanding")));
+        validateNumberForEqual("2900", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
+        validateNumberForEqual("100", String.valueOf(fourthInstallment.getInterestPaid()));
+        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.getInterestOutstanding()));
 
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("3000"), loanID);
+        makeRepayment("20 January 2012", Float.parseFloat("3000"), loanID);
 
         /***
          * verify loan is closed as we paid full amount
          */
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
+        verifyLoanAccountIsClosed(loanID);
 
     }
 
     @Test
     public void testLoanPrePaymentWithMultiplePayments() {
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
 
         // Create a loan product
-        Integer loanProductId = createLoanProduct(false, NONE);
-        Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
-        Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
-        List<HashMap> collaterals = List.of(collaterals(clientCollateralId, BigDecimal.ONE));
+        Long loanProductId = createLoanProduct(false, NONE);
+        Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
+        Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
+        List<PostLoansRequestCollateralData> collaterals = List.of(collateral(clientCollateralId, BigDecimal.ONE));
 
         // Apply for a loan
         final String disbursementDate = "1 May 2023";
         final String approvalDate = "1 April 2023";
         final String submissionDate = "1 March 2023";
         final String interestRate = "7";
-        final Integer loanID = applyForLoanApplication(clientID, loanProductId, disbursementDate, submissionDate, interestRate, null, null,
+        final Long loanID = applyForLoanApplication(clientID, loanProductId, disbursementDate, submissionDate, interestRate, null, null,
                 "1000", collaterals);
         Assertions.assertNotNull(loanID);
 
         // Check loan status
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
         // Approve the loan
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(approvalDate, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(approvalDate, loanID));
 
         // Disburse the loan
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(disbursementDate, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(disbursementDate, loanID));
 
         // Make the first partial repayment
         LOG.info("------------------------MAKE FIRST PARTIAL REPAYMENT-----------------------------------");
         Float firstRepaymentAmount = 500.0f; // First partial repayment
         String firstRepaymentDate = "1 June 2023";
-        LOAN_TRANSACTION_HELPER.makeRepayment(firstRepaymentDate, firstRepaymentAmount, loanID);
+        makeRepayment(firstRepaymentDate, firstRepaymentAmount, loanID);
 
         // Verify the prepayment amount after the first partial repayment
         LOG.info("------------------------GET PREPAYMENT AMOUNT AFTER FIRST PAYMENT-----------------------");
-        HashMap<String, Object> prepayAmount = loanTransactionHelper.getPrepayAmount(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        GetLoansLoanIdTransactionsTemplateResponse prepayAmount = getPrepayAmount(loanID);
         Assertions.assertNotNull(prepayAmount);
 
         // Extract the principal and interest portions
-        Float totalPrepayAmount = (Float) prepayAmount.get("amount");
-        Float principalAmount = (Float) prepayAmount.get("principalPortion");
-        Float interestAmount = (Float) prepayAmount.get("interestPortion");
+        Float totalPrepayAmount = prepayAmount.getAmount().floatValue();
+        Float principalAmount = prepayAmount.getPrincipalPortion().floatValue();
+        Float interestAmount = prepayAmount.getInterestPortion().floatValue();
 
         // Expected values after the first partial repayment
         Float expectedTotalPrepayAmount = 606.18f;
@@ -3217,24 +3047,23 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         LOG.info("------------------------MAKE SECOND PARTIAL REPAYMENT----------------------------------");
         Float secondRepaymentAmount = 606.18f;
         String secondRepaymentDate = "1 July 2023";
-        LOAN_TRANSACTION_HELPER.makeRepayment(secondRepaymentDate, secondRepaymentAmount, loanID);
+        makeRepayment(secondRepaymentDate, secondRepaymentAmount, loanID);
 
         // Recheck the prepayment amount
         LOG.info("------------------------RECHECK PREPAYMENT AMOUNT AFTER FULL REPAYMENT------------------");
-        HashMap<String, Object> postPrepayAmount = loanTransactionHelper.getPrepayAmount(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        GetLoansLoanIdTransactionsTemplateResponse postPrepayAmount = getPrepayAmount(loanID);
         Assertions.assertNotNull(postPrepayAmount);
 
         // Verify that the principal and interest portions are zero
-        Float postPrincipalAmount = (Float) postPrepayAmount.get("principalPortion");
-        Float postInterestAmount = (Float) postPrepayAmount.get("interestPortion");
+        Float postPrincipalAmount = postPrepayAmount.getPrincipalPortion().floatValue();
+        Float postInterestAmount = postPrepayAmount.getInterestPortion().floatValue();
 
         validateNumberForEqual("0.0", String.valueOf(postPrincipalAmount));
         validateNumberForEqual("0.0", String.valueOf(postInterestAmount));
 
         // Check the loan status after repayment
         LOG.info("------------------------CHECK LOAN STATUS---------------------------------------------");
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
+        verifyLoanAccountIsClosed(loanID);
     }
 
     @Test
@@ -3247,23 +3076,21 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         todaysDate.add(Calendar.DAY_OF_MONTH, -14);
         final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todaysDate.getTime());
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProductWithInterestRecalculation(LoanProductTestBuilder.DEFAULT_STRATEGY,
-                LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_NONE,
-                LoanProductTestBuilder.RECALCULATION_STRATEGY_REDUCE_EMI_AMOUN,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_SAME_AS_REPAYMENT_PERIOD, "0", null,
-                LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE, null, null, null);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Long loanProductID = createLoanProductWithInterestRecalculation(DEFAULT_STRATEGY,
+                LoanTestData.InterestRecalculationCompoundingMethod.NONE, LoanTestData.RescheduleStrategyMethod.REDUCE_EMI_AMOUNT,
+                LoanTestData.RecalculationRestFrequencyType.SAME_AS_REPAYMENT_PERIOD, 0,
+                LoanTestData.PreClosureInterestCalculationStrategy.TILL_PRE_CLOSE_DATE, null, null, null);
 
-        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE, null,
-                LoanApplicationTestBuilder.DEFAULT_STRATEGY, new ArrayList<>(0));
+        final Long loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
+                DEFAULT_STRATEGY, new ArrayList<>(0));
 
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        List<Map<String, Object>> expectedvalues = new ArrayList<>();
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        List<ExpectedInstallment> expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2494.22", "34.69", "0.0", "0.0");
@@ -3272,17 +3099,12 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(LOAN_DISBURSEMENT_DATE, loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID));
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
@@ -3295,10 +3117,10 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -7);
         final String LOAN_FIRST_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
-        Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        Float totalDueForCurrentPeriod = loanSchedule.get(1).getTotalDueForPeriod().floatValue();
+        makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
@@ -3311,8 +3133,8 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -5);
         final String LOAN_SECOND_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_SECOND_REPAYMENT_DATE, earlyPayment, loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        makeRepayment(LOAN_SECOND_REPAYMENT_DATE, earlyPayment, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
@@ -3321,19 +3143,18 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "1780.05", "8.22", "0.0", "0.0");
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
-        HashMap prepayDetail = LOAN_TRANSACTION_HELPER.getPrepayAmount(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        String prepayAmount = String.valueOf(prepayDetail.get("amount"));
+        GetLoansLoanIdTransactionsTemplateResponse prepayDetail = getPrepayAmount(loanID);
+        String prepayAmount = String.valueOf(prepayDetail.getAmount());
         validateNumberForEqualWithMsg("verify pre-close amount", "3551.93", prepayAmount);
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         final String loanRepaymentDate = dateFormat.format(todaysDate.getTime());
-        LOAN_TRANSACTION_HELPER.makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanID);
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
+        makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanID);
+        verifyLoanAccountIsClosed(loanID);
     }
 
     @Test
     public void testLoanScheduleWithInterestRecalculation_WITH_REST_SAME_AS_REPAYMENT_INTEREST_COMPOUND_NONE_STRATEGY_REDUCE_EMI_PRE_CLOSE_INTEREST_PRE_CLOSE_DATE() {
-        String preCloseInterestStrategy = LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE;
+        Integer preCloseInterestStrategy = LoanTestData.PreClosureInterestCalculationStrategy.TILL_PRE_CLOSE_DATE;
         String preCloseAmount = "7561.84";
         testLoanScheduleWithInterestRecalculation_WITH_REST_SAME_AS_REPAYMENT_INTEREST_COMPOUND_NONE_STRATEGY_REDUCE_EMI_PRE_CLOSE_INTEREST(
                 preCloseInterestStrategy, preCloseAmount);
@@ -3341,7 +3162,7 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
     @Test
     public void testLoanScheduleWithInterestRecalculation_WITH_REST_SAME_AS_REPAYMENT_INTEREST_COMPOUND_NONE_STRATEGY_REDUCE_EMI_PRE_CLOSE_INTEREST_REST_DATE() {
-        String preCloseInterestStrategy = LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_REST_DATE;
+        Integer preCloseInterestStrategy = LoanTestData.PreClosureInterestCalculationStrategy.TILL_REST_FREQUENCY_DATE;
         String preCloseAmount = "7586.62";
         testLoanScheduleWithInterestRecalculation_WITH_REST_SAME_AS_REPAYMENT_INTEREST_COMPOUND_NONE_STRATEGY_REDUCE_EMI_PRE_CLOSE_INTEREST(
                 preCloseInterestStrategy, preCloseAmount);
@@ -3357,27 +3178,25 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         todaysDate.add(Calendar.DAY_OF_MONTH, -14);
         final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todaysDate.getTime());
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProductWithInterestRecalculation(LoanProductTestBuilder.DEFAULT_STRATEGY,
-                LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_NONE,
-                LoanProductTestBuilder.RECALCULATION_STRATEGY_REDUCE_EMI_AMOUN,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_SAME_AS_REPAYMENT_PERIOD, "0", null,
-                LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE, null, null, null);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Long loanProductID = createLoanProductWithInterestRecalculation(DEFAULT_STRATEGY,
+                LoanTestData.InterestRecalculationCompoundingMethod.NONE, LoanTestData.RescheduleStrategyMethod.REDUCE_EMI_AMOUNT,
+                LoanTestData.RecalculationRestFrequencyType.SAME_AS_REPAYMENT_PERIOD, 0,
+                LoanTestData.PreClosureInterestCalculationStrategy.TILL_PRE_CLOSE_DATE, null, null, null);
 
-        List<HashMap> charges = new ArrayList<>();
-        Integer installmentCharge = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_INTEREST, "10", false));
-        addCharges(charges, installmentCharge, "10", null);
-        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE, null,
-                LoanApplicationTestBuilder.DEFAULT_STRATEGY, charges);
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
+        Long installmentCharge = chargesHelper.createLoanInstallmentCharge(ChargeCalculationType.PERCENT_OF_INTEREST, 10.0, false)
+                .getResourceId();
+        addCharges(charges, installmentCharge, 10.0, null);
+        final Long loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
+                DEFAULT_STRATEGY, charges);
 
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        List<Map<String, Object>> expectedvalues = new ArrayList<>();
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        List<ExpectedInstallment> expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "4.62", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2494.22", "34.69", "3.47", "0.0");
@@ -3386,17 +3205,12 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(LOAN_DISBURSEMENT_DATE, loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID));
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "4.62", "0.0");
@@ -3409,10 +3223,10 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -7);
         final String LOAN_FIRST_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
-        Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        Float totalDueForCurrentPeriod = loanSchedule.get(1).getTotalDueForPeriod().floatValue();
+        makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "4.62", "0.0");
@@ -3425,8 +3239,8 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -5);
         final String LOAN_SECOND_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_SECOND_REPAYMENT_DATE, earlyPayment, loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        makeRepayment(LOAN_SECOND_REPAYMENT_DATE, earlyPayment, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "4.62", "0.0");
@@ -3435,13 +3249,12 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "1781.79", "8.22", "0.82", "0.0");
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
-        HashMap prepayDetail = LOAN_TRANSACTION_HELPER.getPrepayAmount(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        String prepayAmount = String.valueOf(prepayDetail.get("amount"));
+        GetLoansLoanIdTransactionsTemplateResponse prepayDetail = getPrepayAmount(loanID);
+        String prepayAmount = String.valueOf(prepayDetail.getAmount());
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         final String loanRepaymentDate = dateFormat.format(todaysDate.getTime());
-        LOAN_TRANSACTION_HELPER.makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanID);
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
+        makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanID);
+        verifyLoanAccountIsClosed(loanID);
     }
 
     @Test
@@ -3455,24 +3268,22 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todaysDate.getTime());
         Integer dayOfWeek = getDayOfWeek(todaysDate);
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProductWithInterestRecalculationAndCompoundingDetails(
-                LoanProductTestBuilder.RBI_INDIA_STRATEGY, LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_INTEREST,
-                LoanProductTestBuilder.RECALCULATION_STRATEGY_REDUCE_NUMBER_OF_INSTALLMENTS,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_DAILY, "1", LOAN_DISBURSEMENT_DATE,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_WEEKLY, "1", LOAN_DISBURSEMENT_DATE,
-                LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE, null, null, dayOfWeek, null, dayOfWeek);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Long loanProductID = createLoanProductWithInterestRecalculationAndCompoundingDetails(RBI_INDIA_STRATEGY,
+                LoanTestData.InterestRecalculationCompoundingMethod.INTEREST,
+                LoanTestData.RescheduleStrategyMethod.REDUCE_NUMBER_OF_INSTALLMENTS, LoanTestData.RecalculationRestFrequencyType.DAILY, 1,
+                LoanTestData.RecalculationRestFrequencyType.WEEKLY, 1,
+                LoanTestData.PreClosureInterestCalculationStrategy.TILL_PRE_CLOSE_DATE, null, null, dayOfWeek, null, dayOfWeek);
 
-        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
-                LoanApplicationTestBuilder.RBI_INDIA_STRATEGY, new ArrayList<>(0));
+        final Long loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
+                RBI_INDIA_STRATEGY, new ArrayList<>(0));
 
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        List<Map<String, Object>> expectedvalues = new ArrayList<>();
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        List<ExpectedInstallment> expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2494.22", "34.69", "0.0", "0.0");
@@ -3482,17 +3293,12 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(LOAN_DISBURSEMENT_DATE, loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID));
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
@@ -3502,7 +3308,7 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanFutureRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanFutureRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, 0, false, "4965.3", "92.52", "0.0", "0.0");
@@ -3514,10 +3320,10 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -7);
         final String LOAN_FIRST_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
-        Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        Float totalDueForCurrentPeriod = loanSchedule.get(1).getTotalDueForPeriod().floatValue();
+        makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
@@ -3530,30 +3336,24 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -5);
         final String LOAN_SECOND_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_SECOND_REPAYMENT_DATE, earlyPayment, loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        makeRepayment(LOAN_SECOND_REPAYMENT_DATE, earlyPayment, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         Calendar today = Calendar.getInstance(Utils.getTimeZoneOfTenant());
-        Map<String, Object> paymentday = new HashMap<>(3);
-        paymentday.put("dueDate", getDateAsArray(today, -5, Calendar.DAY_OF_MONTH));
-        paymentday.put("principalDue", "3990.09");
-        paymentday.put("interestDue", "9.91");
-        paymentday.put("feeChargesDue", "0");
-        paymentday.put("penaltyChargesDue", "0");
+        ExpectedInstallment paymentday = new ExpectedInstallment(addDays(today, -5), "3990.09", "9.91", "0", "0");
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
         expectedvalues.add(paymentday);
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2517.31", "11.6", "0.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "1009.84", "4.66", "0.0", "0.0");
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
-        HashMap prepayDetail = LOAN_TRANSACTION_HELPER.getPrepayAmount(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        String prepayAmount = String.valueOf(prepayDetail.get("amount"));
+        GetLoansLoanIdTransactionsTemplateResponse prepayDetail = getPrepayAmount(loanID);
+        String prepayAmount = String.valueOf(prepayDetail.getAmount());
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         final String loanRepaymentDate = dateFormat.format(todaysDate.getTime());
-        LOAN_TRANSACTION_HELPER.makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanID);
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
+        makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanID);
+        verifyLoanAccountIsClosed(loanID);
 
     }
 
@@ -3575,42 +3375,34 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             String firstRepayment = dateFormat.format(firstRepaymentDate.getTime());
 
             final String loanDisbursementDate = dateFormat.format(startDate.getTime());
-            final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-            ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-            final Integer loanProductID = createLoanProductWithInterestRecalculationAndCompoundingDetails(
-                    LoanProductTestBuilder.INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY,
-                    LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_NONE,
-                    LoanProductTestBuilder.RECALCULATION_STRATEGY_REDUCE_NUMBER_OF_INSTALLMENTS,
-                    LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_SAME_AS_REPAYMENT_PERIOD,
-                    LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE, null, "12");
+            final Long clientID = createClient();
+            verifyClientCreatedOnServer(clientID);
+            final Long loanProductID = createLoanProductWithInterestRecalculationAndInstallmentAmount(
+                    INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY, LoanTestData.InterestRecalculationCompoundingMethod.NONE,
+                    LoanTestData.RescheduleStrategyMethod.REDUCE_NUMBER_OF_INSTALLMENTS,
+                    LoanTestData.PreClosureInterestCalculationStrategy.TILL_PRE_CLOSE_DATE, null, 12);
 
-            final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, loanDisbursementDate,
-                    LoanApplicationTestBuilder.INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY, firstRepayment);
+            final Long loanID = applyForLoanApplicationForInterestRecalculationWithFirstRepaymentDate(clientID, loanProductID,
+                    loanDisbursementDate, INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY, firstRepayment);
 
             Assertions.assertNotNull(loanID);
-            HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+            verifyLoanIsPending(loanID);
 
             LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(loanDisbursementDate, loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-            LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+            verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(loanDisbursementDate, loanID));
 
             LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-            String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(loanDisbursementDate, loanID,
-                    JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+            verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(loanDisbursementDate, loanID));
 
-            ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+            List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
             Assertions.assertNotNull(loanSchedule);
             startDate.add(Calendar.DAY_OF_MONTH, 2);
             String loanFirstRepaymentDate = dateFormat.format(startDate.getTime());
 
             Float earlyPayment = Float.parseFloat("3000");
-            String accountNo = JsonPath.from(loanDetails).get("accountNo").toString();
+            String accountNo = getLoanDetails(loanID).getAccountNo();
 
-            HashMap loanRepayment = LOAN_TRANSACTION_HELPER.makeRepaymentWithAccountNo(loanFirstRepaymentDate, earlyPayment, accountNo);
+            String loanRepayment = makeRepaymentByAccountNo(accountNo, loanFirstRepaymentDate, earlyPayment);
             assertNotNull(loanRepayment);
         } finally {
             globalConfigurationHelper.updateGlobalConfiguration(
@@ -3641,34 +3433,31 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         final String LOAN_FLAT_CHARGE_DATE = dateFormat.format(todaysDate.getTime());
         todaysDate.add(Calendar.DAY_OF_MONTH, 14);
         final String LOAN_INTEREST_CHARGE_DATE = dateFormat.format(todaysDate.getTime());
-        List<HashMap> charges = new ArrayList<>(2);
-        Integer flat = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "100", false));
-        Integer principalPercentage = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "2", false));
+        List<PostLoansRequestChargeData> charges = new ArrayList<>(2);
+        Long flat = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.FLAT, 100.0, false).getResourceId();
+        Long principalPercentage = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 2.0, false)
+                .getResourceId();
 
-        addCharges(charges, flat, "100", LOAN_FLAT_CHARGE_DATE);
-        addCharges(charges, principalPercentage, "2", LOAN_INTEREST_CHARGE_DATE);
+        addCharges(charges, flat, 100.0, LOAN_FLAT_CHARGE_DATE);
+        addCharges(charges, principalPercentage, 2.0, LOAN_INTEREST_CHARGE_DATE);
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProductWithInterestRecalculationAndCompoundingDetails(
-                LoanProductTestBuilder.DEFAULT_STRATEGY, LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_INTEREST_AND_FEE,
-                LoanProductTestBuilder.RECALCULATION_STRATEGY_RESCHEDULE_NEXT_REPAYMENTS,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_WEEKLY, "1", REST_START_DATE,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_WEEKLY, "1", LOAN_DISBURSEMENT_DATE,
-                LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE, null, compoundingDayOfMonth, compoundingDayOfWeek,
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Long loanProductID = createLoanProductWithInterestRecalculationAndCompoundingDetails(DEFAULT_STRATEGY,
+                LoanTestData.InterestRecalculationCompoundingMethod.INTEREST_AND_FEE,
+                LoanTestData.RescheduleStrategyMethod.RESCHEDULE_NEXT_REPAYMENTS, LoanTestData.RecalculationRestFrequencyType.WEEKLY, 1,
+                LoanTestData.RecalculationRestFrequencyType.WEEKLY, 1,
+                LoanTestData.PreClosureInterestCalculationStrategy.TILL_PRE_CLOSE_DATE, null, compoundingDayOfMonth, compoundingDayOfWeek,
                 restDayOfMonth, restDayOfWeek);
 
-        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
-                LOAN_DISBURSEMENT_DATE, LoanApplicationTestBuilder.DEFAULT_STRATEGY, charges);
+        final Long loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
+                DEFAULT_STRATEGY, charges);
 
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        List<Map<String, Object>> expectedvalues = new ArrayList<>();
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        List<ExpectedInstallment> expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "100.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2494.22", "34.69", "0.0", "0.0");
@@ -3677,17 +3466,12 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(LOAN_DISBURSEMENT_DATE, loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID));
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "100.0", "0.0");
@@ -3700,10 +3484,10 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         Calendar repaymentDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         repaymentDate.add(Calendar.DAY_OF_MONTH, -7);
         final String LOAN_FIRST_REPAYMENT_DATE = dateFormat.format(repaymentDate.getTime());
-        Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        Float totalDueForCurrentPeriod = loanSchedule.get(1).getTotalDueForPeriod().floatValue();
+        makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "100.0", "0.0");
@@ -3716,9 +3500,9 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         repaymentDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         repaymentDate.add(Calendar.DAY_OF_MONTH, -5);
         final String LOAN_SECOND_REPAYMENT_DATE = dateFormat.format(repaymentDate.getTime());
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_SECOND_REPAYMENT_DATE, earlyPayment, loanID);
+        makeRepayment(LOAN_SECOND_REPAYMENT_DATE, earlyPayment, loanID);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "100.0", "0.0");
@@ -3727,19 +3511,18 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2451.93", "11.32", "0.0", "0.0");
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
-        HashMap prepayDetail = LOAN_TRANSACTION_HELPER.getPrepayAmount(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        String prepayAmount = String.valueOf(prepayDetail.get("amount"));
+        GetLoansLoanIdTransactionsTemplateResponse prepayDetail = getPrepayAmount(loanID);
+        String prepayAmount = String.valueOf(prepayDetail.getAmount());
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         final String loanRepaymentDate = dateFormat.format(todaysDate.getTime());
-        LOAN_TRANSACTION_HELPER.makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanID);
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
+        makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanID);
+        verifyLoanAccountIsClosed(loanID);
 
     }
 
     @Test
     public void testLoanScheduleWithInterestRecalculation_WITH_REST_WEEKLY_INTEREST_COMPOUND_INTEREST_FEE_STRATEGY_REDUCE_NEXT_INSTALLMENTS_PRE_CLOSE_INTEREST_PRE_CLOSE_DATE() {
-        String preCloseInterestStrategy = LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE;
+        Integer preCloseInterestStrategy = LoanTestData.PreClosureInterestCalculationStrategy.TILL_PRE_CLOSE_DATE;
         String preCloseAmount = "7761.89";
         testLoanScheduleWithInterestRecalculation_WITH_REST_WEEKLY_INTEREST_COMPOUND_INTEREST_FEE_STRATEGY_REDUCE_NEXT_INSTALLMENTS_PRE_CLOSE_INTEREST(
                 preCloseInterestStrategy, preCloseAmount);
@@ -3748,7 +3531,7 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
     @Test
     public void testLoanScheduleWithInterestRecalculation_WITH_REST_WEEKLY_INTEREST_COMPOUND_INTEREST_FEE_STRATEGY_REDUCE_NEXT_INSTALLMENTS_PRE_CLOSE_INTEREST_REST_DATE() {
-        String preCloseInterestStrategy = LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_REST_DATE;
+        Integer preCloseInterestStrategy = LoanTestData.PreClosureInterestCalculationStrategy.TILL_REST_FREQUENCY_DATE;
         String preCloseAmount = "7786.79";
         testLoanScheduleWithInterestRecalculation_WITH_REST_WEEKLY_INTEREST_COMPOUND_INTEREST_FEE_STRATEGY_REDUCE_NEXT_INSTALLMENTS_PRE_CLOSE_INTEREST(
                 preCloseInterestStrategy, preCloseAmount);
@@ -3768,31 +3551,28 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         todaysDate.add(Calendar.DAY_OF_MONTH, -2);
         final String REST_START_DATE = dateFormat.format(todaysDate.getTime());
 
-        Integer overdueFeeChargeId = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("10"));
+        Long overdueFeeChargeId = chargesHelper.createCharge(ChargeRequestBuilders.loanOverdueFeePercentageOfAmountAndInterest(10.0))
+                .getResourceId();
         Assertions.assertNotNull(overdueFeeChargeId);
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final String recalculationCompoundingFrequencyInterval = null;
-        final String recalculationCompoundingFrequencyDate = null;
-        final Integer loanProductID = createLoanProductWithInterestRecalculation(LoanProductTestBuilder.DEFAULT_STRATEGY,
-                LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_INTEREST_AND_FEE,
-                LoanProductTestBuilder.RECALCULATION_STRATEGY_RESCHEDULE_NEXT_REPAYMENTS,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_DAILY, "1", REST_START_DATE,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_SAME_AS_REPAYMENT_PERIOD, recalculationCompoundingFrequencyInterval,
-                recalculationCompoundingFrequencyDate, LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE, null,
-                overdueFeeChargeId.toString(), false, null, null, null, null);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Integer recalculationCompoundingFrequencyInterval = null;
+        final Long loanProductID = createLoanProductWithInterestRecalculation(DEFAULT_STRATEGY,
+                LoanTestData.InterestRecalculationCompoundingMethod.INTEREST_AND_FEE,
+                LoanTestData.RescheduleStrategyMethod.RESCHEDULE_NEXT_REPAYMENTS, LoanTestData.RecalculationRestFrequencyType.DAILY, 1,
+                LoanTestData.RecalculationRestFrequencyType.SAME_AS_REPAYMENT_PERIOD, recalculationCompoundingFrequencyInterval,
+                LoanTestData.PreClosureInterestCalculationStrategy.TILL_PRE_CLOSE_DATE, null, overdueFeeChargeId, false, null, null, null,
+                null);
 
-        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
-                REST_START_DATE, LoanApplicationTestBuilder.DEFAULT_STRATEGY, null);
+        final Long loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
+                DEFAULT_STRATEGY, null);
 
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        List<Map<String, Object>> expectedvalues = new ArrayList<>();
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        List<ExpectedInstallment> expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -2, false, "2482.76", "46.15", "0.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2494.22", "34.69", "0.0", "0.0");
@@ -3801,17 +3581,12 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(LOAN_DISBURSEMENT_DATE, loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID));
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
 
@@ -3823,9 +3598,9 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         String JobName = "Apply penalty to overdue loans";
-        SchedulerJobHelper.executeAndAwaitJob(JobName);
+        schedulerHelper.executeAndAwaitJob(JobName);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -2, false, "2482.76", "46.15", "0.0", "252.89");
@@ -3837,11 +3612,11 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         Calendar repaymentDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         repaymentDate.add(Calendar.DAY_OF_MONTH, -7 * 2);
         final String LOAN_FIRST_REPAYMENT_DATE = dateFormat.format(repaymentDate.getTime());
-        Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
+        Float totalDueForCurrentPeriod = loanSchedule.get(1).getTotalDueForPeriod().floatValue();
         totalDueForCurrentPeriod = totalDueForCurrentPeriod - Float.parseFloat("252.89");
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -2, false, "2482.76", "46.15", "0.0", "252.89");
@@ -3853,10 +3628,10 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         repaymentDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         repaymentDate.add(Calendar.DAY_OF_MONTH, -3);
         final String LOAN_SECOND_REPAYMENT_DATE = dateFormat.format(repaymentDate.getTime());
-        totalDueForCurrentPeriod = (Float) loanSchedule.get(2).get("totalDueForPeriod");
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_SECOND_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        totalDueForCurrentPeriod = loanSchedule.get(2).getTotalDueForPeriod().floatValue();
+        makeRepayment(LOAN_SECOND_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -2, false, "2482.76", "46.15", "0.0", "252.89");
@@ -3873,34 +3648,32 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         DateFormat dateFormat = new SimpleDateFormat(DATETIME_PATTERN, Locale.US);
         dateFormat.setTimeZone(Utils.getTimeZoneOfTenant());
 
-        final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-        final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-        final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-        final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+        final Account assetAccount = accountHelper.createAssetAccount();
+        final Account incomeAccount = accountHelper.createIncomeAccount();
+        final Account expenseAccount = accountHelper.createExpenseAccount();
+        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
         Calendar todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         LOG.info("Disbursal Date Calendar {}", todaysDate.getTime());
         todaysDate.add(Calendar.DAY_OF_MONTH, -14);
         final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todaysDate.getTime());
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
         Account[] accounts = { assetAccount, incomeAccount, expenseAccount, overpaymentAccount };
-        final Integer loanProductID = createLoanProductWithInterestRecalculation(LoanProductTestBuilder.DEFAULT_STRATEGY,
-                LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_NONE,
-                LoanProductTestBuilder.RECALCULATION_STRATEGY_REDUCE_EMI_AMOUN,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_SAME_AS_REPAYMENT_PERIOD, "0", null,
-                LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE, accounts, null, null);
+        final Long loanProductID = createLoanProductWithInterestRecalculation(DEFAULT_STRATEGY,
+                LoanTestData.InterestRecalculationCompoundingMethod.NONE, LoanTestData.RescheduleStrategyMethod.REDUCE_EMI_AMOUNT,
+                LoanTestData.RecalculationRestFrequencyType.SAME_AS_REPAYMENT_PERIOD, 0,
+                LoanTestData.PreClosureInterestCalculationStrategy.TILL_PRE_CLOSE_DATE, accounts, null, null);
 
-        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE, null,
-                LoanApplicationTestBuilder.DEFAULT_STRATEGY, new ArrayList<>(0));
+        final Long loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
+                DEFAULT_STRATEGY, new ArrayList<>(0));
 
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        List<Map<String, Object>> expectedvalues = new ArrayList<>();
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        List<ExpectedInstallment> expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         LOG.info("Date during repayment schedule {}", todaysDate.getTime());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
@@ -3910,17 +3683,12 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(LOAN_DISBURSEMENT_DATE, loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID));
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
@@ -3930,23 +3698,24 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
-        final JournalEntry[] assetAccountInitialEntry = { new JournalEntry(10000.0f, JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(10000.0f, JournalEntry.TransactionType.DEBIT), };
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, LOAN_DISBURSEMENT_DATE, assetAccountInitialEntry);
+        final LoanTestData.Journal[] assetAccountInitialEntry = {
+                journalEntry(10000.0f, assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(10000.0f, assetAccount, JournalEntry.TransactionType.DEBIT.name()), };
+        checkJournalEntryForAssetAccount(assetAccount, LOAN_DISBURSEMENT_DATE, assetAccountInitialEntry);
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         String runOndate = dateFormat.format(todaysDate.getTime());
         LOG.info("runOndate : {}", runOndate);
-        PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting(runOndate);
-        LOAN_TRANSACTION_HELPER.checkAccrualTransactionForRepayment(Utils.getLocalDateOfTenant().minusDays(7), 46.15f, 0f, 0f, loanID);
-        LOAN_TRANSACTION_HELPER.checkAccrualTransactionForRepayment(Utils.getLocalDateOfTenant(), 46.15f, 0f, 0f, loanID);
+        runPeriodicAccrualAccounting(runOndate);
+        checkAccrualTransactionForRepayment(Utils.getLocalDateOfTenant().minusDays(7), 46.15f, 0f, 0f, loanID);
+        checkAccrualTransactionForRepayment(Utils.getLocalDateOfTenant(), 46.15f, 0f, 0f, loanID);
 
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -7);
         final String LOAN_FIRST_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
-        Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        Float totalDueForCurrentPeriod = loanSchedule.get(1).getTotalDueForPeriod().floatValue();
+        makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
@@ -3955,20 +3724,19 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2517.29", "11.62", "0.0", "0.0");
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
-        PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting(runOndate);
-        LOAN_TRANSACTION_HELPER.checkAccrualTransactionForRepayment(Utils.getLocalDateOfTenant().minusDays(7), 46.15f, 0f, 0f, loanID);
-        LOAN_TRANSACTION_HELPER.checkAccrualTransactionForRepayment(Utils.getLocalDateOfTenant(), 34.69f, 0f, 0f, loanID);
+        runPeriodicAccrualAccounting(runOndate);
+        checkAccrualTransactionForRepayment(Utils.getLocalDateOfTenant().minusDays(7), 46.15f, 0f, 0f, loanID);
+        checkAccrualTransactionForRepayment(Utils.getLocalDateOfTenant(), 34.69f, 0f, 0f, loanID);
 
-        HashMap prepayDetail = LOAN_TRANSACTION_HELPER.getPrepayAmount(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        String prepayAmount = String.valueOf(prepayDetail.get("amount"));
+        GetLoansLoanIdTransactionsTemplateResponse prepayDetail = getPrepayAmount(loanID);
+        String prepayAmount = String.valueOf(prepayDetail.getAmount());
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         final String loanRepaymentDate = dateFormat.format(todaysDate.getTime());
-        LOAN_TRANSACTION_HELPER.makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanID);
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
+        makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanID);
+        verifyLoanAccountIsClosed(loanID);
 
-        LOAN_TRANSACTION_HELPER.checkAccrualTransactionForRepayment(Utils.getLocalDateOfTenant().minusDays(7), 46.15f, 0f, 0f, loanID);
-        LOAN_TRANSACTION_HELPER.checkAccrualTransactionForRepayment(Utils.getLocalDateOfTenant(), 34.69f, 0f, 0f, loanID);
+        checkAccrualTransactionForRepayment(Utils.getLocalDateOfTenant().minusDays(7), 46.15f, 0f, 0f, loanID);
+        checkAccrualTransactionForRepayment(Utils.getLocalDateOfTenant(), 34.69f, 0f, 0f, loanID);
 
     }
 
@@ -3982,25 +3750,23 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         todaysDate.add(Calendar.DAY_OF_MONTH, -14);
         final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todaysDate.getTime());
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProductWithInterestRecalculationAndCompoundingDetails(
-                LoanProductTestBuilder.RBI_INDIA_STRATEGY, LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_INTEREST,
-                LoanProductTestBuilder.RECALCULATION_STRATEGY_RESCHEDULE_NEXT_REPAYMENTS,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_DAILY, "1", LOAN_DISBURSEMENT_DATE,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_SAME_AS_REPAYMENT_PERIOD, "1", LOAN_DISBURSEMENT_DATE,
-                LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE, null, getDayOfMonth(todaysDate),
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Long loanProductID = createLoanProductWithInterestRecalculationAndCompoundingDetails(RBI_INDIA_STRATEGY,
+                LoanTestData.InterestRecalculationCompoundingMethod.INTEREST,
+                LoanTestData.RescheduleStrategyMethod.RESCHEDULE_NEXT_REPAYMENTS, LoanTestData.RecalculationRestFrequencyType.DAILY, 1,
+                LoanTestData.RecalculationRestFrequencyType.SAME_AS_REPAYMENT_PERIOD, 1,
+                LoanTestData.PreClosureInterestCalculationStrategy.TILL_PRE_CLOSE_DATE, null, getDayOfMonth(todaysDate),
                 getDayOfWeek(todaysDate), getDayOfMonth(todaysDate), getDayOfWeek(todaysDate));
 
-        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
-                LOAN_DISBURSEMENT_DATE, LoanApplicationTestBuilder.RBI_INDIA_STRATEGY, new ArrayList<>(0));
+        final Long loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
+                RBI_INDIA_STRATEGY, new ArrayList<>(0));
 
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        List<Map<String, Object>> expectedvalues = new ArrayList<>();
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        List<ExpectedInstallment> expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2494.22", "34.69", "0.0", "0.0");
@@ -4010,17 +3776,12 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(LOAN_DISBURSEMENT_DATE, loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID));
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
@@ -4031,25 +3792,19 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -7);
-        HashMap loanSummary = LOAN_TRANSACTION_HELPER.getLoanSummary(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        List dates = (List) loanSummary.get("overdueSinceDate");
-        assertEquals(todaysDate.get(Calendar.YEAR), dates.get(0));
-        assertEquals(todaysDate.get(Calendar.MONTH) + 1, dates.get(1));
-        assertEquals(todaysDate.get(Calendar.DAY_OF_MONTH), dates.get(2));
+        GetLoansLoanIdSummary loanSummary = getLoanDetails(loanID).getSummary();
+        assertEquals(toLocalDate(todaysDate), loanSummary.getOverdueSinceDate());
 
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -8);
         final String LOAN_FIRST_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
-        Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        Float totalDueForCurrentPeriod = loanSchedule.get(1).getTotalDueForPeriod().floatValue();
+        makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
 
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -7);
-        loanSummary = LOAN_TRANSACTION_HELPER.getLoanSummary(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        dates = (List) loanSummary.get("overdueSinceDate");
-        assertEquals(todaysDate.get(Calendar.YEAR), dates.get(0));
-        assertEquals(todaysDate.get(Calendar.MONTH) + 1, dates.get(1));
-        assertEquals(todaysDate.get(Calendar.DAY_OF_MONTH), dates.get(2));
+        loanSummary = getLoanDetails(loanID).getSummary();
+        assertEquals(toLocalDate(todaysDate), loanSummary.getOverdueSinceDate());
 
     }
 
@@ -4064,27 +3819,24 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         todaysDate.add(Calendar.DAY_OF_MONTH, -14);
         final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todaysDate.getTime());
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final String recalculationCompoundingFrequencyInterval = null;
-        final String recalculationCompoundingFrequencyDate = null;
-        final Integer loanProductID = createLoanProductWithInterestRecalculation(LoanProductTestBuilder.RBI_INDIA_STRATEGY,
-                LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_INTEREST,
-                LoanProductTestBuilder.RECALCULATION_STRATEGY_RESCHEDULE_NEXT_REPAYMENTS,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_DAILY, "1", LOAN_DISBURSEMENT_DATE,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_SAME_AS_REPAYMENT_PERIOD, recalculationCompoundingFrequencyInterval,
-                recalculationCompoundingFrequencyDate, LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE, null, null,
-                true, null, null, getDayOfMonth(todaysDate), getDayOfWeek(todaysDate));
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Integer recalculationCompoundingFrequencyInterval = null;
+        final Long loanProductID = createLoanProductWithInterestRecalculation(RBI_INDIA_STRATEGY,
+                LoanTestData.InterestRecalculationCompoundingMethod.INTEREST,
+                LoanTestData.RescheduleStrategyMethod.RESCHEDULE_NEXT_REPAYMENTS, LoanTestData.RecalculationRestFrequencyType.DAILY, 1,
+                LoanTestData.RecalculationRestFrequencyType.SAME_AS_REPAYMENT_PERIOD, recalculationCompoundingFrequencyInterval,
+                LoanTestData.PreClosureInterestCalculationStrategy.TILL_PRE_CLOSE_DATE, null, null, true, null, null,
+                getDayOfMonth(todaysDate), getDayOfWeek(todaysDate));
 
-        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
-                LOAN_DISBURSEMENT_DATE, LoanApplicationTestBuilder.RBI_INDIA_STRATEGY, new ArrayList<>(0));
+        final Long loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
+                RBI_INDIA_STRATEGY, new ArrayList<>(0));
 
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        List<Map<String, Object>> expectedvalues = new ArrayList<>();
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        List<ExpectedInstallment> expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2494.22", "34.69", "0.0", "0.0");
@@ -4094,17 +3846,12 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(LOAN_DISBURSEMENT_DATE, loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID));
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
@@ -4115,36 +3862,32 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -7);
-        HashMap loanSummary = LOAN_TRANSACTION_HELPER.getLoanSummary(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        List dates = (List) loanSummary.get("overdueSinceDate");
-        assertEquals(todaysDate.get(Calendar.YEAR), dates.get(0));
-        assertEquals(todaysDate.get(Calendar.MONTH) + 1, dates.get(1));
-        assertEquals(todaysDate.get(Calendar.DAY_OF_MONTH), dates.get(2));
+        GetLoansLoanIdSummary loanSummary = getLoanDetails(loanID).getSummary();
+        assertEquals(toLocalDate(todaysDate), loanSummary.getOverdueSinceDate());
 
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -8);
         final String LOAN_FIRST_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
-        Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        Float totalDueForCurrentPeriod = loanSchedule.get(1).getTotalDueForPeriod().floatValue();
+        makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
 
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -7);
-        loanSummary = LOAN_TRANSACTION_HELPER.getLoanSummary(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        dates = (List) loanSummary.get("overdueSinceDate");
-        Assertions.assertNull(dates);
+        loanSummary = getLoanDetails(loanID).getSummary();
+        Assertions.assertNull(loanSummary.getOverdueSinceDate());
 
     }
 
     @Test
     public void testLoanScheduleWithInterestRecalculation_FOR_PRE_CLOSE_WITH_MORATORIUM_INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE() {
         testLoanScheduleWithInterestRecalculation_FOR_PRE_CLOSE_WITH_MORATORIUM(
-                LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE, "10006.59");
+                LoanTestData.PreClosureInterestCalculationStrategy.TILL_PRE_CLOSE_DATE, "10006.59");
     }
 
     @Test
     public void testLoanScheduleWithInterestRecalculation_FOR_PRE_CLOSE_WITH_MORATORIUM_INTEREST_APPLICABLE_STRATEGY_REST_DATE() {
         testLoanScheduleWithInterestRecalculation_FOR_PRE_CLOSE_WITH_MORATORIUM(
-                LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_REST_DATE, "10046.15");
+                LoanTestData.PreClosureInterestCalculationStrategy.TILL_REST_FREQUENCY_DATE, "10046.15");
     }
 
     /***
@@ -4166,68 +3909,60 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
         String fourMonthsfromNow = Utils.convertDateToURLFormat(fourMonthsfromNowCalendar);
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
 
         /***
          * Create loan product with Default STYLE strategy
          */
 
-        final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-        final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-        final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-        final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+        final Account assetAccount = accountHelper.createAssetAccount();
+        final Account incomeAccount = accountHelper.createIncomeAccount();
+        final Account expenseAccount = accountHelper.createExpenseAccount();
+        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-        final Integer loanProductID = createLoanProduct("0", "0", LoanProductTestBuilder.DEFAULT_STRATEGY, CASH_BASED, assetAccount,
-                incomeAccount, expenseAccount, overpaymentAccount);
+        final Long loanProductID = createLoanProduct(0, 0, DEFAULT_STRATEGY, CASH_BASED, assetAccount, incomeAccount, expenseAccount,
+                overpaymentAccount);
         Assertions.assertNotNull(loanProductID);
 
         /***
          * Apply for loan application and verify loan status
          */
-        final String savingsId = null;
+        final Long savingsId = null;
         final String principal = "12,000.00";
 
         // Add charges with payment mode regular
-        List<HashMap> charges = new ArrayList<>();
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
 
-        Integer flatInstallmentFee = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "50", false));
-        addCharges(charges, flatInstallmentFee, "50", null);
+        Long flatInstallmentFee = chargesHelper.createLoanInstallmentCharge(ChargeCalculationType.FLAT, 50.0, false).getResourceId();
+        addCharges(charges, flatInstallmentFee, 50.0, null);
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
 
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanID = applyForLoanApplicationWithPaymentStrategyAndPastMonth(clientID, loanProductID, charges, savingsId,
-                principal, LoanApplicationTestBuilder.DEFAULT_STRATEGY, fourMonthsfromNow, collaterals);
+        final Long loanID = applyForLoanApplicationWithPaymentStrategyAndPastMonth(clientID, loanProductID, charges, savingsId, principal,
+                DEFAULT_STRATEGY, fourMonthsfromNow, collaterals);
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(fourMonthsfromNow, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(fourMonthsfromNow, loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(fourMonthsfromNow, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(fourMonthsfromNow, loanID));
 
-        final JournalEntry[] assetAccountInitialEntry = {
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.DEBIT) };
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, fourMonthsfromNow, assetAccountInitialEntry);
+        final LoanTestData.Journal[] assetAccountInitialEntry = {
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()) };
+        checkJournalEntryForAssetAccount(assetAccount, fourMonthsfromNow, assetAccountInitialEntry);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap firstInstallment = loanSchedule.get(1);
-        validateNumberForEqual("2290", String.valueOf(firstInstallment.get("totalOutstandingForPeriod")));
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod firstInstallment = loanSchedule.get(1);
+        validateNumberForEqual("2290", String.valueOf(firstInstallment.getTotalOutstandingForPeriod()));
 
         // Make payment for installment #1
 
@@ -4235,29 +3970,29 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
         final String threeMonthsfromNow = Utils.convertDateToURLFormat(fourMonthsfromNowCalendar);
 
-        LOAN_TRANSACTION_HELPER.makeRepayment(threeMonthsfromNow, Float.parseFloat("2290"), loanID);
+        makeRepayment(threeMonthsfromNow, Float.parseFloat("2290"), loanID);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         firstInstallment = loanSchedule.get(1);
-        validateNumberForEqual("0.00", String.valueOf(firstInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0.00", String.valueOf(firstInstallment.getTotalOutstandingForPeriod()));
 
         // Make payment for installment #2
         fourMonthsfromNowCalendar.add(Calendar.MONTH, 1);
 
         final String twoMonthsfromNow = Utils.convertDateToURLFormat(fourMonthsfromNowCalendar);
 
-        LOAN_TRANSACTION_HELPER.makeRepayment(twoMonthsfromNow, Float.parseFloat("2290"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, twoMonthsfromNow,
-                new JournalEntry(Float.parseFloat("2290"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("2000"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, twoMonthsfromNow,
-                new JournalEntry(Float.parseFloat("50"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("240"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment(twoMonthsfromNow, Float.parseFloat("2290"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, twoMonthsfromNow,
+                journalEntry(Float.parseFloat("2290"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("2000"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, twoMonthsfromNow,
+                journalEntry(Float.parseFloat("50"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("240"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        Map secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("0.00", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod secondInstallment = loanSchedule.get(2);
+        validateNumberForEqual("0.00", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
         // Make payment for installment #3
         // Pay 2290 more than expected
@@ -4265,18 +4000,18 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
         final String oneMonthfromNow = Utils.convertDateToURLFormat(fourMonthsfromNowCalendar);
 
-        LOAN_TRANSACTION_HELPER.makeRepayment(oneMonthfromNow, Float.parseFloat("4580"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, oneMonthfromNow,
-                new JournalEntry(Float.parseFloat("4580"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("4000"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, oneMonthfromNow,
-                new JournalEntry(Float.parseFloat("100"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("480"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment(oneMonthfromNow, Float.parseFloat("4580"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, oneMonthfromNow,
+                journalEntry(Float.parseFloat("4580"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("4000"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, oneMonthfromNow,
+                journalEntry(Float.parseFloat("100"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("480"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap thirdInstallment = loanSchedule.get(3);
-        validateNumberForEqual("0.00", String.valueOf(thirdInstallment.get("totalOutstandingForPeriod")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod thirdInstallment = loanSchedule.get(3);
+        validateNumberForEqual("0.00", String.valueOf(thirdInstallment.getTotalOutstandingForPeriod()));
 
         // Make refund of 20
         // max 2290 to refund. Pay 20 means only principal
@@ -4290,39 +4025,39 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         fourMonthsfromNowCalendar.setTime(Date.from(Utils.getLocalDateOfTenant().atStartOfDay(Utils.getZoneIdOfTenant()).toInstant()));
         final String now = Utils.convertDateToURLFormat(fourMonthsfromNowCalendar);
 
-        LOAN_TRANSACTION_HELPER.makeRefundByCash(now, Float.parseFloat("20"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, now,
-                new JournalEntry(Float.parseFloat("20"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("20"), JournalEntry.TransactionType.DEBIT));
+        makeRefundByCash(now, Float.parseFloat("20"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, now,
+                journalEntry(Float.parseFloat("20"), assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("20"), assetAccount, JournalEntry.TransactionType.DEBIT.name()));
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("20.00", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
-        validateNumberForEqual("20.00", String.valueOf(fourthInstallment.get("principalOutstanding")));
-        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.get("interestOutstanding")));
-        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.get("feeChargesOutstanding")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod fourthInstallment = loanSchedule.get(4);
+        validateNumberForEqual("20.00", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
+        validateNumberForEqual("20.00", String.valueOf(fourthInstallment.getPrincipalOutstanding()));
+        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.getInterestOutstanding()));
+        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.getFeeChargesOutstanding()));
 
         // Make refund of 2000
         // max 2270 to refund. Pay 2000 means only principal
         // paid: principal 1980, interest 240, fees 50, penalty 0
         // refund 2000 means paid: principal 0, interest 220, fees 50, penalty 0
 
-        LOAN_TRANSACTION_HELPER.makeRefundByCash(now, Float.parseFloat("2000"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, now,
-                new JournalEntry(Float.parseFloat("2000"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("1980"), JournalEntry.TransactionType.DEBIT));
+        makeRefundByCash(now, Float.parseFloat("2000"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, now,
+                journalEntry(Float.parseFloat("2000"), assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("1980"), assetAccount, JournalEntry.TransactionType.DEBIT.name()));
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, now,
-                new JournalEntry(Float.parseFloat("20"), JournalEntry.TransactionType.DEBIT));
+        checkJournalEntryForIncomeAccount(incomeAccount, now,
+                journalEntry(Float.parseFloat("20"), incomeAccount, JournalEntry.TransactionType.DEBIT.name()));
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("2020.00", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
-        validateNumberForEqual("2000.00", String.valueOf(fourthInstallment.get("principalOutstanding")));
-        validateNumberForEqual("20.00", String.valueOf(fourthInstallment.get("interestOutstanding")));
-        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.get("feeChargesOutstanding")));
+        validateNumberForEqual("2020.00", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
+        validateNumberForEqual("2000.00", String.valueOf(fourthInstallment.getPrincipalOutstanding()));
+        validateNumberForEqual("20.00", String.valueOf(fourthInstallment.getInterestOutstanding()));
+        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.getFeeChargesOutstanding()));
 
     }
 
@@ -4344,20 +4079,20 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
         String fourMonthsfromNow = Utils.convertDateToURLFormat(fourMonthsfromNowCalendar);
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
 
         /***
          * Create loan product with Default STYLE strategy
          */
 
-        final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-        final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-        final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-        final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+        final Account assetAccount = accountHelper.createAssetAccount();
+        final Account incomeAccount = accountHelper.createIncomeAccount();
+        final Account expenseAccount = accountHelper.createExpenseAccount();
+        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-        final Integer loanProductID = createLoanProduct("0", "0", LoanProductTestBuilder.DEFAULT_STRATEGY, ACCRUAL_UPFRONT, assetAccount,
-                incomeAccount, expenseAccount, overpaymentAccount);// ,
+        final Long loanProductID = createLoanProduct(0, 0, DEFAULT_STRATEGY, ACCRUAL_UPFRONT, assetAccount, incomeAccount, expenseAccount,
+                overpaymentAccount);// ,
         // LoanProductTestBuilder.EQUAL_INSTALLMENTS,
         // LoanProductTestBuilder.FLAT_BALANCE);
         Assertions.assertNotNull(loanProductID);
@@ -4365,51 +4100,44 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         /***
          * Apply for loan application and verify loan status
          */
-        final String savingsId = null;
+        final Long savingsId = null;
         final String principal = "12,000.00";
 
         // Add charges with payment mode regular
-        List<HashMap> charges = new ArrayList<>();
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
 
-        Integer flatInstallmentFee = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "50", false));
-        addCharges(charges, flatInstallmentFee, "50", null);
+        Long flatInstallmentFee = chargesHelper.createLoanInstallmentCharge(ChargeCalculationType.FLAT, 50.0, false).getResourceId();
+        addCharges(charges, flatInstallmentFee, 50.0, null);
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
         Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
         Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanID = applyForLoanApplicationWithPaymentStrategyAndPastMonth(clientID, loanProductID, charges, savingsId,
-                principal, LoanApplicationTestBuilder.DEFAULT_STRATEGY, fourMonthsfromNow, collaterals);
+        final Long loanID = applyForLoanApplicationWithPaymentStrategyAndPastMonth(clientID, loanProductID, charges, savingsId, principal,
+                DEFAULT_STRATEGY, fourMonthsfromNow, collaterals);
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(fourMonthsfromNow, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(fourMonthsfromNow, loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(fourMonthsfromNow, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(fourMonthsfromNow, loanID));
 
-        final JournalEntry[] assetAccountInitialEntry = { new JournalEntry(Float.parseFloat("1440"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("300.00"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.DEBIT) };
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, fourMonthsfromNow, assetAccountInitialEntry);
+        final LoanTestData.Journal[] assetAccountInitialEntry = {
+                journalEntry(Float.parseFloat("1440"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("300.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()) };
+        checkJournalEntryForAssetAccount(assetAccount, fourMonthsfromNow, assetAccountInitialEntry);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap firstInstallment = loanSchedule.get(1);
-        validateNumberForEqual("2290", String.valueOf(firstInstallment.get("totalOutstandingForPeriod")));
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod firstInstallment = loanSchedule.get(1);
+        validateNumberForEqual("2290", String.valueOf(firstInstallment.getTotalOutstandingForPeriod()));
 
         // Make payment for installment #1
 
@@ -4417,26 +4145,26 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
         final String threeMonthsfromNow = Utils.convertDateToURLFormat(fourMonthsfromNowCalendar);
 
-        LOAN_TRANSACTION_HELPER.makeRepayment(threeMonthsfromNow, Float.parseFloat("2290"), loanID);
+        makeRepayment(threeMonthsfromNow, Float.parseFloat("2290"), loanID);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         firstInstallment = loanSchedule.get(1);
-        validateNumberForEqual("0.00", String.valueOf(firstInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0.00", String.valueOf(firstInstallment.getTotalOutstandingForPeriod()));
 
         // Make payment for installment #2
         fourMonthsfromNowCalendar.add(Calendar.MONTH, 1);
 
         final String twoMonthsfromNow = Utils.convertDateToURLFormat(fourMonthsfromNowCalendar);
 
-        LOAN_TRANSACTION_HELPER.makeRepayment(twoMonthsfromNow, Float.parseFloat("2290"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, twoMonthsfromNow,
-                new JournalEntry(Float.parseFloat("2290"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("2290"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment(twoMonthsfromNow, Float.parseFloat("2290"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, twoMonthsfromNow,
+                journalEntry(Float.parseFloat("2290"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("2290"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        Map secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("0.00", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod secondInstallment = loanSchedule.get(2);
+        validateNumberForEqual("0.00", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
         // Make payment for installment #3
         // Pay 2290 more than expected
@@ -4444,15 +4172,15 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
         final String oneMonthfromNow = Utils.convertDateToURLFormat(fourMonthsfromNowCalendar);
 
-        LOAN_TRANSACTION_HELPER.makeRepayment(oneMonthfromNow, Float.parseFloat("4580"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, oneMonthfromNow,
-                new JournalEntry(Float.parseFloat("4580"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("4580"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment(oneMonthfromNow, Float.parseFloat("4580"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, oneMonthfromNow,
+                journalEntry(Float.parseFloat("4580"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("4580"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap thirdInstallment = loanSchedule.get(3);
-        validateNumberForEqual("0.00", String.valueOf(thirdInstallment.get("totalOutstandingForPeriod")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod thirdInstallment = loanSchedule.get(3);
+        validateNumberForEqual("0.00", String.valueOf(thirdInstallment.getTotalOutstandingForPeriod()));
 
         // Make refund of 20
         // max 2290 to refund. Pay 20 means only principal
@@ -4466,37 +4194,37 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         fourMonthsfromNowCalendar.setTime(Date.from(Utils.getLocalDateOfTenant().atStartOfDay(Utils.getZoneIdOfTenant()).toInstant()));
         final String now = Utils.convertDateToURLFormat(fourMonthsfromNowCalendar);
 
-        LOAN_TRANSACTION_HELPER.makeRefundByCash(now, Float.parseFloat("20"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, now,
-                new JournalEntry(Float.parseFloat("20"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("20"), JournalEntry.TransactionType.DEBIT));
+        makeRefundByCash(now, Float.parseFloat("20"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, now,
+                journalEntry(Float.parseFloat("20"), assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("20"), assetAccount, JournalEntry.TransactionType.DEBIT.name()));
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("20.00", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
-        validateNumberForEqual("20.00", String.valueOf(fourthInstallment.get("principalOutstanding")));
-        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.get("interestOutstanding")));
-        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.get("feeChargesOutstanding")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod fourthInstallment = loanSchedule.get(4);
+        validateNumberForEqual("20.00", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
+        validateNumberForEqual("20.00", String.valueOf(fourthInstallment.getPrincipalOutstanding()));
+        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.getInterestOutstanding()));
+        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.getFeeChargesOutstanding()));
 
         // Make refund of 2000
         // max 2270 to refund. Pay 2000 means only principal
         // paid: principal 1980, interest 240, fees 50, penalty 0
         // refund 2000 means paid: principal 0, interest 220, fees 50, penalty 0
 
-        LOAN_TRANSACTION_HELPER.makeRefundByCash(now, Float.parseFloat("2000"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, now,
-                new JournalEntry(Float.parseFloat("2000"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("1980"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("20"), JournalEntry.TransactionType.DEBIT));
+        makeRefundByCash(now, Float.parseFloat("2000"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, now,
+                journalEntry(Float.parseFloat("2000"), assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("1980"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("20"), assetAccount, JournalEntry.TransactionType.DEBIT.name()));
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("2020.00", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
-        validateNumberForEqual("2000.00", String.valueOf(fourthInstallment.get("principalOutstanding")));
-        validateNumberForEqual("20.00", String.valueOf(fourthInstallment.get("interestOutstanding")));
-        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.get("feeChargesOutstanding")));
+        validateNumberForEqual("2020.00", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
+        validateNumberForEqual("2000.00", String.valueOf(fourthInstallment.getPrincipalOutstanding()));
+        validateNumberForEqual("20.00", String.valueOf(fourthInstallment.getInterestOutstanding()));
+        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.getFeeChargesOutstanding()));
 
     }
 
@@ -4516,38 +4244,37 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
         String fourMonthsfromNow = Utils.convertDateToURLFormat(fourMonthsfromNowCalendar);
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
 
-        final Integer savingsProductID = createSavingsProduct(MINIMUM_OPENING_BALANCE);
+        final Long savingsProductID = createSavingsProduct(MINIMUM_OPENING_BALANCE);
         Assertions.assertNotNull(savingsProductID);
 
-        final Integer savingsId = SAVINGS_ACCOUNT_HELPER.applyForSavingsApplication(clientID, savingsProductID, ACCOUNT_TYPE_INDIVIDUAL);
-        Assertions.assertNotNull(savingsProductID);
+        final Long savingsId = savingsHelper.submitApplication(clientID, savingsProductID, SAVINGS_CREATED_DATE).getSavingsId();
+        Assertions.assertNotNull(savingsId);
 
-        HashMap modifications = SAVINGS_ACCOUNT_HELPER.updateSavingsAccount(clientID, savingsProductID, savingsId, ACCOUNT_TYPE_INDIVIDUAL);
-        assertTrue(modifications.containsKey("submittedOnDate"));
+        assertTrue(updateSavingsSubmittedOnDate(savingsId, clientID, savingsProductID, SAVINGS_CREATED_DATE_PLUS_ONE),
+                "Expected submittedOnDate to be reported as modified");
 
-        HashMap savingsStatusHashMap = SavingsStatusChecker.getStatusOfSavings(REQUEST_SPEC, RESPONSE_SPEC, savingsId);
-        SavingsStatusChecker.verifySavingsIsPending(savingsStatusHashMap);
+        assertTrue(savingsHelper.getSavingsDetails(savingsId).getStatus().getSubmittedAndPendingApproval());
 
-        savingsStatusHashMap = SAVINGS_ACCOUNT_HELPER.approveSavings(savingsId);
-        SavingsStatusChecker.verifySavingsIsApproved(savingsStatusHashMap);
+        savingsHelper.approveSavings(savingsId, SAVINGS_TRANSACTION_DATE);
+        assertTrue(savingsHelper.getSavingsDetails(savingsId).getStatus().getApproved());
 
-        savingsStatusHashMap = SAVINGS_ACCOUNT_HELPER.activateSavings(savingsId);
-        SavingsStatusChecker.verifySavingsIsActive(savingsStatusHashMap);
+        savingsHelper.activateSavings(savingsId, SAVINGS_TRANSACTION_DATE);
+        assertTrue(savingsHelper.getSavingsDetails(savingsId).getStatus().getActive());
 
         /***
          * Create loan product with Default STYLE strategy
          */
 
-        final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-        final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-        final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-        final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+        final Account assetAccount = accountHelper.createAssetAccount();
+        final Account incomeAccount = accountHelper.createIncomeAccount();
+        final Account expenseAccount = accountHelper.createExpenseAccount();
+        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-        final Integer loanProductID = createLoanProduct("0", "0", LoanProductTestBuilder.DEFAULT_STRATEGY, CASH_BASED, assetAccount,
-                incomeAccount, expenseAccount, overpaymentAccount);
+        final Long loanProductID = createLoanProduct(0, 0, DEFAULT_STRATEGY, CASH_BASED, assetAccount, incomeAccount, expenseAccount,
+                overpaymentAccount);
         Assertions.assertNotNull(loanProductID);
 
         /***
@@ -4557,46 +4284,38 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         final String principal = "12,000.00";
 
         // Add charges with payment mode regular
-        List<HashMap> charges = new ArrayList<>();
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
 
-        Integer flatInstallmentFee = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "50", false));
-        addCharges(charges, flatInstallmentFee, "50", null);
+        Long flatInstallmentFee = chargesHelper.createLoanInstallmentCharge(ChargeCalculationType.FLAT, 50.0, false).getResourceId();
+        addCharges(charges, flatInstallmentFee, 50.0, null);
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
         Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                clientID.toString(), collateralId);
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
         Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanID = applyForLoanApplicationWithPaymentStrategyAndPastMonth(clientID, loanProductID, charges, null, principal,
-                LoanApplicationTestBuilder.DEFAULT_STRATEGY, fourMonthsfromNow, collaterals);
+        final Long loanID = applyForLoanApplicationWithPaymentStrategyAndPastMonth(clientID, loanProductID, charges, null, principal,
+                DEFAULT_STRATEGY, fourMonthsfromNow, collaterals);
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(fourMonthsfromNow, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(fourMonthsfromNow, loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(fourMonthsfromNow, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(fourMonthsfromNow, loanID));
 
-        final JournalEntry[] assetAccountInitialEntry = {
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.DEBIT) };
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, fourMonthsfromNow, assetAccountInitialEntry);
+        final LoanTestData.Journal[] assetAccountInitialEntry = {
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()) };
+        checkJournalEntryForAssetAccount(assetAccount, fourMonthsfromNow, assetAccountInitialEntry);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap firstInstallment = loanSchedule.get(1);
-        validateNumberForEqual("2290", String.valueOf(firstInstallment.get("totalOutstandingForPeriod")));
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod firstInstallment = loanSchedule.get(1);
+        validateNumberForEqual("2290", String.valueOf(firstInstallment.getTotalOutstandingForPeriod()));
 
         // Make payment for installment #1
 
@@ -4604,29 +4323,29 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
         final String threeMonthsfromNow = Utils.convertDateToURLFormat(fourMonthsfromNowCalendar);
 
-        LOAN_TRANSACTION_HELPER.makeRepayment(threeMonthsfromNow, Float.parseFloat("2290"), loanID);
+        makeRepayment(threeMonthsfromNow, Float.parseFloat("2290"), loanID);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         firstInstallment = loanSchedule.get(1);
-        validateNumberForEqual("0.00", String.valueOf(firstInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0.00", String.valueOf(firstInstallment.getTotalOutstandingForPeriod()));
 
         // Make payment for installment #2
         fourMonthsfromNowCalendar.add(Calendar.MONTH, 1);
 
         final String twoMonthsfromNow = Utils.convertDateToURLFormat(fourMonthsfromNowCalendar);
 
-        LOAN_TRANSACTION_HELPER.makeRepayment(twoMonthsfromNow, Float.parseFloat("2290"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, twoMonthsfromNow,
-                new JournalEntry(Float.parseFloat("2290"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("2000"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, twoMonthsfromNow,
-                new JournalEntry(Float.parseFloat("50"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("240"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment(twoMonthsfromNow, Float.parseFloat("2290"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, twoMonthsfromNow,
+                journalEntry(Float.parseFloat("2290"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("2000"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, twoMonthsfromNow,
+                journalEntry(Float.parseFloat("50"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("240"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        Map secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("0.00", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod secondInstallment = loanSchedule.get(2);
+        validateNumberForEqual("0.00", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
         // Make payment for installment #3
         // Pay 2290 more than expected
@@ -4634,18 +4353,18 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
         final String oneMonthfromNow = Utils.convertDateToURLFormat(fourMonthsfromNowCalendar);
 
-        LOAN_TRANSACTION_HELPER.makeRepayment(oneMonthfromNow, Float.parseFloat("4580"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, oneMonthfromNow,
-                new JournalEntry(Float.parseFloat("4580"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("4000"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, oneMonthfromNow,
-                new JournalEntry(Float.parseFloat("100"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("480"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment(oneMonthfromNow, Float.parseFloat("4580"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, oneMonthfromNow,
+                journalEntry(Float.parseFloat("4580"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("4000"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, oneMonthfromNow,
+                journalEntry(Float.parseFloat("100"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("480"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap thirdInstallment = loanSchedule.get(3);
-        validateNumberForEqual("0.00", String.valueOf(thirdInstallment.get("totalOutstandingForPeriod")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod thirdInstallment = loanSchedule.get(3);
+        validateNumberForEqual("0.00", String.valueOf(thirdInstallment.getTotalOutstandingForPeriod()));
 
         // Make refund of 20
         // max 2290 to refund. Pay 20 means only principal
@@ -4664,30 +4383,29 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         final String FROM_LOAN_ACCOUNT_TYPE = "1";
         final String TO_SAVINGS_ACCOUNT_TYPE = "2";
 
-        ACCOUNT_TRANSFER_HELPER.refundLoanByTransfer(now, clientID, loanID, clientID, savingsId, FROM_LOAN_ACCOUNT_TYPE,
-                TO_SAVINGS_ACCOUNT_TYPE, transferAmountValue.toString());
+        accountTransferHelper.refundLoanByTransfer(now, clientID, loanID, savingsId, transferAmountValue.toString());
 
         Float toSavingsBalance = Float.parseFloat(MINIMUM_OPENING_BALANCE);
 
-        HashMap toSavingsSummaryAfter = SAVINGS_ACCOUNT_HELPER.getSavingsSummary(savingsId);
+        SavingsAccountSummaryData toSavingsSummaryAfter = savingsHelper.getSavingsSummary(savingsId);
 
         toSavingsBalance += transferAmountValue;
 
         // Verifying toSavings Account Balance after Account Transfer
-        assertEquals(toSavingsBalance, toSavingsSummaryAfter.get("accountBalance"),
+        assertEquals(toSavingsBalance, toSavingsSummaryAfter.getAccountBalance().floatValue(),
                 "Verifying From Savings Account Balance after Account Transfer");
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, now,
-                new JournalEntry(Float.parseFloat("20"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("20"), JournalEntry.TransactionType.DEBIT));
+        checkJournalEntryForAssetAccount(assetAccount, now,
+                journalEntry(Float.parseFloat("20"), assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("20"), assetAccount, JournalEntry.TransactionType.DEBIT.name()));
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("20.00", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
-        validateNumberForEqual("20.00", String.valueOf(fourthInstallment.get("principalOutstanding")));
-        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.get("interestOutstanding")));
-        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.get("feeChargesOutstanding")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod fourthInstallment = loanSchedule.get(4);
+        validateNumberForEqual("20.00", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
+        validateNumberForEqual("20.00", String.valueOf(fourthInstallment.getPrincipalOutstanding()));
+        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.getInterestOutstanding()));
+        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.getFeeChargesOutstanding()));
 
         // Make refund of 2000
         // max 2270 to refund. Pay 2000 means only principal
@@ -4697,58 +4415,45 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
         transferAmountValue = 2000f;
 
-        ACCOUNT_TRANSFER_HELPER.refundLoanByTransfer(now, clientID, loanID, clientID, savingsId, FROM_LOAN_ACCOUNT_TYPE,
-                TO_SAVINGS_ACCOUNT_TYPE, transferAmountValue.toString());
+        accountTransferHelper.refundLoanByTransfer(now, clientID, loanID, savingsId, transferAmountValue.toString());
 
-        toSavingsSummaryAfter = SAVINGS_ACCOUNT_HELPER.getSavingsSummary(savingsId);
+        toSavingsSummaryAfter = savingsHelper.getSavingsSummary(savingsId);
 
         toSavingsBalance += transferAmountValue;
 
         // Verifying toSavings Account Balance after Account Transfer
-        assertEquals(toSavingsBalance, toSavingsSummaryAfter.get("accountBalance"),
+        assertEquals(toSavingsBalance, toSavingsSummaryAfter.getAccountBalance().floatValue(),
                 "Verifying From Savings Account Balance after Account Transfer");
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, now,
-                new JournalEntry(Float.parseFloat("2000"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("1980"), JournalEntry.TransactionType.DEBIT));
+        checkJournalEntryForAssetAccount(assetAccount, now,
+                journalEntry(Float.parseFloat("2000"), assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("1980"), assetAccount, JournalEntry.TransactionType.DEBIT.name()));
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, now,
-                new JournalEntry(Float.parseFloat("20"), JournalEntry.TransactionType.DEBIT));
+        checkJournalEntryForIncomeAccount(incomeAccount, now,
+                journalEntry(Float.parseFloat("20"), incomeAccount, JournalEntry.TransactionType.DEBIT.name()));
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("2020.00", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
-        validateNumberForEqual("2000.00", String.valueOf(fourthInstallment.get("principalOutstanding")));
-        validateNumberForEqual("20.00", String.valueOf(fourthInstallment.get("interestOutstanding")));
-        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.get("feeChargesOutstanding")));
+        validateNumberForEqual("2020.00", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
+        validateNumberForEqual("2000.00", String.valueOf(fourthInstallment.getPrincipalOutstanding()));
+        validateNumberForEqual("20.00", String.valueOf(fourthInstallment.getInterestOutstanding()));
+        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.getFeeChargesOutstanding()));
 
     }
 
     @Test
     public void testLoanProductConfiguration() {
         final String proposedAmount = "5000";
-        JsonObject loanProductConfigurationAsTrue = new JsonObject();
-        loanProductConfigurationAsTrue = createLoanProductConfigurationDetail(loanProductConfigurationAsTrue, true);
 
-        JsonObject loanProductConfigurationAsFalse = new JsonObject();
-        loanProductConfigurationAsFalse = createLoanProductConfigurationDetail(loanProductConfigurationAsFalse, false);
-
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC, "01 January 2012");
-        Integer loanProductID = LOAN_TRANSACTION_HELPER
-                .getLoanProductId(new LoanProductTestBuilder().withAmortizationTypeAsEqualInstallments().withRepaymentTypeAsMonth()
-                        .withRepaymentAfterEvery("1").withRepaymentStrategy(LoanProductTestBuilder.DEFAULT_STRATEGY)
-                        .withInterestTypeAsDecliningBalance().withInterestCalculationPeriodTypeAsDays().withInArrearsTolerance("10")
-                        .withMoratorium("2", "3").withLoanProductConfiguration(loanProductConfigurationAsTrue).build(null));
+        final Long clientID = createClient("01 January 2012");
+        Long loanProductID = createLoanProductWithAttributeOverrides(true);
         LOG.info("-----------------------LOAN PRODUCT CREATED WITH ATTRIBUTE CONFIGURATION AS TRUE-------------------------- {}",
                 loanProductID);
-        Integer loanID = applyForLoanApplicationWithProductConfigurationAsTrue(clientID, loanProductID, proposedAmount);
+        Long loanID = applyForLoanApplicationWithProductConfigurationAsTrue(clientID, loanProductID, proposedAmount);
         LOG.info("------------------------LOAN CREATED WITH ID------------------------------{}", loanID);
 
-        loanProductID = LOAN_TRANSACTION_HELPER.getLoanProductId(new LoanProductTestBuilder().withAmortizationTypeAsEqualInstallments()
-                .withRepaymentTypeAsMonth().withRepaymentAfterEvery("1").withRepaymentStrategy(LoanProductTestBuilder.DEFAULT_STRATEGY)
-                .withInterestTypeAsDecliningBalance().withInterestCalculationPeriodTypeAsDays().withInArrearsTolerance("10")
-                .withMoratorium("2", "3").withLoanProductConfiguration(loanProductConfigurationAsFalse).build(null));
+        loanProductID = createLoanProductWithAttributeOverrides(false);
         LOG.info("-------------------LOAN PRODUCT CREATED WITH ATTRIBUTE CONFIGURATION AS FALSE---------------------- {}", loanProductID);
         /*
          * Try to override attribute values in loan account when attribute configurations are set to false at product
@@ -4765,59 +4470,51 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void testLoanForeclosure() {
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProduct(false, NONE);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Long loanProductID = createLoanProduct(false, NONE);
 
-        List<HashMap> charges = new ArrayList<>();
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
 
-        Integer flatAmountChargeOne = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "50", false));
-        addCharges(charges, flatAmountChargeOne, "50", "01 October 2011");
-        Integer flatAmountChargeTwo = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "100", true));
-        addCharges(charges, flatAmountChargeTwo, "100", "15 December 2011");
+        Long flatAmountChargeOne = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.FLAT, 50.0, false).getResourceId();
+        addCharges(charges, flatAmountChargeOne, 50.0, "01 October 2011");
+        Long flatAmountChargeTwo = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.FLAT, 100.0, true).getResourceId();
+        addCharges(charges, flatAmountChargeTwo, 100.0, "15 December 2011");
 
-        List<HashMap> collaterals = new ArrayList<>();
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
         Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
         Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "10,000.00", collaterals);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "10,000.00", collaterals);
         Assertions.assertNotNull(loanID);
 
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
         LOG.info("----------------------------------- APPROVE LOAN -----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("20 September 2011", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("20 September 2011", loanID));
 
         LOG.info("----------------------------------- DISBURSE LOAN ----------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("20 September 2011", loanID, "10,000.00",
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanID);
+        GetLoansLoanIdResponse loanStatusHashMap = disburseLoanWithNetDisbursalAmount("20 September 2011", loanID, "10,000.00");
         LOG.info("DISBURSE {}", loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(loanStatusHashMap);
 
         LOG.info("---------------------------------- Make repayment 1 --------------------------------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 October 2011", Float.parseFloat("2676.24"), loanID);
+        makeRepayment("20 October 2011", Float.parseFloat("2676.24"), loanID);
 
         LOG.info("---------------------------------- FORECLOSE LOAN ----------------------------------------");
-        LOAN_TRANSACTION_HELPER.forecloseLoan("08 November 2011", loanID);
+        forecloseLoan(loanID, new PostLoansLoanIdTransactionsRequest().transactionDate("08 November 2011").dateFormat(DATETIME_PATTERN)
+                .locale(LOCALE).note("Foreclosure"));
 
         // retrieving the loan status
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanStatusHashMap = getLoanDetails(loanID);
         // verifying the loan status is closed
-        LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
-        // retrieving the loan sub-status
-        loanStatusHashMap = LoanStatusChecker.getSubStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        verifyLoanStatus(loanStatusHashMap, GetLoansLoanIdStatus::getClosed);
         // verifying the loan sub-status is foreclosed
-        LoanStatusChecker.verifyLoanAccountForeclosed(loanStatusHashMap);
+        assertEquals("Foreclosed", loanStatusHashMap.getSubStatus().getValue());
 
     }
 
@@ -4832,25 +4529,22 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todaysDate.getTime());
         Integer dayOfWeek = getDayOfWeek(todaysDate);
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProductWithInterestRecalculationAndCompoundingDetails(
-                LoanProductTestBuilder.INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY,
-                LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_INTEREST,
-                LoanProductTestBuilder.RECALCULATION_STRATEGY_REDUCE_NUMBER_OF_INSTALLMENTS,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_DAILY, "1", LOAN_DISBURSEMENT_DATE,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_WEEKLY, "1", LOAN_DISBURSEMENT_DATE,
-                LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE, null, null, dayOfWeek, null, dayOfWeek);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Long loanProductID = createLoanProductWithInterestRecalculationAndCompoundingDetails(
+                INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY, LoanTestData.InterestRecalculationCompoundingMethod.INTEREST,
+                LoanTestData.RescheduleStrategyMethod.REDUCE_NUMBER_OF_INSTALLMENTS, LoanTestData.RecalculationRestFrequencyType.DAILY, 1,
+                LoanTestData.RecalculationRestFrequencyType.WEEKLY, 1,
+                LoanTestData.PreClosureInterestCalculationStrategy.TILL_PRE_CLOSE_DATE, null, null, dayOfWeek, null, dayOfWeek);
 
-        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
-                LoanApplicationTestBuilder.INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY, new ArrayList<HashMap>(0));
+        final Long loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
+                INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY, Collections.emptyList());
 
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        List<Map<String, Object>> expectedvalues = new ArrayList<>();
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        List<ExpectedInstallment> expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2494.22", "34.69", "0.0", "0.0");
@@ -4860,17 +4554,12 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(LOAN_DISBURSEMENT_DATE, loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID));
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
@@ -4880,7 +4569,7 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanFutureRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanFutureRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, 0, false, "4965.3", "92.52", "0.0", "0.0");
@@ -4892,10 +4581,10 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -7);
         final String LOAN_FIRST_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
-        Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        Float totalDueForCurrentPeriod = loanSchedule.get(1).getTotalDueForPeriod().floatValue();
+        makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
@@ -4908,30 +4597,24 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -5);
         final String LOAN_SECOND_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_SECOND_REPAYMENT_DATE, earlyPayment, loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        makeRepayment(LOAN_SECOND_REPAYMENT_DATE, earlyPayment, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         Calendar today = Calendar.getInstance(Utils.getTimeZoneOfTenant());
-        Map<String, Object> paymentday = new HashMap<>(3);
-        paymentday.put("dueDate", getDateAsArray(today, -5, Calendar.DAY_OF_MONTH));
-        paymentday.put("principalDue", "3990.09");
-        paymentday.put("interestDue", "9.91");
-        paymentday.put("feeChargesDue", "0");
-        paymentday.put("penaltyChargesDue", "0");
+        ExpectedInstallment paymentday = new ExpectedInstallment(addDays(today, -5), "3990.09", "9.91", "0", "0");
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
         expectedvalues.add(paymentday);
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2517.31", "11.6", "0.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "1009.84", "4.66", "0.0", "0.0");
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
-        HashMap prepayDetail = LOAN_TRANSACTION_HELPER.getPrepayAmount(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        String prepayAmount = String.valueOf(prepayDetail.get("amount"));
+        GetLoansLoanIdTransactionsTemplateResponse prepayDetail = getPrepayAmount(loanID);
+        String prepayAmount = String.valueOf(prepayDetail.getAmount());
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         final String loanRepaymentDate = dateFormat.format(todaysDate.getTime());
-        LOAN_TRANSACTION_HELPER.makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanID);
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
+        makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanID);
+        verifyLoanAccountIsClosed(loanID);
 
     }
 
@@ -4946,25 +4629,22 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todaysDate.getTime());
         Integer dayOfWeek = getDayOfWeek(todaysDate);
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProductWithInterestRecalculationAndCompoundingDetails(
-                LoanProductTestBuilder.INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY,
-                LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_INTEREST,
-                LoanProductTestBuilder.RECALCULATION_STRATEGY_REDUCE_NUMBER_OF_INSTALLMENTS,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_DAILY, "1", LOAN_DISBURSEMENT_DATE,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_WEEKLY, "1", LOAN_DISBURSEMENT_DATE,
-                LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE, null, null, dayOfWeek, null, dayOfWeek);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Long loanProductID = createLoanProductWithInterestRecalculationAndCompoundingDetails(
+                INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY, LoanTestData.InterestRecalculationCompoundingMethod.INTEREST,
+                LoanTestData.RescheduleStrategyMethod.REDUCE_NUMBER_OF_INSTALLMENTS, LoanTestData.RecalculationRestFrequencyType.DAILY, 1,
+                LoanTestData.RecalculationRestFrequencyType.WEEKLY, 1,
+                LoanTestData.PreClosureInterestCalculationStrategy.TILL_PRE_CLOSE_DATE, null, null, dayOfWeek, null, dayOfWeek);
 
-        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
-                LoanApplicationTestBuilder.INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY, new ArrayList<HashMap>(0));
+        final Long loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
+                INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY, Collections.emptyList());
 
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        List<Map<String, Object>> expectedvalues = new ArrayList<>();
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        List<ExpectedInstallment> expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2494.22", "34.69", "0.0", "0.0");
@@ -4974,17 +4654,12 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(LOAN_DISBURSEMENT_DATE, loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID));
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
@@ -4994,7 +4669,7 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanFutureRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanFutureRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, 0, false, "4965.3", "92.52", "0.0", "0.0");
@@ -5006,10 +4681,10 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -7);
         final String LOAN_FIRST_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
-        Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        Float totalDueForCurrentPeriod = loanSchedule.get(1).getTotalDueForPeriod().floatValue();
+        makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
@@ -5023,8 +4698,8 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -2);
         final String LOAN_SECOND_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_SECOND_REPAYMENT_DATE, earlyPayment, loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        makeRepayment(LOAN_SECOND_REPAYMENT_DATE, earlyPayment, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         Calendar today = Calendar.getInstance(Utils.getTimeZoneOfTenant());
@@ -5036,13 +4711,12 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2490.78", "11.5", "0.0", "0.0");
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
-        HashMap prepayDetail = LOAN_TRANSACTION_HELPER.getPrepayAmount(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        String prepayAmount = String.valueOf(prepayDetail.get("amount"));
+        GetLoansLoanIdTransactionsTemplateResponse prepayDetail = getPrepayAmount(loanID);
+        String prepayAmount = String.valueOf(prepayDetail.getAmount());
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         final String loanRepaymentDate = dateFormat.format(todaysDate.getTime());
-        LOAN_TRANSACTION_HELPER.makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanID);
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
+        makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanID);
+        verifyLoanAccountIsClosed(loanID);
 
     }
 
@@ -5065,47 +4739,38 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             String firstRepayment = dateFormat.format(firstRepaymentDate.getTime());
 
             final String loanDisbursementDate = dateFormat.format(startDate.getTime());
-            final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-            ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-            final Integer loanProductID = createLoanProductWithInterestRecalculationAndCompoundingDetails(
-                    LoanProductTestBuilder.INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY,
-                    LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_NONE,
-                    LoanProductTestBuilder.RECALCULATION_STRATEGY_REDUCE_NUMBER_OF_INSTALLMENTS,
-                    LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_SAME_AS_REPAYMENT_PERIOD,
-                    LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE, null, "12");
+            final Long clientID = createClient();
+            verifyClientCreatedOnServer(clientID);
+            final Long loanProductID = createLoanProductWithInterestRecalculationAndInstallmentAmount(
+                    INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY, LoanTestData.InterestRecalculationCompoundingMethod.NONE,
+                    LoanTestData.RescheduleStrategyMethod.REDUCE_NUMBER_OF_INSTALLMENTS,
+                    LoanTestData.PreClosureInterestCalculationStrategy.TILL_PRE_CLOSE_DATE, null, 12);
 
-            final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, loanDisbursementDate,
-                    LoanApplicationTestBuilder.INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY, firstRepayment);
+            final Long loanID = applyForLoanApplicationForInterestRecalculationWithFirstRepaymentDate(clientID, loanProductID,
+                    loanDisbursementDate, INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY, firstRepayment);
 
             Assertions.assertNotNull(loanID);
-            HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+            verifyLoanIsPending(loanID);
 
             LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(loanDisbursementDate, loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-            LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+            verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(loanDisbursementDate, loanID));
 
             LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-            String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(loanDisbursementDate, loanID,
-                    JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+            verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(loanDisbursementDate, loanID));
 
-            ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+            List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
             Assertions.assertNotNull(loanSchedule);
             startDate.add(Calendar.DAY_OF_MONTH, 2);
             String loanFirstRepaymentDate = dateFormat.format(startDate.getTime());
             //
             Float earlyPayment = Float.parseFloat("3000");
-            LOAN_TRANSACTION_HELPER.makeRepayment(loanFirstRepaymentDate, earlyPayment, loanID);
+            makeRepayment(loanFirstRepaymentDate, earlyPayment, loanID);
 
-            HashMap prepayDetail = LOAN_TRANSACTION_HELPER.getPrepayAmount(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            String prepayAmount = String.valueOf(prepayDetail.get("amount"));
+            GetLoansLoanIdTransactionsTemplateResponse prepayDetail = getPrepayAmount(loanID);
+            String prepayAmount = String.valueOf(prepayDetail.getAmount());
             String loanPrepaymentDate = dateFormat.format(currentDate.getTime());
-            LOAN_TRANSACTION_HELPER.makeRepayment(loanPrepaymentDate, Float.parseFloat(prepayAmount), loanID);
-            loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
+            makeRepayment(loanPrepaymentDate, Float.parseFloat(prepayAmount), loanID);
+            verifyLoanAccountIsClosed(loanID);
         } finally {
             globalConfigurationHelper.updateGlobalConfiguration(
                     GlobalConfigurationConstants.IS_INTEREST_TO_BE_RECOVERED_FIRST_WHEN_GREATER_THAN_EMI,
@@ -5116,8 +4781,6 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void testLoanScheduleWithInterestRecalculationMakeAdvancePaymentTillSettlement() {
         try {
-            final ResponseSpecification errorResponse = new ResponseSpecBuilder().expectStatusCode(403).build();
-            final LoanTransactionHelper validationErrorHelper = new LoanTransactionHelper(REQUEST_SPEC, errorResponse);
             DateFormat dateFormat = new SimpleDateFormat(DATETIME_PATTERN, Locale.US);
             dateFormat.setTimeZone(Utils.getTimeZoneOfTenant());
             globalConfigurationHelper.updateGlobalConfiguration(
@@ -5134,34 +4797,26 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             String firstRepayment = dateFormat.format(firstRepaymentDate.getTime());
 
             final String loanDisbursementDate = dateFormat.format(startDate.getTime());
-            final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-            ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-            final Integer loanProductID = createLoanProductWithInterestRecalculationAndCompoundingDetails(
-                    LoanProductTestBuilder.INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY,
-                    LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_NONE,
-                    LoanProductTestBuilder.RECALCULATION_STRATEGY_REDUCE_NUMBER_OF_INSTALLMENTS,
-                    LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_SAME_AS_REPAYMENT_PERIOD,
-                    LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE, null, "12");
+            final Long clientID = createClient();
+            verifyClientCreatedOnServer(clientID);
+            final Long loanProductID = createLoanProductWithInterestRecalculationAndInstallmentAmount(
+                    INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY, LoanTestData.InterestRecalculationCompoundingMethod.NONE,
+                    LoanTestData.RescheduleStrategyMethod.REDUCE_NUMBER_OF_INSTALLMENTS,
+                    LoanTestData.PreClosureInterestCalculationStrategy.TILL_PRE_CLOSE_DATE, null, 12);
 
-            final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, loanDisbursementDate,
-                    LoanApplicationTestBuilder.INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY, firstRepayment);
+            final Long loanID = applyForLoanApplicationForInterestRecalculationWithFirstRepaymentDate(clientID, loanProductID,
+                    loanDisbursementDate, INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY, firstRepayment);
 
             Assertions.assertNotNull(loanID);
-            HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+            verifyLoanIsPending(loanID);
 
             LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(loanDisbursementDate, loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-            LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+            verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(loanDisbursementDate, loanID));
 
             LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-            String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(loanDisbursementDate, loanID,
-                    JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+            verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(loanDisbursementDate, loanID));
 
-            ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+            List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
             Assertions.assertNotNull(loanSchedule);
             Calendar repaymentDate = (Calendar) firstRepaymentDate.clone();
             startDate.add(Calendar.DAY_OF_MONTH, 2);
@@ -5170,22 +4825,25 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             Float earlyPayment = Float.parseFloat("3000");
             String retrieveDueDate = null;
             Float amount = null;
-            LOAN_TRANSACTION_HELPER.makeRepayment(loanFirstRepaymentDate, earlyPayment, loanID);
+            makeRepayment(loanFirstRepaymentDate, earlyPayment, loanID);
             for (int i = 1; i < loanSchedule.size(); i++) {
 
                 retrieveDueDate = dateFormat.format(repaymentDate.getTime());
-                amount = ((Number) loanSchedule.get(i).get("principalOriginalDue")).floatValue()
-                        + ((Number) loanSchedule.get(i).get("interestOriginalDue")).floatValue();
+                amount = ((Number) loanSchedule.get(i).getPrincipalOriginalDue()).floatValue()
+                        + ((Number) loanSchedule.get(i).getInterestOriginalDue()).floatValue();
                 if (currentDate.after(repaymentDate)) {
-                    LOAN_TRANSACTION_HELPER.makeRepayment(retrieveDueDate, amount, loanID);
+                    makeRepayment(retrieveDueDate, amount, loanID);
                 } else {
                     break;
                 }
                 repaymentDate.add(Calendar.MONTH, 1);
             }
-            HashMap savingsAccountErrorData = validationErrorHelper.makeRepayment(retrieveDueDate, amount, loanID);
-            ArrayList<HashMap> error = (ArrayList<HashMap>) savingsAccountErrorData.get("errors");
-            assertEquals("error.msg.loan.transaction.cannot.be.a.future.date", error.get(0).get("userMessageGlobalisationCode"));
+            final String futureRepaymentDate = retrieveDueDate;
+            final Float futureRepaymentAmount = amount;
+            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
+                    () -> makeRepayment(futureRepaymentDate, futureRepaymentAmount, loanID));
+            assertEquals(403, exception.getStatus());
+            assertTrue(exception.getMessage().contains("error.msg.loan.transaction.cannot.be.a.future.date"));
         } finally {
             globalConfigurationHelper.updateGlobalConfiguration(
                     GlobalConfigurationConstants.IS_INTEREST_TO_BE_RECOVERED_FIRST_WHEN_GREATER_THAN_EMI,
@@ -5197,112 +4855,103 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
     public void testCollateralDataIsAvailableWhenRequested() {
         // given
 
-        Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
-        List<HashMap> collaterals = new ArrayList<>();
-        Integer clientId = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientId);
+        Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
+        Long clientId = createClient();
+        verifyClientCreatedOnServer(clientId);
 
-        Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientId), collateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        Long clientCollateralId = collateralHelper.createClientCollateral(clientId, collateralId).getResourceId();
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        Integer loanProductId = createLoanProduct(false, NONE);
+        Long loanProductId = createLoanProduct(false, NONE);
 
         // when
-        Integer loanId = applyForLoanApplication(clientId, loanProductId, null, null, "12,000.00", collaterals);
+        Long loanId = applyForLoanApplication(clientId, loanProductId, null, null, "12,000.00", collaterals);
 
         // then
-        List<Integer> clientCollateralIds = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanId,
-                "collateral.clientCollateralId");
-        Integer clientCollateralIdResult = clientCollateralIds.get(0);
-        assertEquals(clientCollateralId, clientCollateralIdResult);
+        List<GetLoansLoanIdCollateralData> loanCollateral = getLoanDetails(loanId).getCollateral();
+        assertEquals(clientCollateralId, loanCollateral.get(0).getClientCollateralId());
     }
 
     @Test
     public void undoWaivedChargeTransactionDoesNotExist() {
-        LoanTransactionHelper loanTransactionHelper = new LoanTransactionHelper(REQUEST_SPEC, createResponseSpecification(404));
-        HashMap response = loanTransactionHelper.undoWaiveChargesForLoan(-1, -2, "");
-        assertEquals("error.msg.loan.transaction.id.invalid",
-                ((Map) ((List) response.get("errors")).get(0)).get("userMessageGlobalisationCode"));
-        assertEquals("Transaction with identifier -2 does not exist for loan with identifier -1.",
-                ((Map) ((List) response.get("errors")).get(0)).get("defaultUserMessage"));
+        CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
+                () -> undoWaiveLoanCharge(-1L, -2L, new PutChargeTransactionChangesRequest().id(-2L).loanId(-1L)));
+        assertEquals(404, exception.getStatus());
+        assertTrue(exception.getMessage().contains("error.msg.loan.transaction.id.invalid"));
+        assertTrue(exception.getMessage().contains("Transaction with identifier -2 does not exist for loan with identifier -1."));
     }
 
     @Test
     public void chargeAdjustmentChargeWrongParams() {
         CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                () -> LOAN_TRANSACTION_HELPER.chargeAdjustment(0L, 0L, new PostLoansLoanIdChargesChargeIdRequest().amount(0.0)));
-        assertEquals(400, exception.getResponse().code());
+                () -> chargeAdjustment(0L, 0L, new PostLoansLoanIdChargesChargeIdRequest().amount(0.0)));
+        assertEquals(400, exception.getStatus());
         assertTrue(exception.getMessage().contains("validation.msg.loan.charge.adjustment.request.amount.not.greater.than.zero"));
         assertTrue(exception.getMessage().contains("validation.msg.loan.charge.adjustment.request.loanId.not.greater.than.zero"));
         assertTrue(exception.getMessage().contains("validation.msg.loan.charge.adjustment.request.loanChargeId.not.greater.than.zero"));
         exception = assertThrows(CallFailedRuntimeException.class,
-                () -> LOAN_TRANSACTION_HELPER.chargeAdjustment(1L, 0L, new PostLoansLoanIdChargesChargeIdRequest().amount(0.0)));
-        assertEquals(400, exception.getResponse().code());
+                () -> chargeAdjustment(1L, 0L, new PostLoansLoanIdChargesChargeIdRequest().amount(0.0)));
+        assertEquals(400, exception.getStatus());
         assertTrue(exception.getMessage().contains("validation.msg.loan.charge.adjustment.request.amount.not.greater.than.zero"));
         assertTrue(exception.getMessage().contains("validation.msg.loan.charge.adjustment.request.loanChargeId.not.greater.than.zero"));
         exception = assertThrows(CallFailedRuntimeException.class,
-                () -> LOAN_TRANSACTION_HELPER.chargeAdjustment(1L, 1L, new PostLoansLoanIdChargesChargeIdRequest().amount(0.0)));
-        assertEquals(400, exception.getResponse().code());
+                () -> chargeAdjustment(1L, 1L, new PostLoansLoanIdChargesChargeIdRequest().amount(0.0)));
+        assertEquals(400, exception.getStatus());
         assertTrue(exception.getMessage().contains("validation.msg.loan.charge.adjustment.request.amount.not.greater.than.zero"));
     }
 
     @Test
     public void chargeAdjustmentChargeDoesNotExist() {
-        final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-        final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-        final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-        final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+        final Account assetAccount = accountHelper.createAssetAccount();
+        final Account incomeAccount = accountHelper.createIncomeAccount();
+        final Account expenseAccount = accountHelper.createExpenseAccount();
+        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-        final Integer loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount, expenseAccount,
+        final Long loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount, expenseAccount,
                 overpaymentAccount);
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC, "01 January 2011");
+        final Long clientID = createClient("01 January 2011");
 
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID);
 
         CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                () -> LOAN_TRANSACTION_HELPER.chargeAdjustment((long) loanID, 1L, new PostLoansLoanIdChargesChargeIdRequest().amount(1.0)));
-        assertEquals(404, exception.getResponse().code());
+                () -> chargeAdjustment((long) loanID, 1L, new PostLoansLoanIdChargesChargeIdRequest().amount(1.0)));
+        assertEquals(404, exception.getStatus());
         assertTrue(exception.getMessage().contains("error.msg.loanCharge.id.invalid"));
     }
 
     @Test
     public void chargeAdjustmentChargeDoesNotExistForLoan() {
-        final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-        final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-        final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-        final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+        final Account assetAccount = accountHelper.createAssetAccount();
+        final Account incomeAccount = accountHelper.createIncomeAccount();
+        final Account expenseAccount = accountHelper.createExpenseAccount();
+        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-        final Integer loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount, expenseAccount,
+        final Long loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount, expenseAccount,
                 overpaymentAccount);
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC, "01 January 2011");
+        final Long clientID = createClient("01 January 2011");
 
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID);
 
-        HashMap<String, Object> loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("02 September 2022", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("02 September 2022", loanID));
 
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        GetLoansLoanIdResponse loanStatusHashMap = disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
+        verifyLoanIsActive(loanStatusHashMap);
 
-        Integer penalty = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", true));
+        Long penalty = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.FLAT, 10.0, true).getResourceId();
         LocalDate targetDate = LocalDate.of(2022, 9, 7);
-        final String penaltyCharge1AddedDate = DATE_TIME_FORMATTER.format(targetDate);
-        Integer penalty1LoanChargeId = LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID,
-                LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), penaltyCharge1AddedDate, "10"));
+        final String penaltyCharge1AddedDate = dateTimeFormatter.format(targetDate);
+        Long penalty1LoanChargeId = addLoanCharge(loanID, penalty, penaltyCharge1AddedDate, 10.0).getResourceId();
 
-        final Integer loanID2 = applyForLoanApplication(clientID, loanProductID);
+        final Long loanID2 = applyForLoanApplication(clientID, loanProductID);
 
-        CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class, () -> LOAN_TRANSACTION_HELPER
-                .chargeAdjustment((long) loanID2, (long) penalty1LoanChargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(1.0)));
-        assertEquals(404, exception.getResponse().code());
+        CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
+                () -> chargeAdjustment(loanID2, penalty1LoanChargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(1.0)));
+        assertEquals(404, exception.getStatus());
         assertTrue(exception.getMessage().contains("error.msg.loanCharge.id.invalid.for.given.loan"));
     }
 
@@ -5311,82 +4960,75 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         try {
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
-            BUSINESS_DATE_HELPER.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("01 November 2022").dateFormat(DATETIME_PATTERN).locale("en"));
-            final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-            final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-            final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-            final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+            updateBusinessDate("01 November 2022");
+            final Account assetAccount = accountHelper.createAssetAccount();
+            final Account incomeAccount = accountHelper.createIncomeAccount();
+            final Account expenseAccount = accountHelper.createExpenseAccount();
+            final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-            Integer penalty = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", true));
-            final Integer loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount,
-                    expenseAccount, overpaymentAccount);
+            Long penalty = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.FLAT, 10.0, true).getResourceId();
+            final Long loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount, expenseAccount,
+                    overpaymentAccount);
 
-            final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC, "01 January 2011");
+            final Long clientID = createClient("01 January 2011");
 
-            final Integer loanID = applyForLoanApplication(clientID, loanProductID);
+            final Long loanID = applyForLoanApplication(clientID, loanProductID);
 
-            HashMap<String, Object> loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+            verifyLoanIsPending(loanID);
 
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("02 September 2022", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-            LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+            verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("02 September 2022", loanID));
 
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+            GetLoansLoanIdResponse loanStatusHashMap = disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
+            verifyLoanIsActive(loanStatusHashMap);
 
-            ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+            List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
             assertEquals(2, loanSchedule.size());
-            assertEquals(0, loanSchedule.get(1).get("penaltyChargesDue"));
-            assertEquals(0, loanSchedule.get(1).get("penaltyChargesOutstanding"));
-            assertEquals(1000.0f, loanSchedule.get(1).get("totalDueForPeriod"));
-            assertEquals(1000.0f, loanSchedule.get(1).get("totalOutstandingForPeriod"));
+            assertEquals(0.0f, loanSchedule.get(1).getPenaltyChargesDue().floatValue());
+            assertEquals(0.0f, loanSchedule.get(1).getPenaltyChargesOutstanding().floatValue());
+            assertEquals(1000.0f, loanSchedule.get(1).getTotalDueForPeriod().floatValue());
+            assertEquals(1000.0f, loanSchedule.get(1).getTotalOutstandingForPeriod().floatValue());
             LocalDate targetDate = LocalDate.of(2022, 9, 7);
-            final String penaltyCharge1AddedDate = DATE_TIME_FORMATTER.format(targetDate);
-            Integer penalty1LoanChargeId = LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), penaltyCharge1AddedDate, "10"));
+            final String penaltyCharge1AddedDate = dateTimeFormatter.format(targetDate);
+            Long penalty1LoanChargeId = addLoanCharge(loanID, penalty, penaltyCharge1AddedDate, 10.0).getResourceId();
 
-            LOAN_TRANSACTION_HELPER.noAccrualTransactionForRepayment(loanID);
+            assertNoAccrualTransactions(loanID);
 
-            loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+            loanSchedule = getLoanRepaymentSchedule(loanID);
             assertEquals(2, loanSchedule.size());
-            assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesDue"));
-            assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesOutstanding"));
-            assertEquals(1010.0f, loanSchedule.get(1).get("totalDueForPeriod"));
-            assertEquals(1010.0f, loanSchedule.get(1).get("totalOutstandingForPeriod"));
-            assertEquals(0, loanSchedule.get(1).get("totalWaivedForPeriod"));
+            assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesDue().floatValue());
+            assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesOutstanding().floatValue());
+            assertEquals(1010.0f, loanSchedule.get(1).getTotalDueForPeriod().floatValue());
+            assertEquals(1010.0f, loanSchedule.get(1).getTotalOutstandingForPeriod().floatValue());
+            assertEquals(0, loanSchedule.get(1).getTotalWaivedForPeriod().floatValue());
 
-            HashMap loanSummary = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "summary");
-            assertEquals(10.0f, loanSummary.get("penaltyChargesCharged"));
-            assertEquals(10.0f, loanSummary.get("penaltyChargesOutstanding"));
-            assertEquals(0.0f, loanSummary.get("penaltyChargesWaived"));
-            assertEquals(1010.0f, loanSummary.get("totalOutstanding"));
-            assertEquals(0.0f, loanSummary.get("totalWaived"));
+            GetLoansLoanIdSummary loanSummary = getLoanDetails(loanID).getSummary();
+            assertEquals(10.0f, loanSummary.getPenaltyChargesCharged().floatValue());
+            assertEquals(10.0f, loanSummary.getPenaltyChargesOutstanding().floatValue());
+            assertEquals(0.0f, loanSummary.getPenaltyChargesWaived().floatValue());
+            assertEquals(1010.0f, loanSummary.getTotalOutstanding().floatValue());
+            assertEquals(0.0f, loanSummary.getTotalWaived().floatValue());
 
             String externalId = UUID.randomUUID().toString();
-            PostLoansLoanIdChargesChargeIdResponse chargeAdjustmentResponse = LOAN_TRANSACTION_HELPER.chargeAdjustment((long) loanID,
-                    (long) penalty1LoanChargeId,
+            PostLoansLoanIdChargesChargeIdResponse chargeAdjustmentResponse = chargeAdjustment((long) loanID, (long) penalty1LoanChargeId,
                     new PostLoansLoanIdChargesChargeIdRequest().amount(10.0).externalId(externalId).paymentTypeId(1L));
 
-            loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+            loanSchedule = getLoanRepaymentSchedule(loanID);
             assertEquals(2, loanSchedule.size());
-            assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesDue"));
-            assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesPaid"));
-            assertEquals(0.0f, loanSchedule.get(1).get("penaltyChargesOutstanding"));
-            assertEquals(1010.0f, loanSchedule.get(1).get("totalDueForPeriod"));
-            assertEquals(1000.0f, loanSchedule.get(1).get("totalOutstandingForPeriod"));
-            assertEquals(10.0f, loanSchedule.get(1).get("totalPaidForPeriod"));
+            assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesDue().floatValue());
+            assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesPaid().floatValue());
+            assertEquals(0.0f, loanSchedule.get(1).getPenaltyChargesOutstanding().floatValue());
+            assertEquals(1010.0f, loanSchedule.get(1).getTotalDueForPeriod().floatValue());
+            assertEquals(1000.0f, loanSchedule.get(1).getTotalOutstandingForPeriod().floatValue());
+            assertEquals(10.0f, loanSchedule.get(1).getTotalPaidForPeriod().floatValue());
 
-            loanSummary = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "summary");
-            assertEquals(10.0f, loanSummary.get("penaltyChargesCharged"));
-            assertEquals(0.0f, loanSummary.get("penaltyChargesOutstanding"));
-            assertEquals(10.0f, loanSummary.get("penaltyChargesPaid"));
-            assertEquals(1000.0f, loanSummary.get("totalOutstanding"));
+            loanSummary = getLoanDetails(loanID).getSummary();
+            assertEquals(10.0f, loanSummary.getPenaltyChargesCharged().floatValue());
+            assertEquals(0.0f, loanSummary.getPenaltyChargesOutstanding().floatValue());
+            assertEquals(10.0f, loanSummary.getPenaltyChargesPaid().floatValue());
+            assertEquals(1000.0f, loanSummary.getTotalOutstanding().floatValue());
 
-            GetLoansLoanIdTransactionsTransactionIdResponse chargeAdjustmentTransaction = LOAN_TRANSACTION_HELPER
-                    .getLoanTransactionDetails((long) loanID, chargeAdjustmentResponse.getSubResourceId());
+            GetLoansLoanIdTransactionsTransactionIdResponse chargeAdjustmentTransaction = getLoanTransactionDetails(loanID,
+                    chargeAdjustmentResponse.getSubResourceId());
             assertEquals(10.0, chargeAdjustmentTransaction.getAmount());
             assertEquals(10.0, chargeAdjustmentTransaction.getPenaltyChargesPortion());
             assertEquals("loanTransactionType.chargeAdjustment", chargeAdjustmentTransaction.getType().getCode());
@@ -5397,32 +5039,31 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals("CHARGE_ADJUSTMENT", transactionRelation.getRelationType());
             assertEquals(1L, chargeAdjustmentTransaction.getPaymentDetailData().getPaymentType().getId());
 
-            PostLoansLoanIdTransactionsResponse repaymentResult = LOAN_TRANSACTION_HELPER.makeLoanRepayment((long) loanID,
-                    new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate("06 September 2022").locale("en")
-                            .transactionAmount(5.0));
+            PostLoansLoanIdTransactionsResponse repaymentResult = makeLoanRepayment((long) loanID, new PostLoansLoanIdTransactionsRequest()
+                    .dateFormat(DATETIME_PATTERN).transactionDate("06 September 2022").locale("en").transactionAmount(5.0));
 
-            loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+            loanSchedule = getLoanRepaymentSchedule(loanID);
             assertEquals(2, loanSchedule.size());
-            assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesDue"));
-            assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesPaid"));
-            assertEquals(0.0f, loanSchedule.get(1).get("penaltyChargesOutstanding"));
-            assertEquals(1000.0f, loanSchedule.get(1).get("principalDue"));
-            assertEquals(5.0f, loanSchedule.get(1).get("principalPaid"));
-            assertEquals(995.0f, loanSchedule.get(1).get("principalOutstanding"));
-            assertEquals(1010.0f, loanSchedule.get(1).get("totalDueForPeriod"));
-            assertEquals(995.0f, loanSchedule.get(1).get("totalOutstandingForPeriod"));
-            assertEquals(15.0f, loanSchedule.get(1).get("totalPaidForPeriod"));
+            assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesDue().floatValue());
+            assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesPaid().floatValue());
+            assertEquals(0.0f, loanSchedule.get(1).getPenaltyChargesOutstanding().floatValue());
+            assertEquals(1000.0f, loanSchedule.get(1).getPrincipalDue().floatValue());
+            assertEquals(5.0f, loanSchedule.get(1).getPrincipalPaid().floatValue());
+            assertEquals(995.0f, loanSchedule.get(1).getPrincipalOutstanding().floatValue());
+            assertEquals(1010.0f, loanSchedule.get(1).getTotalDueForPeriod().floatValue());
+            assertEquals(995.0f, loanSchedule.get(1).getTotalOutstandingForPeriod().floatValue());
+            assertEquals(15.0f, loanSchedule.get(1).getTotalPaidForPeriod().floatValue());
 
-            loanSummary = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "summary");
-            assertEquals(10.0f, loanSummary.get("penaltyChargesCharged"));
-            assertEquals(0.0f, loanSummary.get("penaltyChargesOutstanding"));
-            assertEquals(10.0f, loanSummary.get("penaltyChargesPaid"));
-            assertEquals(1000.0f, loanSummary.get("principalDisbursed"));
-            assertEquals(995.0f, loanSummary.get("principalOutstanding"));
-            assertEquals(5.0f, loanSummary.get("principalPaid"));
-            assertEquals(995.0f, loanSummary.get("totalOutstanding"));
+            loanSummary = getLoanDetails(loanID).getSummary();
+            assertEquals(10.0f, loanSummary.getPenaltyChargesCharged().floatValue());
+            assertEquals(0.0f, loanSummary.getPenaltyChargesOutstanding().floatValue());
+            assertEquals(10.0f, loanSummary.getPenaltyChargesPaid().floatValue());
+            assertEquals(1000.0f, loanSummary.getPrincipalDisbursed().floatValue());
+            assertEquals(995.0f, loanSummary.getPrincipalOutstanding().floatValue());
+            assertEquals(5.0f, loanSummary.getPrincipalPaid().floatValue());
+            assertEquals(995.0f, loanSummary.getTotalOutstanding().floatValue());
 
-            GetLoansLoanIdResponse loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanID);
             GetLoansLoanIdTransactions replayedTransaction = loanDetails.getTransactions().stream()
                     .filter(t -> externalId.equals(t.getExternalId())).findFirst().get();
 
@@ -5441,36 +5082,36 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             }
 
             String uuid = UUID.randomUUID().toString();
-            LOAN_TRANSACTION_HELPER.reverseLoanTransaction((long) loanID, replayedTransaction.getId(),
+            reverseLoanTransaction((long) loanID, replayedTransaction.getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("08 September 2022")
                             .transactionAmount(0.0).locale("en").reversalExternalId(uuid));
 
             // Should fail due to external id collusion
             assertThrows(CallFailedRuntimeException.class,
-                    () -> LOAN_TRANSACTION_HELPER.reverseLoanTransaction((long) loanID, repaymentResult.getResourceId(),
+                    () -> reverseLoanTransaction((long) loanID, repaymentResult.getResourceId(),
                             new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN)
                                     .transactionDate("08 September 2022").transactionAmount(0.0).locale("en").reversalExternalId(uuid)));
 
-            loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+            loanSchedule = getLoanRepaymentSchedule(loanID);
             assertEquals(2, loanSchedule.size());
-            assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesDue"));
-            assertEquals(5.0f, loanSchedule.get(1).get("penaltyChargesPaid"));
-            assertEquals(5.0f, loanSchedule.get(1).get("penaltyChargesOutstanding"));
-            assertEquals(1000.0f, loanSchedule.get(1).get("principalDue"));
-            assertEquals(0, loanSchedule.get(1).get("principalPaid"));
-            assertEquals(1000.0f, loanSchedule.get(1).get("principalOutstanding"));
-            assertEquals(1010.0f, loanSchedule.get(1).get("totalDueForPeriod"));
-            assertEquals(1005.0f, loanSchedule.get(1).get("totalOutstandingForPeriod"));
-            assertEquals(5.0f, loanSchedule.get(1).get("totalPaidForPeriod"));
+            assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesDue().floatValue());
+            assertEquals(5.0f, loanSchedule.get(1).getPenaltyChargesPaid().floatValue());
+            assertEquals(5.0f, loanSchedule.get(1).getPenaltyChargesOutstanding().floatValue());
+            assertEquals(1000.0f, loanSchedule.get(1).getPrincipalDue().floatValue());
+            assertEquals(0.0f, loanSchedule.get(1).getPrincipalPaid().floatValue());
+            assertEquals(1000.0f, loanSchedule.get(1).getPrincipalOutstanding().floatValue());
+            assertEquals(1010.0f, loanSchedule.get(1).getTotalDueForPeriod().floatValue());
+            assertEquals(1005.0f, loanSchedule.get(1).getTotalOutstandingForPeriod().floatValue());
+            assertEquals(5.0f, loanSchedule.get(1).getTotalPaidForPeriod().floatValue());
 
-            loanSummary = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "summary");
-            assertEquals(10.0f, loanSummary.get("penaltyChargesCharged"));
-            assertEquals(5.0f, loanSummary.get("penaltyChargesOutstanding"));
-            assertEquals(5.0f, loanSummary.get("penaltyChargesPaid"));
-            assertEquals(1000.0f, loanSummary.get("principalDisbursed"));
-            assertEquals(1000.0f, loanSummary.get("principalOutstanding"));
-            assertEquals(0.0f, loanSummary.get("principalPaid"));
-            assertEquals(1005.0f, loanSummary.get("totalOutstanding"));
+            loanSummary = getLoanDetails(loanID).getSummary();
+            assertEquals(10.0f, loanSummary.getPenaltyChargesCharged().floatValue());
+            assertEquals(5.0f, loanSummary.getPenaltyChargesOutstanding().floatValue());
+            assertEquals(5.0f, loanSummary.getPenaltyChargesPaid().floatValue());
+            assertEquals(1000.0f, loanSummary.getPrincipalDisbursed().floatValue());
+            assertEquals(1000.0f, loanSummary.getPrincipalOutstanding().floatValue());
+            assertEquals(0.0f, loanSummary.getPrincipalPaid().floatValue());
+            assertEquals(1005.0f, loanSummary.getTotalOutstanding().floatValue());
         } finally {
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(false));
@@ -5482,62 +5123,71 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         try {
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
-            BUSINESS_DATE_HELPER.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("01 November 2022").dateFormat(DATETIME_PATTERN).locale("en"));
-            final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-            final Account assetFeeAndPenaltyAccount = ACCOUNT_HELPER.createAssetAccount();
-            final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-            final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-            final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
-            final PostGLAccountsResponse uniqueIncomeAccountForFee = ACCOUNT_HELPER.createGLAccount(new PostGLAccountsRequest()
+            updateBusinessDate("01 November 2022");
+            final Account assetAccount = accountHelper.createAssetAccount();
+            final Account assetFeeAndPenaltyAccount = accountHelper.createAssetAccount();
+            final Account incomeAccount = accountHelper.createIncomeAccount();
+            final Account expenseAccount = accountHelper.createExpenseAccount();
+            final Account overpaymentAccount = accountHelper.createLiabilityAccount();
+            final PostGLAccountsResponse uniqueIncomeAccountForFee = accountHelper.createGLAccount(new PostGLAccountsRequest()
                     .type(GLAccountType.INCOME.getValue())
                     .glCode(Utils.uniqueRandomStringGenerator("UNIQUE_FEE_INCOME" + Calendar.getInstance().getTimeInMillis(), 5))
                     .manualEntriesAllowed(true)
                     .name(Utils.uniqueRandomStringGenerator("UNIQUE_FEE_INCOME" + Calendar.getInstance().getTimeInMillis(), 5)).usage(1));
-            final PostGLAccountsResponse uniqueIncomeAccountForPenalty = ACCOUNT_HELPER.createGLAccount(new PostGLAccountsRequest()
+            final PostGLAccountsResponse uniqueIncomeAccountForPenalty = accountHelper.createGLAccount(new PostGLAccountsRequest()
                     .type(GLAccountType.INCOME.getValue())
                     .glCode(Utils.uniqueRandomStringGenerator("UNIQUE_PENALTY_INCOME" + Calendar.getInstance().getTimeInMillis(), 5))
                     .manualEntriesAllowed(true)
                     .name(Utils.uniqueRandomStringGenerator("UNIQUE_PENALTY_INCOME" + Calendar.getInstance().getTimeInMillis(), 5))
                     .usage(1));
 
-            PostChargesResponse penaltyCharge = CHARGES_HELPER.createCharges(new ChargeRequest().penalty(true).amount(10.0)
+            PostChargesResponse penaltyCharge = chargesHelper.createCharge(new ChargeRequest().penalty(true).amount(10.0)
                     .chargeCalculationType(ChargeCalculationType.FLAT.getValue())
                     .chargeTimeType(ChargeTimeType.SPECIFIED_DUE_DATE.getValue()).chargePaymentMode(ChargePaymentMode.REGULAR.getValue())
                     .currencyCode("USD").name(Utils.randomStringGenerator("PENALTY_" + Calendar.getInstance().getTimeInMillis(), 5))
                     .chargeAppliesTo(1).locale("en").active(true));
 
-            PostChargesResponse feeCharge = CHARGES_HELPER.createCharges(new ChargeRequest().penalty(false).amount(9.0)
+            PostChargesResponse feeCharge = chargesHelper.createCharge(new ChargeRequest().penalty(false).amount(9.0)
                     .chargeCalculationType(ChargeCalculationType.FLAT.getValue())
                     .chargeTimeType(ChargeTimeType.SPECIFIED_DUE_DATE.getValue()).chargePaymentMode(ChargePaymentMode.REGULAR.getValue())
                     .currencyCode("USD").name(Utils.randomStringGenerator("FEE_" + Calendar.getInstance().getTimeInMillis(), 5))
                     .chargeAppliesTo(1).locale("en").active(true));
 
-            final String loanProductJSON = new LoanProductTestBuilder().withPrincipal("1000").withRepaymentTypeAsMonth()
-                    .withRepaymentAfterEvery("1").withNumberOfRepayments("1").withRepaymentTypeAsMonth().withinterestRatePerPeriod("0")
-                    .withInterestRateFrequencyTypeAsMonths().withAmortizationTypeAsEqualPrincipalPayment().withInterestTypeAsFlat()
-                    .withAccountingRulePeriodicAccrual(new Account[] { assetAccount, incomeAccount, expenseAccount, overpaymentAccount })
-                    .withDaysInMonth("30").withDaysInYear("365").withMoratorium("0", "0")
-                    .withFeeToIncomeAccountMapping(feeCharge.getResourceId(), uniqueIncomeAccountForFee.getResourceId())
-                    .withPenaltyToIncomeAccountMapping(penaltyCharge.getResourceId(), uniqueIncomeAccountForPenalty.getResourceId())
-                    .withFeeAndPenaltyAssetAccount(assetFeeAndPenaltyAccount).build(null);
-            final Integer loanProductID = LOAN_TRANSACTION_HELPER.getLoanProductId(loanProductJSON);
+            PostLoanProductsRequest product = baseLoanProduct()//
+                    .principal(1000.00)//
+                    .numberOfRepayments(1)//
+                    .repaymentEvery(1)//
+                    .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS_L)//
+                    .interestRatePerPeriod(0.0)//
+                    .interestRateFrequencyType(LoanTestData.InterestRateFrequencyType.MONTHS)//
+                    .amortizationType(LoanTestData.AmortizationType.EQUAL_PRINCIPAL)//
+                    .interestType(LoanTestData.InterestType.FLAT)//
+                    .daysInMonthType(30)//
+                    .daysInYearType(365)//
+                    .graceOnPrincipalPayment(0)//
+                    .graceOnInterestPayment(0)//
+                    .feeToIncomeAccountMappings(List.of(new LoanProductChargeToGLAccountMapper().chargeId(feeCharge.getResourceId())
+                            .incomeAccountId(uniqueIncomeAccountForFee.getResourceId())))//
+                    .penaltyToIncomeAccountMappings(List.of(new LoanProductChargeToGLAccountMapper().chargeId(penaltyCharge.getResourceId())
+                            .incomeAccountId(uniqueIncomeAccountForPenalty.getResourceId())));
+            withAccounting(product, ACCRUAL_PERIODIC, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
+            // withFeeAndPenaltyAssetAccount: fee and penalty receivables point at a dedicated asset account
+            product.receivableFeeAccountId(assetFeeAndPenaltyAccount.getAccountID().longValue())//
+                    .receivablePenaltyAccountId(assetFeeAndPenaltyAccount.getAccountID().longValue());
+            final Long loanProductID = createLoanProduct(product);
 
-            final PostClientsResponse client = CLIENT_HELPER.createClient(ClientHelper.defaultClientCreationRequest());
+            final Long clientID = createClient();
 
-            final Integer loanID = applyForLoanApplication(client.getClientId().intValue(), loanProductID);
+            final Long loanID = applyForLoanApplication(clientID, loanProductID);
 
-            HashMap<String, Object> loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+            verifyLoanIsPending(loanID);
 
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("02 September 2022", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-            LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+            verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("02 September 2022", loanID));
 
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+            GetLoansLoanIdResponse loanStatusHashMap = disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
+            verifyLoanIsActive(loanStatusHashMap);
 
-            GetLoansLoanIdResponse loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanID);
             List<GetLoansLoanIdRepaymentPeriod> loanSchedulePeriods = loanDetails.getRepaymentSchedule().getPeriods();
             assertEquals(2, loanSchedulePeriods.size());
             assertEquals(0.0, Utils.getDoubleValue(loanSchedulePeriods.get(1).getPenaltyChargesDue()));
@@ -5546,27 +5196,27 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(1000.0, Utils.getDoubleValue(loanSchedulePeriods.get(1).getTotalOutstandingForPeriod()));
 
             LocalDate targetDate = LocalDate.of(2022, 9, 7);
-            final String penaltyCharge1AddedDate = DATE_TIME_FORMATTER.format(targetDate);
-            Integer penaltyLoanChargeId = LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                    .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penaltyCharge.getResourceId()), penaltyCharge1AddedDate, "10"));
+            final String penaltyCharge1AddedDate = dateTimeFormatter.format(targetDate);
+            Long penaltyLoanChargeId = addLoanCharge(loanID, penaltyCharge.getResourceId(), penaltyCharge1AddedDate, 10.0).getResourceId();
 
-            final String penalty1LoanChargeDate = DATE_TIME_FORMATTER.format(targetDate);
-            PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting(penalty1LoanChargeDate);
+            final String penalty1LoanChargeDate = dateTimeFormatter.format(targetDate);
+            runPeriodicAccrualAccounting(penalty1LoanChargeDate);
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
             List<GetLoansLoanIdTransactions> transactions = loanDetails.getTransactions();
             assertEquals(10.0, Utils.getDoubleValue(transactions.get(1).getAmount()));
             assertTrue(transactions.get(1).getType().getAccrual());
             assertEquals(10.0, Utils.getDoubleValue(transactions.get(1).getPenaltyChargesPortion()));
             Long accrualTransactionId = transactions.get(1).getId();
 
-            List<HashMap> journalEntries = JOURNAL_ENTRY_HELPER.getJournalEntriesByTransactionId("L" + accrualTransactionId);
-            assertEquals(10.0f, (float) journalEntries.get(0).get("amount"));
-            assertEquals(assetFeeAndPenaltyAccount.getAccountID(), (int) journalEntries.get(0).get("glAccountId"));
-            assertEquals("DEBIT", ((HashMap) journalEntries.get(0).get("entryType")).get("value"));
-            assertEquals(10.0f, (float) journalEntries.get(1).get("amount"));
-            assertEquals(uniqueIncomeAccountForPenalty.getResourceId(), (int) journalEntries.get(1).get("glAccountId"));
-            assertEquals("CREDIT", ((HashMap) journalEntries.get(1).get("entryType")).get("value"));
+            List<JournalEntryTransactionItem> journalEntries = journalHelper.getJournalEntriesByTransactionId("L" + accrualTransactionId)
+                    .getPageItems();
+            assertEquals(10.0f, journalEntries.get(0).getAmount().floatValue());
+            assertEquals(assetFeeAndPenaltyAccount.getAccountID(), journalEntries.get(0).getGlAccountId().intValue());
+            assertEquals("DEBIT", journalEntries.get(0).getEntryType().getValue());
+            assertEquals(10.0f, journalEntries.get(1).getAmount().floatValue());
+            assertEquals(uniqueIncomeAccountForPenalty.getResourceId(), journalEntries.get(1).getGlAccountId().intValue());
+            assertEquals("CREDIT", journalEntries.get(1).getEntryType().getValue());
 
             loanSchedulePeriods = loanDetails.getRepaymentSchedule().getPeriods();
             assertEquals(2, loanSchedulePeriods.size());
@@ -5581,10 +5231,10 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(1010.0, Utils.getDoubleValue(loanSummary.getTotalOutstanding()));
 
             String externalId = UUID.randomUUID().toString();
-            PostLoansLoanIdChargesChargeIdResponse chargeAdjustmentResponse = LOAN_TRANSACTION_HELPER.chargeAdjustment((long) loanID,
-                    (long) penaltyLoanChargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(10.0).externalId(externalId));
+            PostLoansLoanIdChargesChargeIdResponse chargeAdjustmentResponse = chargeAdjustment((long) loanID, (long) penaltyLoanChargeId,
+                    new PostLoansLoanIdChargesChargeIdRequest().amount(10.0).externalId(externalId));
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
 
             loanSchedulePeriods = loanDetails.getRepaymentSchedule().getPeriods();
             assertEquals(2, loanSchedulePeriods.size());
@@ -5607,43 +5257,42 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(10.0, Utils.getDoubleValue(transactions.get(2).getPenaltyChargesPortion()));
             Long chargeAdjustmentTransactionId = transactions.get(2).getId();
 
-            journalEntries = JOURNAL_ENTRY_HELPER.getJournalEntriesByTransactionId("L" + chargeAdjustmentTransactionId);
-            assertEquals(10.0f, (float) journalEntries.get(0).get("amount"));
-            assertEquals(uniqueIncomeAccountForPenalty.getResourceId().intValue(), (int) journalEntries.get(0).get("glAccountId"));
-            assertEquals("DEBIT", ((HashMap) journalEntries.get(0).get("entryType")).get("value"));
-            assertEquals(10.0f, (float) journalEntries.get(1).get("amount"));
-            assertEquals(assetFeeAndPenaltyAccount.getAccountID(), (int) journalEntries.get(1).get("glAccountId"));
-            assertEquals("CREDIT", ((HashMap) journalEntries.get(1).get("entryType")).get("value"));
+            journalEntries = journalHelper.getJournalEntriesByTransactionId("L" + chargeAdjustmentTransactionId).getPageItems();
+            assertEquals(10.0f, journalEntries.get(0).getAmount().floatValue());
+            assertEquals(uniqueIncomeAccountForPenalty.getResourceId().intValue(), journalEntries.get(0).getGlAccountId().intValue());
+            assertEquals("DEBIT", journalEntries.get(0).getEntryType().getValue());
+            assertEquals(10.0f, journalEntries.get(1).getAmount().floatValue());
+            assertEquals(assetFeeAndPenaltyAccount.getAccountID(), journalEntries.get(1).getGlAccountId().intValue());
+            assertEquals("CREDIT", journalEntries.get(1).getEntryType().getValue());
 
             String uuid = UUID.randomUUID().toString();
-            LOAN_TRANSACTION_HELPER.reverseLoanTransaction((long) loanID, chargeAdjustmentTransactionId,
+            reverseLoanTransaction((long) loanID, chargeAdjustmentTransactionId,
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("08 September 2022")
                             .transactionAmount(0.0).locale("en").reversalExternalId(uuid));
 
-            journalEntries = JOURNAL_ENTRY_HELPER.getJournalEntriesByTransactionId("L" + chargeAdjustmentTransactionId);
-            assertEquals(10.0f, (float) journalEntries.get(0).get("amount"));
-            assertEquals(uniqueIncomeAccountForPenalty.getResourceId().intValue(), (int) journalEntries.get(0).get("glAccountId"));
-            assertEquals("CREDIT", ((HashMap) journalEntries.get(0).get("entryType")).get("value"));
-            assertEquals(10.0f, (float) journalEntries.get(1).get("amount"));
-            assertEquals(assetFeeAndPenaltyAccount.getAccountID(), (int) journalEntries.get(1).get("glAccountId"));
-            assertEquals("DEBIT", ((HashMap) journalEntries.get(1).get("entryType")).get("value"));
-            assertEquals(10.0f, (float) journalEntries.get(2).get("amount"));
-            assertEquals(uniqueIncomeAccountForPenalty.getResourceId().intValue(), (int) journalEntries.get(2).get("glAccountId"));
-            assertEquals("DEBIT", ((HashMap) journalEntries.get(2).get("entryType")).get("value"));
-            assertEquals(10.0f, (float) journalEntries.get(3).get("amount"));
-            assertEquals(assetFeeAndPenaltyAccount.getAccountID(), (int) journalEntries.get(3).get("glAccountId"));
-            assertEquals("CREDIT", ((HashMap) journalEntries.get(3).get("entryType")).get("value"));
+            journalEntries = journalHelper.getJournalEntriesByTransactionId("L" + chargeAdjustmentTransactionId).getPageItems();
+            assertEquals(10.0f, journalEntries.get(0).getAmount().floatValue());
+            assertEquals(uniqueIncomeAccountForPenalty.getResourceId().intValue(), journalEntries.get(0).getGlAccountId().intValue());
+            assertEquals("CREDIT", journalEntries.get(0).getEntryType().getValue());
+            assertEquals(10.0f, journalEntries.get(1).getAmount().floatValue());
+            assertEquals(assetFeeAndPenaltyAccount.getAccountID(), journalEntries.get(1).getGlAccountId().intValue());
+            assertEquals("DEBIT", journalEntries.get(1).getEntryType().getValue());
+            assertEquals(10.0f, journalEntries.get(2).getAmount().floatValue());
+            assertEquals(uniqueIncomeAccountForPenalty.getResourceId().intValue(), journalEntries.get(2).getGlAccountId().intValue());
+            assertEquals("DEBIT", journalEntries.get(2).getEntryType().getValue());
+            assertEquals(10.0f, journalEntries.get(3).getAmount().floatValue());
+            assertEquals(assetFeeAndPenaltyAccount.getAccountID(), journalEntries.get(3).getGlAccountId().intValue());
+            assertEquals("CREDIT", journalEntries.get(3).getEntryType().getValue());
 
             targetDate = LocalDate.of(2022, 9, 10);
-            final String feeCharge1AddedDate = DATE_TIME_FORMATTER.format(targetDate);
-            Integer feeLoanChargeId = LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                    .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(feeCharge.getResourceId()), feeCharge1AddedDate, "3"));
+            final String feeCharge1AddedDate = dateTimeFormatter.format(targetDate);
+            Long feeLoanChargeId = addLoanCharge(loanID, feeCharge.getResourceId(), feeCharge1AddedDate, 3.0).getResourceId();
 
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            final String feeLoanChargeDate = DATE_TIME_FORMATTER.format(targetDate);
-            PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting(feeLoanChargeDate);
+            final String feeLoanChargeDate = dateTimeFormatter.format(targetDate);
+            runPeriodicAccrualAccounting(feeLoanChargeDate);
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
             transactions = loanDetails.getTransactions();
             assertEquals(3.0, Utils.getDoubleValue(transactions.get(2).getAmount()));
             assertTrue(transactions.get(2).getType().getAccrual());
@@ -5651,14 +5300,14 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertTrue(StringUtils.isNotBlank(transactions.get(2).getExternalId()));
             accrualTransactionId = transactions.get(2).getId();
 
-            journalEntries = JOURNAL_ENTRY_HELPER.getJournalEntriesByTransactionId("L" + accrualTransactionId);
+            journalEntries = journalHelper.getJournalEntriesByTransactionId("L" + accrualTransactionId).getPageItems();
             // FINERACT-2323: Journal entry order changed - DEBIT entries come first, then CREDIT entries
-            assertEquals(3.0f, (float) journalEntries.get(0).get("amount"));
-            assertEquals(assetFeeAndPenaltyAccount.getAccountID(), (int) journalEntries.get(0).get("glAccountId"));
-            assertEquals("DEBIT", ((HashMap) journalEntries.get(0).get("entryType")).get("value"));
-            assertEquals(3.0f, (float) journalEntries.get(1).get("amount"));
-            assertEquals(uniqueIncomeAccountForFee.getResourceId().intValue(), (int) journalEntries.get(1).get("glAccountId"));
-            assertEquals("CREDIT", ((HashMap) journalEntries.get(1).get("entryType")).get("value"));
+            assertEquals(3.0f, journalEntries.get(0).getAmount().floatValue());
+            assertEquals(assetFeeAndPenaltyAccount.getAccountID(), journalEntries.get(0).getGlAccountId().intValue());
+            assertEquals("DEBIT", journalEntries.get(0).getEntryType().getValue());
+            assertEquals(3.0f, journalEntries.get(1).getAmount().floatValue());
+            assertEquals(uniqueIncomeAccountForFee.getResourceId().intValue(), journalEntries.get(1).getGlAccountId().intValue());
+            assertEquals("CREDIT", journalEntries.get(1).getEntryType().getValue());
 
             loanSchedulePeriods = loanDetails.getRepaymentSchedule().getPeriods();
             assertEquals(2, loanSchedulePeriods.size());
@@ -5676,14 +5325,14 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(3.0, Utils.getDoubleValue(loanSummary.getFeeChargesOutstanding()));
             assertEquals(1013.0, Utils.getDoubleValue(loanSummary.getTotalOutstanding()));
 
-            LOAN_TRANSACTION_HELPER.makeLoanRepayment((long) loanID, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+            makeLoanRepayment((long) loanID, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
                     .transactionDate("11 September 2022").locale("en").transactionAmount(5.0));
 
             externalId = UUID.randomUUID().toString();
-            chargeAdjustmentResponse = LOAN_TRANSACTION_HELPER.chargeAdjustment((long) loanID, (long) feeLoanChargeId,
+            chargeAdjustmentResponse = chargeAdjustment((long) loanID, (long) feeLoanChargeId,
                     new PostLoansLoanIdChargesChargeIdRequest().amount(2.0).externalId(externalId));
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
 
             loanSchedulePeriods = loanDetails.getRepaymentSchedule().getPeriods();
             assertEquals(2, loanSchedulePeriods.size());
@@ -5720,19 +5369,19 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(0.0, Utils.getDoubleValue(transactions.get(5).getPrincipalPortion()));
             chargeAdjustmentTransactionId = transactions.get(5).getId();
 
-            journalEntries = JOURNAL_ENTRY_HELPER.getJournalEntriesByTransactionId("L" + chargeAdjustmentTransactionId);
-            assertEquals(2.0f, (float) journalEntries.get(0).get("amount"));
-            assertEquals(uniqueIncomeAccountForFee.getResourceId().intValue(), (int) journalEntries.get(0).get("glAccountId"));
-            assertEquals("DEBIT", ((HashMap) journalEntries.get(0).get("entryType")).get("value"));
-            assertEquals(2.0f, (float) journalEntries.get(1).get("amount"));
-            assertEquals(assetFeeAndPenaltyAccount.getAccountID(), (int) journalEntries.get(1).get("glAccountId"));
-            assertEquals("CREDIT", ((HashMap) journalEntries.get(1).get("entryType")).get("value"));
+            journalEntries = journalHelper.getJournalEntriesByTransactionId("L" + chargeAdjustmentTransactionId).getPageItems();
+            assertEquals(2.0f, journalEntries.get(0).getAmount().floatValue());
+            assertEquals(uniqueIncomeAccountForFee.getResourceId().intValue(), journalEntries.get(0).getGlAccountId().intValue());
+            assertEquals("DEBIT", journalEntries.get(0).getEntryType().getValue());
+            assertEquals(2.0f, journalEntries.get(1).getAmount().floatValue());
+            assertEquals(assetFeeAndPenaltyAccount.getAccountID(), journalEntries.get(1).getGlAccountId().intValue());
+            assertEquals("CREDIT", journalEntries.get(1).getEntryType().getValue());
 
             externalId = UUID.randomUUID().toString();
-            chargeAdjustmentResponse = LOAN_TRANSACTION_HELPER.chargeAdjustment((long) loanID, (long) penaltyLoanChargeId,
+            chargeAdjustmentResponse = chargeAdjustment((long) loanID, (long) penaltyLoanChargeId,
                     new PostLoansLoanIdChargesChargeIdRequest().amount(7.0).externalId(externalId));
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
 
             loanSchedulePeriods = loanDetails.getRepaymentSchedule().getPeriods();
             assertEquals(2, loanSchedulePeriods.size());
@@ -5769,36 +5418,36 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(1.0, Utils.getDoubleValue(transactions.get(6).getPrincipalPortion()));
             chargeAdjustmentTransactionId = transactions.get(6).getId();
 
-            journalEntries = JOURNAL_ENTRY_HELPER.getJournalEntriesByTransactionId("L" + chargeAdjustmentTransactionId);
-            assertEquals(7.0f, (float) journalEntries.get(0).get("amount"));
-            assertEquals(uniqueIncomeAccountForPenalty.getResourceId().intValue(), (int) journalEntries.get(0).get("glAccountId"));
-            assertEquals("DEBIT", ((HashMap) journalEntries.get(0).get("entryType")).get("value"));
-            if (assetAccount.getAccountID() == (int) journalEntries.get(1).get("glAccountId")) {
-                assertEquals(1.0f, (float) journalEntries.get(1).get("amount"));
-                assertEquals(assetAccount.getAccountID(), (int) journalEntries.get(1).get("glAccountId"));
-                assertEquals("CREDIT", ((HashMap) journalEntries.get(1).get("entryType")).get("value"));
+            journalEntries = journalHelper.getJournalEntriesByTransactionId("L" + chargeAdjustmentTransactionId).getPageItems();
+            assertEquals(7.0f, journalEntries.get(0).getAmount().floatValue());
+            assertEquals(uniqueIncomeAccountForPenalty.getResourceId().intValue(), journalEntries.get(0).getGlAccountId().intValue());
+            assertEquals("DEBIT", journalEntries.get(0).getEntryType().getValue());
+            if (assetAccount.getAccountID() == journalEntries.get(1).getGlAccountId().intValue()) {
+                assertEquals(1.0f, journalEntries.get(1).getAmount().floatValue());
+                assertEquals(assetAccount.getAccountID(), journalEntries.get(1).getGlAccountId().intValue());
+                assertEquals("CREDIT", journalEntries.get(1).getEntryType().getValue());
 
-                assertEquals(6.0f, (float) journalEntries.get(2).get("amount"));
-                assertEquals(assetFeeAndPenaltyAccount.getAccountID(), (int) journalEntries.get(2).get("glAccountId"));
-                assertEquals("CREDIT", ((HashMap) journalEntries.get(2).get("entryType")).get("value"));
+                assertEquals(6.0f, journalEntries.get(2).getAmount().floatValue());
+                assertEquals(assetFeeAndPenaltyAccount.getAccountID(), journalEntries.get(2).getGlAccountId().intValue());
+                assertEquals("CREDIT", journalEntries.get(2).getEntryType().getValue());
             } else {
-                assertEquals(1.0f, (float) journalEntries.get(2).get("amount"));
-                assertEquals(assetAccount.getAccountID(), (int) journalEntries.get(2).get("glAccountId"));
-                assertEquals("CREDIT", ((HashMap) journalEntries.get(2).get("entryType")).get("value"));
+                assertEquals(1.0f, journalEntries.get(2).getAmount().floatValue());
+                assertEquals(assetAccount.getAccountID(), journalEntries.get(2).getGlAccountId().intValue());
+                assertEquals("CREDIT", journalEntries.get(2).getEntryType().getValue());
 
-                assertEquals(6.0f, (float) journalEntries.get(1).get("amount"));
-                assertEquals(assetFeeAndPenaltyAccount.getAccountID(), (int) journalEntries.get(1).get("glAccountId"));
-                assertEquals("CREDIT", ((HashMap) journalEntries.get(1).get("entryType")).get("value"));
+                assertEquals(6.0f, journalEntries.get(1).getAmount().floatValue());
+                assertEquals(assetFeeAndPenaltyAccount.getAccountID(), journalEntries.get(1).getGlAccountId().intValue());
+                assertEquals("CREDIT", journalEntries.get(1).getEntryType().getValue());
             }
 
-            LOAN_TRANSACTION_HELPER.makeLoanRepayment((long) loanID, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+            makeLoanRepayment((long) loanID, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
                     .transactionDate("13 September 2022").locale("en").transactionAmount(998.0));
 
             externalId = UUID.randomUUID().toString();
-            chargeAdjustmentResponse = LOAN_TRANSACTION_HELPER.chargeAdjustment((long) loanID, (long) feeLoanChargeId,
+            chargeAdjustmentResponse = chargeAdjustment((long) loanID, (long) feeLoanChargeId,
                     new PostLoansLoanIdChargesChargeIdRequest().amount(1.0).externalId(externalId));
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
 
             loanSchedulePeriods = loanDetails.getRepaymentSchedule().getPeriods();
             assertEquals(2, loanSchedulePeriods.size());
@@ -5835,21 +5484,21 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(1.0, Utils.getDoubleValue(transactions.get(8).getPrincipalPortion()));
             chargeAdjustmentTransactionId = transactions.get(8).getId();
 
-            journalEntries = JOURNAL_ENTRY_HELPER.getJournalEntriesByTransactionId("L" + chargeAdjustmentTransactionId);
-            assertEquals(1.0f, (float) journalEntries.get(0).get("amount"));
-            assertEquals(uniqueIncomeAccountForFee.getResourceId().intValue(), (int) journalEntries.get(0).get("glAccountId"));
-            assertEquals("DEBIT", ((HashMap) journalEntries.get(0).get("entryType")).get("value"));
-            assertEquals(1.0f, (float) journalEntries.get(1).get("amount"));
-            assertEquals(assetAccount.getAccountID(), (int) journalEntries.get(1).get("glAccountId"));
-            assertEquals("CREDIT", ((HashMap) journalEntries.get(1).get("entryType")).get("value"));
+            journalEntries = journalHelper.getJournalEntriesByTransactionId("L" + chargeAdjustmentTransactionId).getPageItems();
+            assertEquals(1.0f, journalEntries.get(0).getAmount().floatValue());
+            assertEquals(uniqueIncomeAccountForFee.getResourceId().intValue(), journalEntries.get(0).getGlAccountId().intValue());
+            assertEquals("DEBIT", journalEntries.get(0).getEntryType().getValue());
+            assertEquals(1.0f, journalEntries.get(1).getAmount().floatValue());
+            assertEquals(assetAccount.getAccountID(), journalEntries.get(1).getGlAccountId().intValue());
+            assertEquals("CREDIT", journalEntries.get(1).getEntryType().getValue());
 
             assertTrue(loanDetails.getStatus().getClosedObligationsMet());
 
             externalId = UUID.randomUUID().toString();
-            chargeAdjustmentResponse = LOAN_TRANSACTION_HELPER.chargeAdjustment((long) loanID, (long) penaltyLoanChargeId,
+            chargeAdjustmentResponse = chargeAdjustment((long) loanID, (long) penaltyLoanChargeId,
                     new PostLoansLoanIdChargesChargeIdRequest().amount(1.0).externalId(externalId));
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
 
             transactions = loanDetails.getTransactions();
             assertEquals(1.0, Utils.getDoubleValue(transactions.get(9).getAmount()));
@@ -5860,13 +5509,13 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(1.0, Utils.getDoubleValue(transactions.get(9).getOverpaymentPortion()));
             chargeAdjustmentTransactionId = transactions.get(9).getId();
 
-            journalEntries = JOURNAL_ENTRY_HELPER.getJournalEntriesByTransactionId("L" + chargeAdjustmentTransactionId);
-            assertEquals(1.0f, (float) journalEntries.get(0).get("amount"));
-            assertEquals(uniqueIncomeAccountForPenalty.getResourceId().intValue(), (int) journalEntries.get(0).get("glAccountId"));
-            assertEquals("DEBIT", ((HashMap) journalEntries.get(0).get("entryType")).get("value"));
-            assertEquals(1.0f, (float) journalEntries.get(1).get("amount"));
-            assertEquals(overpaymentAccount.getAccountID(), (int) journalEntries.get(1).get("glAccountId"));
-            assertEquals("CREDIT", ((HashMap) journalEntries.get(1).get("entryType")).get("value"));
+            journalEntries = journalHelper.getJournalEntriesByTransactionId("L" + chargeAdjustmentTransactionId).getPageItems();
+            assertEquals(1.0f, journalEntries.get(0).getAmount().floatValue());
+            assertEquals(uniqueIncomeAccountForPenalty.getResourceId().intValue(), journalEntries.get(0).getGlAccountId().intValue());
+            assertEquals("DEBIT", journalEntries.get(0).getEntryType().getValue());
+            assertEquals(1.0f, journalEntries.get(1).getAmount().floatValue());
+            assertEquals(overpaymentAccount.getAccountID(), journalEntries.get(1).getGlAccountId().intValue());
+            assertEquals("CREDIT", journalEntries.get(1).getEntryType().getValue());
 
             assertTrue(loanDetails.getStatus().getOverpaid());
         } finally {
@@ -5878,292 +5527,283 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
     @Test
     public void undoWaivedChargeWaiveTransactionDoesNotExist() {
-        final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-        final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-        final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-        final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+        final Account assetAccount = accountHelper.createAssetAccount();
+        final Account incomeAccount = accountHelper.createIncomeAccount();
+        final Account expenseAccount = accountHelper.createExpenseAccount();
+        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-        final Integer loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount, expenseAccount,
+        final Long loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount, expenseAccount,
                 overpaymentAccount);
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC, "01 January 2011");
+        final Long clientID = createClient("01 January 2011");
 
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID);
 
-        HashMap<String, Object> loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("02 September 2022", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("02 September 2022", loanID));
 
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        final Integer loanTransactionId = (Integer) ((Map) ((List) JsonPath.from(loanDetails).get("transactions")).get(0)).get("id");
-        LoanTransactionHelper loanTransactionHelper = new LoanTransactionHelper(REQUEST_SPEC, createResponseSpecification(403));
-        HashMap response = loanTransactionHelper.undoWaiveChargesForLoan(loanID, loanTransactionId, "");
-        assertEquals("error.msg.loan.transaction.undo.waive.charge",
-                ((Map) ((List) response.get("errors")).get(0)).get("userMessageGlobalisationCode"));
-        assertEquals("Transaction is not a waive charge type.", ((Map) ((List) response.get("errors")).get(0)).get("defaultUserMessage"));
+        GetLoansLoanIdResponse loanStatusHashMap = disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
+        verifyLoanIsActive(loanStatusHashMap);
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanID);
+        final Long loanTransactionId = loanDetails.getTransactions().get(0).getId();
+        CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class, () -> undoWaiveLoanCharge(loanID,
+                loanTransactionId, new PutChargeTransactionChangesRequest().id(loanTransactionId).loanId(loanID)));
+        assertEquals(403, exception.getStatus());
+        assertTrue(exception.getMessage().contains("error.msg.loan.transaction.undo.waive.charge"));
+        assertTrue(exception.getMessage().contains("Transaction is not a waive charge type."));
     }
 
     @Test
     public void undoWaivedCharge() {
-        final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-        final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-        final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-        final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+        final Account assetAccount = accountHelper.createAssetAccount();
+        final Account incomeAccount = accountHelper.createIncomeAccount();
+        final Account expenseAccount = accountHelper.createExpenseAccount();
+        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-        Integer penalty = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", true));
-        final Integer loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount, expenseAccount,
+        Long penalty = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.FLAT, 10.0, true).getResourceId();
+        final Long loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount, expenseAccount,
                 overpaymentAccount);
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC, "01 January 2011");
+        final Long clientID = createClient("01 January 2011");
 
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID);
 
-        HashMap<String, Object> loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("02 September 2022", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("02 September 2022", loanID));
 
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        GetLoansLoanIdResponse loanStatusHashMap = disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
+        verifyLoanIsActive(loanStatusHashMap);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
         assertEquals(2, loanSchedule.size());
-        assertEquals(0, loanSchedule.get(1).get("feeChargesDue"));
-        assertEquals(0, loanSchedule.get(1).get("feeChargesOutstanding"));
-        assertEquals(0, loanSchedule.get(1).get("penaltyChargesDue"));
-        assertEquals(0, loanSchedule.get(1).get("penaltyChargesOutstanding"));
-        assertEquals(1000.0f, loanSchedule.get(1).get("totalDueForPeriod"));
-        assertEquals(1000.0f, loanSchedule.get(1).get("totalOutstandingForPeriod"));
+        assertEquals(0.0f, loanSchedule.get(1).getFeeChargesDue().floatValue());
+        assertEquals(0.0f, loanSchedule.get(1).getFeeChargesOutstanding().floatValue());
+        assertEquals(0.0f, loanSchedule.get(1).getPenaltyChargesDue().floatValue());
+        assertEquals(0.0f, loanSchedule.get(1).getPenaltyChargesOutstanding().floatValue());
+        assertEquals(1000.0f, loanSchedule.get(1).getTotalDueForPeriod().floatValue());
+        assertEquals(1000.0f, loanSchedule.get(1).getTotalOutstandingForPeriod().floatValue());
         LocalDate targetDate = LocalDate.of(2022, 9, 7);
-        final String penaltyCharge1AddedDate = DATE_TIME_FORMATTER.format(targetDate);
-        Integer penalty1LoanChargeId = LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID,
-                LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), penaltyCharge1AddedDate, "10"));
+        final String penaltyCharge1AddedDate = dateTimeFormatter.format(targetDate);
+        Long penalty1LoanChargeId = addLoanCharge(loanID, penalty, penaltyCharge1AddedDate, 10.0).getResourceId();
 
-        LOAN_TRANSACTION_HELPER.noAccrualTransactionForRepayment(loanID);
+        assertNoAccrualTransactions(loanID);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         assertEquals(2, loanSchedule.size());
-        assertEquals(0, loanSchedule.get(1).get("feeChargesDue"));
-        assertEquals(0, loanSchedule.get(1).get("feeChargesOutstanding"));
-        assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesDue"));
-        assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesOutstanding"));
-        assertEquals(1010.0f, loanSchedule.get(1).get("totalDueForPeriod"));
-        assertEquals(1010.0f, loanSchedule.get(1).get("totalOutstandingForPeriod"));
-        assertEquals(0, loanSchedule.get(1).get("totalWaivedForPeriod"));
+        assertEquals(0.0f, loanSchedule.get(1).getFeeChargesDue().floatValue());
+        assertEquals(0.0f, loanSchedule.get(1).getFeeChargesOutstanding().floatValue());
+        assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesDue().floatValue());
+        assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesOutstanding().floatValue());
+        assertEquals(1010.0f, loanSchedule.get(1).getTotalDueForPeriod().floatValue());
+        assertEquals(1010.0f, loanSchedule.get(1).getTotalOutstandingForPeriod().floatValue());
+        assertEquals(0, loanSchedule.get(1).getTotalWaivedForPeriod().floatValue());
 
-        HashMap loanSummary = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "summary");
-        assertEquals(10.0f, loanSummary.get("penaltyChargesCharged"));
-        assertEquals(10.0f, loanSummary.get("penaltyChargesOutstanding"));
-        assertEquals(0.0f, loanSummary.get("penaltyChargesWaived"));
-        assertEquals(0.0f, loanSummary.get("feeChargesCharged"));
-        assertEquals(0.0f, loanSummary.get("feeChargesOutstanding"));
-        assertEquals(0.0f, loanSummary.get("feeChargesWaived"));
-        assertEquals(1010.0f, loanSummary.get("totalOutstanding"));
-        assertEquals(0.0f, loanSummary.get("totalWaived"));
+        GetLoansLoanIdSummary loanSummary = getLoanDetails(loanID).getSummary();
+        assertEquals(10.0f, loanSummary.getPenaltyChargesCharged().floatValue());
+        assertEquals(10.0f, loanSummary.getPenaltyChargesOutstanding().floatValue());
+        assertEquals(0.0f, loanSummary.getPenaltyChargesWaived().floatValue());
+        assertEquals(0.0f, loanSummary.getFeeChargesCharged().floatValue());
+        assertEquals(0.0f, loanSummary.getFeeChargesOutstanding().floatValue());
+        assertEquals(0.0f, loanSummary.getFeeChargesWaived().floatValue());
+        assertEquals(1010.0f, loanSummary.getTotalOutstanding().floatValue());
+        assertEquals(0.0f, loanSummary.getTotalWaived().floatValue());
 
-        LOAN_TRANSACTION_HELPER.waiveChargesForLoan(loanID, penalty1LoanChargeId, "");
+        waiveWholeLoanCharge(loanID, penalty1LoanChargeId);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         assertEquals(2, loanSchedule.size());
-        assertEquals(0, loanSchedule.get(1).get("feeChargesDue"));
-        assertEquals(0, loanSchedule.get(1).get("feeChargesOutstanding"));
-        assertEquals(0, loanSchedule.get(1).get("feeChargesWaived"));
-        assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesDue"));
-        assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesWaived"));
-        assertEquals(0.0f, loanSchedule.get(1).get("penaltyChargesOutstanding"));
-        assertEquals(1010.0f, loanSchedule.get(1).get("totalDueForPeriod"));
-        assertEquals(1000.0f, loanSchedule.get(1).get("totalOutstandingForPeriod"));
-        assertEquals(10.0f, loanSchedule.get(1).get("totalWaivedForPeriod"));
+        assertEquals(0.0f, loanSchedule.get(1).getFeeChargesDue().floatValue());
+        assertEquals(0.0f, loanSchedule.get(1).getFeeChargesOutstanding().floatValue());
+        assertEquals(0.0f, loanSchedule.get(1).getFeeChargesWaived().floatValue());
+        assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesDue().floatValue());
+        assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesWaived().floatValue());
+        assertEquals(0.0f, loanSchedule.get(1).getPenaltyChargesOutstanding().floatValue());
+        assertEquals(1010.0f, loanSchedule.get(1).getTotalDueForPeriod().floatValue());
+        assertEquals(1000.0f, loanSchedule.get(1).getTotalOutstandingForPeriod().floatValue());
+        assertEquals(10.0f, loanSchedule.get(1).getTotalWaivedForPeriod().floatValue());
 
-        loanSummary = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "summary");
-        assertEquals(10.0f, loanSummary.get("penaltyChargesCharged"));
-        assertEquals(0.0f, loanSummary.get("penaltyChargesOutstanding"));
-        assertEquals(10.0f, loanSummary.get("penaltyChargesWaived"));
-        assertEquals(0.0f, loanSummary.get("feeChargesCharged"));
-        assertEquals(0.0f, loanSummary.get("feeChargesOutstanding"));
-        assertEquals(0.0f, loanSummary.get("feeChargesWaived"));
-        assertEquals(1000.0f, loanSummary.get("totalOutstanding"));
-        assertEquals(10.0f, loanSummary.get("totalWaived"));
+        loanSummary = getLoanDetails(loanID).getSummary();
+        assertEquals(10.0f, loanSummary.getPenaltyChargesCharged().floatValue());
+        assertEquals(0.0f, loanSummary.getPenaltyChargesOutstanding().floatValue());
+        assertEquals(10.0f, loanSummary.getPenaltyChargesWaived().floatValue());
+        assertEquals(0.0f, loanSummary.getFeeChargesCharged().floatValue());
+        assertEquals(0.0f, loanSummary.getFeeChargesOutstanding().floatValue());
+        assertEquals(0.0f, loanSummary.getFeeChargesWaived().floatValue());
+        assertEquals(1000.0f, loanSummary.getTotalOutstanding().floatValue());
+        assertEquals(10.0f, loanSummary.getTotalWaived().floatValue());
 
-        List<HashMap> transactions = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "transactions");
-        assertEquals(10.0f, (float) transactions.get(1).get("amount"));
-        assertEquals(9, (int) ((HashMap) transactions.get(1).get("type")).get("id"));
-        Integer waiveTransactionId = (int) transactions.get(1).get("id");
-        LOAN_TRANSACTION_HELPER.undoWaiveChargesForLoan(loanID, waiveTransactionId, "");
+        List<GetLoansLoanIdTransactions> transactions = getLoanDetails(loanID).getTransactions();
+        assertEquals(10.0f, transactions.get(1).getAmount().floatValue());
+        assertEquals(9, transactions.get(1).getType().getId().intValue());
+        Long waiveTransactionId = transactions.get(1).getId();
+        undoWaiveLoanCharge(loanID, waiveTransactionId, new PutChargeTransactionChangesRequest().id(waiveTransactionId).loanId(loanID));
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         assertEquals(2, loanSchedule.size());
-        assertEquals(0, loanSchedule.get(1).get("feeChargesDue"));
-        assertEquals(0, loanSchedule.get(1).get("feeChargesOutstanding"));
-        assertEquals(0, loanSchedule.get(1).get("feeChargesWaived"));
-        assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesDue"));
-        assertEquals(0, loanSchedule.get(1).get("penaltyChargesWaived"));
-        assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesOutstanding"));
-        assertEquals(1010.0f, loanSchedule.get(1).get("totalDueForPeriod"));
-        assertEquals(1010.0f, loanSchedule.get(1).get("totalOutstandingForPeriod"));
-        assertEquals(0, loanSchedule.get(1).get("totalWaivedForPeriod"));
+        assertEquals(0.0f, loanSchedule.get(1).getFeeChargesDue().floatValue());
+        assertEquals(0.0f, loanSchedule.get(1).getFeeChargesOutstanding().floatValue());
+        assertEquals(0.0f, loanSchedule.get(1).getFeeChargesWaived().floatValue());
+        assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesDue().floatValue());
+        assertEquals(0.0f, loanSchedule.get(1).getPenaltyChargesWaived().floatValue());
+        assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesOutstanding().floatValue());
+        assertEquals(1010.0f, loanSchedule.get(1).getTotalDueForPeriod().floatValue());
+        assertEquals(1010.0f, loanSchedule.get(1).getTotalOutstandingForPeriod().floatValue());
+        assertEquals(0, loanSchedule.get(1).getTotalWaivedForPeriod().floatValue());
 
-        loanSummary = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "summary");
-        assertEquals(10.0f, loanSummary.get("penaltyChargesCharged"));
-        assertEquals(10.0f, loanSummary.get("penaltyChargesOutstanding"));
-        assertEquals(0.0f, loanSummary.get("penaltyChargesWaived"));
-        assertEquals(0.0f, loanSummary.get("feeChargesCharged"));
-        assertEquals(0.0f, loanSummary.get("feeChargesOutstanding"));
-        assertEquals(0.0f, loanSummary.get("feeChargesWaived"));
-        assertEquals(1010.0f, loanSummary.get("totalOutstanding"));
-        assertEquals(0.0f, loanSummary.get("totalWaived"));
+        loanSummary = getLoanDetails(loanID).getSummary();
+        assertEquals(10.0f, loanSummary.getPenaltyChargesCharged().floatValue());
+        assertEquals(10.0f, loanSummary.getPenaltyChargesOutstanding().floatValue());
+        assertEquals(0.0f, loanSummary.getPenaltyChargesWaived().floatValue());
+        assertEquals(0.0f, loanSummary.getFeeChargesCharged().floatValue());
+        assertEquals(0.0f, loanSummary.getFeeChargesOutstanding().floatValue());
+        assertEquals(0.0f, loanSummary.getFeeChargesWaived().floatValue());
+        assertEquals(1010.0f, loanSummary.getTotalOutstanding().floatValue());
+        assertEquals(0.0f, loanSummary.getTotalWaived().floatValue());
 
-        transactions = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "transactions");
-        assertEquals(10.0f, (float) transactions.get(1).get("amount"));
-        assertEquals(9, (int) ((HashMap) transactions.get(1).get("type")).get("id"));
-        assertEquals(true, transactions.get(1).get("manuallyReversed"));
+        transactions = getLoanDetails(loanID).getTransactions();
+        assertEquals(10.0f, transactions.get(1).getAmount().floatValue());
+        assertEquals(9, transactions.get(1).getType().getId().intValue());
+        assertEquals(true, transactions.get(1).getManuallyReversed());
 
-        Integer fee = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", false));
+        Long fee = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.FLAT, 10.0, false).getResourceId();
 
-        final String feeCharge1AddedDate = DATE_TIME_FORMATTER.format(targetDate);
-        Integer fee1LoanChargeId = LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID,
-                LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(fee), feeCharge1AddedDate, "10"));
+        final String feeCharge1AddedDate = dateTimeFormatter.format(targetDate);
+        Long fee1LoanChargeId = addLoanCharge(loanID, fee, feeCharge1AddedDate, 10.0).getResourceId();
 
-        PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting(feeCharge1AddedDate);
+        runPeriodicAccrualAccounting(feeCharge1AddedDate);
 
-        transactions = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "transactions");
-        assertEquals(10, (int) ((HashMap) transactions.get(2).get("type")).get("id"));
-        assertEquals(20.0f, (float) transactions.get(2).get("amount"));
-        Integer accrualTransactionId = (int) transactions.get(2).get("id");
+        transactions = getLoanDetails(loanID).getTransactions();
+        assertEquals(10, transactions.get(2).getType().getId().intValue());
+        assertEquals(20.0f, transactions.get(2).getAmount().floatValue());
+        Long accrualTransactionId = transactions.get(2).getId();
 
-        List<HashMap> journalEntries = JOURNAL_ENTRY_HELPER.getJournalEntriesByTransactionId("L" + accrualTransactionId);
+        List<JournalEntryTransactionItem> journalEntries = journalHelper.getJournalEntriesByTransactionId("L" + accrualTransactionId)
+                .getPageItems();
         // FINERACT-2323: Due to multiple legs for journal entries, the system now uses charge-specific GL accounts
         // instead of product-level defaults. The journal entry structure has changed with alternating DEBIT/CREDIT
         // pairs.
         // This transaction accrues both penalty (10) and fee (10) charges.
         // Entry 0: DEBIT for penalty receivable
-        assertEquals(10.0f, (float) journalEntries.get(0).get("amount"));
-        assertEquals(assetAccount.getAccountID(), (int) journalEntries.get(0).get("glAccountId"));
-        assertEquals("DEBIT", ((HashMap) journalEntries.get(0).get("entryType")).get("value"));
+        assertEquals(10.0f, journalEntries.get(0).getAmount().floatValue());
+        assertEquals(assetAccount.getAccountID(), journalEntries.get(0).getGlAccountId().intValue());
+        assertEquals("DEBIT", journalEntries.get(0).getEntryType().getValue());
         // Entry 1: CREDIT for penalty income
-        assertEquals(10.0f, (float) journalEntries.get(1).get("amount"));
-        assertEquals(incomeAccount.getAccountID(), (int) journalEntries.get(1).get("glAccountId"));
-        assertEquals("CREDIT", ((HashMap) journalEntries.get(1).get("entryType")).get("value"));
+        assertEquals(10.0f, journalEntries.get(1).getAmount().floatValue());
+        assertEquals(incomeAccount.getAccountID(), journalEntries.get(1).getGlAccountId().intValue());
+        assertEquals("CREDIT", journalEntries.get(1).getEntryType().getValue());
         // Entry 2: DEBIT for fee receivable (uses charge-specific or fallback account due to FINERACT-2323)
-        assertEquals(10.0f, (float) journalEntries.get(2).get("amount"));
+        assertEquals(10.0f, journalEntries.get(2).getAmount().floatValue());
         // Due to FINERACT-2323, the fee uses a different asset account
-        assertEquals(assetAccount.getAccountID(), (int) journalEntries.get(2).get("glAccountId"));
-        assertEquals("DEBIT", ((HashMap) journalEntries.get(2).get("entryType")).get("value"));
+        assertEquals(assetAccount.getAccountID(), journalEntries.get(2).getGlAccountId().intValue());
+        assertEquals("DEBIT", journalEntries.get(2).getEntryType().getValue());
         // Entry 3: CREDIT for fee income
-        assertEquals(10.0f, (float) journalEntries.get(3).get("amount"));
-        assertEquals(incomeAccount.getAccountID(), (int) journalEntries.get(3).get("glAccountId"));
-        assertEquals("CREDIT", ((HashMap) journalEntries.get(3).get("entryType")).get("value"));
+        assertEquals(10.0f, journalEntries.get(3).getAmount().floatValue());
+        assertEquals(incomeAccount.getAccountID(), journalEntries.get(3).getGlAccountId().intValue());
+        assertEquals("CREDIT", journalEntries.get(3).getEntryType().getValue());
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         assertEquals(2, loanSchedule.size());
-        assertEquals(10.0f, loanSchedule.get(1).get("feeChargesDue"));
-        assertEquals(10.0f, loanSchedule.get(1).get("feeChargesOutstanding"));
-        assertEquals(0, loanSchedule.get(1).get("feeChargesWaived"));
-        assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesDue"));
-        assertEquals(0, loanSchedule.get(1).get("penaltyChargesWaived"));
-        assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesOutstanding"));
-        assertEquals(1020.0f, loanSchedule.get(1).get("totalDueForPeriod"));
-        assertEquals(1020.0f, loanSchedule.get(1).get("totalOutstandingForPeriod"));
-        assertEquals(0, loanSchedule.get(1).get("totalWaivedForPeriod"));
+        assertEquals(10.0f, loanSchedule.get(1).getFeeChargesDue().floatValue());
+        assertEquals(10.0f, loanSchedule.get(1).getFeeChargesOutstanding().floatValue());
+        assertEquals(0.0f, loanSchedule.get(1).getFeeChargesWaived().floatValue());
+        assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesDue().floatValue());
+        assertEquals(0.0f, loanSchedule.get(1).getPenaltyChargesWaived().floatValue());
+        assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesOutstanding().floatValue());
+        assertEquals(1020.0f, loanSchedule.get(1).getTotalDueForPeriod().floatValue());
+        assertEquals(1020.0f, loanSchedule.get(1).getTotalOutstandingForPeriod().floatValue());
+        assertEquals(0, loanSchedule.get(1).getTotalWaivedForPeriod().floatValue());
 
-        loanSummary = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "summary");
-        assertEquals(10.0f, loanSummary.get("penaltyChargesCharged"));
-        assertEquals(10.0f, loanSummary.get("penaltyChargesOutstanding"));
-        assertEquals(0.0f, loanSummary.get("penaltyChargesWaived"));
-        assertEquals(10.0f, loanSummary.get("feeChargesCharged"));
-        assertEquals(10.0f, loanSummary.get("feeChargesOutstanding"));
-        assertEquals(0.0f, loanSummary.get("feeChargesWaived"));
-        assertEquals(1020.0f, loanSummary.get("totalOutstanding"));
-        assertEquals(0.0f, loanSummary.get("totalWaived"));
+        loanSummary = getLoanDetails(loanID).getSummary();
+        assertEquals(10.0f, loanSummary.getPenaltyChargesCharged().floatValue());
+        assertEquals(10.0f, loanSummary.getPenaltyChargesOutstanding().floatValue());
+        assertEquals(0.0f, loanSummary.getPenaltyChargesWaived().floatValue());
+        assertEquals(10.0f, loanSummary.getFeeChargesCharged().floatValue());
+        assertEquals(10.0f, loanSummary.getFeeChargesOutstanding().floatValue());
+        assertEquals(0.0f, loanSummary.getFeeChargesWaived().floatValue());
+        assertEquals(1020.0f, loanSummary.getTotalOutstanding().floatValue());
+        assertEquals(0.0f, loanSummary.getTotalWaived().floatValue());
 
-        LOAN_TRANSACTION_HELPER.waiveChargesForLoan(loanID, fee1LoanChargeId, "");
+        waiveWholeLoanCharge(loanID, fee1LoanChargeId);
 
-        transactions = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "transactions");
-        assertEquals(10.0f, (float) transactions.get(3).get("amount"));
-        assertEquals(9, (int) ((HashMap) transactions.get(3).get("type")).get("id"));
-        Integer waive2TransactionId = (int) transactions.get(3).get("id");
+        transactions = getLoanDetails(loanID).getTransactions();
+        assertEquals(10.0f, transactions.get(3).getAmount().floatValue());
+        assertEquals(9, transactions.get(3).getType().getId().intValue());
+        Long waive2TransactionId = transactions.get(3).getId();
 
-        journalEntries = JOURNAL_ENTRY_HELPER.getJournalEntriesByTransactionId("L" + waive2TransactionId);
-        assertEquals(10.0f, (float) journalEntries.get(0).get("amount"));
-        assertEquals(expenseAccount.getAccountID(), (int) journalEntries.get(0).get("glAccountId"));
-        assertEquals("DEBIT", ((HashMap) journalEntries.get(0).get("entryType")).get("value"));
-        assertEquals(10.0f, (float) journalEntries.get(1).get("amount"));
-        assertEquals(assetAccount.getAccountID(), (int) journalEntries.get(1).get("glAccountId"));
-        assertEquals("CREDIT", ((HashMap) journalEntries.get(1).get("entryType")).get("value"));
+        journalEntries = journalHelper.getJournalEntriesByTransactionId("L" + waive2TransactionId).getPageItems();
+        assertEquals(10.0f, journalEntries.get(0).getAmount().floatValue());
+        assertEquals(expenseAccount.getAccountID(), journalEntries.get(0).getGlAccountId().intValue());
+        assertEquals("DEBIT", journalEntries.get(0).getEntryType().getValue());
+        assertEquals(10.0f, journalEntries.get(1).getAmount().floatValue());
+        assertEquals(assetAccount.getAccountID(), journalEntries.get(1).getGlAccountId().intValue());
+        assertEquals("CREDIT", journalEntries.get(1).getEntryType().getValue());
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         assertEquals(2, loanSchedule.size());
-        assertEquals(10.0f, loanSchedule.get(1).get("feeChargesDue"));
-        assertEquals(0.0f, loanSchedule.get(1).get("feeChargesOutstanding"));
-        assertEquals(10.0f, loanSchedule.get(1).get("feeChargesWaived"));
-        assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesDue"));
-        assertEquals(0, loanSchedule.get(1).get("penaltyChargesWaived"));
-        assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesOutstanding"));
-        assertEquals(1020.0f, loanSchedule.get(1).get("totalDueForPeriod"));
-        assertEquals(1010.0f, loanSchedule.get(1).get("totalOutstandingForPeriod"));
-        assertEquals(10.0f, loanSchedule.get(1).get("totalWaivedForPeriod"));
+        assertEquals(10.0f, loanSchedule.get(1).getFeeChargesDue().floatValue());
+        assertEquals(0.0f, loanSchedule.get(1).getFeeChargesOutstanding().floatValue());
+        assertEquals(10.0f, loanSchedule.get(1).getFeeChargesWaived().floatValue());
+        assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesDue().floatValue());
+        assertEquals(0.0f, loanSchedule.get(1).getPenaltyChargesWaived().floatValue());
+        assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesOutstanding().floatValue());
+        assertEquals(1020.0f, loanSchedule.get(1).getTotalDueForPeriod().floatValue());
+        assertEquals(1010.0f, loanSchedule.get(1).getTotalOutstandingForPeriod().floatValue());
+        assertEquals(10.0f, loanSchedule.get(1).getTotalWaivedForPeriod().floatValue());
 
-        loanSummary = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "summary");
-        assertEquals(10.0f, loanSummary.get("penaltyChargesCharged"));
-        assertEquals(10.0f, loanSummary.get("penaltyChargesOutstanding"));
-        assertEquals(0.0f, loanSummary.get("penaltyChargesWaived"));
-        assertEquals(10.0f, loanSummary.get("feeChargesCharged"));
-        assertEquals(0.0f, loanSummary.get("feeChargesOutstanding"));
-        assertEquals(10.0f, loanSummary.get("feeChargesWaived"));
-        assertEquals(1010.0f, loanSummary.get("totalOutstanding"));
-        assertEquals(10.0f, loanSummary.get("totalWaived"));
+        loanSummary = getLoanDetails(loanID).getSummary();
+        assertEquals(10.0f, loanSummary.getPenaltyChargesCharged().floatValue());
+        assertEquals(10.0f, loanSummary.getPenaltyChargesOutstanding().floatValue());
+        assertEquals(0.0f, loanSummary.getPenaltyChargesWaived().floatValue());
+        assertEquals(10.0f, loanSummary.getFeeChargesCharged().floatValue());
+        assertEquals(0.0f, loanSummary.getFeeChargesOutstanding().floatValue());
+        assertEquals(10.0f, loanSummary.getFeeChargesWaived().floatValue());
+        assertEquals(1010.0f, loanSummary.getTotalOutstanding().floatValue());
+        assertEquals(10.0f, loanSummary.getTotalWaived().floatValue());
 
-        LOAN_TRANSACTION_HELPER.undoWaiveChargesForLoan(loanID, waive2TransactionId, "");
+        undoWaiveLoanCharge(loanID, waive2TransactionId, new PutChargeTransactionChangesRequest().id(waive2TransactionId).loanId(loanID));
 
-        transactions = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "transactions");
-        assertEquals(10.0f, (float) transactions.get(3).get("amount"));
-        assertEquals(9, (int) ((HashMap) transactions.get(3).get("type")).get("id"));
-        assertEquals(true, transactions.get(3).get("manuallyReversed"));
+        transactions = getLoanDetails(loanID).getTransactions();
+        assertEquals(10.0f, transactions.get(3).getAmount().floatValue());
+        assertEquals(9, transactions.get(3).getType().getId().intValue());
+        assertEquals(true, transactions.get(3).getManuallyReversed());
 
-        journalEntries = JOURNAL_ENTRY_HELPER.getJournalEntriesByTransactionId("L" + waive2TransactionId);
-        assertEquals(10.0f, (float) journalEntries.get(0).get("amount"));
-        assertEquals(expenseAccount.getAccountID(), (int) journalEntries.get(0).get("glAccountId"));
-        assertEquals("CREDIT", ((HashMap) journalEntries.get(0).get("entryType")).get("value"));
-        assertEquals(10.0f, (float) journalEntries.get(1).get("amount"));
-        assertEquals(assetAccount.getAccountID(), (int) journalEntries.get(1).get("glAccountId"));
-        assertEquals("DEBIT", ((HashMap) journalEntries.get(1).get("entryType")).get("value"));
-        assertEquals(10.0f, (float) journalEntries.get(2).get("amount"));
-        assertEquals(expenseAccount.getAccountID(), (int) journalEntries.get(2).get("glAccountId"));
-        assertEquals("DEBIT", ((HashMap) journalEntries.get(2).get("entryType")).get("value"));
-        assertEquals(10.0f, (float) journalEntries.get(3).get("amount"));
-        assertEquals(assetAccount.getAccountID(), (int) journalEntries.get(3).get("glAccountId"));
-        assertEquals("CREDIT", ((HashMap) journalEntries.get(3).get("entryType")).get("value"));
+        journalEntries = journalHelper.getJournalEntriesByTransactionId("L" + waive2TransactionId).getPageItems();
+        assertEquals(10.0f, journalEntries.get(0).getAmount().floatValue());
+        assertEquals(expenseAccount.getAccountID(), journalEntries.get(0).getGlAccountId().intValue());
+        assertEquals("CREDIT", journalEntries.get(0).getEntryType().getValue());
+        assertEquals(10.0f, journalEntries.get(1).getAmount().floatValue());
+        assertEquals(assetAccount.getAccountID(), journalEntries.get(1).getGlAccountId().intValue());
+        assertEquals("DEBIT", journalEntries.get(1).getEntryType().getValue());
+        assertEquals(10.0f, journalEntries.get(2).getAmount().floatValue());
+        assertEquals(expenseAccount.getAccountID(), journalEntries.get(2).getGlAccountId().intValue());
+        assertEquals("DEBIT", journalEntries.get(2).getEntryType().getValue());
+        assertEquals(10.0f, journalEntries.get(3).getAmount().floatValue());
+        assertEquals(assetAccount.getAccountID(), journalEntries.get(3).getGlAccountId().intValue());
+        assertEquals("CREDIT", journalEntries.get(3).getEntryType().getValue());
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         assertEquals(2, loanSchedule.size());
-        assertEquals(10.0f, loanSchedule.get(1).get("feeChargesDue"));
-        assertEquals(10.0f, loanSchedule.get(1).get("feeChargesOutstanding"));
-        assertEquals(0, loanSchedule.get(1).get("feeChargesWaived"));
-        assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesDue"));
-        assertEquals(0, loanSchedule.get(1).get("penaltyChargesWaived"));
-        assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesOutstanding"));
-        assertEquals(1020.0f, loanSchedule.get(1).get("totalDueForPeriod"));
-        assertEquals(1020.0f, loanSchedule.get(1).get("totalOutstandingForPeriod"));
-        assertEquals(0, loanSchedule.get(1).get("totalWaivedForPeriod"));
+        assertEquals(10.0f, loanSchedule.get(1).getFeeChargesDue().floatValue());
+        assertEquals(10.0f, loanSchedule.get(1).getFeeChargesOutstanding().floatValue());
+        assertEquals(0.0f, loanSchedule.get(1).getFeeChargesWaived().floatValue());
+        assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesDue().floatValue());
+        assertEquals(0.0f, loanSchedule.get(1).getPenaltyChargesWaived().floatValue());
+        assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesOutstanding().floatValue());
+        assertEquals(1020.0f, loanSchedule.get(1).getTotalDueForPeriod().floatValue());
+        assertEquals(1020.0f, loanSchedule.get(1).getTotalOutstandingForPeriod().floatValue());
+        assertEquals(0, loanSchedule.get(1).getTotalWaivedForPeriod().floatValue());
 
-        loanSummary = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "summary");
-        assertEquals(10.0f, loanSummary.get("penaltyChargesCharged"));
-        assertEquals(10.0f, loanSummary.get("penaltyChargesOutstanding"));
-        assertEquals(0.0f, loanSummary.get("penaltyChargesWaived"));
-        assertEquals(10.0f, loanSummary.get("feeChargesCharged"));
-        assertEquals(10.0f, loanSummary.get("feeChargesOutstanding"));
-        assertEquals(0.0f, loanSummary.get("feeChargesWaived"));
-        assertEquals(1020.0f, loanSummary.get("totalOutstanding"));
-        assertEquals(0.0f, loanSummary.get("totalWaived"));
+        loanSummary = getLoanDetails(loanID).getSummary();
+        assertEquals(10.0f, loanSummary.getPenaltyChargesCharged().floatValue());
+        assertEquals(10.0f, loanSummary.getPenaltyChargesOutstanding().floatValue());
+        assertEquals(0.0f, loanSummary.getPenaltyChargesWaived().floatValue());
+        assertEquals(10.0f, loanSummary.getFeeChargesCharged().floatValue());
+        assertEquals(10.0f, loanSummary.getFeeChargesOutstanding().floatValue());
+        assertEquals(0.0f, loanSummary.getFeeChargesWaived().floatValue());
+        assertEquals(1020.0f, loanSummary.getTotalOutstanding().floatValue());
+        assertEquals(0.0f, loanSummary.getTotalWaived().floatValue());
     }
 
     @Test
@@ -6173,60 +5813,48 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
                     new PutGlobalConfigurationsRequest().enabled(true));
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
-            BUSINESS_DATE_HELPER.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("04 September 2022").dateFormat(DATETIME_PATTERN).locale("en"));
-            final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-            final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-            final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-            final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+            updateBusinessDate("04 September 2022");
+            final Account assetAccount = accountHelper.createAssetAccount();
+            final Account incomeAccount = accountHelper.createIncomeAccount();
+            final Account expenseAccount = accountHelper.createExpenseAccount();
+            final Account overpaymentAccount = accountHelper.createLiabilityAccount();
             String randomText = UUID.randomUUID().toString();
-            Integer chargeOffReasonId = CodeHelper.createChargeOffCodeValue(REQUEST_SPEC, RESPONSE_SPEC, randomText, 1);
-            final Integer loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterestMultiDisbursement(assetAccount,
+            Long chargeOffReasonId = codeHelper.createChargeOffCodeValue(randomText, 1);
+            final Long loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterestMultiDisbursement(assetAccount,
                     incomeAccount, expenseAccount, overpaymentAccount);
 
-            final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC, "01 January 2011");
+            final Long clientID = createClient("01 January 2011");
 
-            final Integer loanID = applyForLoanApplication(clientID, loanProductID);
+            final Long loanID = applyForLoanApplication(clientID, loanProductID);
 
-            HashMap<String, Object> loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
-
-            ResponseSpecification errorResponseSpec = new ResponseSpecBuilder().expectStatusCode(403).build();
-            LoanTransactionHelper errorLoanTransactionHelper = new LoanTransactionHelper(REQUEST_SPEC, errorResponseSpec);
+            verifyLoanIsPending(loanID);
 
             CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class, () -> {
-                errorLoanTransactionHelper.chargeOffLoan((long) loanID,
-                        new PostLoansLoanIdTransactionsRequest().transactionDate("4 September 2022").locale("en")
-                                .dateFormat(DATETIME_PATTERN).externalId(UUID.randomUUID().toString())
-                                .chargeOffReasonId((long) chargeOffReasonId));
+                chargeOffLoan(loanID, new PostLoansLoanIdTransactionsRequest().transactionDate("4 September 2022").locale("en")
+                        .dateFormat(DATETIME_PATTERN).externalId(UUID.randomUUID().toString()).chargeOffReasonId(chargeOffReasonId));
             });
 
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("error.msg.loan.is.not.active"));
 
-            exception = assertThrows(CallFailedRuntimeException.class, () -> {
-                LOAN_TRANSACTION_HELPER.undoChargeOffLoan((long) loanID, new PostLoansLoanIdTransactionsRequest());
-            });
-            assertEquals(403, exception.getResponse().code());
+            exception = assertThrows(CallFailedRuntimeException.class, () -> undoChargeOffLoan(loanID));
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("error.msg.loan.is.not.active"));
 
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("02 September 2022", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-            LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+            verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("02 September 2022", loanID));
 
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithTransactionAmount("02 September 2022", loanID, "1000");
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithTransactionAmount("03 September 2022", loanID, "1000");
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+            GetLoansLoanIdResponse loanStatusHashMap = disburseLoanWithTransactionAmount(loanID, "02 September 2022", "1000");
+            loanStatusHashMap = disburseLoanWithTransactionAmount(loanID, "03 September 2022", "1000");
+            verifyLoanIsActive(loanStatusHashMap);
 
             exception = assertThrows(CallFailedRuntimeException.class, () -> {
-                LOAN_TRANSACTION_HELPER.chargeOffLoan((long) loanID,
-                        new PostLoansLoanIdTransactionsRequest().transactionDate("1 October 2022").locale("en").dateFormat(DATETIME_PATTERN)
-                                .chargeOffReasonId((long) chargeOffReasonId));
+                chargeOffLoan((long) loanID, new PostLoansLoanIdTransactionsRequest().transactionDate("1 October 2022").locale("en")
+                        .dateFormat(DATETIME_PATTERN).chargeOffReasonId(chargeOffReasonId));
             });
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("error.msg.loan.transaction.cannot.be.a.future.date"));
 
-            GetLoansLoanIdResponse loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanID);
             assertTrue(loanDetails.getStatus().getActive());
             assertEquals(2000.0, Utils.getDoubleValue(loanDetails.getSummary().getTotalOutstanding()));
             assertFalse(loanDetails.getChargedOff());
@@ -6237,22 +5865,19 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertNull(loanDetails.getTimeline().getChargedOffByFirstname());
             assertNull(loanDetails.getTimeline().getChargedOffByLastname());
 
-            Integer flatPenaltySpecifiedDueDate = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "3", true));
-            LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                    .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flatPenaltySpecifiedDueDate), "04 September 2022", "3"));
-            Integer chargeId = LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                    .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flatPenaltySpecifiedDueDate), "04 September 2022", "5"));
+            Long flatPenaltySpecifiedDueDate = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.FLAT, 3.0, true)
+                    .getResourceId();
+            addLoanCharge(loanID, flatPenaltySpecifiedDueDate, "04 September 2022", 3.0);
+            Long chargeId = addLoanCharge(loanID, flatPenaltySpecifiedDueDate, "04 September 2022", 5.0).getResourceId();
 
-            PostLoansLoanIdChargesChargeIdResponse waiveChargeResponse = LOAN_TRANSACTION_HELPER.waiveLoanCharge((long) loanID,
-                    (long) chargeId, new PostLoansLoanIdChargesChargeIdRequest());
+            PostLoansLoanIdChargesChargeIdResponse waiveChargeResponse = waiveLoanCharge((long) loanID, (long) chargeId,
+                    new PostLoansLoanIdChargesChargeIdRequest().locale(LOCALE));
 
             String transactionExternalId = UUID.randomUUID().toString();
-            LOAN_TRANSACTION_HELPER.chargeOffLoan((long) loanID,
-                    new PostLoansLoanIdTransactionsRequest().transactionDate("4 September 2022").locale("en").dateFormat(DATETIME_PATTERN)
-                            .externalId(transactionExternalId).chargeOffReasonId((long) chargeOffReasonId));
+            chargeOffLoan((long) loanID, new PostLoansLoanIdTransactionsRequest().transactionDate("4 September 2022").locale("en")
+                    .dateFormat(DATETIME_PATTERN).externalId(transactionExternalId).chargeOffReasonId((long) chargeOffReasonId));
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
             assertTrue(loanDetails.getStatus().getActive());
             assertEquals(2003.0, Utils.getDoubleValue(loanDetails.getSummary().getTotalOutstanding()));
             assertTrue(loanDetails.getChargedOff());
@@ -6270,30 +5895,26 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(3.0, Utils.getDoubleValue(chargeOffTransaction.getPenaltyChargesPortion()));
 
             exception = assertThrows(CallFailedRuntimeException.class, () -> {
-                errorLoanTransactionHelper.chargeOffLoan((long) loanID,
-                        new PostLoansLoanIdTransactionsRequest().transactionDate("4 September 2022").locale("en")
-                                .dateFormat(DATETIME_PATTERN).externalId(UUID.randomUUID().toString())
-                                .chargeOffReasonId((long) chargeOffReasonId));
+                chargeOffLoan(loanID, new PostLoansLoanIdTransactionsRequest().transactionDate("4 September 2022").locale("en")
+                        .dateFormat(DATETIME_PATTERN).externalId(UUID.randomUUID().toString()).chargeOffReasonId(chargeOffReasonId));
             });
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("error.msg.loan.is.already.charged.off"));
 
-            HashMap chargeAddingError = errorLoanTransactionHelper.addChargesForLoanGetFullResponse(loanID, LoanTransactionHelper
-                    .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flatPenaltySpecifiedDueDate), "04 September 2022", "3"));
-
-            assertEquals("error.msg.loan.is.charged.off",
-                    ((Map) ((List) chargeAddingError.get("errors")).get(0)).get("userMessageGlobalisationCode"));
+            CallFailedRuntimeException chargeAddingError = assertThrows(CallFailedRuntimeException.class,
+                    () -> addLoanCharge(loanID, flatPenaltySpecifiedDueDate, "04 September 2022", 3.0));
+            assertEquals(403, chargeAddingError.getStatus());
+            assertTrue(chargeAddingError.getMessage().contains("error.msg.loan.is.charged.off"));
 
             exception = assertThrows(CallFailedRuntimeException.class, () -> {
-                errorLoanTransactionHelper.undoWaiveLoanCharge((long) loanID, waiveChargeResponse.getSubResourceId(),
-                        new PutChargeTransactionChangesRequest());
+                undoWaiveLoanCharge(loanID, waiveChargeResponse.getSubResourceId(), new PutChargeTransactionChangesRequest());
             });
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("error.msg.transaction.date.cannot.be.earlier.than.charge.off.date"));
 
-            LOAN_TRANSACTION_HELPER.undoChargeOffLoan((long) loanID, new PostLoansLoanIdTransactionsRequest());
+            undoChargeOffLoan(loanID);
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
             assertFalse(loanDetails.getChargedOff());
             assertNull(loanDetails.getSummary().getChargeOffReasonId());
             assertNull(loanDetails.getSummary().getChargeOffReason());
@@ -6305,128 +5926,122 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertTrue(undoChargeOffTransaction.getManuallyReversed());
 
             exception = assertThrows(CallFailedRuntimeException.class, () -> {
-                errorLoanTransactionHelper.undoChargeOffLoan((long) loanID, new PostLoansLoanIdTransactionsRequest());
+                undoChargeOffLoan(loanID);
             });
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("error.msg.loan.is.not.charged.off"));
 
-            BUSINESS_DATE_HELPER.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("08 September 2022").dateFormat(DATETIME_PATTERN).locale("en"));
+            updateBusinessDate("08 September 2022");
 
-            PostLoansLoanIdTransactionsResponse loanRepaymentResponse = LOAN_TRANSACTION_HELPER.makeLoanRepayment((long) loanID,
+            PostLoansLoanIdTransactionsResponse loanRepaymentResponse = makeLoanRepayment((long) loanID,
                     new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate("05 September 2022").locale("en")
                             .transactionAmount(5.0));
 
             exception = assertThrows(CallFailedRuntimeException.class, () -> {
-                errorLoanTransactionHelper.chargeOffLoan((long) loanID,
-                        new PostLoansLoanIdTransactionsRequest().transactionDate("04 September 2022").locale("en")
-                                .dateFormat(DATETIME_PATTERN).externalId(UUID.randomUUID().toString())
-                                .chargeOffReasonId((long) chargeOffReasonId));
+                chargeOffLoan(loanID, new PostLoansLoanIdTransactionsRequest().transactionDate("04 September 2022").locale("en")
+                        .dateFormat(DATETIME_PATTERN).externalId(UUID.randomUUID().toString()).chargeOffReasonId(chargeOffReasonId));
             });
 
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("error.msg.loan.charge.off.is.before.than.the.last.user.transaction"));
 
-            LOAN_TRANSACTION_HELPER.chargeOffLoan((long) loanID,
-                    new PostLoansLoanIdTransactionsRequest().transactionDate("06 September 2022").locale("en").dateFormat(DATETIME_PATTERN)
-                            .externalId(UUID.randomUUID().toString()).chargeOffReasonId((long) chargeOffReasonId));
+            chargeOffLoan((long) loanID, new PostLoansLoanIdTransactionsRequest().transactionDate("06 September 2022").locale("en")
+                    .dateFormat(DATETIME_PATTERN).externalId(UUID.randomUUID().toString()).chargeOffReasonId((long) chargeOffReasonId));
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
             chargeOffTransaction = loanDetails.getTransactions().get(loanDetails.getTransactions().size() - 1);
 
             assertEquals(1998.0, Utils.getDoubleValue(chargeOffTransaction.getAmount()));
             assertEquals(1998.0, Utils.getDoubleValue(chargeOffTransaction.getPrincipalPortion()));
 
-            LOAN_TRANSACTION_HELPER.makeLoanRepayment((long) loanID, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+            makeLoanRepayment((long) loanID, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
                     .transactionDate("07 September 2022").locale("en").transactionAmount(5.0));
 
             exception = assertThrows(CallFailedRuntimeException.class, () -> {
-                errorLoanTransactionHelper.undoChargeOffLoan((long) loanID, new PostLoansLoanIdTransactionsRequest());
+                undoChargeOffLoan(loanID);
             });
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("error.msg.loan.charge.off.is.not.the.last.user.transaction"));
 
             exception = assertThrows(CallFailedRuntimeException.class, () -> {
-                errorLoanTransactionHelper.makeWriteoff((long) loanID, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                writeOffLoan(loanID, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
                         .transactionDate("05 September 2022").locale("en"));
             });
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("error.msg.transaction.date.cannot.be.earlier.than.charge.off.date"));
 
             exception = assertThrows(CallFailedRuntimeException.class, () -> {
-                errorLoanTransactionHelper.closeLoan((long) loanID, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                closeLoan(loanID, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate("05 September 2022")
+                        .locale("en"));
+            });
+            assertEquals(403, exception.getStatus());
+            assertTrue(exception.getMessage().contains("error.msg.transaction.date.cannot.be.earlier.than.charge.off.date"));
+
+            exception = assertThrows(CallFailedRuntimeException.class, () -> {
+                forecloseLoan(loanID, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
                         .transactionDate("05 September 2022").locale("en"));
             });
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("error.msg.transaction.date.cannot.be.earlier.than.charge.off.date"));
 
             exception = assertThrows(CallFailedRuntimeException.class, () -> {
-                errorLoanTransactionHelper.forecloseLoan((long) loanID, new PostLoansLoanIdTransactionsRequest()
-                        .dateFormat(DATETIME_PATTERN).transactionDate("05 September 2022").locale("en"));
+                closeRescheduledLoan(loanID, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                        .transactionDate("05 September 2022").locale("en"));
             });
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
+            assertTrue(exception.getMessage().contains("error.msg.loan.is.charged.off"));
+
+            CallFailedRuntimeException disbursementDetailError = assertThrows(CallFailedRuntimeException.class,
+                    () -> addAndDeleteDisbursementDetail(loanID, List
+                            .of(new DisbursementDetail().expectedDisbursementDate("05 September 2022").principal(new BigDecimal("200")))));
+            assertEquals(403, disbursementDetailError.getStatus());
+            assertTrue(disbursementDetailError.getMessage().contains("error.msg.loan.is.charged.off"));
+
+            exception = assertThrows(CallFailedRuntimeException.class, () -> {
+                undoLastDisbursement(loanID, new PostLoansLoanIdRequest());
+            });
+            assertEquals(403, exception.getStatus());
+            assertTrue(exception.getMessage().contains("error.msg.loan.is.charged.off"));
+
+            exception = assertThrows(CallFailedRuntimeException.class, () -> {
+                undoDisbursement(loanID, new PostLoansLoanIdRequest());
+            });
+            assertEquals(403, exception.getStatus());
+            assertTrue(exception.getMessage().contains("error.msg.loan.is.charged.off"));
+
+            exception = assertThrows(CallFailedRuntimeException.class, () -> {
+                makeCreditBalanceRefund(loanID, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                        .transactionDate("05 September 2022").locale("en").transactionAmount(5.0));
+            });
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("error.msg.transaction.date.cannot.be.earlier.than.charge.off.date"));
 
             exception = assertThrows(CallFailedRuntimeException.class, () -> {
-                errorLoanTransactionHelper.closeRescheduledLoan((long) loanID, new PostLoansLoanIdTransactionsRequest()
-                        .dateFormat(DATETIME_PATTERN).transactionDate("05 September 2022").locale("en"));
+                disburseLoan(loanID, new PostLoansLoanIdRequest().actualDisbursementDate("4 September 2022")
+                        .transactionAmount(new BigDecimal("10")).locale("en").dateFormat(DATETIME_PATTERN));
             });
-            assertEquals(403, exception.getResponse().code());
-            assertTrue(exception.getMessage().contains("error.msg.loan.is.charged.off"));
-
-            HashMap disbursementDetailREsponse = (HashMap) errorLoanTransactionHelper.addAndDeleteDisbursementDetail(loanID, "1000",
-                    "03 September 2022", List.of(LOAN_TRANSACTION_HELPER.createTrancheDetail(null, "05 September 2022", "200")), "");
-
-            assertEquals("error.msg.loan.is.charged.off",
-                    ((Map) ((List) disbursementDetailREsponse.get("errors")).get(0)).get("userMessageGlobalisationCode"));
-
-            exception = assertThrows(CallFailedRuntimeException.class, () -> {
-                errorLoanTransactionHelper.undoLastDisbursalLoan((long) loanID, new PostLoansLoanIdRequest());
-            });
-            assertEquals(403, exception.getResponse().code());
-            assertTrue(exception.getMessage().contains("error.msg.loan.is.charged.off"));
-
-            exception = assertThrows(CallFailedRuntimeException.class, () -> {
-                errorLoanTransactionHelper.undoDisbursalLoan((long) loanID, new PostLoansLoanIdRequest());
-            });
-            assertEquals(403, exception.getResponse().code());
-            assertTrue(exception.getMessage().contains("error.msg.loan.is.charged.off"));
-
-            exception = assertThrows(CallFailedRuntimeException.class, () -> {
-                errorLoanTransactionHelper.makeCreditBalanceRefund((long) loanID, new PostLoansLoanIdTransactionsRequest()
-                        .dateFormat(DATETIME_PATTERN).transactionDate("05 September 2022").locale("en").transactionAmount(5.0));
-            });
-            assertEquals(403, exception.getResponse().code());
-            assertTrue(exception.getMessage().contains("error.msg.transaction.date.cannot.be.earlier.than.charge.off.date"));
-
-            exception = assertThrows(CallFailedRuntimeException.class, () -> {
-                errorLoanTransactionHelper.disburseLoan((long) loanID,
-                        new PostLoansLoanIdRequest().actualDisbursementDate("4 September 2022").transactionAmount(new BigDecimal("10"))
-                                .locale("en").dateFormat(DATETIME_PATTERN));
-            });
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("amount.can't.be.greater.than.maximum.applied.loan.amount.calculation"));
 
             exception = assertThrows(CallFailedRuntimeException.class, () -> {
-                errorLoanTransactionHelper.disburseLoan((long) loanID,
-                        new PostLoansLoanIdRequest().actualDisbursementDate("7 September 2022").transactionAmount(new BigDecimal("10"))
-                                .locale("en").dateFormat(DATETIME_PATTERN));
+                disburseLoan(loanID, new PostLoansLoanIdRequest().actualDisbursementDate("7 September 2022")
+                        .transactionAmount(new BigDecimal("10")).locale("en").dateFormat(DATETIME_PATTERN));
             });
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("amount.can't.be.greater.than.maximum.applied.loan.amount.calculation"));
 
-            LOAN_TRANSACTION_HELPER.makeLoanRepayment((long) loanID, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+            makeLoanRepayment((long) loanID, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
                     .transactionDate("07 September 2022").locale("en").transactionAmount(5000.0));
 
             exception = assertThrows(CallFailedRuntimeException.class, () -> {
-                errorLoanTransactionHelper.makeRefundByCash((long) loanID, new PostLoansLoanIdTransactionsRequest()
-                        .dateFormat(DATETIME_PATTERN).transactionDate("05 September 2022").locale("en").transactionAmount(5.0));
+                transactionHelper.makeRefundByCash(loanID, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                        .transactionDate("05 September 2022").locale("en").transactionAmount(5.0));
             });
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("error.msg.transaction.date.cannot.be.earlier.than.charge.off.date"));
 
-            LOAN_TRANSACTION_HELPER.makeCreditBalanceRefund((long) loanID, new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("08 September 2022").locale("en").transactionAmount(3007.0));
+            makeCreditBalanceRefund((long) loanID, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("08 September 2022").locale("en").transactionAmount(3007.0));
         } finally {
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(false));
@@ -6440,38 +6055,35 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         try {
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID,
                     new PutGlobalConfigurationsRequest().enabled(true));
-            final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-            final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-            final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-            final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+            final Account assetAccount = accountHelper.createAssetAccount();
+            final Account incomeAccount = accountHelper.createIncomeAccount();
+            final Account expenseAccount = accountHelper.createExpenseAccount();
+            final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-            final Integer loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount,
-                    expenseAccount, overpaymentAccount);
+            final Long loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount, expenseAccount,
+                    overpaymentAccount);
 
-            final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC, "01 January 2011");
+            final Long clientID = createClient("01 January 2011");
 
-            final Integer loanID = applyForLoanApplication(clientID, loanProductID);
+            final Long loanID = applyForLoanApplication(clientID, loanProductID);
 
-            HashMap<String, Object> loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+            verifyLoanIsPending(loanID);
 
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("02 September 2022", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-            LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+            verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("02 September 2022", loanID));
 
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+            GetLoansLoanIdResponse loanStatusHashMap = disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
+            verifyLoanIsActive(loanStatusHashMap);
 
-            GetLoansLoanIdResponse loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanID);
             LocalDate expectedMaturityDate = loanDetails.getTimeline().getExpectedMaturityDate();
             LocalDate actualMaturityDate = loanDetails.getTimeline().getActualMaturityDate();
 
             assertTrue(DateUtils.isEqual(expectedMaturityDate, actualMaturityDate));
 
-            LOAN_TRANSACTION_HELPER.makeRepayment("04 September 2022", Float.parseFloat("500"), loanID);
-            LOAN_TRANSACTION_HELPER.makeRepayment("05 September 2022", Float.parseFloat("700"), loanID);
+            makeRepayment("04 September 2022", Float.parseFloat("500"), loanID);
+            makeRepayment("05 September 2022", Float.parseFloat("700"), loanID);
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
 
             expectedMaturityDate = loanDetails.getTimeline().getExpectedMaturityDate();
             actualMaturityDate = loanDetails.getTimeline().getActualMaturityDate();
@@ -6479,11 +6091,11 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertNotNull(expectedMaturityDate);
             assertNull(actualMaturityDate);
 
-            LOAN_TRANSACTION_HELPER.reverseLoanTransaction((long) loanID, loanDetails.getTransactions().get(1).getId(),
+            reverseLoanTransaction((long) loanID, loanDetails.getTransactions().get(1).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("04 September 2022")
                             .transactionAmount(0.0).locale("en"));
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
 
             expectedMaturityDate = loanDetails.getTimeline().getExpectedMaturityDate();
             actualMaturityDate = loanDetails.getTimeline().getActualMaturityDate();
@@ -6503,34 +6115,31 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         try {
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID,
                     new PutGlobalConfigurationsRequest().enabled(true));
-            final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-            final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-            final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-            final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+            final Account assetAccount = accountHelper.createAssetAccount();
+            final Account incomeAccount = accountHelper.createIncomeAccount();
+            final Account expenseAccount = accountHelper.createExpenseAccount();
+            final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-            final Integer loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount,
-                    expenseAccount, overpaymentAccount);
+            final Long loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount, expenseAccount,
+                    overpaymentAccount);
 
-            final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC, "01 January 2011");
+            final Long clientID = createClient("01 January 2011");
 
-            final Integer loanID = applyForLoanApplication(clientID, loanProductID);
+            final Long loanID = applyForLoanApplication(clientID, loanProductID);
 
-            HashMap<String, Object> loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+            verifyLoanIsPending(loanID);
 
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("02 September 2022", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-            LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+            verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("02 September 2022", loanID));
 
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+            GetLoansLoanIdResponse loanStatusHashMap = disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
+            verifyLoanIsActive(loanStatusHashMap);
 
-            LOAN_TRANSACTION_HELPER.makeRepayment("04 September 2022", Float.parseFloat("500"), loanID);
-            LOAN_TRANSACTION_HELPER.makeRepayment("05 September 2022", Float.parseFloat("10"), loanID);
-            LOAN_TRANSACTION_HELPER.makeRepayment("06 September 2022", Float.parseFloat("400"), loanID);
-            LOAN_TRANSACTION_HELPER.makeRepayment("07 September 2022", Float.parseFloat("390"), loanID);
+            makeRepayment("04 September 2022", Float.parseFloat("500"), loanID);
+            makeRepayment("05 September 2022", Float.parseFloat("10"), loanID);
+            makeRepayment("06 September 2022", Float.parseFloat("400"), loanID);
+            makeRepayment("07 September 2022", Float.parseFloat("390"), loanID);
 
-            GetLoansLoanIdResponse loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanID);
 
             assertEquals(300.0, Utils.getDoubleValue(loanDetails.getTotalOverpaid()));
 
@@ -6551,11 +6160,11 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(300.0, Utils.getDoubleValue(loanDetails.getTransactions().get(4).getOverpaymentPortion()));
             assertEquals(LocalDate.of(2022, 9, 7), loanDetails.getTransactions().get(4).getDate());
 
-            LOAN_TRANSACTION_HELPER.reverseLoanTransaction((long) loanID, loanDetails.getTransactions().get(2).getId(),
+            reverseLoanTransaction((long) loanID, loanDetails.getTransactions().get(2).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("05 September 2022")
                             .transactionAmount(0.0).locale("en"));
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
 
             assertEquals(290.0, Utils.getDoubleValue(loanDetails.getTotalOverpaid()));
 
@@ -6577,11 +6186,11 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(290.0, Utils.getDoubleValue(loanDetails.getTransactions().get(4).getOverpaymentPortion()));
             assertEquals(LocalDate.of(2022, 9, 7), loanDetails.getTransactions().get(4).getDate());
 
-            LOAN_TRANSACTION_HELPER.reverseLoanTransaction((long) loanID, loanDetails.getTransactions().get(1).getId(),
+            reverseLoanTransaction((long) loanID, loanDetails.getTransactions().get(1).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("05 September 2022")
                             .transactionAmount(0.0).locale("en"));
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
 
             assertEquals(210.0, Utils.getDoubleValue(loanDetails.getSummary().getTotalOutstanding()));
 
@@ -6603,9 +6212,9 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(390.0, Utils.getDoubleValue(loanDetails.getTransactions().get(4).getPrincipalPortion()));
             assertEquals(LocalDate.of(2022, 9, 7), loanDetails.getTransactions().get(4).getDate());
 
-            LOAN_TRANSACTION_HELPER.makeRepayment("04 September 2022", Float.parseFloat("500"), loanID);
+            makeRepayment("04 September 2022", Float.parseFloat("500"), loanID);
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
 
             assertEquals(290.0, Utils.getDoubleValue(loanDetails.getTotalOverpaid()));
 
@@ -6644,42 +6253,38 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
                     new PutGlobalConfigurationsRequest().enabled(true));
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
-            BUSINESS_DATE_HELPER.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("10 October 2022").dateFormat(DATETIME_PATTERN).locale("en"));
+            updateBusinessDate("10 October 2022");
 
-            final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-            final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-            final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-            final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+            final Account assetAccount = accountHelper.createAssetAccount();
+            final Account incomeAccount = accountHelper.createIncomeAccount();
+            final Account expenseAccount = accountHelper.createExpenseAccount();
+            final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-            final Integer loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount,
-                    expenseAccount, overpaymentAccount);
+            final Long loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount, expenseAccount,
+                    overpaymentAccount);
 
-            final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC, "01 January 2011");
+            final Long clientID = createClient("01 January 2011");
 
-            final Integer loanID = applyForLoanApplication(clientID, loanProductID);
+            final Long loanID = applyForLoanApplication(clientID, loanProductID);
 
-            HashMap<String, Object> loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+            verifyLoanIsPending(loanID);
 
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("02 September 2022", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-            LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+            verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("02 September 2022", loanID));
 
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+            GetLoansLoanIdResponse loanStatusHashMap = disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
+            verifyLoanIsActive(loanStatusHashMap);
 
-            LOAN_TRANSACTION_HELPER.makeRepayment("04 September 2022", Float.parseFloat("100"), loanID);
-            LOAN_TRANSACTION_HELPER.makeRepayment("05 September 2022", Float.parseFloat("1100"), loanID);
+            makeRepayment("04 September 2022", Float.parseFloat("100"), loanID);
+            makeRepayment("05 September 2022", Float.parseFloat("1100"), loanID);
 
-            GetLoansLoanIdResponse loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanID);
             assertEquals(200.0, Utils.getDoubleValue(loanDetails.getTotalOverpaid()));
             assertTrue(loanDetails.getStatus().getOverpaid());
 
-            LOAN_TRANSACTION_HELPER.makeCreditBalanceRefund((long) loanID, new PostLoansLoanIdTransactionsRequest().transactionAmount(200.0)
+            makeCreditBalanceRefund((long) loanID, new PostLoansLoanIdTransactionsRequest().transactionAmount(200.0)
                     .transactionDate("10 October 2022").dateFormat(DATETIME_PATTERN).locale("en").paymentTypeId(1L));
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
             assertTrue(loanDetails.getStatus().getClosedObligationsMet());
 
             assertEquals(2, loanDetails.getRepaymentSchedule().getPeriods().size());
@@ -6699,7 +6304,7 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(LocalDate.of(2022, 10, 10), loanDetails.getTransactions().get(3).getDate());
             assertEquals(0.0, Utils.getDoubleValue(loanDetails.getTransactions().get(3).getOutstandingLoanBalance()));
             assertEquals(1L, loanDetails.getTransactions().get(3).getPaymentDetailData().getPaymentType().getId());
-            GetJournalEntriesTransactionIdResponse journalEntriesForTransaction = JOURNAL_ENTRY_HELPER
+            GetJournalEntriesTransactionIdResponse journalEntriesForTransaction = journalHelper
                     .getJournalEntries("L" + loanDetails.getTransactions().get(3).getId());
             List<JournalEntryTransactionItem> journalItems = journalEntriesForTransaction.getPageItems();
             assertEquals(2, journalItems.size());
@@ -6711,11 +6316,11 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(200.0, journalItems.stream().filter(j -> "CREDIT".equalsIgnoreCase(j.getEntryType().getValue())
                     && j.getGlAccountId().equals(assetAccount.getAccountID().longValue())).findFirst().get().getAmount());
 
-            LOAN_TRANSACTION_HELPER.reverseLoanTransaction(loanDetails.getId(), loanDetails.getTransactions().get(1).getId(),
+            reverseLoanTransaction(loanDetails.getId(), loanDetails.getTransactions().get(1).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionAmount(0.0)
                             .transactionDate("10 October 2022").locale("en"));
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
 
             assertEquals(100.0, Utils.getDoubleValue(loanDetails.getTransactions().get(1).getAmount()));
             assertEquals(100.0, Utils.getDoubleValue(loanDetails.getTransactions().get(1).getPrincipalPortion()));
@@ -6746,7 +6351,7 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(100.0, Utils.getDoubleValue(loanDetails.getRepaymentSchedule().getPeriods().get(2).getPrincipalPaid()));
             assertEquals(100.0, Utils.getDoubleValue(loanDetails.getRepaymentSchedule().getPeriods().get(2).getPrincipalOutstanding()));
 
-            journalEntriesForTransaction = JOURNAL_ENTRY_HELPER.getJournalEntries("L" + loanDetails.getTransactions().get(3).getId());
+            journalEntriesForTransaction = journalHelper.getJournalEntries("L" + loanDetails.getTransactions().get(3).getId());
             journalItems = journalEntriesForTransaction.getPageItems();
             assertEquals(3, journalItems.size());
             assertEquals(1,
@@ -6780,48 +6385,44 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
                     new PutGlobalConfigurationsRequest().enabled(true));
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
-            BUSINESS_DATE_HELPER.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("10 October 2022").dateFormat(DATETIME_PATTERN).locale("en"));
+            updateBusinessDate("10 October 2022");
 
-            final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-            final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-            final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-            final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+            final Account assetAccount = accountHelper.createAssetAccount();
+            final Account incomeAccount = accountHelper.createIncomeAccount();
+            final Account expenseAccount = accountHelper.createExpenseAccount();
+            final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-            final Integer loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount,
-                    expenseAccount, overpaymentAccount);
+            final Long loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount, expenseAccount,
+                    overpaymentAccount);
 
-            final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC, "01 January 2011");
+            final Long clientID = createClient("01 January 2011");
 
-            final Integer loanID = applyForLoanApplication(clientID, loanProductID);
+            final Long loanID = applyForLoanApplication(clientID, loanProductID);
 
-            HashMap<String, Object> loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+            verifyLoanIsPending(loanID);
 
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("02 September 2022", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-            LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+            verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("02 September 2022", loanID));
 
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+            GetLoansLoanIdResponse loanStatusHashMap = disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
+            verifyLoanIsActive(loanStatusHashMap);
 
-            LOAN_TRANSACTION_HELPER.makeRepayment("04 September 2022", Float.parseFloat("500"), loanID);
-            LOAN_TRANSACTION_HELPER.makeRepayment("05 September 2022", Float.parseFloat("700"), loanID);
+            makeRepayment("04 September 2022", Float.parseFloat("500"), loanID);
+            makeRepayment("05 September 2022", Float.parseFloat("700"), loanID);
 
-            GetLoansLoanIdResponse loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanID);
             assertEquals(200.0, Utils.getDoubleValue(loanDetails.getTotalOverpaid()));
             assertTrue(loanDetails.getStatus().getOverpaid());
 
-            LOAN_TRANSACTION_HELPER.makeCreditBalanceRefund((long) loanID, new PostLoansLoanIdTransactionsRequest().transactionAmount(200.0)
+            makeCreditBalanceRefund((long) loanID, new PostLoansLoanIdTransactionsRequest().transactionAmount(200.0)
                     .transactionDate("06 September 2022").dateFormat(DATETIME_PATTERN).locale("en"));
 
-            LOAN_TRANSACTION_HELPER.makeMerchantIssuedRefund((long) loanID, new PostLoansLoanIdTransactionsRequest().locale("en")
-                    .dateFormat(DATETIME_PATTERN).transactionDate("07 September 2022").transactionAmount(500.0));
+            makeMerchantIssuedRefund((long) loanID, new PostLoansLoanIdTransactionsRequest().locale("en").dateFormat(DATETIME_PATTERN)
+                    .transactionDate("07 September 2022").transactionAmount(500.0));
 
-            LOAN_TRANSACTION_HELPER.makeCreditBalanceRefund((long) loanID, new PostLoansLoanIdTransactionsRequest().transactionAmount(500.0)
+            makeCreditBalanceRefund((long) loanID, new PostLoansLoanIdTransactionsRequest().transactionAmount(500.0)
                     .transactionDate("08 September 2022").dateFormat(DATETIME_PATTERN).locale("en"));
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
             assertTrue(loanDetails.getStatus().getClosedObligationsMet());
 
             assertEquals(2, loanDetails.getRepaymentSchedule().getPeriods().size());
@@ -6853,11 +6454,11 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(LocalDate.of(2022, 9, 8), loanDetails.getTransactions().get(5).getDate());
             assertEquals(0.0, Utils.getDoubleValue(loanDetails.getTransactions().get(5).getOutstandingLoanBalance()));
 
-            LOAN_TRANSACTION_HELPER.reverseLoanTransaction(loanDetails.getId(), loanDetails.getTransactions().get(2).getId(),
+            reverseLoanTransaction(loanDetails.getId(), loanDetails.getTransactions().get(2).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionAmount(0.0)
                             .transactionDate("07 September 2022").locale("en"));
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
 
             assertEquals(500.0, Utils.getDoubleValue(loanDetails.getTransactions().get(1).getAmount()));
             assertEquals(500.0, Utils.getDoubleValue(loanDetails.getTransactions().get(1).getPrincipalPortion()));
@@ -6912,53 +6513,45 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
                     new PutGlobalConfigurationsRequest().enabled(true));
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
-            BUSINESS_DATE_HELPER.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("10 October 2022").dateFormat(DATETIME_PATTERN).locale("en"));
+            updateBusinessDate("10 October 2022");
 
-            final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-            final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-            final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-            final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+            final Account assetAccount = accountHelper.createAssetAccount();
+            final Account incomeAccount = accountHelper.createIncomeAccount();
+            final Account expenseAccount = accountHelper.createExpenseAccount();
+            final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-            final Integer loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount,
-                    expenseAccount, overpaymentAccount);
+            final Long loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount, expenseAccount,
+                    overpaymentAccount);
 
-            final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC, "01 January 2011");
-            List<HashMap> charges = new ArrayList<>();
-            Integer installmentFee = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                    ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", false));
-            addCharges(charges, installmentFee, "10", null);
+            final Long clientID = createClient("01 January 2011");
+            List<PostLoansRequestChargeData> charges = new ArrayList<>();
+            Long installmentFee = chargesHelper.createLoanInstallmentCharge(ChargeCalculationType.FLAT, 10.0, false).getResourceId();
+            addCharges(charges, installmentFee, 10.0, null);
 
-            final Integer loanID = applyForLoanApplication(clientID, loanProductID, charges);
+            final Long loanID = applyForLoanApplication(clientID, loanProductID, charges);
 
-            HashMap<String, Object> loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+            verifyLoanIsPending(loanID);
 
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("02 September 2022", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-            LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+            verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("02 September 2022", loanID));
 
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+            GetLoansLoanIdResponse loanStatusHashMap = disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
+            verifyLoanIsActive(loanStatusHashMap);
 
-            LOAN_TRANSACTION_HELPER.makeRepayment("04 September 2022", Float.parseFloat("5"), loanID);
+            makeRepayment("04 September 2022", Float.parseFloat("5"), loanID);
 
-            PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting("04 September 2022");
+            runPeriodicAccrualAccounting("04 September 2022");
 
-            Integer penalty = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "11", true));
+            Long penalty = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.FLAT, 11.0, true).getResourceId();
             LocalDate targetDate = LocalDate.of(2022, 9, 6);
-            final String penaltyCharge1AddedDate = DATE_TIME_FORMATTER.format(targetDate);
+            final String penaltyCharge1AddedDate = dateTimeFormatter.format(targetDate);
 
-            Integer penalty1LoanChargeId = LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), penaltyCharge1AddedDate, "11"));
+            Long penalty1LoanChargeId = addLoanCharge(loanID, penalty, penaltyCharge1AddedDate, 11.0).getResourceId();
 
-            LOAN_TRANSACTION_HELPER.waiveLoanCharge((long) loanID, (long) penalty1LoanChargeId,
-                    new PostLoansLoanIdChargesChargeIdRequest());
+            waiveWholeLoanCharge(loanID, penalty1LoanChargeId);
 
-            LOAN_TRANSACTION_HELPER.makeRepayment("08 September 2022", Float.parseFloat("1010"), loanID);
+            makeRepayment("08 September 2022", Float.parseFloat("1010"), loanID);
 
-            GetLoansLoanIdResponse loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanID);
 
             GetLoansLoanIdTransactions lastAccrualTransaction = loanDetails.getTransactions().stream()
                     .filter(t -> Boolean.TRUE.equals(t.getType().getAccrual())).findFirst().get();
@@ -6966,8 +6559,8 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(5.0, Utils.getDoubleValue(lastAccrualTransaction.getPenaltyChargesPortion()));
             assertEquals(10.0, Utils.getDoubleValue(lastAccrualTransaction.getFeeChargesPortion()));
 
-            GetLoansLoanIdTransactionsTransactionIdResponse accrualTransactionDetails = LOAN_TRANSACTION_HELPER
-                    .getLoanTransactionDetails((long) loanID, lastAccrualTransaction.getId());
+            GetLoansLoanIdTransactionsTransactionIdResponse accrualTransactionDetails = getLoanTransactionDetails(loanID,
+                    lastAccrualTransaction.getId());
 
             assertEquals(2, accrualTransactionDetails.getLoanChargePaidByList().size());
             accrualTransactionDetails.getLoanChargePaidByList().forEach(loanCharge -> {
@@ -6994,65 +6587,61 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
                     new PutGlobalConfigurationsRequest().enabled(true));
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
-            BUSINESS_DATE_HELPER.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("01 January 2023").dateFormat(DATETIME_PATTERN).locale("en"));
+            updateBusinessDate("01 January 2023");
             LOG.info("-----------------------------------NEW CLIENT-----------------------------------------");
-            final PostClientsRequest newClient = createRandomClientWithDate("01 January 2023");
-            final PostClientsResponse clientResponse = CLIENT_HELPER.createClient(newClient);
+            final Long newClientId = createClient("01 January 2023");
             LOG.info("-----------------------------------NEW LOAN PRODUCT-----------------------------------------");
             PostLoanProductsRequest loanProductsRequest = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct();
-            final PostLoanProductsResponse loanProductResponse = LOAN_PRODUCT_HELPER.createLoanProduct(loanProductsRequest);
+            final Long loanProductId = createLoanProduct(loanProductsRequest);
             LOG.info("-----------------------------------CREATE CHARGES-----------------------------------------");
-            PostChargesResponse penaltyCharge = CHARGES_HELPER.createCharges(new ChargeRequest().penalty(true).amount(10.0)
+            PostChargesResponse penaltyCharge = chargesHelper.createCharge(new ChargeRequest().penalty(true).amount(10.0)
                     .chargeCalculationType(ChargeCalculationType.FLAT.getValue())
                     .chargeTimeType(ChargeTimeType.SPECIFIED_DUE_DATE.getValue()).chargePaymentMode(ChargePaymentMode.REGULAR.getValue())
                     .currencyCode("USD").name(Utils.randomStringGenerator("PENALTY_" + Calendar.getInstance().getTimeInMillis(), 5))
                     .chargeAppliesTo(1).locale("en").active(true));
             LOG.info("-----------------------------------SUBMIT LOAN-----------------------------------------");
             final PostLoansResponse loanApplicationResult = applyForLoanApplicationForOnePeriod30DaysLongNoInterestPeriodicAccrual(
-                    clientResponse.getResourceId(), loanProductResponse.getResourceId(), "01 January 2023",
-                    LoanApplicationTestBuilder.DUE_PENALTY_INTEREST_PRINCIPAL_FEE_IN_ADVANCE_PENALTY_INTEREST_PRINCIPAL_FEE_STRATEGY);
+                    newClientId, loanProductId, "01 January 2023",
+                    DUE_PENALTY_INTEREST_PRINCIPAL_FEE_IN_ADVANCE_PENALTY_INTEREST_PRINCIPAL_FEE_STRATEGY);
             LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-            PostLoansLoanIdResponse approvedLoanResult = LOAN_TRANSACTION_HELPER.approveLoan(loanApplicationResult.getResourceId(),
+            PostLoansLoanIdResponse approvedLoanResult = approveLoan(loanApplicationResult.getResourceId(),
                     new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000.0)).dateFormat(DATETIME_PATTERN)
                             .approvedOnDate("01 January 2023").locale("en"));
             LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
             String loanDisbursementUUID = UUID.randomUUID().toString();
-            PostLoansLoanIdResponse disbursedLoanResult = LOAN_TRANSACTION_HELPER.disburseLoan(loanApplicationResult.getResourceId(),
+            PostLoansLoanIdResponse disbursedLoanResult = disburseLoan(loanApplicationResult.getResourceId(),
                     new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
                             .transactionAmount(BigDecimal.valueOf(1000.00)).locale("en").externalId(loanDisbursementUUID));
             Long loanId = disbursedLoanResult.getResourceId();
             LOG.info("-------------------------------ADD CHARGES-------------------------------------------");
-            PostLoansLoanIdChargesResponse penaltyLoanChargeResult = LOAN_TRANSACTION_HELPER.addChargesForLoan(loanId,
+            PostLoansLoanIdChargesResponse penaltyLoanChargeResult = addLoanCharge(loanId,
                     new PostLoansLoanIdChargesRequest().chargeId(penaltyCharge.getResourceId()).dateFormat(DATETIME_PATTERN).locale("en")
                             .amount(10.0).dueDate("10 January 2023"));
             LOG.info("-------------------------------DO SOME PARTIAL REPAYMENTS-------------------------------------------");
-            BUSINESS_DATE_HELPER.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("07 January 2023").dateFormat(DATETIME_PATTERN).locale("en"));
+            updateBusinessDate("07 January 2023");
             String firstRepaymentUUID = UUID.randomUUID().toString();
-            PostLoansLoanIdTransactionsResponse firstRepaymentResult = LOAN_TRANSACTION_HELPER.makeLoanRepayment(loanId,
+            PostLoansLoanIdTransactionsResponse firstRepaymentResult = makeLoanRepayment(loanId,
                     new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate("07 January 2023").locale("en")
                             .transactionAmount(9.0).externalId(firstRepaymentUUID));
             String secondRepaymentUUID = UUID.randomUUID().toString();
-            PostLoansLoanIdTransactionsResponse secondRepaymentResult = LOAN_TRANSACTION_HELPER.makeLoanRepayment(loanId,
+            PostLoansLoanIdTransactionsResponse secondRepaymentResult = makeLoanRepayment(loanId,
                     new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate("07 January 2023").locale("en")
                             .transactionAmount(8.0).externalId(secondRepaymentUUID));
             String thirdRepaymentUUID = UUID.randomUUID().toString();
-            PostLoansLoanIdTransactionsResponse thirdRepaymentResult = LOAN_TRANSACTION_HELPER.makeLoanRepayment(loanId,
+            PostLoansLoanIdTransactionsResponse thirdRepaymentResult = makeLoanRepayment(loanId,
                     new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate("07 January 2023").locale("en")
                             .transactionAmount(7.0).externalId(thirdRepaymentUUID));
             LOG.info("-------------------------------CHECK LOAN TRANSACTION ORDER-------------------------------------------");
             checkLoanTransactionOrder(loanId, loanDisbursementUUID, firstRepaymentUUID, secondRepaymentUUID, thirdRepaymentUUID);
             LOG.info(
                     "-------------------------------REVERT FIRST REPAYMENT AND CHECK LOAN TRANSACTION ORDER-------------------------------------------");
-            LOAN_TRANSACTION_HELPER.reverseLoanTransaction(loanId, firstRepaymentUUID, new PostLoansLoanIdTransactionsTransactionIdRequest()
+            reverseLoanTransaction(loanId, firstRepaymentUUID, new PostLoansLoanIdTransactionsTransactionIdRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("07 January 2023").transactionAmount(0.0).locale("en"));
             checkLoanTransactionOrder(loanId, loanDisbursementUUID, firstRepaymentUUID, secondRepaymentUUID, thirdRepaymentUUID);
             LOG.info(
                     "-------------------------------REVERT SECOND REPAYMENT AND CHECK LOAN TRANSACTION ORDER-------------------------------------------");
-            LOAN_TRANSACTION_HELPER.reverseLoanTransaction(loanId, secondRepaymentUUID,
-                    new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("07 January 2023")
-                            .transactionAmount(0.0).locale("en"));
+            reverseLoanTransaction(loanId, secondRepaymentUUID, new PostLoansLoanIdTransactionsTransactionIdRequest()
+                    .dateFormat(DATETIME_PATTERN).transactionDate("07 January 2023").transactionAmount(0.0).locale("en"));
             checkLoanTransactionOrder(loanId, loanDisbursementUUID, firstRepaymentUUID, secondRepaymentUUID, thirdRepaymentUUID);
         } finally {
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
@@ -7073,172 +6662,893 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         }
 
         String fourMonthsfromNow = Utils.convertDateToURLFormat(fourMonthsfromNowCalendar);
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProduct(false, NONE);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Long loanProductID = createLoanProduct(false, NONE);
 
-        List<HashMap> charges = new ArrayList<>();
-        Integer disbursementFee = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanDisbursementJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT_AND_INTEREST, "2"));
-        addCharges(charges, disbursementFee, "2", null);
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
+        Long disbursementFee = chargesHelper.createLoanDisbursementCharge(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST, 2.0)
+                .getResourceId();
+        addCharges(charges, disbursementFee, 2.0, null);
 
-        List<HashMap> collaterals = new ArrayList<>();
-        final Integer loanID = applyForLoanApplicationWithPaymentStrategyAndPastMonth(clientID, loanProductID, charges, null, "1000",
-                LoanApplicationTestBuilder.DEFAULT_STRATEGY, fourMonthsfromNow, collaterals);
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
+        final Long loanID = applyForLoanApplicationWithPaymentStrategyAndPastMonth(clientID, loanProductID, charges, null, "1000",
+                DEFAULT_STRATEGY, fourMonthsfromNow, collaterals);
         Assertions.assertNotNull(loanID);
 
-        LOAN_TRANSACTION_HELPER.approveLoan(fourMonthsfromNow, loanID);
+        approveLoan(fourMonthsfromNow, loanID);
 
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(fourMonthsfromNow, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanID);
+        disburseLoanWithNetDisbursalAmount(fourMonthsfromNow, loanID);
 
         // check for disbursement fee: Principal 1,000 with 24% Annual Rate for 6 Months we have Total Interest of:
         // 120.00
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap disbursementDetail = loanSchedule.get(0);
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod disbursementDetail = loanSchedule.get(0);
         // Disbursement Fee: 2% of 1,120.00 = 22.40
-        validateNumberForEqual("22.40", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        validateNumberForEqual("22.40", String.valueOf(disbursementDetail.getFeeChargesDue()));
     }
 
     private void checkLoanTransactionOrder(Long loanId, String... transactionUUIDs) {
         LOG.info("-------------------------------CHECK LOAN TRANSACTION ORDER-------------------------------------------");
-        GetLoansLoanIdResponse loanDetailsResult = LOAN_TRANSACTION_HELPER.getLoanDetails(loanId);
+        GetLoansLoanIdResponse loanDetailsResult = getLoanDetails(loanId);
         for (int i = 0; i < transactionUUIDs.length; i++) {
             assertEquals(transactionUUIDs[i], loanDetailsResult.getTransactions().get(i).getExternalId());
         }
     }
 
-    private PostClientsRequest createRandomClientWithDate(String date) {
-        return new PostClientsRequest().officeId(1L).legalFormId(1L).firstname(Utils.randomFirstNameGenerator())
-                .lastname(Utils.randomLastNameGenerator()).active(true).locale("en").activationDate(date).dateFormat(DATETIME_PATTERN);
+    // ----------------------------------------------------------------------------------------------------
+    // Loan product builders
+    // ----------------------------------------------------------------------------------------------------
+
+    /** The defaults previously supplied by {@code LoanProductTestBuilder}. */
+    private PostLoanProductsRequest baseLoanProduct() {
+        return new PostLoanProductsRequest()//
+                .name(Utils.uniqueRandomStringGenerator("LOAN_PRODUCT_", 6))//
+                .shortName(Utils.uniqueRandomStringGenerator("", 4))//
+                .currencyCode("USD")//
+                .locale(LOCALE)//
+                .dateFormat(DATETIME_PATTERN)//
+                .digitsAfterDecimal(2)//
+                .inMultiplesOf(0)//
+                .principal(10000.00)//
+                .minPrincipal(1000.00)//
+                .maxPrincipal(10000000.00)//
+                .numberOfRepayments(5)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS_L)//
+                .interestRatePerPeriod(2.0)//
+                .interestRateFrequencyType(LoanTestData.InterestRateFrequencyType.MONTHS)//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_INSTALLMENTS)//
+                .interestType(LoanTestData.InterestType.FLAT)//
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)//
+                .inArrearsTolerance(0)//
+                .transactionProcessingStrategyCode(DEFAULT_STRATEGY)//
+                .accountingRule(NONE)//
+                .isEqualAmortization(false)//
+                .overdueDaysForNPA(5)//
+                .loanScheduleType(LoanScheduleType.CUMULATIVE.name())//
+                .loanScheduleProcessingType(LoanScheduleProcessingType.HORIZONTAL.name())//
+                .daysInYearType(1)//
+                .daysInMonthType(1)//
+                .isInterestRecalculationEnabled(false)//
+                .allowPartialPeriodInterestCalculation(false)//
+                .allowVariableInstallments(false);
     }
 
-    private Integer applyForLoanApplication(final Integer clientID, final Integer loanProductID, final List<HashMap> charges) {
-        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
-        final String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal("1000").withLoanTermFrequency("1")
-                .withLoanTermFrequencyAsMonths().withNumberOfRepayments("1").withRepaymentEveryAfter("1")
-                .withRepaymentFrequencyTypeAsMonths().withInterestRatePerPeriod("0").withInterestTypeAsFlatBalance()
-                .withAmortizationTypeAsEqualPrincipalPayments().withInterestCalculationPeriodTypeSameAsRepaymentPeriod()
-                .withCharges(charges).withExpectedDisbursementDate("03 September 2022").withSubmittedOnDate("01 September 2022")
-                .withLoanType("individual").build(clientID.toString(), loanProductID.toString(), null);
-        return LOAN_TRANSACTION_HELPER.getLoanId(loanApplicationJSON);
-    }
-
-    private Integer applyForLoanApplication(final Integer clientID, final Integer loanProductID) {
-        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
-        final String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal("1000").withLoanTermFrequency("1")
-                .withLoanTermFrequencyAsMonths().withNumberOfRepayments("1").withRepaymentEveryAfter("1")
-                .withRepaymentFrequencyTypeAsMonths().withInterestRatePerPeriod("0").withInterestTypeAsDecliningBalance()
-                .withAmortizationTypeAsEqualPrincipalPayments().withInterestCalculationPeriodTypeSameAsRepaymentPeriod()
-                .withExpectedDisbursementDate("03 September 2022").withSubmittedOnDate("01 September 2022").withLoanType("individual")
-                .build(clientID.toString(), loanProductID.toString(), null);
-        return LOAN_TRANSACTION_HELPER.getLoanId(loanApplicationJSON);
-    }
-
-    private Integer createLoanProductWithPeriodicAccrualAccountingNoInterest(final Account... accounts) {
-        LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-        final String loanProductJSON = new LoanProductTestBuilder().withPrincipal("1000").withRepaymentTypeAsMonth()
-                .withRepaymentAfterEvery("1").withNumberOfRepayments("1").withRepaymentTypeAsMonth().withinterestRatePerPeriod("0")
-                .withInterestRateFrequencyTypeAsMonths().withAmortizationTypeAsEqualPrincipalPayment().withInterestTypeAsFlat()
-                .withAccountingRulePeriodicAccrual(accounts).withDaysInMonth("30").withDaysInYear("365").withMoratorium("0", "0")
-                .build(null);
-        return LOAN_TRANSACTION_HELPER.getLoanProductId(loanProductJSON);
-    }
-
-    private Integer createLoanProductWithPeriodicAccrualAccountingNoInterestMultiDisbursement(final Account... accounts) {
-        LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-        final String loanProductJSON = new LoanProductTestBuilder().withPrincipal("1000").withRepaymentTypeAsMonth()
-                .withRepaymentAfterEvery("1").withNumberOfRepayments("1").withRepaymentTypeAsMonth().withinterestRatePerPeriod("0")
-                .withInterestRateFrequencyTypeAsMonths().withAmortizationTypeAsEqualPrincipalPayment().withInterestTypeAsDecliningBalance()
-                .withAccountingRulePeriodicAccrual(accounts).withInterestCalculationPeriodTypeAsRepaymentPeriod(true).withDaysInMonth("30")
-                .withDaysInYear("365").withMoratorium("0", "0").withMultiDisburse().withDisallowExpectedDisbursements(true).build(null);
-        return LOAN_TRANSACTION_HELPER.getLoanProductId(loanProductJSON);
-    }
-
-    private void validateIfValuesAreNotOverridden(Integer loanID, Integer loanProductID) {
-        String loanProductDetails = LOAN_TRANSACTION_HELPER.getLoanProductDetails(REQUEST_SPEC, RESPONSE_SPEC, loanProductID);
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        List<String> comparisonAttributes = Arrays.asList("amortizationType", "interestType", "transactionProcessingStrategyCode",
-                "interestCalculationPeriodType", "repaymentFrequencyType", "graceOnPrincipalPayment", "graceOnInterestPayment",
-                "inArrearsTolerance", "graceOnArrearsAgeing");
-
-        for (String comparisonAttribute : comparisonAttributes) {
-            Object val1 = JsonPath.from(loanProductDetails).get(comparisonAttribute);
-            Object val2 = JsonPath.from(loanDetails).get(comparisonAttribute);
-            assertEquals(val1, val2);
+    /**
+     * Mirrors {@code LoanProductTestBuilder}'s account mapping: every account of a given type overwrites the mapping
+     * contributed by the previous account of that type, so the last one in {@code accounts} wins.
+     */
+    private PostLoanProductsRequest withAccounting(PostLoanProductsRequest product, Integer accountingRule, Account... accounts) {
+        product.accountingRule(accountingRule);
+        if (NONE.equals(accountingRule) || accounts == null) {
+            return product;
         }
+        boolean accrualBased = ACCRUAL_PERIODIC.equals(accountingRule) || ACCRUAL_UPFRONT.equals(accountingRule);
+        for (Account account : accounts) {
+            Long accountId = account.getAccountID().longValue();
+            switch (account.getAccountType()) {
+                case ASSET -> {
+                    product.fundSourceAccountId(accountId)//
+                            .loanPortfolioAccountId(accountId)//
+                            .transfersInSuspenseAccountId(accountId);
+                    if (accrualBased) {
+                        product.receivableInterestAccountId(accountId)//
+                                .receivableFeeAccountId(accountId)//
+                                .receivablePenaltyAccountId(accountId);
+                    }
+                }
+                case INCOME -> product.interestOnLoanAccountId(accountId)//
+                        .incomeFromFeeAccountId(accountId)//
+                        .incomeFromPenaltyAccountId(accountId)//
+                        .incomeFromRecoveryAccountId(accountId)//
+                        .incomeFromChargeOffInterestAccountId(accountId)//
+                        .incomeFromChargeOffFeesAccountId(accountId)//
+                        .incomeFromChargeOffPenaltyAccountId(accountId)//
+                        .incomeFromGoodwillCreditInterestAccountId(accountId)//
+                        .incomeFromGoodwillCreditFeesAccountId(accountId)//
+                        .incomeFromGoodwillCreditPenaltyAccountId(accountId);
+                case EXPENSE -> product.writeOffAccountId(accountId)//
+                        .goodwillCreditAccountId(accountId)//
+                        .chargeOffExpenseAccountId(accountId)//
+                        .chargeOffFraudExpenseAccountId(accountId);
+                case LIABILITY -> product.overpaymentLiabilityAccountId(accountId);
+                default -> throw new IllegalArgumentException("Unsupported GL account type: " + account.getAccountType());
+            }
+        }
+        return product;
     }
 
-    private JsonObject createLoanProductConfigurationDetail(JsonObject loanProductConfiguration, Boolean bool) {
-        loanProductConfiguration.addProperty("amortizationType", bool);
-        loanProductConfiguration.addProperty("interestType", bool);
-        loanProductConfiguration.addProperty("transactionProcessingStrategyCode", bool);
-        loanProductConfiguration.addProperty("interestCalculationPeriodType", bool);
-        loanProductConfiguration.addProperty("inArrearsTolerance", bool);
-        loanProductConfiguration.addProperty("repaymentEvery", bool);
-        loanProductConfiguration.addProperty("graceOnPrincipalAndInterestPayment", bool);
-        loanProductConfiguration.addProperty("graceOnArrearsAgeing", bool);
-        return loanProductConfiguration;
+    private PostLoanProductsRequest withTranches(PostLoanProductsRequest product) {
+        return product.multiDisburseLoan(true)//
+                .allowFullTermForTranche(false)//
+                .maxTrancheCount(3)//
+                .outstandingLoanBalance(35000.0)//
+                .disallowExpectedDisbursements(false);
     }
 
-    private Integer applyForLoanApplicationWithProductConfigurationAsTrue(final Integer clientID, final Integer loanProductID,
-            String principal) {
+    private Long createLoanProduct(final boolean multiDisburseLoan, final Integer accountingRule, final Account... accounts) {
+        LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
+        PostLoanProductsRequest product = baseLoanProduct()//
+                .principal(12000.00)//
+                .numberOfRepayments(4)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS_L)//
+                .interestRatePerPeriod(1.0)//
+                .interestRateFrequencyType(LoanTestData.InterestRateFrequencyType.MONTHS)//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_INSTALLMENTS)//
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE);
+        if (multiDisburseLoan) {
+            withTranches(product);
+            product.interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)
+                    .allowPartialPeriodInterestCalculation(true);
+        }
+        withAccounting(product, accountingRule, accounts);
+        return createLoanProduct(product);
+    }
+
+    private Long createLoanProduct(final Integer inMultiplesOf, final Integer digitsAfterDecimal, final String repaymentStrategy) {
+        return createLoanProduct(inMultiplesOf, digitsAfterDecimal, repaymentStrategy, NONE);
+    }
+
+    private Long createLoanProduct(final Integer inMultiplesOf, final Integer digitsAfterDecimal, final String repaymentStrategy,
+            final Integer accountingRule, final Account... accounts) {
+        LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
+        PostLoanProductsRequest product = baseLoanProduct()//
+                .principal(10000000.00)//
+                .numberOfRepayments(24)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS_L)//
+                .interestRatePerPeriod(2.0)//
+                .interestRateFrequencyType(LoanTestData.InterestRateFrequencyType.MONTHS)//
+                .transactionProcessingStrategyCode(repaymentStrategy)//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_PRINCIPAL)//
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE)//
+                .digitsAfterDecimal(digitsAfterDecimal)//
+                .inMultiplesOf(inMultiplesOf);
+        withAccounting(product, accountingRule, accounts);
+        return createLoanProduct(product);
+    }
+
+    private Long createLoanProductWithPeriodicAccrualAccountingNoInterest(final Account... accounts) {
+        LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
+        PostLoanProductsRequest product = baseLoanProduct()//
+                .principal(1000.00)//
+                .numberOfRepayments(1)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS_L)//
+                .interestRatePerPeriod(0.0)//
+                .interestRateFrequencyType(LoanTestData.InterestRateFrequencyType.MONTHS)//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_PRINCIPAL)//
+                .interestType(LoanTestData.InterestType.FLAT)//
+                .daysInMonthType(30)//
+                .daysInYearType(365)//
+                .graceOnPrincipalPayment(0)//
+                .graceOnInterestPayment(0);
+        withAccounting(product, ACCRUAL_PERIODIC, accounts);
+        return createLoanProduct(product);
+    }
+
+    private Long createLoanProductWithPeriodicAccrualAccountingNoInterestMultiDisbursement(final Account... accounts) {
+        LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
+        PostLoanProductsRequest product = baseLoanProduct()//
+                .principal(1000.00)//
+                .numberOfRepayments(1)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS_L)//
+                .interestRatePerPeriod(0.0)//
+                .interestRateFrequencyType(LoanTestData.InterestRateFrequencyType.MONTHS)//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_PRINCIPAL)//
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE)//
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)//
+                .allowPartialPeriodInterestCalculation(true)//
+                .daysInMonthType(30)//
+                .daysInYearType(365)//
+                .graceOnPrincipalPayment(0)//
+                .graceOnInterestPayment(0);
+        withTranches(product);
+        // The pre-migration LoanProductTestBuilder.withDisallowExpectedDisbursements(true) implicitly enabled a 100%
+        // over-applied allowance. chargeOff() relies on it to disburse two 1000 tranches against a 1000 approval.
+        product.disallowExpectedDisbursements(true)//
+                .allowApprovedDisbursedAmountsOverApplied(true)//
+                .overAppliedCalculationType("percentage")//
+                .overAppliedNumber(100);
+        withAccounting(product, ACCRUAL_PERIODIC, accounts);
+        return createLoanProduct(product);
+    }
+
+    private PostLoanProductsRequest withInterestRecalculation(PostLoanProductsRequest product,
+            final Integer interestRecalculationCompoundingMethod, final Integer rescheduleStrategyMethod,
+            final Integer preCloseInterestCalculationStrategy, final Integer recalculationRestFrequencyType,
+            final Integer recalculationRestFrequencyInterval, final Integer recalculationCompoundingFrequencyType,
+            final Integer recalculationCompoundingFrequencyInterval, final Integer recalculationCompoundingFrequencyOnDayType,
+            final Integer recalculationCompoundingFrequencyDayOfWeekType, final Integer recalculationRestFrequencyOnDayType,
+            final Integer recalculationRestFrequencyDayOfWeekType) {
+        product.isInterestRecalculationEnabled(true)//
+                .interestRecalculationCompoundingMethod(interestRecalculationCompoundingMethod)//
+                .rescheduleStrategyMethod(rescheduleStrategyMethod)//
+                .recalculationRestFrequencyType(recalculationRestFrequencyType)//
+                .recalculationRestFrequencyInterval(recalculationRestFrequencyInterval)//
+                .preClosureInterestCalculationStrategy(preCloseInterestCalculationStrategy)//
+                .recalculationCompoundingFrequencyOnDayType(recalculationCompoundingFrequencyOnDayType)//
+                .recalculationCompoundingFrequencyDayOfWeekType(recalculationCompoundingFrequencyDayOfWeekType)//
+                .recalculationRestFrequencyOnDayType(recalculationRestFrequencyOnDayType)//
+                .recalculationRestFrequencyDayOfWeekType(recalculationRestFrequencyDayOfWeekType);
+        if (!LoanTestData.InterestRecalculationCompoundingMethod.NONE.equals(interestRecalculationCompoundingMethod)) {
+            product.recalculationCompoundingFrequencyType(recalculationCompoundingFrequencyType)//
+                    .recalculationCompoundingFrequencyInterval(recalculationCompoundingFrequencyInterval);
+        }
+        return product;
+    }
+
+    private Long createLoanProductWithInterestRecalculation(final String repaymentStrategy,
+            final Integer interestRecalculationCompoundingMethod, final Integer rescheduleStrategyMethod,
+            final Integer recalculationRestFrequencyType, final Integer recalculationRestFrequencyInterval,
+            final Integer preCloseInterestCalculationStrategy, final Account[] accounts, final Integer recalculationRestFrequencyOnDayType,
+            final Integer recalculationRestFrequencyDayOfWeekType) {
+        return createLoanProductWithInterestRecalculationAndCompoundingDetails(repaymentStrategy, interestRecalculationCompoundingMethod,
+                rescheduleStrategyMethod, recalculationRestFrequencyType, recalculationRestFrequencyInterval, null, null,
+                preCloseInterestCalculationStrategy, accounts, null, null, recalculationRestFrequencyOnDayType,
+                recalculationRestFrequencyDayOfWeekType);
+    }
+
+    /** The 24-repayment weekly product used by the interest-recalculation tests. */
+    private Long createLoanProductWithInterestRecalculationAndCompoundingDetails(final String repaymentStrategy,
+            final Integer interestRecalculationCompoundingMethod, final Integer rescheduleStrategyMethod,
+            final Integer recalculationRestFrequencyType, final Integer recalculationRestFrequencyInterval,
+            final Integer recalculationCompoundingFrequencyType, final Integer recalculationCompoundingFrequencyInterval,
+            final Integer preCloseInterestCalculationStrategy, final Account[] accounts,
+            final Integer recalculationCompoundingFrequencyOnDayType, final Integer recalculationCompoundingFrequencyDayOfWeekType,
+            final Integer recalculationRestFrequencyOnDayType, final Integer recalculationRestFrequencyDayOfWeekType) {
+        return createLoanProductWithInterestRecalculation(repaymentStrategy, interestRecalculationCompoundingMethod,
+                rescheduleStrategyMethod, recalculationRestFrequencyType, recalculationRestFrequencyInterval,
+                recalculationCompoundingFrequencyType, recalculationCompoundingFrequencyInterval, preCloseInterestCalculationStrategy,
+                accounts, null, false, recalculationCompoundingFrequencyOnDayType, recalculationCompoundingFrequencyDayOfWeekType,
+                recalculationRestFrequencyOnDayType, recalculationRestFrequencyDayOfWeekType);
+    }
+
+    /**
+     * The 24-repayment weekly product used by the interest-recalculation tests, optionally with a charge and arrears
+     * config.
+     */
+    private Long createLoanProductWithInterestRecalculation(final String repaymentStrategy,
+            final Integer interestRecalculationCompoundingMethod, final Integer rescheduleStrategyMethod,
+            final Integer recalculationRestFrequencyType, final Integer recalculationRestFrequencyInterval,
+            final Integer recalculationCompoundingFrequencyType, final Integer recalculationCompoundingFrequencyInterval,
+            final Integer preCloseInterestCalculationStrategy, final Account[] accounts, final Long chargeId,
+            boolean isArrearsBasedOnOriginalSchedule, final Integer recalculationCompoundingFrequencyOnDayType,
+            final Integer recalculationCompoundingFrequencyDayOfWeekType, final Integer recalculationRestFrequencyOnDayType,
+            final Integer recalculationRestFrequencyDayOfWeekType) {
+        LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
+        PostLoanProductsRequest product = baseLoanProduct()//
+                .principal(10000000.00)//
+                .numberOfRepayments(24)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.WEEKS_L)//
+                .interestRatePerPeriod(2.0)//
+                .interestRateFrequencyType(LoanTestData.InterestRateFrequencyType.MONTHS)//
+                .transactionProcessingStrategyCode(repaymentStrategy)//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_PRINCIPAL)//
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)//
+                .allowPartialPeriodInterestCalculation(true)//
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE);
+        withInterestRecalculation(product, interestRecalculationCompoundingMethod, rescheduleStrategyMethod,
+                preCloseInterestCalculationStrategy, recalculationRestFrequencyType, recalculationRestFrequencyInterval,
+                recalculationCompoundingFrequencyType, recalculationCompoundingFrequencyInterval,
+                recalculationCompoundingFrequencyOnDayType, recalculationCompoundingFrequencyDayOfWeekType,
+                recalculationRestFrequencyOnDayType, recalculationRestFrequencyDayOfWeekType);
+        if (accounts != null) {
+            withAccounting(product, ACCRUAL_PERIODIC, accounts);
+        }
+        if (isArrearsBasedOnOriginalSchedule) {
+            product.isArrearsBasedOnOriginalSchedule(true);
+        }
+        if (chargeId != null) {
+            product.charges(List.of(new LoanProductChargeData().id(chargeId)));
+        }
+        return createLoanProduct(product);
+    }
+
+    /** The 12-repayment monthly 19.9% product used by the daily-interest-calculation recalculation tests. */
+    private Long createLoanProductWithInterestRecalculationAndInstallmentAmount(final String repaymentStrategy,
+            final Integer interestRecalculationCompoundingMethod, final Integer rescheduleStrategyMethod,
+            final Integer preCloseInterestCalculationStrategy, final Account[] accounts, final Integer installmentAmountInMultiplesOf) {
+        LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
+        PostLoanProductsRequest product = baseLoanProduct()//
+                .principal(10000.00)//
+                .numberOfRepayments(12)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS_L)//
+                .interestRatePerPeriod(19.9)//
+                .interestRateFrequencyType(LoanTestData.InterestRateFrequencyType.MONTHS)//
+                .transactionProcessingStrategyCode(repaymentStrategy)//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_INSTALLMENTS)//
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE)//
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.DAILY)//
+                .canDefineInstallmentAmount(true)//
+                .installmentAmountInMultiplesOf(installmentAmountInMultiplesOf);
+        // The RestAssured builder left the rest frequency at its defaults (daily, every 1) for this product shape.
+        withInterestRecalculation(product, interestRecalculationCompoundingMethod, rescheduleStrategyMethod,
+                preCloseInterestCalculationStrategy, LoanTestData.RecalculationRestFrequencyType.DAILY, 1, null, null, null, null, null,
+                null);
+        if (accounts != null) {
+            withAccounting(product, ACCRUAL_PERIODIC, accounts);
+        }
+        return createLoanProduct(product);
+    }
+
+    // ----------------------------------------------------------------------------------------------------
+    // Loan application builders
+    // ----------------------------------------------------------------------------------------------------
+
+    /** The defaults previously supplied by {@code LoanApplicationTestBuilder}. */
+    private PostLoansRequest baseLoanApplication(final Long clientId, final Long loanProductId) {
+        return new PostLoansRequest()//
+                .clientId(clientId)//
+                .productId(loanProductId)//
+                .dateFormat(DATETIME_PATTERN)//
+                .locale(LOCALE)//
+                .loanType("individual")//
+                .transactionProcessingStrategyCode(DEFAULT_STRATEGY)//
+                .interestRatePerPeriod(BigDecimal.valueOf(2))//
+                .interestType(LoanTestData.InterestType.FLAT)//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_PRINCIPAL)//
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)//
+                .maxOutstandingLoanBalance(BigDecimal.valueOf(36000))//
+                .collateral(Collections.emptyList());
+    }
+
+    private Long applyForLoanApplication(final Long clientId, final Long loanProductId, final List<PostLoansRequestChargeData> charges) {
         LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
-        Assertions.assertNotNull(collateralId);
-        List<HashMap> collaterals = new ArrayList<>();
-
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
-        Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
-        final String loanApplicationJSON = new LoanApplicationTestBuilder() //
-                .withPrincipal(principal) //
-                .withRepaymentEveryAfter("1") //
-                .withLoanTermFrequency("4") //
-                .withLoanTermFrequencyAsMonths() //
-                .withNumberOfRepayments("4") //
-                .withRepaymentFrequencyTypeAsMonths() //
-                .withInterestRatePerPeriod("2") //
-                .withInterestCalculationPeriodTypeSameAsRepaymentPeriod() //
-                .withExpectedDisbursementDate("01 March 2014") //
-                .withSubmittedOnDate("01 March 2014") //
-                .withCollaterals(collaterals).build(clientID.toString(), loanProductID.toString(), null);
-        return LOAN_TRANSACTION_HELPER.getLoanId(loanApplicationJSON);
+        return applyForLoan(baseLoanApplication(clientId, loanProductId)//
+                .principal(BigDecimal.valueOf(1000))//
+                .loanTermFrequency(1)//
+                .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .numberOfRepayments(1)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .interestRatePerPeriod(BigDecimal.ZERO)//
+                .interestType(LoanTestData.InterestType.FLAT)//
+                .expectedDisbursementDate("03 September 2022")//
+                .submittedOnDate("01 September 2022")//
+                .charges(charges));
     }
 
-    private Integer applyForLoanApplicationWithProductConfigurationAsFalse(final Integer clientID, final Integer loanProductID,
-            String principal) {
+    private Long applyForLoanApplication(final Long clientId, final Long loanProductId) {
         LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        return applyForLoan(baseLoanApplication(clientId, loanProductId)//
+                .principal(BigDecimal.valueOf(1000))//
+                .loanTermFrequency(1)//
+                .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .numberOfRepayments(1)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .interestRatePerPeriod(BigDecimal.ZERO)//
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE)//
+                .expectedDisbursementDate("03 September 2022")//
+                .submittedOnDate("01 September 2022"));
+    }
+
+    /** The 4-month, 2%, equal-installment application shared by the charge tests. */
+    private PostLoansRequest fourMonthLoanApplication(final Long clientId, final Long loanProductId, final BigDecimal principal,
+            final List<PostLoansRequestChargeData> charges, final Long savingsId, final List<PostLoansRequestCollateralData> collaterals) {
+        return baseLoanApplication(clientId, loanProductId)//
+                .principal(principal)//
+                .loanTermFrequency(4)//
+                .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .numberOfRepayments(4)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .interestRatePerPeriod(BigDecimal.valueOf(2))//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_INSTALLMENTS)//
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE)//
+                .expectedDisbursementDate("20 September 2011")//
+                .submittedOnDate("20 September 2011")//
+                .collateral(collaterals)//
+                .charges(charges)//
+                .linkAccountId(savingsId);
+    }
+
+    private Long applyForLoanApplication(final Long clientId, final Long loanProductId, final List<PostLoansRequestChargeData> charges,
+            final Long savingsId, final String principal, final List<PostLoansRequestCollateralData> collaterals) {
+        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
+        return applyForLoan(fourMonthLoanApplication(clientId, loanProductId, toAmount(principal), charges, savingsId, collaterals));
+    }
+
+    private Long applyForLoanApplication(final Long clientId, final Long loanProductId, final String disbursementDate,
+            final String submissionDate, final String interestRate, final List<PostLoansRequestChargeData> charges, final Long savingsId,
+            final String principal, final List<PostLoansRequestCollateralData> collaterals) {
+        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
+        return applyForLoan(baseLoanApplication(clientId, loanProductId)//
+                .principal(toAmount(principal))//
+                .loanTermFrequency(2)//
+                .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .numberOfRepayments(2)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .interestRatePerPeriod(new BigDecimal(interestRate))//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_INSTALLMENTS)//
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE)//
+                .expectedDisbursementDate(disbursementDate)//
+                .submittedOnDate(submissionDate)//
+                .collateral(collaterals)//
+                .charges(charges)//
+                .linkAccountId(savingsId));
+    }
+
+    /** The 24-repayment, equal-principal application used by the currency-detail tests. */
+    private Long applyForLoanApplication(final Long clientId, final Long loanProductId, final Integer graceOnPrincipalPayment,
+            final List<PostLoansRequestCollateralData> collaterals) {
+        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
+        return applyForLoan(baseLoanApplication(clientId, loanProductId)//
+                .principal(new BigDecimal("10000000.00"))//
+                .loanTermFrequency(24)//
+                .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .numberOfRepayments(24)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .interestRatePerPeriod(BigDecimal.valueOf(2))//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_PRINCIPAL)//
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE)//
+                .graceOnPrincipalPayment(graceOnPrincipalPayment)//
+                .expectedDisbursementDate("02 June 2014")//
+                .submittedOnDate("02 June 2014")//
+                .collateral(collaterals));
+    }
+
+    private Long applyForLoanApplicationWithExternalId(final Long clientId, final Long loanProductId, final String principal,
+            final String externalId) {
+        LOG.info("------------------------APPLYING FOR LOAN APPLICATION WITH EXTERNALID------------------------");
+        return applyForLoan(fourMonthLoanApplication(clientId, loanProductId, toAmount(principal), null, null, Collections.emptyList())
+                .externalId(externalId));
+    }
+
+    private Long applyForLoanApplicationWithTranches(final Long clientId, final Long loanProductId,
+            final List<PostLoansRequestChargeData> charges, final Long savingsId, final String principal,
+            final List<PostLoansDisbursementData> tranches, final List<PostLoansRequestCollateralData> collaterals) {
+        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
+        return applyForLoan(fourMonthLoanApplication(clientId, loanProductId, toAmount(principal), charges, savingsId, collaterals)//
+                .expectedDisbursementDate("01 March 2014")//
+                .submittedOnDate("01 March 2014")//
+                .disbursementData(tranches)//
+                .fixedEmiAmount(BigDecimal.valueOf(10000)));
+    }
+
+    /** Re-expresses an application's charge list as the update endpoint's charge model. */
+    private List<PutLoansLoanIdChargeData> toUpdateCharges(final List<PostLoansRequestChargeData> charges) {
+        return charges.stream().map(charge -> new PutLoansLoanIdChargeData().chargeId(charge.getChargeId()).amount(charge.getAmount())
+                .dueDate(charge.getDueDate())).toList();
+    }
+
+    /** Re-expresses an application's collateral list as the update endpoint's collateral model. */
+    private List<PutLoansLoanIdCollateral> toUpdateCollaterals(final List<PostLoansRequestCollateralData> collaterals) {
+        return collaterals.stream()
+                .map(item -> new PutLoansLoanIdCollateral().clientCollateralId(item.getClientCollateralId()).quantity(item.getQuantity()))
+                .toList();
+    }
+
+    private PutLoansLoanIdRequest updateLoanRequest(final Long clientId, final Long loanProductId,
+            final List<PutLoansLoanIdChargeData> charges, final Long savingsId, final List<PostLoansRequestCollateralData> collaterals) {
+        LOG.info("--------------------------------UPDATING LOAN APPLICATION--------------------------------");
+        return new PutLoansLoanIdRequest()//
+                .clientId(clientId)//
+                .productId(loanProductId)//
+                .dateFormat(DATETIME_PATTERN)//
+                .locale(LOCALE)//
+                .loanType("individual")//
+                .transactionProcessingStrategyCode(DEFAULT_STRATEGY)//
+                .principal(10000L)//
+                .loanTermFrequency(4)//
+                .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .numberOfRepayments(4)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .interestRatePerPeriod(BigDecimal.valueOf(2))//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_INSTALLMENTS)//
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE)//
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)//
+                .maxOutstandingLoanBalance(36000L)//
+                .expectedDisbursementDate("20 September 2011")//
+                .submittedOnDate("20 September 2011")//
+                .collateral(toUpdateCollaterals(collaterals))//
+                .charges(charges)//
+                .linkAccountId(savingsId);
+    }
+
+    private Long applyForLoanApplicationWithPaymentStrategy(final Long clientId, final Long loanProductId,
+            final List<PostLoansRequestChargeData> charges, final Long savingsId, final String principal, final String repaymentStrategy,
+            final List<PostLoansRequestCollateralData> collaterals) {
+        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
+        return applyForLoan(fourMonthLoanApplication(clientId, loanProductId, toAmount(principal), charges, savingsId, collaterals)//
+                .transactionProcessingStrategyCode(repaymentStrategy));
+    }
+
+    private Long applyForLoanApplicationWithPaymentStrategyAndPastMonth(final Long clientId, final Long loanProductId,
+            final List<PostLoansRequestChargeData> charges, final Long savingsId, final String principal, final String repaymentStrategy,
+            final String fourMonthsfromNow, final List<PostLoansRequestCollateralData> collaterals) {
+        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
+        return applyForLoan(baseLoanApplication(clientId, loanProductId)//
+                .principal(toAmount(principal))//
+                .loanTermFrequency(6)//
+                .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .numberOfRepayments(6)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .interestRatePerPeriod(BigDecimal.valueOf(2))//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_INSTALLMENTS)//
+                .interestType(LoanTestData.InterestType.FLAT)//
+                .expectedDisbursementDate(fourMonthsfromNow)//
+                .submittedOnDate(fourMonthsfromNow)//
+                .transactionProcessingStrategyCode(repaymentStrategy)//
+                .collateral(collaterals)//
+                .charges(charges)//
+                .linkAccountId(savingsId));
+    }
+
+    private Long applyForLoanApplicationWithProductConfigurationAsTrue(final Long clientId, final Long loanProductId,
+            final String principal) {
+        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
+        return applyForLoan(baseLoanApplication(clientId, loanProductId)//
+                .principal(toAmount(principal))//
+                .repaymentEvery(1)//
+                .loanTermFrequency(4)//
+                .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .numberOfRepayments(4)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .interestRatePerPeriod(BigDecimal.valueOf(2))//
+                .expectedDisbursementDate("01 March 2014")//
+                .submittedOnDate("01 March 2014")//
+                .collateral(createClientCollateral(clientId)));
+    }
+
+    private Long applyForLoanApplicationWithProductConfigurationAsFalse(final Long clientId, final Long loanProductId,
+            final String principal) {
+        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
+        return applyForLoan(baseLoanApplication(clientId, loanProductId)//
+                .principal(toAmount(principal))//
+                .repaymentEvery(2)//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_PRINCIPAL)//
+                .transactionProcessingStrategyCode(RBI_INDIA_STRATEGY)//
+                .interestType(LoanTestData.InterestType.FLAT)//
+                .graceOnPrincipalPayment(1)//
+                .graceOnInterestPayment(1)//
+                .loanTermFrequency(4)//
+                .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .numberOfRepayments(4)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .interestRatePerPeriod(BigDecimal.valueOf(2))//
+                .expectedDisbursementDate("01 March 2014")//
+                .submittedOnDate("01 March 2014")//
+                .collateral(createClientCollateral(clientId)));
+    }
+
+    /** The 4-week, 2%, equal-installment application used by the interest-recalculation tests. */
+    private Long applyForLoanApplicationForInterestRecalculation(final Long clientId, final Long loanProductId,
+            final String disbursementDate, final String repaymentStrategy, final List<PostLoansRequestChargeData> charges) {
+        return applyForLoanApplicationForInterestRecalculation(clientId, loanProductId, disbursementDate, repaymentStrategy, charges, null,
+                null);
+    }
+
+    private Long applyForLoanApplicationForInterestRecalculationWithMoratorium(final Long clientId, final Long loanProductId,
+            final String disbursementDate, final String repaymentStrategy, final List<PostLoansRequestChargeData> charges,
+            final Integer graceOnInterestPayment, final Integer graceOnPrincipalPayment) {
+        return applyForLoanApplicationForInterestRecalculation(clientId, loanProductId, disbursementDate, repaymentStrategy, charges,
+                graceOnInterestPayment, graceOnPrincipalPayment);
+    }
+
+    private Long applyForLoanApplicationForInterestRecalculation(final Long clientId, final Long loanProductId,
+            final String disbursementDate, final String repaymentStrategy, final List<PostLoansRequestChargeData> charges,
+            final Integer graceOnInterestPayment, final Integer graceOnPrincipalPayment) {
+        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
+        return applyForLoan(baseLoanApplication(clientId, loanProductId)//
+                .principal(new BigDecimal("10000.00"))//
+                .loanTermFrequency(4)//
+                .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.WEEKS)//
+                .numberOfRepayments(4)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.WEEKS)//
+                .interestRatePerPeriod(BigDecimal.valueOf(2))//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_INSTALLMENTS)//
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE)//
+                .expectedDisbursementDate(disbursementDate)//
+                .submittedOnDate(disbursementDate)//
+                .transactionProcessingStrategyCode(repaymentStrategy)//
+                .graceOnPrincipalPayment(graceOnPrincipalPayment)//
+                .graceOnInterestPayment(graceOnInterestPayment)//
+                .charges(charges)//
+                .collateral(createClientCollateral(clientId)));
+    }
+
+    /** The 12-month, 19.9%, daily-interest application whose first repayment date is pinned. */
+    private Long applyForLoanApplicationForInterestRecalculationWithFirstRepaymentDate(final Long clientId, final Long loanProductId,
+            final String disbursementDate, final String repaymentStrategy, final String firstRepaymentDate) {
+        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
+        PostLoansRequest request = baseLoanApplication(clientId, loanProductId)//
+                .principal(new BigDecimal("10000.00"))//
+                .loanTermFrequency(12)//
+                .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .numberOfRepayments(12)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .interestRatePerPeriod(BigDecimal.valueOf(19.9))//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_INSTALLMENTS)//
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE)//
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.DAILY)//
+                .expectedDisbursementDate(disbursementDate)//
+                .submittedOnDate(disbursementDate)//
+                .transactionProcessingStrategyCode(repaymentStrategy)//
+                .collateral(createClientCollateral(clientId));
+        return applyForLoan(LoanRequestBuilders.applyLoanWithLegacyDates(request, null, firstRepaymentDate));
+    }
+
+    private PostLoansResponse applyForLoanApplicationForOnePeriod30DaysLongNoInterestPeriodicAccrual(Long clientId, Long loanProductId,
+            String loanDisbursementDate, String repaymentStrategyCode) {
+        return loanHelper.applyForLoan(new PostLoansRequest().clientId(clientId).productId(loanProductId)
+                .expectedDisbursementDate(loanDisbursementDate).dateFormat(DATETIME_PATTERN)
+                .transactionProcessingStrategyCode(repaymentStrategyCode).locale("en").submittedOnDate(loanDisbursementDate)
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_INSTALLMENTS).interestRatePerPeriod(BigDecimal.ZERO)
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE).repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.DAYS)
+                .repaymentEvery(30).numberOfRepayments(1).loanTermFrequency(30)
+                .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.DAYS).principal(BigDecimal.valueOf(1000.0))
+                .loanType("individual"));
+    }
+
+    // ----------------------------------------------------------------------------------------------------
+    // Collateral / charge / savings helpers
+    // ----------------------------------------------------------------------------------------------------
+
+    /**
+     * Creates a collateral product plus a client collateral, returning the single-entry collateral list a loan needs.
+     */
+    private List<PostLoansRequestCollateralData> createClientCollateral(final Long clientId) {
+        Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
         Assertions.assertNotNull(collateralId);
-        List<HashMap> collaterals = new ArrayList<>();
-
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
+        Long clientCollateralId = collateralHelper.createClientCollateral(clientId, collateralId).getResourceId();
         Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
-        final String loanApplicationJSON = new LoanApplicationTestBuilder()
-                //
-                .withPrincipal(principal)
-                //
-                .withRepaymentEveryAfter("2")
-                //
-                .withAmortizationTypeAsEqualPrincipalPayments().withRepaymentFrequencyTypeAsWeeks()
-                .withRepaymentStrategy(LoanProductTestBuilder.RBI_INDIA_STRATEGY).withInterestTypeAsFlatBalance()
-                .withInterestCalculationPeriodTypeSameAsRepaymentPeriod().withPrincipalGrace("1").withInterestGrace("1")
-                .withLoanTermFrequency("4") //
-                .withLoanTermFrequencyAsMonths() //
-                .withNumberOfRepayments("4") //
-                .withRepaymentFrequencyTypeAsMonths() //
-                .withInterestRatePerPeriod("2") //
-                .withInterestCalculationPeriodTypeSameAsRepaymentPeriod() //
-                .withExpectedDisbursementDate("01 March 2014") //
-                .withSubmittedOnDate("01 March 2014") //
-                .withCollaterals(collaterals).build(clientID.toString(), loanProductID.toString(), null);
+        return List.of(collateral(clientCollateralId, BigDecimal.ONE));
+    }
 
-        return LOAN_TRANSACTION_HELPER.getLoanId(loanApplicationJSON);
+    private PostLoansRequestCollateralData collateral(final Long clientCollateralId, final BigDecimal quantity) {
+        return new PostLoansRequestCollateralData().clientCollateralId(clientCollateralId).quantity(quantity);
+    }
+
+    /**
+     * Parses an amount that may carry {@code en_GB} grouping separators, e.g. {@code "12,000.00"}. The RestAssured
+     * builders sent these strings verbatim and let the server parse them under the request's locale; the typed models
+     * carry a JSON number, so the grouping has to be removed here.
+     */
+    private BigDecimal toAmount(final String value) {
+        return new BigDecimal(value.replace(",", ""));
+    }
+
+    private PostLoansRequestChargeData charge(final Long chargeId, final Double amount, final String dueDate) {
+        PostLoansRequestChargeData charge = new PostLoansRequestChargeData().chargeId(chargeId).amount(BigDecimal.valueOf(amount));
+        if (dueDate != null) {
+            charge.dueDate(dueDate);
+        }
+        return charge;
+    }
+
+    private void addCharges(List<PostLoansRequestChargeData> charges, Long chargeId, Double amount, String dueDate) {
+        charges.add(charge(chargeId, amount, dueDate));
+    }
+
+    /**
+     * Compares an installment's period against an installment number. The schedule exposes the period as an
+     * {@link Integer} while installment numbers are sent as {@link Long}, so {@code equals} between the two is always
+     * false - compare the numeric values instead.
+     */
+    private boolean isPeriod(GetLoansLoanIdRepaymentPeriod installment, Long installmentNumber) {
+        return installment.getPeriod() != null && installmentNumber != null && installment.getPeriod().longValue() == installmentNumber;
+    }
+
+    private GetLoansLoanIdChargesChargeIdResponse getloanCharge(Long chargeId, List<GetLoansLoanIdChargesChargeIdResponse> charges) {
+        return charges.stream().filter(charge -> Objects.equals(charge.getChargeId(), chargeId)).reduce((first, second) -> second)
+                .orElse(null);
+    }
+
+    /**
+     * Rebuilds the loan's charge array for a loan-application update, optionally dropping one charge and overriding the
+     * amount.
+     */
+    private List<PutLoansLoanIdChargeData> copyChargesForUpdate(List<GetLoansLoanIdChargesChargeIdResponse> charges,
+            Long deleteWithChargeId, Double amount) {
+        List<PutLoansLoanIdChargeData> loanCharges = new ArrayList<>();
+        for (GetLoansLoanIdChargesChargeIdResponse charge : charges) {
+            if (!Objects.equals(charge.getChargeId(), deleteWithChargeId)) {
+                loanCharges.add(copyForUpdate(charge, amount));
+            }
+        }
+        return loanCharges;
+    }
+
+    private PutLoansLoanIdChargeData copyForUpdate(GetLoansLoanIdChargesChargeIdResponse charge, Double amount) {
+        PutLoansLoanIdChargeData data = new PutLoansLoanIdChargeData()//
+                .id(charge.getId())//
+                .chargeId(charge.getChargeId())//
+                .amount(BigDecimal.valueOf(amount == null ? charge.getAmountOrPercentage() : amount));
+        if (charge.getDueDate() != null) {
+            data.dueDate(dateTimeFormatter.format(charge.getDueDate()));
+        }
+        return data;
+    }
+
+    private PostLoansDisbursementData createTrancheDetail(final String date, final String amount) {
+        return new PostLoansDisbursementData().expectedDisbursementDate(date).principal(toAmount(amount));
+    }
+
+    /** Adds an installment-fee loan charge whose amount is sent as a JSON number under the given locale. */
+    private void addInstallmentChargeWithLocale(final Long loanId, final Long chargeId, final Double amount, final Locale locale) {
+        addLoanCharge(loanId, new PostLoansLoanIdChargesRequest()//
+                .chargeId(chargeId)//
+                .amount(amount)//
+                .locale(locale.getLanguage())//
+                .dateFormat(DATETIME_PATTERN));
+    }
+
+    /**
+     * Adds an installment-fee loan charge whose {@code amount} is a locale-formatted <em>string</em> (the German
+     * {@code "50,05"}), which is what this test exists to prove the server parses.
+     *
+     * <p>
+     * {@code PostLoansLoanIdChargesRequest.amount} is a JSON number, so the generated model cannot carry a decimal
+     * comma - see {@link LoanChargeCommandsApi#createLoanChargeWithLocaleFormattedAmount} for why this gets its own
+     * request model instead of a Swagger change.
+     *
+     * @param amountText
+     *            the {@code amount} formatted for {@code locale}, e.g. the German {@code "50,05"}
+     */
+    private void addInstallmentChargeWithLocaleFormattedAmount(final Long loanId, final Long chargeId, final String amountText,
+            final Locale locale) {
+        ok(() -> loanChargeCommands().createLoanChargeWithLocaleFormattedAmount(loanId,
+                new LoanChargeCommandsApi.LocaleFormattedAmountLoanChargeRequest()//
+                        .chargeId(String.valueOf(chargeId))//
+                        .amount(amountText)//
+                        .locale(locale.getLanguage())//
+                        .dateFormat(DATETIME_PATTERN)));
+    }
+
+    /**
+     * Waives a loan charge in full: no installment is named, so the request carries no fields.
+     *
+     * @return the waived loan charge's id
+     */
+    private Long waiveWholeLoanCharge(final Long loanId, final Long loanChargeId) {
+        return waiveLoanCharge(loanId, loanChargeId, new PostLoansLoanIdChargesChargeIdRequest()).getResourceId();
+    }
+
+    private static LoanChargeCommandsApi loanChargeCommands() {
+        return FineractFeignClientHelper.getFineractFeignClient().create(LoanChargeCommandsApi.class);
+    }
+
+    /**
+     * Re-submits a savings application with a new {@code submittedOnDate} and reports whether the server echoed that
+     * field back as changed.
+     *
+     * @return whether {@code submittedOnDate} comes back in the response's {@code changes}
+     */
+    private boolean updateSavingsSubmittedOnDate(final Long savingsId, final Long clientId, final Long productId,
+            final String submittedOnDate) {
+        PutSavingsAccountsAccountIdRequest request = new PutSavingsAccountsAccountIdRequest()//
+                .clientId(clientId)//
+                .productId(productId)//
+                .submittedOnDate(submittedOnDate)//
+                .locale(LOCALE)//
+                .dateFormat(DATETIME_PATTERN);
+        PutSavingsAccountsAccountIdResponse response = ok(() -> FineractFeignClientHelper.getFineractFeignClient().savingsAccount()
+                .updateSavingsAccount(savingsId, request, (String) null));
+        return response.getChanges() != null && response.getChanges().getSubmittedOnDate() != null;
+    }
+
+    private Long createSavingsProduct(final String minOpenningBalance) {
+        LOG.info("------------------------------CREATING NEW SAVINGS PRODUCT ---------------------------------------");
+        return savingsProductHelper.createSavingsProduct(SavingsRequestBuilders.defaultSavingsProduct()//
+                .minRequiredOpeningBalance(new BigDecimal(minOpenningBalance))).getResourceId();
+    }
+
+    /**
+     * Opens a savings account submitted on {@code 08 January 2013} and activated on {@code 01 March 2013}, funded by
+     * the product's minimum opening balance. The inherited {@code openSavingsAccount} activates on today's date, which
+     * is after the 2011-2013 transaction dates these tests use.
+     */
+    private Long openSavingsAccountActivatedOnTransactionDate(final Long clientId, final String minimumOpeningBalance) {
+        final Long savingsProductId = createSavingsProduct(minimumOpeningBalance);
+        Assertions.assertNotNull(savingsProductId);
+        final Long savingsId = savingsHelper.submitApplication(clientId, savingsProductId, SAVINGS_CREATED_DATE).getSavingsId();
+        Assertions.assertNotNull(savingsId);
+        savingsHelper.approveSavings(savingsId, SAVINGS_TRANSACTION_DATE);
+        savingsHelper.activateSavings(savingsId, SAVINGS_TRANSACTION_DATE);
+        return savingsId;
+    }
+
+    // ----------------------------------------------------------------------------------------------------
+    // Assertion helpers
+    // ----------------------------------------------------------------------------------------------------
+
+    /**
+     * Asserts the loan did not override any of the product's defaults — the same attribute set the RestAssured version
+     * compared. The enum-valued attributes reach the two responses as different generated wrapper types, so they are
+     * compared on their {@code id} and {@code code} rather than by {@code equals}.
+     */
+    private void validateIfValuesAreNotOverridden(Long loanId, Long loanProductId) {
+        GetLoanProductsProductIdResponse loanProduct = retrieveLoanProduct(loanProductId);
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
+
+        assertEnumEquals(loanProduct.getAmortizationType().getId(), loanProduct.getAmortizationType().getCode(),
+                loanDetails.getAmortizationType().getId(), loanDetails.getAmortizationType().getCode(), "amortizationType");
+        assertEnumEquals(loanProduct.getInterestType().getId(), loanProduct.getInterestType().getCode(),
+                loanDetails.getInterestType().getId(), loanDetails.getInterestType().getCode(), "interestType");
+        assertEnumEquals(loanProduct.getInterestCalculationPeriodType().getId(), loanProduct.getInterestCalculationPeriodType().getCode(),
+                loanDetails.getInterestCalculationPeriodType().getId(), loanDetails.getInterestCalculationPeriodType().getCode(),
+                "interestCalculationPeriodType");
+        assertEnumEquals(loanProduct.getRepaymentFrequencyType().getId(), loanProduct.getRepaymentFrequencyType().getCode(),
+                loanDetails.getRepaymentFrequencyType().getId(), loanDetails.getRepaymentFrequencyType().getCode(),
+                "repaymentFrequencyType");
+
+        assertEquals(loanProduct.getTransactionProcessingStrategyCode(), loanDetails.getTransactionProcessingStrategyCode(),
+                OVERRIDE_MESSAGE.formatted("transactionProcessingStrategyCode"));
+        assertEquals(loanProduct.getGraceOnPrincipalPayment(), loanDetails.getGraceOnPrincipalPayment(),
+                OVERRIDE_MESSAGE.formatted("graceOnPrincipalPayment"));
+        assertEquals(loanProduct.getGraceOnInterestPayment(), loanDetails.getGraceOnInterestPayment(),
+                OVERRIDE_MESSAGE.formatted("graceOnInterestPayment"));
+        assertEquals(loanProduct.getInArrearsTolerance(), loanDetails.getInArrearsTolerance(),
+                OVERRIDE_MESSAGE.formatted("inArrearsTolerance"));
+        assertEquals(loanProduct.getGraceOnArrearsAgeing(), loanDetails.getGraceOnArrearsAgeing(),
+                OVERRIDE_MESSAGE.formatted("graceOnArrearsAgeing"));
+    }
+
+    private static void assertEnumEquals(Long productId, String productCode, Long loanId, String loanCode, String attribute) {
+        assertEquals(productId, loanId, OVERRIDE_MESSAGE.formatted(attribute));
+        assertEquals(productCode, loanCode, OVERRIDE_MESSAGE.formatted(attribute));
+    }
+
+    /**
+     * A product whose {@code allowAttributeOverrides} are all set to {@code allowOverride}, so a loan application
+     * either may or may not deviate from the product's defaults.
+     */
+    private Long createLoanProductWithAttributeOverrides(boolean allowOverride) {
+        PostLoanProductsRequest product = baseLoanProduct()//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_INSTALLMENTS)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS_L)//
+                .repaymentEvery(1)//
+                .transactionProcessingStrategyCode(DEFAULT_STRATEGY)//
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE)//
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.DAILY)//
+                .inArrearsTolerance(10)//
+                .graceOnPrincipalPayment(2)//
+                .graceOnInterestPayment(3)//
+                .allowAttributeOverrides(new AllowAttributeOverrides()//
+                        .amortizationType(allowOverride)//
+                        .interestType(allowOverride)//
+                        .transactionProcessingStrategyCode(allowOverride)//
+                        .interestCalculationPeriodType(allowOverride)//
+                        .inArrearsTolerance(allowOverride)//
+                        .repaymentEvery(allowOverride)//
+                        .graceOnPrincipalAndInterestPayment(allowOverride)//
+                        .graceOnArrearsAgeing(allowOverride));
+        return createLoanProduct(product);
     }
 
     private Integer getDayOfWeek(Calendar date) {
@@ -7260,494 +7570,344 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
                 dayOfMonth = 28;
             }
         }
-
         return dayOfMonth;
     }
 
-    private void validateCharge(Integer amountPercentage, final List<HashMap> loanCharges, final String amount, final String outstanding,
-            String amountPaid, String amountWaived) {
-        HashMap chargeDetail = getloanCharge(amountPercentage, loanCharges);
-        assertTrue(Float.valueOf(amount).compareTo(Float.valueOf(String.valueOf(chargeDetail.get("amountOrPercentage")))) == 0);
-        assertTrue(Float.valueOf(outstanding).compareTo(Float.valueOf(String.valueOf(chargeDetail.get("amountOutstanding")))) == 0);
-        assertTrue(Float.valueOf(amountPaid).compareTo(Float.valueOf(String.valueOf(chargeDetail.get("amountPaid")))) == 0);
-        assertTrue(Float.valueOf(amountWaived).compareTo(Float.valueOf(String.valueOf(chargeDetail.get("amountWaived")))) == 0);
+    private void validateCharge(Long chargeId, final List<GetLoansLoanIdChargesChargeIdResponse> loanCharges, final String amount,
+            final String outstanding, String amountPaid, String amountWaived) {
+        GetLoansLoanIdChargesChargeIdResponse chargeDetail = getloanCharge(chargeId, loanCharges);
+        assertNotNull(chargeDetail, "Loan charge not found for charge " + chargeId);
+        validateNumberForEqual(amount, String.valueOf(chargeDetail.getAmountOrPercentage()));
+        validateNumberForEqual(outstanding, String.valueOf(chargeDetail.getAmountOutstanding()));
+        validateNumberForEqual(amountPaid, String.valueOf(chargeDetail.getAmountPaid()));
+        validateNumberForEqual(amountWaived, String.valueOf(chargeDetail.getAmountWaived()));
     }
 
-    private void validateChargeExcludePrecission(Integer amountPercentage, final List<HashMap> loanCharges, final String amount,
-            final String outstanding, String amountPaid, String amountWaived) {
-        DecimalFormat twoDForm = new DecimalFormat("#");
-        HashMap chargeDetail = getloanCharge(amountPercentage, loanCharges);
-        assertTrue(Float.valueOf(twoDForm.format(Float.valueOf(amount)))
-                .compareTo(Float.parseFloat(twoDForm.format(Float.valueOf(String.valueOf(chargeDetail.get("amountOrPercentage")))))) == 0);
-        assertTrue(Float.valueOf(twoDForm.format(Float.valueOf(outstanding)))
-                .compareTo(Float.valueOf(twoDForm.format(Float.parseFloat(String.valueOf(chargeDetail.get("amountOutstanding")))))) == 0);
-        assertTrue(Float.valueOf(twoDForm.format(Float.parseFloat(amountPaid)))
-                .compareTo(Float.valueOf(twoDForm.format(Float.parseFloat(String.valueOf(chargeDetail.get("amountPaid")))))) == 0);
-        assertTrue(Float.valueOf(twoDForm.format(Float.parseFloat(amountWaived)))
-                .compareTo(Float.valueOf(twoDForm.format(Float.parseFloat(String.valueOf(chargeDetail.get("amountWaived")))))) == 0);
+    private void validateChargeExcludePrecission(Long chargeId, final List<GetLoansLoanIdChargesChargeIdResponse> loanCharges,
+            final String amount, final String outstanding, String amountPaid, String amountWaived) {
+        GetLoansLoanIdChargesChargeIdResponse chargeDetail = getloanCharge(chargeId, loanCharges);
+        assertNotNull(chargeDetail, "Loan charge not found for charge " + chargeId);
+        validateNumberForEqualExcludePrecission(amount, String.valueOf(chargeDetail.getAmountOrPercentage()));
+        validateNumberForEqualExcludePrecission(outstanding, String.valueOf(chargeDetail.getAmountOutstanding()));
+        validateNumberForEqualExcludePrecission(amountPaid, String.valueOf(chargeDetail.getAmountPaid()));
+        validateNumberForEqualExcludePrecission(amountWaived, String.valueOf(chargeDetail.getAmountWaived()));
     }
 
     private void validateNumberForEqual(String val, String val2) {
-        assertTrue(Float.valueOf(val).compareTo(Float.valueOf(val2)) == 0);
+        assertEquals(0, Float.valueOf(val).compareTo(Float.valueOf(val2)), String.format("%s is not equal to %s", val, val2));
     }
 
     private void validateNumberForEqualWithMsg(String msg, String val, String val2) {
-        assertTrue(Float.valueOf(val).compareTo(Float.valueOf(val2)) == 0, msg + "expected " + val + " but was " + val2);
+        assertEquals(0, Float.valueOf(val).compareTo(Float.valueOf(val2)), msg + "expected " + val + " but was " + val2);
     }
 
     private void validateNumberForEqualExcludePrecission(String val, String val2) {
         DecimalFormat twoDForm = new DecimalFormat("#");
-        assertTrue(Float.valueOf(twoDForm.format(Float.valueOf(val))).compareTo(Float.valueOf(twoDForm.format(Float.valueOf(val2)))) == 0,
+        assertEquals(0, Float.valueOf(twoDForm.format(Float.valueOf(val))).compareTo(Float.valueOf(twoDForm.format(Float.valueOf(val2)))),
                 String.format("%s is not equal to %s", val, val2));
     }
 
-    private Integer createLoanProduct(final boolean multiDisburseLoan, final String accountingRule, final Account... accounts) {
-        LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-        LoanProductTestBuilder builder = new LoanProductTestBuilder() //
-                .withPrincipal("12,000.00") //
-                .withNumberOfRepayments("4") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("1") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualInstallments() //
-                .withInterestTypeAsDecliningBalance() //
-                .withTranches(multiDisburseLoan) //
-                .withAccounting(accountingRule, accounts);
-        if (multiDisburseLoan) {
-            builder = builder.withInterestCalculationPeriodTypeAsRepaymentPeriod(true);
+    private List<GetLoansLoanIdRepaymentPeriod> getLoanRepaymentSchedule(Long loanId) {
+        return getLoanDetails(loanId).getRepaymentSchedule().getPeriods();
+    }
+
+    /**
+     * The future (not-yet-due) repayment periods. {@code getLoanDetails} excludes the {@code futureSchedule}
+     * association, so this asks for it explicitly.
+     */
+    private List<GetLoansLoanIdRepaymentPeriod> getLoanFutureRepaymentSchedule(Long loanId) {
+        return loanHelper.getLoanDetails(loanId, "repaymentSchedule,futureSchedule").getRepaymentSchedule().getFuturePeriods();
+    }
+
+    /**
+     * The prepayment template with no explicit transaction date, letting the server default it, exactly as the
+     * RestAssured helper did. Passing a date here would require a business date to be set.
+     */
+    private GetLoansLoanIdTransactionsTemplateResponse getPrepayAmount(Long loanId) {
+        return transactionHelper.getPrepaymentAmount(loanId, null, null);
+    }
+
+    private void verifyLoanRepaymentSchedule(final List<GetLoansLoanIdRepaymentPeriod> loanSchedule) {
+        LOG.info("--------------------VERIFYING THE PRINCIPAL DUES,INTEREST DUE AND DUE DATE--------------------------");
+
+        assertEquals(LocalDate.of(2011, 10, 20), loanSchedule.get(1).getDueDate(), "Checking for Due Date for 1st Month");
+        validateNumberForEqualWithMsg("Checking for Principal Due for 1st Month", "2911.49",
+                String.valueOf(loanSchedule.get(1).getPrincipalOriginalDue()));
+        validateNumberForEqualWithMsg("Checking for Interest Due for 1st Month", "240.00",
+                String.valueOf(loanSchedule.get(1).getInterestOriginalDue()));
+
+        assertEquals(LocalDate.of(2011, 11, 20), loanSchedule.get(2).getDueDate(), "Checking for Due Date for 2nd Month");
+        validateNumberForEqualWithMsg("Checking for Principal Due for 2nd Month", "2969.72",
+                String.valueOf(loanSchedule.get(2).getPrincipalDue()));
+        validateNumberForEqualWithMsg("Checking for Interest Due for 2nd Month", "181.77",
+                String.valueOf(loanSchedule.get(2).getInterestOriginalDue()));
+
+        assertEquals(LocalDate.of(2011, 12, 20), loanSchedule.get(3).getDueDate(), "Checking for Due Date for 3rd Month");
+        validateNumberForEqualWithMsg("Checking for Principal Due for 3rd Month", "3029.11",
+                String.valueOf(loanSchedule.get(3).getPrincipalDue()));
+        validateNumberForEqualWithMsg("Checking for Interest Due for 3rd Month", "122.38",
+                String.valueOf(loanSchedule.get(3).getInterestOriginalDue()));
+
+        assertEquals(LocalDate.of(2012, 1, 20), loanSchedule.get(4).getDueDate(), "Checking for Due Date for 4th Month");
+        validateNumberForEqualWithMsg("Checking for Principal Due for 4th Month", "3089.68",
+                String.valueOf(loanSchedule.get(4).getPrincipalDue()));
+        validateNumberForEqualWithMsg("Checking for Interest Due for 4th Month", "61.79",
+                String.valueOf(loanSchedule.get(4).getInterestOriginalDue()));
+    }
+
+    private void verifyLoanRepaymentScheduleForEqualPrincipal(final List<GetLoansLoanIdRepaymentPeriod> loanSchedule) {
+        LOG.info("--------------------VERIFYING THE PRINCIPAL DUES,INTEREST DUE AND DUE DATE--------------------------");
+
+        verifyEqualPrincipalInstallment(loanSchedule, 1, LocalDate.of(2014, 7, 2), "416700", "200000", true);
+        verifyEqualPrincipalInstallment(loanSchedule, 2, LocalDate.of(2014, 8, 2), "416700", "191700", false);
+        verifyEqualPrincipalInstallment(loanSchedule, 3, LocalDate.of(2014, 9, 2), "416700", "183300", false);
+        verifyEqualPrincipalInstallment(loanSchedule, 4, LocalDate.of(2014, 10, 2), "416700", "175000", false);
+        verifyEqualPrincipalInstallment(loanSchedule, 5, LocalDate.of(2014, 11, 2), "416700", "166700", false);
+        verifyEqualPrincipalInstallment(loanSchedule, 6, LocalDate.of(2014, 12, 2), "416700", "158300", false);
+        verifyEqualPrincipalInstallment(loanSchedule, 10, LocalDate.of(2015, 4, 2), "416700", "125000", false);
+        verifyEqualPrincipalInstallment(loanSchedule, 20, LocalDate.of(2016, 2, 2), "416700", "41700", false);
+        verifyEqualPrincipalInstallment(loanSchedule, 24, LocalDate.of(2016, 6, 2), "415900", "8300", false);
+    }
+
+    private void verifyLoanRepaymentScheduleForEqualPrincipalWithGrace(final List<GetLoansLoanIdRepaymentPeriod> loanSchedule) {
+        LOG.info("--------------------VERIFYING THE PRINCIPAL DUES,INTEREST DUE AND DUE DATE--------------------------");
+
+        verifyEqualPrincipalInstallment(loanSchedule, 1, LocalDate.of(2014, 7, 2), "0.0", "200000", true);
+        verifyEqualPrincipalInstallment(loanSchedule, 2, LocalDate.of(2014, 8, 2), "0.0", "200000", true);
+        verifyEqualPrincipalInstallment(loanSchedule, 3, LocalDate.of(2014, 9, 2), "0.0", "200000", false);
+        verifyEqualPrincipalInstallment(loanSchedule, 4, LocalDate.of(2014, 10, 2), "0", "200000", false);
+        verifyEqualPrincipalInstallment(loanSchedule, 5, LocalDate.of(2014, 11, 2), "0", "200000", false);
+        verifyEqualPrincipalInstallment(loanSchedule, 6, LocalDate.of(2014, 12, 2), "526300", "200000", false);
+        verifyEqualPrincipalInstallment(loanSchedule, 7, LocalDate.of(2015, 1, 2), "526300", "189500", false);
+        verifyEqualPrincipalInstallment(loanSchedule, 10, LocalDate.of(2015, 4, 2), "526300", "157900", false);
+        verifyEqualPrincipalInstallment(loanSchedule, 20, LocalDate.of(2016, 2, 2), "526300", "52600", false);
+        verifyEqualPrincipalInstallment(loanSchedule, 24, LocalDate.of(2016, 6, 2), "526600", "10500", false);
+    }
+
+    /**
+     * @param useOriginalPrincipalDue
+     *            reads {@code principalOriginalDue} instead of {@code principalDue}, mirroring the assertions the
+     *            RestAssured version of this test made per installment.
+     */
+    private void verifyEqualPrincipalInstallment(final List<GetLoansLoanIdRepaymentPeriod> loanSchedule, int installment,
+            LocalDate expectedDueDate, String expectedPrincipalDue, String expectedInterestDue, boolean useOriginalPrincipalDue) {
+        GetLoansLoanIdRepaymentPeriod period = loanSchedule.get(installment);
+        assertEquals(expectedDueDate, period.getDueDate(), "Checking for Due Date for installment " + installment);
+        BigDecimal principalDue = useOriginalPrincipalDue ? period.getPrincipalOriginalDue() : period.getPrincipalDue();
+        validateNumberForEqualWithMsg("Checking for Principal Due for installment " + installment, expectedPrincipalDue,
+                String.valueOf(principalDue));
+        validateNumberForEqualWithMsg("Checking for Interest Due for installment " + installment, expectedInterestDue,
+                String.valueOf(period.getInterestOriginalDue()));
+    }
+
+    private void addRepaymentValues(List<ExpectedInstallment> expectedvalues, Calendar todaysDate, int addPeriod, boolean isAddDays,
+            String principalDue, String interestDue, String feeChargesDue, String penaltyChargesDue) {
+        LocalDate dueDate = isAddDays ? addDays(todaysDate, addPeriod) : addDays(todaysDate, addPeriod * 7);
+        LOG.info("Updated date {}", dueDate);
+        expectedvalues.add(new ExpectedInstallment(dueDate, principalDue, interestDue, feeChargesDue, penaltyChargesDue));
+    }
+
+    private LocalDate addDays(Calendar todaysDate, int addValue) {
+        todaysDate.add(Calendar.DAY_OF_MONTH, addValue);
+        return toLocalDate(todaysDate);
+    }
+
+    private LocalDate toLocalDate(Calendar date) {
+        return LocalDate.of(date.get(Calendar.YEAR), date.get(Calendar.MONTH) + 1, date.get(Calendar.DAY_OF_MONTH));
+    }
+
+    /**
+     * One expected repayment-schedule row, replacing the untyped {@code Map<String, Object>} the RestAssured test used.
+     */
+    private record ExpectedInstallment(LocalDate dueDate, String principalDue, String interestDue, String feeChargesDue,
+            String penaltyChargesDue) {
+    }
+
+    private void verifyLoanRepaymentSchedule(final List<GetLoansLoanIdRepaymentPeriod> loanSchedule,
+            List<ExpectedInstallment> expectedvalues) {
+        verifyLoanRepaymentSchedule(loanSchedule, expectedvalues, 1);
+    }
+
+    private void verifyLoanRepaymentSchedule(final List<GetLoansLoanIdRepaymentPeriod> loanSchedule,
+            List<ExpectedInstallment> expectedvalues, int index) {
+        LOG.info("--------------------VERIFYING THE PRINCIPAL DUES,INTEREST DUE AND DUE DATE--------------------------");
+        for (ExpectedInstallment values : expectedvalues) {
+            GetLoansLoanIdRepaymentPeriod period = loanSchedule.get(index);
+            assertEquals(values.dueDate(), period.getDueDate(), "Checking for Due Date for  installment " + index);
+            validateNumberForEqualWithMsg("Checking for Principal Due for installment " + index, values.principalDue(),
+                    String.valueOf(period.getPrincipalDue()));
+            validateNumberForEqualWithMsg("Checking for Interest Due for installment " + index, values.interestDue(),
+                    String.valueOf(period.getInterestDue()));
+            validateNumberForEqualWithMsg("Checking for Fee charge Due for installment " + index, values.feeChargesDue(),
+                    String.valueOf(period.getFeeChargesDue()));
+            validateNumberForEqualWithMsg("Checking for Penalty charge Due for installment " + index, values.penaltyChargesDue(),
+                    String.valueOf(period.getPenaltyChargesDue()));
+            index++;
         }
-        final String loanProductJSON = builder.build(null);
-        return LOAN_TRANSACTION_HELPER.getLoanProductId(loanProductJSON);
     }
 
-    private Integer createLoanProduct(final String inMultiplesOf, final String digitsAfterDecimal, final String repaymentStrategy) {
-        LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withRepaymentStrategy(repaymentStrategy) //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails(digitsAfterDecimal, inMultiplesOf).build(null);
-        return LOAN_TRANSACTION_HELPER.getLoanProductId(loanProductJSON);
-    }
+    private void checkAccrualTransactions(final List<GetLoansLoanIdRepaymentPeriod> loanSchedule, final Long loanId) {
+        for (int i = 1; i < loanSchedule.size(); i++) {
+            final GetLoansLoanIdRepaymentPeriod repayment = loanSchedule.get(i);
+            final LocalDate transactionDate = repayment.getDueDate();
 
-    private Integer createLoanProduct(final String inMultiplesOf, final String digitsAfterDecimal, final String repaymentStrategy,
-            final String accountingRule, final Account... accounts) {
-        LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withRepaymentStrategy(repaymentStrategy) //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails(digitsAfterDecimal, inMultiplesOf).withAccounting(accountingRule, accounts).build(null);
-        return LOAN_TRANSACTION_HELPER.getLoanProductId(loanProductJSON);
-    }
+            final Float interestPortion = repayment.getInterestDue().subtract(repayment.getInterestWaived())
+                    .subtract(repayment.getInterestWrittenOff()).floatValue();
+            final Float feePortion = repayment.getFeeChargesDue().subtract(repayment.getFeeChargesWaived())
+                    .subtract(repayment.getFeeChargesWrittenOff()).floatValue();
+            final Float penaltyPortion = repayment.getPenaltyChargesDue().subtract(repayment.getPenaltyChargesWaived())
+                    .subtract(repayment.getPenaltyChargesWrittenOff()).floatValue();
 
-    private Integer applyForLoanApplication(final Integer clientID, final Integer loanProductID, String graceOnPrincipalPayment,
-            List<HashMap> collaterals) {
-        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
-        final String loanApplicationJSON = new LoanApplicationTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withLoanTermFrequency("24") //
-                .withLoanTermFrequencyAsMonths() //
-                .withNumberOfRepayments("24") //
-                .withRepaymentEveryAfter("1") //
-                .withRepaymentFrequencyTypeAsMonths() //
-                .withInterestRatePerPeriod("2") //
-                .withAmortizationTypeAsEqualPrincipalPayments() //
-                .withInterestTypeAsDecliningBalance() //
-                .withInterestCalculationPeriodTypeSameAsRepaymentPeriod() //
-                .withPrincipalGrace(graceOnPrincipalPayment).withExpectedDisbursementDate("02 June 2014") //
-                .withSubmittedOnDate("02 June 2014") //
-                .withCollaterals(collaterals).build(clientID.toString(), loanProductID.toString(), null);
-        return LOAN_TRANSACTION_HELPER.getLoanId(loanApplicationJSON);
-    }
-
-    private Integer applyForLoanApplication(final Integer clientID, final Integer loanProductID, List<HashMap> charges,
-            final String savingsId, String principal, List<HashMap> collaterals) {
-        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
-        final String loanApplicationJSON = new LoanApplicationTestBuilder() //
-                .withPrincipal(principal) //
-                .withLoanTermFrequency("4") //
-                .withLoanTermFrequencyAsMonths() //
-                .withNumberOfRepayments("4") //
-                .withRepaymentEveryAfter("1") //
-                .withRepaymentFrequencyTypeAsMonths() //
-                .withInterestRatePerPeriod("2") //
-                .withAmortizationTypeAsEqualInstallments() //
-                .withInterestTypeAsDecliningBalance() //
-                .withInterestCalculationPeriodTypeSameAsRepaymentPeriod() //
-                .withExpectedDisbursementDate("20 September 2011") //
-                .withSubmittedOnDate("20 September 2011") //
-                .withCollaterals(collaterals).withCharges(charges).build(clientID.toString(), loanProductID.toString(), savingsId);
-        return LOAN_TRANSACTION_HELPER.getLoanId(loanApplicationJSON);
-    }
-
-    private Integer applyForLoanApplication(final Integer clientID, final Integer loanProductID, String disbursementDate,
-            String submissionDate, String interestRate, List<HashMap> charges, final String savingsId, String principal,
-            List<HashMap> collaterals) {
-        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
-        final String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal(principal).withLoanTermFrequency("2")
-                .withLoanTermFrequencyAsMonths().withNumberOfRepayments("2").withRepaymentEveryAfter("1")
-                .withRepaymentFrequencyTypeAsMonths().withInterestRatePerPeriod(interestRate).withAmortizationTypeAsEqualInstallments()
-                .withInterestTypeAsDecliningBalance().withInterestCalculationPeriodTypeSameAsRepaymentPeriod()
-                .withExpectedDisbursementDate(disbursementDate).withSubmittedOnDate(submissionDate).withCollaterals(collaterals)
-                .withCharges(charges).build(clientID.toString(), loanProductID.toString(), savingsId);
-        return LOAN_TRANSACTION_HELPER.getLoanId(loanApplicationJSON);
-    }
-
-    private Integer applyForLoanApplicationWithExternalId(RequestSpecification requestSpecification,
-            ResponseSpecification responseSpecification, final Integer clientID, final Integer loanProductID, String principal,
-            final String externalId) {
-        LOG.info("------------------------APPLYING FOR LOAN APPLICATION WITH EXTERNALID------------------------");
-        final String loanApplicationJSON = new LoanApplicationTestBuilder() //
-                .withPrincipal(principal) //
-                .withExternalId(externalId) //
-                .withLoanTermFrequency("4") //
-                .withLoanTermFrequencyAsMonths() //
-                .withNumberOfRepayments("4") //
-                .withRepaymentEveryAfter("1") //
-                .withRepaymentFrequencyTypeAsMonths() //
-                .withInterestRatePerPeriod("2") //
-                .withAmortizationTypeAsEqualInstallments() //
-                .withInterestTypeAsDecliningBalance() //
-                .withInterestCalculationPeriodTypeSameAsRepaymentPeriod() //
-                .withExpectedDisbursementDate("20 September 2011") //
-                .withSubmittedOnDate("20 September 2011") //
-                .build(clientID.toString(), loanProductID.toString(), null);
-        return LOAN_TRANSACTION_HELPER.getLoanId(loanApplicationJSON, requestSpecification, responseSpecification);
-    }
-
-    private Integer applyForLoanApplicationWithTranches(final Integer clientID, final Integer loanProductID, List<HashMap> charges,
-            final String savingsId, String principal, List<HashMap> tranches, List<HashMap> collaterals) {
-        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
-        final String loanApplicationJSON = new LoanApplicationTestBuilder() //
-                .withPrincipal(principal) //
-                .withLoanTermFrequency("4") //
-                .withLoanTermFrequencyAsMonths() //
-                .withNumberOfRepayments("4") //
-                .withRepaymentEveryAfter("1") //
-                .withRepaymentFrequencyTypeAsMonths() //
-                .withInterestRatePerPeriod("2") //
-                .withAmortizationTypeAsEqualInstallments() //
-                .withInterestTypeAsDecliningBalance() //
-                .withInterestCalculationPeriodTypeSameAsRepaymentPeriod() //
-                .withExpectedDisbursementDate("01 March 2014") //
-                .withCollaterals(collaterals).withTranches(tranches) //
-                .withSubmittedOnDate("01 March 2014") //
-                .withCharges(charges).build(clientID.toString(), loanProductID.toString(), savingsId);
-        return LOAN_TRANSACTION_HELPER.getLoanId(loanApplicationJSON);
-    }
-
-    private String updateLoanJson(final Integer clientID, final Integer loanProductID, List<HashMap> charges, String savingsId,
-            List<HashMap> collaterals) {
-        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
-        final String loanApplicationJSON = new LoanApplicationTestBuilder() //
-                .withPrincipal("10,000.00") //
-                .withLoanTermFrequency("4") //
-                .withLoanTermFrequencyAsMonths() //
-                .withNumberOfRepayments("4") //
-                .withRepaymentEveryAfter("1") //
-                .withRepaymentFrequencyTypeAsMonths() //
-                .withInterestRatePerPeriod("2") //
-                .withAmortizationTypeAsEqualInstallments() //
-                .withInterestTypeAsDecliningBalance() //
-                .withInterestCalculationPeriodTypeSameAsRepaymentPeriod() //
-                .withExpectedDisbursementDate("20 September 2011") //
-                .withSubmittedOnDate("20 September 2011") //
-                .withCollaterals(collaterals).withCharges(charges).build(clientID.toString(), loanProductID.toString(), savingsId);
-        return loanApplicationJSON;
-    }
-
-    private Integer applyForLoanApplicationWithPaymentStrategy(final Integer clientID, final Integer loanProductID, List<HashMap> charges,
-            final String savingsId, String principal, final String repaymentStrategy, final List<HashMap> collaterals) {
-        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
-        final String loanApplicationJSON = new LoanApplicationTestBuilder() //
-                .withPrincipal(principal) //
-                .withLoanTermFrequency("4") //
-                .withLoanTermFrequencyAsMonths() //
-                .withNumberOfRepayments("4") //
-                .withRepaymentEveryAfter("1") //
-                .withRepaymentFrequencyTypeAsMonths() //
-                .withInterestRatePerPeriod("2") //
-                .withAmortizationTypeAsEqualInstallments() //
-                .withInterestTypeAsDecliningBalance() //
-                .withInterestCalculationPeriodTypeSameAsRepaymentPeriod() //
-                .withExpectedDisbursementDate("20 September 2011") //
-                .withSubmittedOnDate("20 September 2011") //
-                .withRepaymentStrategy(repaymentStrategy) //
-                .withCollaterals(collaterals).withCharges(charges).build(clientID.toString(), loanProductID.toString(), savingsId);
-        return LOAN_TRANSACTION_HELPER.getLoanId(loanApplicationJSON);
-    }
-
-    private Integer applyForLoanApplicationWithPaymentStrategyAndPastMonth(final Integer clientID, final Integer loanProductID,
-            List<HashMap> charges, final String savingsId, String principal, final String repaymentStrategy, final String fourMonthsfromNow,
-            List<HashMap> collaterals) {
-        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
-
-        DateFormat dateFormat = new SimpleDateFormat(DATETIME_PATTERN);
-        dateFormat.setTimeZone(Utils.getTimeZoneOfTenant());
-        final String loanApplicationJSON = new LoanApplicationTestBuilder() //
-                .withPrincipal(principal) //
-                .withLoanTermFrequency("6") //
-                .withLoanTermFrequencyAsMonths() //
-                .withNumberOfRepayments("6") //
-                .withRepaymentEveryAfter("1") //
-                .withRepaymentFrequencyTypeAsMonths() //
-                .withInterestRatePerPeriod("2") //
-                .withAmortizationTypeAsEqualInstallments() //
-                .withInterestTypeAsFlatBalance() //
-                .withInterestCalculationPeriodTypeSameAsRepaymentPeriod() //
-                .withExpectedDisbursementDate(fourMonthsfromNow) //
-                .withSubmittedOnDate(fourMonthsfromNow) //
-                .withRepaymentStrategy(repaymentStrategy) //
-                .withCollaterals(collaterals).withCharges(charges).build(clientID.toString(), loanProductID.toString(), savingsId);
-        return LOAN_TRANSACTION_HELPER.getLoanId(loanApplicationJSON);
-    }
-
-    private void verifyLoanRepaymentSchedule(final ArrayList<HashMap> loanSchedule) {
-        LOG.info("--------------------VERIFYING THE PRINCIPAL DUES,INTEREST DUE AND DUE DATE--------------------------");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2011, 10, 20)), loanSchedule.get(1).get("dueDate"),
-                "Checking for Due Date for 1st Month");
-        assertEquals(Float.parseFloat("2911.49"), loanSchedule.get(1).get("principalOriginalDue"),
-                "Checking for Principal Due for 1st Month");
-        assertEquals(Float.parseFloat("240.00"), loanSchedule.get(1).get("interestOriginalDue"), "Checking for Interest Due for 1st Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2011, 11, 20)), loanSchedule.get(2).get("dueDate"),
-                "Checking for Due Date for 2nd Month");
-        assertEquals(Float.parseFloat("2969.72"), loanSchedule.get(2).get("principalDue"), "Checking for Principal Due for 2nd Month");
-        assertEquals(Float.parseFloat("181.77"), loanSchedule.get(2).get("interestOriginalDue"), "Checking for Interest Due for 2nd Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2011, 12, 20)), loanSchedule.get(3).get("dueDate"),
-                "Checking for Due Date for 3rd Month");
-        assertEquals(Float.parseFloat("3029.11"), loanSchedule.get(3).get("principalDue"), "Checking for Principal Due for 3rd Month");
-        assertEquals(Float.parseFloat("122.38"), loanSchedule.get(3).get("interestOriginalDue"), "Checking for Interest Due for 3rd Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2012, 1, 20)), loanSchedule.get(4).get("dueDate"),
-                "Checking for Due Date for 4th Month");
-        assertEquals(Float.parseFloat("3089.68"), loanSchedule.get(4).get("principalDue"), "Checking for Principal Due for 4th Month");
-        assertEquals(Float.parseFloat("61.79"), loanSchedule.get(4).get("interestOriginalDue"), "Checking for Interest Due for 4th Month");
-    }
-
-    private void verifyLoanRepaymentScheduleForEqualPrincipal(final ArrayList<HashMap> loanSchedule) {
-        LOG.info("--------------------VERIFYING THE PRINCIPAL DUES,INTEREST DUE AND DUE DATE--------------------------");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2014, 7, 2)), loanSchedule.get(1).get("dueDate"), "Checking for Due Date for 1st Month");
-        assertEquals(Float.parseFloat("416700"), loanSchedule.get(1).get("principalOriginalDue"),
-                "Checking for Principal Due for 1st Month");
-        assertEquals(Float.parseFloat("200000"), loanSchedule.get(1).get("interestOriginalDue"), "Checking for Interest Due for 1st Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2014, 8, 2)), loanSchedule.get(2).get("dueDate"), "Checking for Due Date for 2nd Month");
-        assertEquals(Float.parseFloat("416700"), loanSchedule.get(2).get("principalDue"), "Checking for Principal Due for 2nd Month");
-        assertEquals(Float.parseFloat("191700"), loanSchedule.get(2).get("interestOriginalDue"), "Checking for Interest Due for 2nd Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2014, 9, 2)), loanSchedule.get(3).get("dueDate"), "Checking for Due Date for 3rd Month");
-        assertEquals(Float.parseFloat("416700"), loanSchedule.get(3).get("principalDue"), "Checking for Principal Due for 3rd Month");
-        assertEquals(Float.parseFloat("183300"), loanSchedule.get(3).get("interestOriginalDue"), "Checking for Interest Due for 3rd Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2014, 10, 2)), loanSchedule.get(4).get("dueDate"),
-                "Checking for Due Date for 4th Month");
-        assertEquals(Float.parseFloat("416700"), loanSchedule.get(4).get("principalDue"), "Checking for Principal Due for 4th Month");
-        assertEquals(Float.parseFloat("175000"), loanSchedule.get(4).get("interestOriginalDue"), "Checking for Interest Due for 4th Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2014, 11, 2)), loanSchedule.get(5).get("dueDate"),
-                "Checking for Due Date for 5th Month");
-        assertEquals(Float.parseFloat("416700"), loanSchedule.get(5).get("principalDue"), "Checking for Principal Due for 5th Month");
-        assertEquals(Float.parseFloat("166700"), loanSchedule.get(5).get("interestOriginalDue"), "Checking for Interest Due for 5th Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2014, 12, 2)), loanSchedule.get(6).get("dueDate"),
-                "Checking for Due Date for 6th Month");
-        assertEquals(Float.parseFloat("416700"), loanSchedule.get(6).get("principalDue"), "Checking for Principal Due for 6th Month");
-        assertEquals(Float.parseFloat("158300"), loanSchedule.get(6).get("interestOriginalDue"), "Checking for Interest Due for 6th Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2015, 4, 2)), loanSchedule.get(10).get("dueDate"),
-                "Checking for Due Date for 10th Month");
-        assertEquals(Float.parseFloat("416700"), loanSchedule.get(10).get("principalDue"), "Checking for Principal Due for 10th Month");
-        assertEquals(Float.parseFloat("125000"), loanSchedule.get(10).get("interestOriginalDue"),
-                "Checking for Interest Due for 10th Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2016, 2, 2)), loanSchedule.get(20).get("dueDate"),
-                "Checking for Due Date for 20th Month");
-        assertEquals(Float.parseFloat("416700"), loanSchedule.get(20).get("principalDue"), "Checking for Principal Due for 20th Month");
-        assertEquals(Float.parseFloat("41700"), loanSchedule.get(20).get("interestOriginalDue"),
-                "Checking for Interest Due for 20th Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2016, 6, 2)), loanSchedule.get(24).get("dueDate"),
-                "Checking for Due Date for 24th Month");
-        assertEquals(Float.parseFloat("415900"), loanSchedule.get(24).get("principalDue"), "Checking for Principal Due for 24th Month");
-        assertEquals(Float.parseFloat("8300"), loanSchedule.get(24).get("interestOriginalDue"), "Checking for Interest Due for 24th Month");
-
-    }
-
-    private void verifyLoanRepaymentScheduleForEqualPrincipalWithGrace(final ArrayList<HashMap> loanSchedule) {
-        LOG.info("--------------------VERIFYING THE PRINCIPAL DUES,INTEREST DUE AND DUE DATE--------------------------");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2014, 7, 2)), loanSchedule.get(1).get("dueDate"), "Checking for Due Date for 1st Month");
-        validateNumberForEqualWithMsg("Checking for Principal Due for 1st Month",
-                String.valueOf(loanSchedule.get(1).get("principalOriginalDue")), "0.0");
-        assertEquals(Float.parseFloat("200000"), loanSchedule.get(1).get("interestOriginalDue"), "Checking for Interest Due for 1st Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2014, 8, 2)), loanSchedule.get(2).get("dueDate"), "Checking for Due Date for 2nd Month");
-        validateNumberForEqualWithMsg("Checking for Principal Due for 2nd Month", "0.0",
-                String.valueOf(loanSchedule.get(2).get("principalOriginalDue")));
-        assertEquals(Float.parseFloat("200000"), loanSchedule.get(2).get("interestOriginalDue"), "Checking for Interest Due for 2nd Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2014, 9, 2)), loanSchedule.get(3).get("dueDate"), "Checking for Due Date for 3rd Month");
-        validateNumberForEqualWithMsg("Checking for Principal Due for 3rd Month", "0.0",
-                String.valueOf(loanSchedule.get(3).get("principalDue")));
-        assertEquals(Float.parseFloat("200000"), loanSchedule.get(3).get("interestOriginalDue"), "Checking for Interest Due for 3rd Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2014, 10, 2)), loanSchedule.get(4).get("dueDate"),
-                "Checking for Due Date for 4th Month");
-        validateNumberForEqualWithMsg("Checking for Principal Due for 4th Month", "0",
-                String.valueOf(loanSchedule.get(4).get("principalDue")));
-        assertEquals(Float.parseFloat("200000"), loanSchedule.get(4).get("interestOriginalDue"), "Checking for Interest Due for 4th Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2014, 11, 2)), loanSchedule.get(5).get("dueDate"),
-                "Checking for Due Date for 5th Month");
-        validateNumberForEqualWithMsg("Checking for Principal Due for 5th Month", "0",
-                String.valueOf(loanSchedule.get(5).get("principalDue")));
-        assertEquals(Float.parseFloat("200000"), loanSchedule.get(5).get("interestOriginalDue"), "Checking for Interest Due for 5th Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2014, 12, 2)), loanSchedule.get(6).get("dueDate"),
-                "Checking for Due Date for 6th Month");
-        assertEquals(Float.parseFloat("526300"), loanSchedule.get(6).get("principalDue"), "Checking for Principal Due for 6th Month");
-        assertEquals(Float.parseFloat("200000"), loanSchedule.get(6).get("interestOriginalDue"), "Checking for Interest Due for 6th Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2015, 1, 2)), loanSchedule.get(7).get("dueDate"), "Checking for Due Date for 7th Month");
-        assertEquals(Float.parseFloat("526300"), loanSchedule.get(7).get("principalDue"), "Checking for Principal Due for 7th Month");
-        assertEquals(Float.parseFloat("189500"), loanSchedule.get(7).get("interestOriginalDue"), "Checking for Interest Due for 7th Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2015, 4, 2)), loanSchedule.get(10).get("dueDate"),
-                "Checking for Due Date for 10th Month");
-        assertEquals(Float.parseFloat("526300"), loanSchedule.get(10).get("principalDue"), "Checking for Principal Due for 10th Month");
-        assertEquals(Float.parseFloat("157900"), loanSchedule.get(10).get("interestOriginalDue"),
-                "Checking for Interest Due for 10th Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2016, 2, 2)), loanSchedule.get(20).get("dueDate"),
-                "Checking for Due Date for 20th Month");
-        assertEquals(Float.parseFloat("526300"), loanSchedule.get(20).get("principalDue"), "Checking for Principal Due for 20th Month");
-        assertEquals(Float.parseFloat("52600"), loanSchedule.get(20).get("interestOriginalDue"),
-                "Checking for Interest Due for 20th Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2016, 6, 2)), loanSchedule.get(24).get("dueDate"),
-                "Checking for Due Date for 24th Month");
-        assertEquals(Float.parseFloat("526600"), loanSchedule.get(24).get("principalDue"), "Checking for Principal Due for 24th Month");
-        assertEquals(Float.parseFloat("10500"), loanSchedule.get(24).get("interestOriginalDue"),
-                "Checking for Interest Due for 24th Month");
-    }
-
-    private void addCharges(List<HashMap> charges, Integer chargeId, String amount, String duedate) {
-        charges.add(charges(chargeId, amount, duedate));
-    }
-
-    private void addCollaterals(List<HashMap> collaterals, Integer collateralId, BigDecimal quantity) {
-        collaterals.add(collaterals(collateralId, quantity));
-    }
-
-    private HashMap charges(Integer chargeId, String amount, String duedate) {
-        HashMap charge = new HashMap(2);
-        charge.put("chargeId", chargeId.toString());
-        charge.put("amount", amount);
-        if (duedate != null) {
-            charge.put("dueDate", duedate);
+            checkAccrualTransactionForRepayment(transactionDate, interestPortion, feePortion, penaltyPortion, loanId);
         }
-        return charge;
     }
 
-    private HashMap<String, String> collaterals(Integer collateralId, BigDecimal quantity) {
-        HashMap<String, String> collateral = new HashMap<String, String>(2);
-        collateral.put("clientCollateralId", collateralId.toString());
-        collateral.put("quantity", quantity.toString());
-        return collateral;
-    }
-
-    private HashMap getloanCharge(Integer chargeId, List<HashMap> charges) {
-        HashMap charge = null;
-        for (HashMap loancharge : charges) {
-            if (loancharge.get("chargeId").equals(chargeId)) {
-                charge = loancharge;
+    /** Asserts that an accrual transaction on {@code transactionDate} carries the expected portions. */
+    private void checkAccrualTransactionForRepayment(final LocalDate transactionDate, final Float interestPortion, final Float feePortion,
+            final Float penaltyPortion, final Long loanId) {
+        boolean isAccrualTransactionFound = false;
+        for (GetLoansLoanIdTransactions transaction : getLoanDetails(loanId).getTransactions()) {
+            if (Boolean.TRUE.equals(transaction.getType().getAccrual()) && transactionDate.equals(transaction.getDate())) {
+                assertEquals(interestPortion, transaction.getInterestPortion().floatValue(), "Mismatch in transaction amounts");
+                assertEquals(feePortion, transaction.getFeeChargesPortion().floatValue(), "Mismatch in transaction amounts");
+                assertEquals(penaltyPortion, transaction.getPenaltyChargesPortion().floatValue(), "Mismatch in transaction amounts");
+                isAccrualTransactionFound = true;
+                break;
             }
         }
-        return charge;
+        assertTrue(isAccrualTransactionFound, "No accrual transaction found on " + transactionDate);
     }
 
-    private List<HashMap> copyChargesForUpdate(List<HashMap> charges, Integer deleteWithChargeId, String amount) {
-        List<HashMap> loanCharges = new ArrayList<>();
-        for (HashMap charge : charges) {
-            if (!charge.get("chargeId").equals(deleteWithChargeId)) {
-                loanCharges.add(copyForUpdate(charge, amount));
-            }
+    // ----------------------------------------------------------------------------------------------------
+    // Loan lifecycle helpers
+    // ----------------------------------------------------------------------------------------------------
+
+    /** Approves the loan for its full principal on {@code approvalDate}, as the RestAssured helper did. */
+    private GetLoansLoanIdResponse approveLoan(String approvalDate, Long loanId) {
+        approveLoan(loanId, new PostLoansLoanIdRequest().approvedOnDate(approvalDate).dateFormat(DATETIME_PATTERN).locale(LOCALE));
+        return getLoanDetails(loanId);
+    }
+
+    /** Disburses echoing the loan's own {@code netDisbursalAmount}, mirroring the RestAssured helper. */
+    private GetLoansLoanIdResponse disburseLoanWithNetDisbursalAmount(String date, Long loanId, String transactionAmount) {
+        BigDecimal netDisbursalAmount = getLoanDetails(loanId).getNetDisbursalAmount();
+        PostLoansLoanIdRequest request = new PostLoansLoanIdRequest()//
+                .actualDisbursementDate(date)//
+                .dateFormat(DATETIME_PATTERN)//
+                .locale(LOCALE)//
+                .netDisbursalAmount(netDisbursalAmount);
+        if (transactionAmount != null) {
+            request.transactionAmount(toAmount(transactionAmount));
         }
-        return loanCharges;
+        disburseLoan(loanId, request);
+        return getLoanDetails(loanId);
     }
 
-    private HashMap copyForUpdate(HashMap charge, String amount) {
-        HashMap map = new HashMap();
-        map.put("id", charge.get("id"));
-        if (amount == null) {
-            map.put("amount", charge.get("amountOrPercentage"));
-        } else {
-            map.put("amount", amount);
+    private GetLoansLoanIdResponse disburseLoanWithNetDisbursalAmount(String date, Long loanId) {
+        return disburseLoanWithNetDisbursalAmount(date, loanId, null);
+    }
+
+    /** Disburses a tranche of {@code transactionAmount} without echoing a net disbursal amount. */
+    private GetLoansLoanIdResponse disburseLoanWithTransactionAmount(Long loanId, String date, String transactionAmount) {
+        disburseLoan(loanId, new PostLoansLoanIdRequest()//
+                .actualDisbursementDate(date)//
+                .dateFormat(DATETIME_PATTERN)//
+                .locale(LOCALE)//
+                .transactionAmount(toAmount(transactionAmount)));
+        return getLoanDetails(loanId);
+    }
+
+    /** Disburses into the loan's linked savings account, echoing the loan's own {@code netDisbursalAmount}. */
+    private GetLoansLoanIdResponse disburseToSavingsWithNetDisbursalAmount(String date, Long loanId) {
+        BigDecimal netDisbursalAmount = getLoanDetails(loanId).getNetDisbursalAmount();
+        disburseToSavings(loanId, new PostLoansLoanIdRequest()//
+                .actualDisbursementDate(date)//
+                .dateFormat(DATETIME_PATTERN)//
+                .locale(LOCALE)//
+                .netDisbursalAmount(netDisbursalAmount));
+        return getLoanDetails(loanId);
+    }
+
+    private void waiveInterestOnLoan(Long loanId, String date, double amountToBeWaived) {
+        addInterestWaiver(loanId, LoanRequestBuilders.waiveInterest(amountToBeWaived, date));
+    }
+
+    /**
+     * Repays a loan through the interoperation API, which addresses the loan by account number. That endpoint forwards
+     * its body straight to the standard loan repayment command, so it takes {@code PostLoansLoanIdTransactionsRequest}.
+     */
+    private String makeRepaymentByAccountNo(String accountNo, String transactionDate, Float transactionAmount) {
+        PostLoansLoanIdTransactionsRequest request = new PostLoansLoanIdTransactionsRequest()//
+                .transactionDate(transactionDate)//
+                .transactionAmount(transactionAmount.doubleValue())//
+                .note("Repayment Made!!!")//
+                .locale(INTEROP_LOCALE)//
+                .dateFormat(DATETIME_PATTERN);
+        return ok(() -> FineractFeignClientHelper.getFineractFeignClient().interOperation().loanRepayment(accountNo, request));
+    }
+
+    /** Asserts that no accrual transaction has been posted on the loan. */
+    private void assertNoAccrualTransactions(Long loanId) {
+        for (GetLoansLoanIdTransactions transaction : getLoanDetails(loanId).getTransactions()) {
+            assertFalse(Boolean.TRUE.equals(transaction.getType().getAccrual()), "Accrual entries are posted!");
         }
-        if (charge.get("dueDate") != null) {
-            map.put("dueDate", DATE_TIME_FORMATTER.format(fromArrayToLocalDate((List) charge.get("dueDate"))));
-        }
-        map.put("chargeId", charge.get("chargeId"));
-        return map;
     }
 
-    private LocalDate fromArrayToLocalDate(List<Integer> dueDate) {
-        return LocalDate.of(dueDate.get(0), dueDate.get(1), dueDate.get(2));
+    private void verifyClientCreatedOnServer(Long clientId) {
+        assertNotNull(clientHelper.getClient(clientId), "Client not found on server: " + clientId);
     }
 
-    private HashMap createTrancheDetail(final String date, final String amount) {
-        HashMap detail = new HashMap();
-        detail.put("expectedDisbursementDate", date);
-        detail.put("principal", amount);
-
-        return detail;
+    private void verifyLoanIsPending(Long loanId) {
+        verifyLoanStatus(getLoanDetails(loanId), LoanStatus.SUBMITTED_AND_PENDING_APPROVAL);
     }
 
-    private void testLoanScheduleWithInterestRecalculation_FOR_PRE_CLOSE_WITH_MORATORIUM(final String preCloseStrategy,
+    private void verifyLoanIsApprovedAndWaitingForDisbursal(GetLoansLoanIdResponse loanDetails) {
+        verifyLoanStatus(loanDetails, LoanStatus.APPROVED);
+        verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getWaitingForDisbursal);
+    }
+
+    private void verifyLoanIsActive(GetLoansLoanIdResponse loanDetails) {
+        verifyLoanStatus(loanDetails, LoanStatus.ACTIVE);
+    }
+
+    private void verifyLoanAccountIsClosed(Long loanId) {
+        verifyLoanStatus(getLoanDetails(loanId), GetLoansLoanIdStatus::getClosed);
+    }
+
+    private String todayAsString(DateFormat dateFormat) {
+        return dateFormat.format(Calendar.getInstance(Utils.getTimeZoneOfTenant()).getTime());
+    }
+
+    private String prepayAmount(Long loanId, String date) {
+        return String.valueOf(getPrepayAmount(loanId, date).getAmount());
+    }
+
+    // ----------------------------------------------------------------------------------------------------
+    // Shared interest-recalculation test bodies
+    // ----------------------------------------------------------------------------------------------------
+
+    private void testLoanScheduleWithInterestRecalculation_FOR_PRE_CLOSE_WITH_MORATORIUM(final Integer preCloseStrategy,
             final String preCloseAmount) {
-
         DateFormat dateFormat = new SimpleDateFormat(DATETIME_PATTERN, Locale.US);
         dateFormat.setTimeZone(Utils.getTimeZoneOfTenant());
 
         Calendar todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -1);
-        final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todaysDate.getTime());
+        final String loanDisbursementDate = dateFormat.format(todaysDate.getTime());
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProductWithInterestRecalculation(LoanProductTestBuilder.DEFAULT_STRATEGY,
-                LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_NONE,
-                LoanProductTestBuilder.RECALCULATION_STRATEGY_REDUCE_EMI_AMOUN,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_SAME_AS_REPAYMENT_PERIOD, "0", null, preCloseStrategy, null, null,
-                null);
+        final Long clientId = createClient();
+        final Long loanProductId = createLoanProductWithInterestRecalculation(DEFAULT_STRATEGY,
+                LoanTestData.InterestRecalculationCompoundingMethod.NONE, LoanTestData.RescheduleStrategyMethod.REDUCE_EMI_AMOUNT,
+                LoanTestData.RecalculationRestFrequencyType.SAME_AS_REPAYMENT_PERIOD, 0, preCloseStrategy, null, null, null);
 
-        final Integer loanID = applyForLoanApplicationForInterestRecalculationWithMoratorium(clientID, loanProductID,
-                LOAN_DISBURSEMENT_DATE, LoanApplicationTestBuilder.DEFAULT_STRATEGY, new ArrayList<HashMap>(0), "1", null);
+        final Long loanId = applyForLoanApplicationForInterestRecalculationWithMoratorium(clientId, loanProductId, loanDisbursementDate,
+                DEFAULT_STRATEGY, Collections.emptyList(), 1, null);
 
-        Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        Assertions.assertNotNull(loanId);
+        verifyLoanIsPending(loanId);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        List<Map<String, Object>> expectedvalues = new ArrayList<>();
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanId);
+        List<ExpectedInstallment> expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -1);
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2482.76", "0.0", "0.0", "0.0");
@@ -7757,17 +7917,12 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(loanDisbursementDate, loanId));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(loanDisbursementDate, loanId));
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanId);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -1);
@@ -7775,317 +7930,37 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2494.22", "80.84", "0.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2505.73", "23.18", "0.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2517.29", "11.62", "0.0", "0.0");
-
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
-        HashMap prepayDetail = LOAN_TRANSACTION_HELPER.getPrepayAmount(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        String prepayAmount = String.valueOf(prepayDetail.get("amount"));
+        final String loanRepaymentDate = todayAsString(dateFormat);
+        String prepayAmount = prepayAmount(loanId, loanRepaymentDate);
         validateNumberForEqualWithMsg("verify pre-close amount", preCloseAmount, prepayAmount);
-        todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
-        final String loanRepaymentDate = dateFormat.format(todaysDate.getTime());
-        LOAN_TRANSACTION_HELPER.makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanID);
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
-    }
-
-    private void addRepaymentValues(List<Map<String, Object>> expectedvalues, Calendar todaysDate, int addPeriod, boolean isAddDays,
-            String principalDue, String interestDue, String feeChargesDue, String penaltyChargesDue) {
-        Map<String, Object> values = new HashMap<>(3);
-        if (isAddDays) {
-            values.put("dueDate", getDateAsArray(todaysDate, addPeriod));
-        } else {
-            values.put("dueDate", getDateAsArray(todaysDate, addPeriod * 7));
-        }
-        LOG.info("Updated date {}", values.get("dueDate"));
-        values.put("principalDue", principalDue);
-        values.put("interestDue", interestDue);
-        values.put("feeChargesDue", feeChargesDue);
-        values.put("penaltyChargesDue", penaltyChargesDue);
-        expectedvalues.add(values);
-    }
-
-    private List getDateAsArray(Calendar todaysDate, int addPeriod) {
-        return getDateAsArray(todaysDate, addPeriod, Calendar.DAY_OF_MONTH);
-    }
-
-    private List getDateAsArray(Calendar todaysDate, int addvalue, int type) {
-        todaysDate.add(type, addvalue);
-        return new ArrayList<>(
-                Arrays.asList(todaysDate.get(Calendar.YEAR), todaysDate.get(Calendar.MONTH) + 1, todaysDate.get(Calendar.DAY_OF_MONTH)));
-    }
-
-    private Integer createLoanProductWithInterestRecalculation(final String repaymentStrategy,
-            final String interestRecalculationCompoundingMethod, final String rescheduleStrategyMethod,
-            final String recalculationRestFrequencyType, final String recalculationRestFrequencyInterval,
-            final String recalculationRestFrequencyDate, final String preCloseInterestCalculationStrategy, final Account[] accounts,
-            final Integer recalculationRestFrequencyOnDayType, final Integer recalculationRestFrequencyDayOfWeekType) {
-        final String recalculationCompoundingFrequencyType = null;
-        final String recalculationCompoundingFrequencyInterval = null;
-        final String recalculationCompoundingFrequencyDate = null;
-        final Integer recalculationCompoundingFrequencyOnDayType = null;
-        final Integer recalculationCompoundingFrequencyDayOfWeekType = null;
-        return createLoanProductWithInterestRecalculation(repaymentStrategy, interestRecalculationCompoundingMethod,
-                rescheduleStrategyMethod, recalculationRestFrequencyType, recalculationRestFrequencyInterval,
-                recalculationRestFrequencyDate, recalculationCompoundingFrequencyType, recalculationCompoundingFrequencyInterval,
-                recalculationCompoundingFrequencyDate, preCloseInterestCalculationStrategy, accounts, null, false,
-                recalculationCompoundingFrequencyOnDayType, recalculationCompoundingFrequencyDayOfWeekType,
-                recalculationRestFrequencyOnDayType, recalculationRestFrequencyDayOfWeekType);
-    }
-
-    private Integer createLoanProductWithInterestRecalculationAndCompoundingDetails(final String repaymentStrategy,
-            final String interestRecalculationCompoundingMethod, final String rescheduleStrategyMethod,
-            final String recalculationRestFrequencyType, final String recalculationRestFrequencyInterval,
-            final String recalculationRestFrequencyDate, final String recalculationCompoundingFrequencyType,
-            final String recalculationCompoundingFrequencyInterval, final String recalculationCompoundingFrequencyDate,
-            final String preCloseInterestCalculationStrategy, final Account[] accounts,
-            final Integer recalculationCompoundingFrequencyOnDayType, final Integer recalculationCompoundingFrequencyDayOfWeekType,
-            final Integer recalculationRestFrequencyOnDayType, final Integer recalculationRestFrequencyDayOfWeekType) {
-        return createLoanProductWithInterestRecalculation(repaymentStrategy, interestRecalculationCompoundingMethod,
-                rescheduleStrategyMethod, recalculationRestFrequencyType, recalculationRestFrequencyInterval,
-                recalculationRestFrequencyDate, recalculationCompoundingFrequencyType, recalculationCompoundingFrequencyInterval,
-                recalculationCompoundingFrequencyDate, preCloseInterestCalculationStrategy, accounts, null, false,
-                recalculationCompoundingFrequencyOnDayType, recalculationCompoundingFrequencyDayOfWeekType,
-                recalculationRestFrequencyOnDayType, recalculationRestFrequencyDayOfWeekType);
-    }
-
-    private Integer createLoanProductWithInterestRecalculation(final String repaymentStrategy,
-            final String interestRecalculationCompoundingMethod, final String rescheduleStrategyMethod,
-            final String recalculationRestFrequencyType, final String recalculationRestFrequencyInterval,
-            final String recalculationRestFrequencyDate, final String recalculationCompoundingFrequencyType,
-            final String recalculationCompoundingFrequencyInterval, final String recalculationCompoundingFrequencyDate,
-            final String preCloseInterestCalculationStrategy, final Account[] accounts, final String chargeId,
-            boolean isArrearsBasedOnOriginalSchedule, final Integer recalculationCompoundingFrequencyOnDayType,
-            final Integer recalculationCompoundingFrequencyDayOfWeekType, final Integer recalculationRestFrequencyOnDayType,
-            final Integer recalculationRestFrequencyDayOfWeekType) {
-        LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-        LoanProductTestBuilder builder = new LoanProductTestBuilder().withPrincipal("10000000.00").withNumberOfRepayments("24")
-                .withRepaymentAfterEvery("1").withRepaymentTypeAsWeek().withinterestRatePerPeriod("2")
-                .withInterestRateFrequencyTypeAsMonths().withRepaymentStrategy(repaymentStrategy)
-                .withAmortizationTypeAsEqualPrincipalPayment().withInterestCalculationPeriodTypeAsRepaymentPeriod(true)
-                .withInterestTypeAsDecliningBalance()
-                .withInterestRecalculationDetails(interestRecalculationCompoundingMethod, rescheduleStrategyMethod,
-                        preCloseInterestCalculationStrategy)
-                .withInterestRecalculationRestFrequencyDetails(recalculationRestFrequencyType, recalculationRestFrequencyInterval,
-                        recalculationRestFrequencyOnDayType, recalculationRestFrequencyDayOfWeekType)
-                .withInterestRecalculationCompoundingFrequencyDetails(recalculationCompoundingFrequencyType,
-                        recalculationCompoundingFrequencyInterval, recalculationCompoundingFrequencyOnDayType,
-                        recalculationCompoundingFrequencyDayOfWeekType);
-        if (accounts != null) {
-            builder = builder.withAccountingRulePeriodicAccrual(accounts);
-        }
-
-        if (isArrearsBasedOnOriginalSchedule) {
-            builder = builder.withArrearsConfiguration();
-        }
-
-        final String loanProductJSON = builder.build(chargeId);
-        return LOAN_TRANSACTION_HELPER.getLoanProductId(loanProductJSON);
-    }
-
-    private Integer createLoanProductWithInterestRecalculationAndCompoundingDetails(final String repaymentStrategy,
-            final String interestRecalculationCompoundingMethod, final String rescheduleStrategyMethod,
-            final String recalculationRestFrequencyType, final String preCloseInterestCalculationStrategy, final Account[] accounts,
-            final String installmentMultipleOf) {
-        final String recalculationCompoundingFrequencyType = null;
-        final String recalculationCompoundingFrequencyInterval = null;
-        final Integer recalculationCompoundingFrequencyOnDayType = null;
-        final Integer recalculationCompoundingFrequencyDayOfWeekType = null;
-        return createLoanProductWithInterestRecalculation(repaymentStrategy, interestRecalculationCompoundingMethod,
-                rescheduleStrategyMethod, recalculationCompoundingFrequencyType, recalculationCompoundingFrequencyInterval,
-                preCloseInterestCalculationStrategy, accounts, null, false, recalculationCompoundingFrequencyOnDayType,
-                recalculationCompoundingFrequencyDayOfWeekType, installmentMultipleOf);
-    }
-
-    private Integer createLoanProductWithInterestRecalculation(final String repaymentStrategy,
-            final String interestRecalculationCompoundingMethod, final String rescheduleStrategyMethod,
-            final String recalculationCompoundingFrequencyType, final String recalculationCompoundingFrequencyInterval,
-            final String preCloseInterestCalculationStrategy, final Account[] accounts, final String chargeId,
-            boolean isArrearsBasedOnOriginalSchedule, final Integer recalculationCompoundingFrequencyOnDayType,
-            final Integer recalculationCompoundingFrequencyDayOfWeekType, final String installmentsMultiplesOf) {
-        LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-        LoanProductTestBuilder builder = new LoanProductTestBuilder().withPrincipal("10000.00").withNumberOfRepayments("12")
-                .withRepaymentAfterEvery("1").withRepaymentTypeAsMonth().withinterestRatePerPeriod("19.9")
-                .withInterestRateFrequencyTypeAsMonths().withRepaymentStrategy(repaymentStrategy).withAmortizationTypeAsEqualInstallments()
-                .withInterestTypeAsDecliningBalance().withInterestCalculationPeriodTypeAsDays()
-                .withInterestRecalculationDetails(interestRecalculationCompoundingMethod, rescheduleStrategyMethod,
-                        preCloseInterestCalculationStrategy)
-                .withInterestRecalculationDetails(interestRecalculationCompoundingMethod, rescheduleStrategyMethod,
-                        preCloseInterestCalculationStrategy)
-                .withInterestRecalculationCompoundingFrequencyDetails(recalculationCompoundingFrequencyType,
-                        recalculationCompoundingFrequencyInterval, recalculationCompoundingFrequencyOnDayType,
-                        recalculationCompoundingFrequencyDayOfWeekType)
-                .withDefineInstallmentAmount(true).withInstallmentAmountInMultiplesOf(installmentsMultiplesOf);
-        if (accounts != null) {
-            builder = builder.withAccountingRulePeriodicAccrual(accounts);
-        }
-
-        if (isArrearsBasedOnOriginalSchedule) {
-            builder = builder.withArrearsConfiguration();
-        }
-
-        final String loanProductJSON = builder.build(chargeId);
-        return LOAN_TRANSACTION_HELPER.getLoanProductId(loanProductJSON);
-    }
-
-    private Integer applyForLoanApplicationForInterestRecalculation(final Integer clientID, final Integer loanProductID,
-            final String disbursementDate, final String repaymentStrategy, final String firstRepaymentDate) {
-        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
-        Assertions.assertNotNull(collateralId);
-        List<HashMap> collaterals = new ArrayList<>();
-
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
-        Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
-
-        final String loanApplicationJSON = new LoanApplicationTestBuilder() //
-                .withPrincipal("10000.00") //
-                .withLoanTermFrequency("12") //
-                .withLoanTermFrequencyAsMonths() //
-                .withNumberOfRepayments("12") //
-                .withRepaymentEveryAfter("1") //
-                .withLoanTermFrequencyAsMonths() //
-                .withInterestRatePerPeriod("19.9") //
-                .withAmortizationTypeAsEqualInstallments() //
-                .withInterestTypeAsDecliningBalance() //
-                .withInterestCalculationPeriodTypeAsDays() //
-                .withExpectedDisbursementDate(disbursementDate) //
-                .withSubmittedOnDate(disbursementDate) //
-                .withRepaymentStrategy(repaymentStrategy).withRepaymentFrequencyTypeAsMonths()//
-                .withFirstRepaymentDate(firstRepaymentDate).withCollaterals(collaterals)
-                .build(clientID.toString(), loanProductID.toString(), null);
-        return LOAN_TRANSACTION_HELPER.getLoanId(loanApplicationJSON);
-    }
-
-    private Integer applyForLoanApplicationForInterestRecalculation(final Integer clientID, final Integer loanProductID,
-            final String disbursementDate, final String repaymentStrategy, final List<HashMap> charges) {
-        return applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, disbursementDate, repaymentStrategy, charges, null,
-                null);
-    }
-
-    private Integer applyForLoanApplicationForInterestRecalculationWithMoratorium(final Integer clientID, final Integer loanProductID,
-            final String disbursementDate, final String repaymentStrategy, final List<HashMap> charges, final String graceOnInterestPayment,
-            final String graceOnPrincipalPayment) {
-        return applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, disbursementDate, repaymentStrategy, charges,
-                graceOnInterestPayment, graceOnPrincipalPayment);
-    }
-
-    private Integer applyForLoanApplicationForInterestRecalculation(final Integer clientID, final Integer loanProductID,
-            final String disbursementDate, final String compoundingStartDate, final String repaymentStrategy, final List<HashMap> charges) {
-        return applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, disbursementDate, repaymentStrategy, charges, null,
-                null);
-    }
-
-    private Integer applyForLoanApplicationForInterestRecalculation(final Integer clientID, final Integer loanProductID,
-            final String disbursementDate, final String repaymentStrategy, final List<HashMap> charges, final String graceOnInterestPayment,
-            final String graceOnPrincipalPayment) {
-        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
-        Assertions.assertNotNull(collateralId);
-        List<HashMap> collaterals = new ArrayList<>();
-
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
-        Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
-
-        final String loanApplicationJSON = new LoanApplicationTestBuilder() //
-                .withPrincipal("10000.00") //
-                .withLoanTermFrequency("4") //
-                .withLoanTermFrequencyAsWeeks() //
-                .withNumberOfRepayments("4") //
-                .withRepaymentEveryAfter("1") //
-                .withRepaymentFrequencyTypeAsWeeks() //
-                .withInterestRatePerPeriod("2") //
-                .withAmortizationTypeAsEqualInstallments() //
-                .withInterestTypeAsDecliningBalance() //
-                .withInterestCalculationPeriodTypeSameAsRepaymentPeriod() //
-                .withExpectedDisbursementDate(disbursementDate) //
-                .withSubmittedOnDate(disbursementDate) //
-                .withRepaymentStrategy(repaymentStrategy) //
-                .withPrincipalGrace(graceOnPrincipalPayment) //
-                .withInterestGrace(graceOnInterestPayment)//
-                .withCharges(charges)//
-                .withCollaterals(collaterals).build(clientID.toString(), loanProductID.toString(), null);
-        return LOAN_TRANSACTION_HELPER.getLoanId(loanApplicationJSON);
-    }
-
-    private void verifyLoanRepaymentSchedule(final ArrayList<HashMap> loanSchedule, List<Map<String, Object>> expectedvalues) {
-        int index = 1;
-        verifyLoanRepaymentSchedule(loanSchedule, expectedvalues, index);
-
-    }
-
-    private void verifyLoanRepaymentSchedule(final ArrayList<HashMap> loanSchedule, List<Map<String, Object>> expectedvalues, int index) {
-        LOG.info("--------------------VERIFYING THE PRINCIPAL DUES,INTEREST DUE AND DUE DATE--------------------------");
-        for (Map<String, Object> values : expectedvalues) {
-            assertEquals(values.get("dueDate"), loanSchedule.get(index).get("dueDate"), "Checking for Due Date for  installment " + index);
-            validateNumberForEqualWithMsg("Checking for Principal Due for installment " + index, String.valueOf(values.get("principalDue")),
-                    String.valueOf(loanSchedule.get(index).get("principalDue")));
-            validateNumberForEqualWithMsg("Checking for Interest Due for installment " + index, String.valueOf(values.get("interestDue")),
-                    String.valueOf(loanSchedule.get(index).get("interestDue")));
-            validateNumberForEqualWithMsg("Checking for Fee charge Due for installment " + index,
-                    String.valueOf(values.get("feeChargesDue")), String.valueOf(loanSchedule.get(index).get("feeChargesDue")));
-            validateNumberForEqualWithMsg("Checking for Penalty charge Due for installment " + index,
-                    String.valueOf(values.get("penaltyChargesDue")), String.valueOf(loanSchedule.get(index).get("penaltyChargesDue")));
-            index++;
-        }
-    }
-
-    private void checkAccrualTransactions(final ArrayList<HashMap> loanSchedule, final Integer loanID) {
-
-        for (int i = 1; i < loanSchedule.size(); i++) {
-
-            final HashMap repayment = loanSchedule.get(i);
-
-            final ArrayList<Integer> dueDateAsArray = (ArrayList<Integer>) repayment.get("dueDate");
-            final LocalDate transactionDate = LocalDate.of(dueDateAsArray.get(0), dueDateAsArray.get(1), dueDateAsArray.get(2));
-
-            final Float interestPortion = BigDecimal.valueOf(Double.parseDouble(repayment.get("interestDue").toString()))
-                    .subtract(BigDecimal.valueOf(Double.parseDouble(repayment.get("interestWaived").toString())))
-                    .subtract(BigDecimal.valueOf(Double.parseDouble(repayment.get("interestWrittenOff").toString()))).floatValue();
-
-            final Float feePortion = BigDecimal.valueOf(Double.parseDouble(repayment.get("feeChargesDue").toString()))
-                    .subtract(BigDecimal.valueOf(Double.parseDouble(repayment.get("feeChargesWaived").toString())))
-                    .subtract(BigDecimal.valueOf(Double.parseDouble(repayment.get("feeChargesWrittenOff").toString()))).floatValue();
-
-            final Float penaltyPortion = BigDecimal.valueOf(Double.parseDouble(repayment.get("penaltyChargesDue").toString()))
-                    .subtract(BigDecimal.valueOf(Double.parseDouble(repayment.get("penaltyChargesWaived").toString())))
-                    .subtract(BigDecimal.valueOf(Double.parseDouble(repayment.get("penaltyChargesWrittenOff").toString()))).floatValue();
-
-            LOAN_TRANSACTION_HELPER.checkAccrualTransactionForRepayment(transactionDate, interestPortion, feePortion, penaltyPortion,
-                    loanID);
-        }
+        makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanId);
+        verifyLoanAccountIsClosed(loanId);
     }
 
     private void testLoanScheduleWithInterestRecalculation_WITH_REST_SAME_AS_REPAYMENT_INTEREST_COMPOUND_NONE_STRATEGY_REDUCE_EMI_PRE_CLOSE_INTEREST(
-            String preCloseInterestStrategy, String preCloseAmount) {
-
+            Integer preCloseInterestStrategy, String preCloseAmount) {
         DateFormat dateFormat = new SimpleDateFormat(DATETIME_PATTERN, Locale.US);
         dateFormat.setTimeZone(Utils.getTimeZoneOfTenant());
 
         Calendar todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -16);
-        final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todaysDate.getTime());
+        final String loanDisbursementDate = dateFormat.format(todaysDate.getTime());
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProductWithInterestRecalculation(LoanProductTestBuilder.DEFAULT_STRATEGY,
-                LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_NONE,
-                LoanProductTestBuilder.RECALCULATION_STRATEGY_REDUCE_EMI_AMOUN,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_SAME_AS_REPAYMENT_PERIOD, "0", null, preCloseInterestStrategy, null,
-                null, null);
+        final Long clientId = createClient();
+        final Long loanProductId = createLoanProductWithInterestRecalculation(DEFAULT_STRATEGY,
+                LoanTestData.InterestRecalculationCompoundingMethod.NONE, LoanTestData.RescheduleStrategyMethod.REDUCE_EMI_AMOUNT,
+                LoanTestData.RecalculationRestFrequencyType.SAME_AS_REPAYMENT_PERIOD, 0, preCloseInterestStrategy, null, null, null);
 
-        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE, null,
-                LoanApplicationTestBuilder.DEFAULT_STRATEGY, new ArrayList<HashMap>(0));
+        final Long loanId = applyForLoanApplicationForInterestRecalculation(clientId, loanProductId, loanDisbursementDate, DEFAULT_STRATEGY,
+                Collections.emptyList());
 
-        Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        Assertions.assertNotNull(loanId);
+        verifyLoanIsPending(loanId);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        List<Map<String, Object>> expectedvalues = new ArrayList<>();
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanId);
+        List<ExpectedInstallment> expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -9, true, "2482.76", "46.15", "0.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2494.22", "34.69", "0.0", "0.0");
@@ -8094,33 +7969,27 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(loanDisbursementDate, loanId));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(loanDisbursementDate, loanId));
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanId);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -9, true, "2482.76", "46.15", "0.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2482.76", "46.15", "0.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2482.76", "46.15", "0.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2551.72", "11.78", "0.0", "0.0");
-
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -9);
-        final String LOAN_FIRST_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
-        Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        final String loanFirstRepaymentDate = dateFormat.format(todaysDate.getTime());
+        float totalDueForCurrentPeriod = loanSchedule.get(1).getTotalDueForPeriod().floatValue();
+        makeRepayment(loanFirstRepaymentDate, totalDueForCurrentPeriod, loanId);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanId);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -9, true, "2482.76", "46.15", "0.0", "0.0");
@@ -8129,63 +7998,54 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2528.8", "11.67", "0.0", "0.0");
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
-        HashMap prepayDetail = LOAN_TRANSACTION_HELPER.getPrepayAmount(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        String prepayAmount = String.valueOf(prepayDetail.get("amount"));
+        final String loanRepaymentDate = todayAsString(dateFormat);
+        String prepayAmount = prepayAmount(loanId, loanRepaymentDate);
         validateNumberForEqualWithMsg("verify pre-close amount", preCloseAmount, prepayAmount);
-        todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
-        final String loanRepaymentDate = dateFormat.format(todaysDate.getTime());
-        LOAN_TRANSACTION_HELPER.makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanID);
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
+        makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanId);
+        verifyLoanAccountIsClosed(loanId);
     }
 
     private void testLoanScheduleWithInterestRecalculation_WITH_REST_WEEKLY_INTEREST_COMPOUND_INTEREST_FEE_STRATEGY_REDUCE_NEXT_INSTALLMENTS_PRE_CLOSE_INTEREST(
-            String preCloseInterestStrategy, String preCloseAmount) {
-
+            Integer preCloseInterestStrategy, String preCloseAmount) {
         DateFormat dateFormat = new SimpleDateFormat(DATETIME_PATTERN, Locale.US);
         dateFormat.setTimeZone(Utils.getTimeZoneOfTenant());
 
         Calendar todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -16);
-        final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todaysDate.getTime());
+        final String loanDisbursementDate = dateFormat.format(todaysDate.getTime());
         todaysDate.add(Calendar.DAY_OF_MONTH, -4);
         Integer restDateOfMonth = getDayOfMonth(todaysDate);
         Integer restDateOfWeek = getDayOfWeek(todaysDate);
-        final String REST_START_DATE = null;
 
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -16);
         todaysDate.add(Calendar.DAY_OF_MONTH, 2);
-        final String LOAN_FLAT_CHARGE_DATE = dateFormat.format(todaysDate.getTime());
+        final String loanFlatChargeDate = dateFormat.format(todaysDate.getTime());
         todaysDate.add(Calendar.DAY_OF_MONTH, 14);
-        final String LOAN_INTEREST_CHARGE_DATE = dateFormat.format(todaysDate.getTime());
-        List<HashMap> charges = new ArrayList<>(2);
-        Integer flat = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "100", false));
-        Integer principalPercentage = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "2", false));
+        final String loanInterestChargeDate = dateFormat.format(todaysDate.getTime());
 
-        addCharges(charges, flat, "100", LOAN_FLAT_CHARGE_DATE);
-        addCharges(charges, principalPercentage, "2", LOAN_INTEREST_CHARGE_DATE);
+        List<PostLoansRequestChargeData> charges = new ArrayList<>(2);
+        Long flat = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.FLAT, 100.0, false).getResourceId();
+        Long principalPercentage = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 2.0, false)
+                .getResourceId();
+        addCharges(charges, flat, 100.0, loanFlatChargeDate);
+        addCharges(charges, principalPercentage, 2.0, loanInterestChargeDate);
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProductWithInterestRecalculationAndCompoundingDetails(
-                LoanProductTestBuilder.DEFAULT_STRATEGY, LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_INTEREST_AND_FEE,
-                LoanProductTestBuilder.RECALCULATION_STRATEGY_RESCHEDULE_NEXT_REPAYMENTS,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_WEEKLY, "1", REST_START_DATE,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_SAME_AS_REPAYMENT_PERIOD, null, null, preCloseInterestStrategy, null,
-                null, null, restDateOfMonth, restDateOfWeek);
+        final Long clientId = createClient();
+        final Long loanProductId = createLoanProductWithInterestRecalculationAndCompoundingDetails(DEFAULT_STRATEGY,
+                LoanTestData.InterestRecalculationCompoundingMethod.INTEREST_AND_FEE,
+                LoanTestData.RescheduleStrategyMethod.RESCHEDULE_NEXT_REPAYMENTS, LoanTestData.RecalculationRestFrequencyType.WEEKLY, 1,
+                LoanTestData.RecalculationCompoundingFrequencyType.SAME_AS_REPAYMENT_PERIOD, null, preCloseInterestStrategy, null, null,
+                null, restDateOfMonth, restDateOfWeek);
 
-        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
-                REST_START_DATE, LoanApplicationTestBuilder.DEFAULT_STRATEGY, charges);
+        final Long loanId = applyForLoanApplicationForInterestRecalculation(clientId, loanProductId, loanDisbursementDate, DEFAULT_STRATEGY,
+                charges);
 
-        Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        Assertions.assertNotNull(loanId);
+        verifyLoanIsPending(loanId);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        List<Map<String, Object>> expectedvalues = new ArrayList<>();
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanId);
+        List<ExpectedInstallment> expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -9, true, "2482.76", "46.15", "100.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2494.22", "34.69", "0.0", "0.0");
@@ -8194,33 +8054,27 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(loanDisbursementDate, loanId));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(loanDisbursementDate, loanId));
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanId);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -9, true, "2482.76", "46.15", "100.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2482.08", "46.83", "0.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2481.87", "47.04", "200", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2553.29", "11.78", "0.0", "0.0");
-
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         Calendar repaymentDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         repaymentDate.add(Calendar.DAY_OF_MONTH, -9);
-        final String LOAN_FIRST_REPAYMENT_DATE = dateFormat.format(repaymentDate.getTime());
-        Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        final String loanFirstRepaymentDate = dateFormat.format(repaymentDate.getTime());
+        float totalDueForCurrentPeriod = loanSchedule.get(1).getTotalDueForPeriod().floatValue();
+        makeRepayment(loanFirstRepaymentDate, totalDueForCurrentPeriod, loanId);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanId);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -9, true, "2482.76", "46.15", "100.0", "0.0");
@@ -8229,40 +8083,11 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2528.97", "11.67", "0.0", "0.0");
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
-        HashMap prepayDetail = LOAN_TRANSACTION_HELPER.getPrepayAmount(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        String prepayAmount = String.valueOf(prepayDetail.get("amount"));
+        final String loanRepaymentDate = todayAsString(dateFormat);
+        String prepayAmount = prepayAmount(loanId, loanRepaymentDate);
         validateNumberForEqualWithMsg("verify pre-close amount", preCloseAmount, prepayAmount);
-        todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
-        final String loanRepaymentDate = dateFormat.format(todaysDate.getTime());
-        LOAN_TRANSACTION_HELPER.makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanID);
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
-    }
-
-    private Integer createSavingsProduct(final String minOpenningBalance) {
-        LOG.info("------------------------------CREATING NEW SAVINGS PRODUCT ---------------------------------------");
-        SavingsProductHelper savingsProductHelper = new SavingsProductHelper();
-
-        final String savingsProductJSON = savingsProductHelper
-                //
-                .withInterestCompoundingPeriodTypeAsDaily()
-                //
-                .withInterestPostingPeriodTypeAsMonthly()
-                //
-                .withInterestCalculationPeriodTypeAsDailyBalance()
-
-                .withMinimumOpenningBalance(minOpenningBalance).build();
-        return SavingsProductHelper.createSavingsProduct(savingsProductJSON, REQUEST_SPEC, RESPONSE_SPEC);
-    }
-
-    private PostLoansResponse applyForLoanApplicationForOnePeriod30DaysLongNoInterestPeriodicAccrual(Long clientId, Long loanProductId,
-            String loanDisbursementDate, String repaymentStrategyCode) {
-        return LOAN_TRANSACTION_HELPER.applyLoan(new PostLoansRequest().clientId(clientId.longValue()).productId(loanProductId)
-                .expectedDisbursementDate(loanDisbursementDate).dateFormat(DATETIME_PATTERN)
-                .transactionProcessingStrategyCode(repaymentStrategyCode).locale("en").submittedOnDate(loanDisbursementDate)
-                .amortizationType(1).interestRatePerPeriod(BigDecimal.ZERO).interestCalculationPeriodType(1).interestType(0)
-                .repaymentFrequencyType(0).repaymentEvery(30).repaymentFrequencyType(0).numberOfRepayments(1).loanTermFrequency(30)
-                .loanTermFrequencyType(0).principal(BigDecimal.valueOf(1000.0)).loanType("individual"));
+        makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanId);
+        verifyLoanAccountIsClosed(loanId);
     }
 
     @Override
@@ -8286,15 +8111,14 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
                 .minInterestRatePerPeriod((double) 0)//
                 .interestRatePerPeriod((double) 0)//
                 .maxInterestRatePerPeriod((double) 0)//
-                .interestRateFrequencyType(2)//
+                .interestRateFrequencyType(LoanTestData.InterestRateFrequencyType.MONTHS)//
                 .repaymentEvery(30)//
-                .repaymentFrequencyType(0L)//
-                .amortizationType(1)//
-                .interestType(0)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.DAYS_L)//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_INSTALLMENTS)//
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE)//
                 .isEqualAmortization(false)//
-                .interestCalculationPeriodType(1)//
-                .transactionProcessingStrategyCode(
-                        LoanProductTestBuilder.DUE_PENALTY_FEE_INTEREST_PRINCIPAL_IN_ADVANCE_PRINCIPAL_PENALTY_FEE_INTEREST_STRATEGY)//
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)//
+                .transactionProcessingStrategyCode(DUE_PENALTY_FEE_INTEREST_PRINCIPAL_IN_ADVANCE_PRINCIPAL_PENALTY_FEE_INTEREST_STRATEGY)//
                 .daysInYearType(1)//
                 .daysInMonthType(1)//
                 .canDefineInstallmentAmount(true)//
@@ -8320,33 +8144,33 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
                 .maxTrancheCount(10)//
                 .outstandingLoanBalance(10000.0)//
                 .charges(Collections.emptyList())//
-                .accountingRule(3)//
-                .fundSourceAccountId(SUSPENSE_CLEARING_ACCOUNT.getAccountID().longValue())//
-                .loanPortfolioAccountId(LOANS_RECEIVABLE_ACCOUNT.getAccountID().longValue())//
-                .transfersInSuspenseAccountId(SUSPENSE_ACCOUNT.getAccountID().longValue())//
-                .interestOnLoanAccountId(INTEREST_INCOME_ACCOUNT.getAccountID().longValue())//
-                .incomeFromFeeAccountId(FEE_INCOME_ACCOUNT.getAccountID().longValue())//
-                .incomeFromPenaltyAccountId(FEE_INCOME_ACCOUNT.getAccountID().longValue())//
-                .incomeFromRecoveryAccountId(RECOVERIES_ACCOUNT.getAccountID().longValue())//
-                .writeOffAccountId(WRITTEN_OFF_ACCOUNT.getAccountID().longValue())//
-                .overpaymentLiabilityAccountId(OVERPAYMENT_ACCOUNT.getAccountID().longValue())//
-                .receivableInterestAccountId(INTEREST_FEE_RECEIVABLE_ACCOUNT.getAccountID().longValue())//
-                .receivableFeeAccountId(INTEREST_FEE_RECEIVABLE_ACCOUNT.getAccountID().longValue())//
-                .receivablePenaltyAccountId(INTEREST_FEE_RECEIVABLE_ACCOUNT.getAccountID().longValue())//
+                .accountingRule(ACCRUAL_PERIODIC)//
+                .fundSourceAccountId(suspenseClearingAccount.getAccountID().longValue())//
+                .loanPortfolioAccountId(loansReceivableAccount.getAccountID().longValue())//
+                .transfersInSuspenseAccountId(suspenseAccount.getAccountID().longValue())//
+                .interestOnLoanAccountId(interestIncomeAccount.getAccountID().longValue())//
+                .incomeFromFeeAccountId(feeIncomeAccount.getAccountID().longValue())//
+                .incomeFromPenaltyAccountId(feeIncomeAccount.getAccountID().longValue())//
+                .incomeFromRecoveryAccountId(recoveriesAccount.getAccountID().longValue())//
+                .writeOffAccountId(writtenOffAccount.getAccountID().longValue())//
+                .overpaymentLiabilityAccountId(overpaymentAccount.getAccountID().longValue())//
+                .receivableInterestAccountId(interestFeeReceivableAccount.getAccountID().longValue())//
+                .receivableFeeAccountId(interestFeeReceivableAccount.getAccountID().longValue())//
+                .receivablePenaltyAccountId(interestFeeReceivableAccount.getAccountID().longValue())//
                 .dateFormat(DATETIME_PATTERN)//
-                .locale("en_GB")//
+                .locale(LOCALE)//
                 .disallowExpectedDisbursements(true)//
                 .allowApprovedDisbursedAmountsOverApplied(true)//
                 .overAppliedCalculationType("percentage")//
                 .overAppliedNumber(50)//
-                .goodwillCreditAccountId(GOODWILL_EXPENSE_ACCOUNT.getAccountID().longValue())//
-                .incomeFromGoodwillCreditInterestAccountId(INTEREST_INCOME_CHARGE_OFF_ACCOUNT.getAccountID().longValue())//
-                .incomeFromGoodwillCreditFeesAccountId(FEE_CHARGE_OFF_ACCOUNT.getAccountID().longValue())//
-                .incomeFromGoodwillCreditPenaltyAccountId(FEE_CHARGE_OFF_ACCOUNT.getAccountID().longValue())//
-                .incomeFromChargeOffInterestAccountId(INTEREST_INCOME_CHARGE_OFF_ACCOUNT.getAccountID().longValue())//
-                .incomeFromChargeOffFeesAccountId(FEE_CHARGE_OFF_ACCOUNT.getAccountID().longValue())//
-                .chargeOffExpenseAccountId(CREDIT_LOSS_BAD_DEBT_ACCOUNT.getAccountID().longValue())//
-                .chargeOffFraudExpenseAccountId(CREDIT_LOSS_BAD_DEBT_FRAUD_ACCOUNT.getAccountID().longValue())//
-                .incomeFromChargeOffPenaltyAccountId(FEE_CHARGE_OFF_ACCOUNT.getAccountID().longValue());
+                .goodwillCreditAccountId(goodwillExpenseAccount.getAccountID().longValue())//
+                .incomeFromGoodwillCreditInterestAccountId(interestIncomeChargeOffAccount.getAccountID().longValue())//
+                .incomeFromGoodwillCreditFeesAccountId(feeChargeOffAccount.getAccountID().longValue())//
+                .incomeFromGoodwillCreditPenaltyAccountId(feeChargeOffAccount.getAccountID().longValue())//
+                .incomeFromChargeOffInterestAccountId(interestIncomeChargeOffAccount.getAccountID().longValue())//
+                .incomeFromChargeOffFeesAccountId(feeChargeOffAccount.getAccountID().longValue())//
+                .chargeOffExpenseAccountId(creditLossBadDebtAccount.getAccountID().longValue())//
+                .chargeOffFraudExpenseAccountId(creditLossBadDebtFraudAccount.getAccountID().longValue())//
+                .incomeFromChargeOffPenaltyAccountId(feeChargeOffAccount.getAccountID().longValue());
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/ClientLoanIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/ClientLoanIntegrationTest.java
@@ -25,53 +25,47 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.path.json.JsonPath;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
 import java.math.BigDecimal;
 import java.text.DateFormat;
 import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import org.apache.fineract.accounting.common.AccountingRuleType;
 import org.apache.fineract.accounting.glaccount.domain.GLAccountType;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
 import org.apache.fineract.client.models.AllowAttributeOverrides;
-import org.apache.fineract.client.models.BusinessDateUpdateRequest;
 import org.apache.fineract.client.models.ChargeRequest;
+import org.apache.fineract.client.models.DisbursementDetail;
 import org.apache.fineract.client.models.GetJournalEntriesTransactionIdResponse;
+import org.apache.fineract.client.models.GetLoanProductsProductIdResponse;
 import org.apache.fineract.client.models.GetLoanTransactionRelation;
+import org.apache.fineract.client.models.GetLoansLoanIdChargesChargeIdResponse;
+import org.apache.fineract.client.models.GetLoansLoanIdCollateralData;
 import org.apache.fineract.client.models.GetLoansLoanIdLoanTransactionRelation;
 import org.apache.fineract.client.models.GetLoansLoanIdRepaymentPeriod;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
+import org.apache.fineract.client.models.GetLoansLoanIdStatus;
 import org.apache.fineract.client.models.GetLoansLoanIdSummary;
 import org.apache.fineract.client.models.GetLoansLoanIdTransactions;
+import org.apache.fineract.client.models.GetLoansLoanIdTransactionsTemplateResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdTransactionsTransactionIdResponse;
 import org.apache.fineract.client.models.JournalEntryTransactionItem;
+import org.apache.fineract.client.models.LoanProductChargeData;
+import org.apache.fineract.client.models.LoanProductChargeToGLAccountMapper;
 import org.apache.fineract.client.models.PostChargesResponse;
-import org.apache.fineract.client.models.PostClientsRequest;
-import org.apache.fineract.client.models.PostClientsResponse;
 import org.apache.fineract.client.models.PostGLAccountsRequest;
 import org.apache.fineract.client.models.PostGLAccountsResponse;
 import org.apache.fineract.client.models.PostLoanProductsRequest;
-import org.apache.fineract.client.models.PostLoanProductsResponse;
+import org.apache.fineract.client.models.PostLoansDisbursementData;
 import org.apache.fineract.client.models.PostLoansLoanIdChargesChargeIdRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdChargesChargeIdResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdChargesRequest;
@@ -82,37 +76,42 @@ import org.apache.fineract.client.models.PostLoansLoanIdTransactionsRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsTransactionIdRequest;
 import org.apache.fineract.client.models.PostLoansRequest;
+import org.apache.fineract.client.models.PostLoansRequestChargeData;
+import org.apache.fineract.client.models.PostLoansRequestCollateralData;
 import org.apache.fineract.client.models.PostLoansResponse;
 import org.apache.fineract.client.models.PutChargeTransactionChangesRequest;
 import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
-import org.apache.fineract.client.util.CallFailedRuntimeException;
+import org.apache.fineract.client.models.PutLoansLoanIdChargeData;
+import org.apache.fineract.client.models.PutLoansLoanIdChargesChargeIdRequest;
+import org.apache.fineract.client.models.PutLoansLoanIdCollateral;
+import org.apache.fineract.client.models.PutLoansLoanIdRequest;
+import org.apache.fineract.client.models.PutSavingsAccountsAccountIdRequest;
+import org.apache.fineract.client.models.PutSavingsAccountsAccountIdResponse;
+import org.apache.fineract.client.models.SavingsAccountSummaryData;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
 import org.apache.fineract.infrastructure.core.service.DateUtils;
-import org.apache.fineract.integrationtests.common.BusinessDateHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.CollateralManagementHelper;
-import org.apache.fineract.integrationtests.common.SchedulerJobHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignAccountTransferHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignCollateralHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignSavingsHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignSavingsProductHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.LoanChargeCommandsApi;
+import org.apache.fineract.integrationtests.client.feign.modules.ChargeRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
+import org.apache.fineract.integrationtests.client.feign.modules.SavingsRequestBuilders;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.common.accounting.Account;
-import org.apache.fineract.integrationtests.common.accounting.AccountHelper;
 import org.apache.fineract.integrationtests.common.accounting.JournalEntry;
-import org.apache.fineract.integrationtests.common.accounting.JournalEntryHelper;
-import org.apache.fineract.integrationtests.common.accounting.PeriodicAccrualAccountingHelper;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
-import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanProductHelper;
-import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanStatusChecker;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.apache.fineract.integrationtests.common.savings.AccountTransferHelper;
-import org.apache.fineract.integrationtests.common.savings.SavingsAccountHelper;
-import org.apache.fineract.integrationtests.common.savings.SavingsProductHelper;
-import org.apache.fineract.integrationtests.common.savings.SavingsStatusChecker;
-import org.apache.fineract.integrationtests.common.system.CodeHelper;
 import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
 import org.apache.fineract.portfolio.charge.domain.ChargePaymentMode;
 import org.apache.fineract.portfolio.charge.domain.ChargeTimeType;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanStatus;
+import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleProcessingType;
+import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleType;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.commons.util.StringUtils;
 import org.slf4j.Logger;
@@ -122,562 +121,543 @@ import org.slf4j.LoggerFactory;
  * Client Loan Integration Test for checking Loan Application Repayments Schedule, loan charges, penalties, loan
  * repayments and verifying accounting transactions
  */
-@SuppressWarnings({ "rawtypes", "unchecked" })
-
-public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
-
-    static {
-        Utils.initializeRESTAssured();
-    }
+public class ClientLoanIntegrationTest extends FeignLoanTestBase {
 
     private static final String MINIMUM_OPENING_BALANCE = "1000.0";
-    private static final String ACCOUNT_TYPE_INDIVIDUAL = "INDIVIDUAL";
     private static final Logger LOG = LoggerFactory.getLogger(ClientLoanIntegrationTest.class);
-    private static final String NONE = "1";
-    private static final String CASH_BASED = "2";
-    private static final String ACCRUAL_PERIODIC = "3";
-    private static final String ACCRUAL_UPFRONT = "4";
 
-    private static final ResponseSpecification RESPONSE_SPEC = createResponseSpecification(200);
-    private static final RequestSpecification REQUEST_SPEC = createRequestSpecification();
-    private static final LoanTransactionHelper LOAN_TRANSACTION_HELPER = new LoanTransactionHelper(REQUEST_SPEC, RESPONSE_SPEC);
-    private static final JournalEntryHelper JOURNAL_ENTRY_HELPER = new JournalEntryHelper(REQUEST_SPEC, RESPONSE_SPEC);
-    private static final AccountHelper ACCOUNT_HELPER = new AccountHelper(REQUEST_SPEC, RESPONSE_SPEC);
+    private static final Integer NONE = AccountingRuleType.NONE.getValue();
+    private static final Integer CASH_BASED = AccountingRuleType.CASH_BASED.getValue();
+    private static final Integer ACCRUAL_PERIODIC = AccountingRuleType.ACCRUAL_PERIODIC.getValue();
+    private static final Integer ACCRUAL_UPFRONT = AccountingRuleType.ACCRUAL_UPFRONT.getValue();
+
+    /** The loan/product JSON builders this test replaced used {@code en_GB}; keep it so number parsing is unchanged. */
+    private static final String LOCALE = "en_GB";
+    private static final String OVERRIDE_MESSAGE = "Loan overrode the product's %s";
+    /** The interoperation repayment body was built with plain {@code en}, unlike the {@code en_GB} used elsewhere. */
+    private static final String INTEROP_LOCALE = "en";
+
+    /** Mirrors the legacy {@code SavingsAccountHelper} date constants. */
+    private static final String SAVINGS_TRANSACTION_DATE = "01 March 2013";
+    private static final String SAVINGS_CREATED_DATE = "08 January 2013";
+    private static final String SAVINGS_CREATED_DATE_PLUS_ONE = "09 January 2013";
+
+    private static final String DEFAULT_STRATEGY = "mifos-standard-strategy";
+    private static final String RBI_INDIA_STRATEGY = "rbi-india-strategy";
+    private static final String INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY = "interest-principal-penalties-fees-order-strategy";
+    private static final String DUE_PENALTY_FEE_INTEREST_PRINCIPAL_IN_ADVANCE_PRINCIPAL_PENALTY_FEE_INTEREST_STRATEGY = "due-penalty-fee-interest-principal-in-advance-principal-penalty-fee-interest-strategy";
+    private static final String DUE_PENALTY_INTEREST_PRINCIPAL_FEE_IN_ADVANCE_PENALTY_INTEREST_PRINCIPAL_FEE_STRATEGY = "due-penalty-interest-principal-fee-in-advance-penalty-interest-principal-fee-strategy";
+
+    /**
+     * GL accounts and helpers are created in {@link #setupClientLoanTest()} rather than in field initializers, because
+     * the inherited Feign helpers are only assigned in the base class {@code @BeforeAll}, which runs after this class
+     * is initialized.
+     */
     // asset
-    private static final Account LOANS_RECEIVABLE_ACCOUNT = ACCOUNT_HELPER.createAssetAccount();
-    private static final Account INTEREST_FEE_RECEIVABLE_ACCOUNT = ACCOUNT_HELPER.createAssetAccount();
-    private static final Account SUSPENSE_ACCOUNT = ACCOUNT_HELPER.createAssetAccount();
+    private static Account loansReceivableAccount;
+    private static Account interestFeeReceivableAccount;
+    private static Account suspenseAccount;
     // liability
-    private static final Account SUSPENSE_CLEARING_ACCOUNT = ACCOUNT_HELPER.createLiabilityAccount();
-    private static final Account OVERPAYMENT_ACCOUNT = ACCOUNT_HELPER.createLiabilityAccount();
+    private static Account suspenseClearingAccount;
+    private static Account overpaymentAccount;
     // income
-    private static final Account INTEREST_INCOME_ACCOUNT = ACCOUNT_HELPER.createIncomeAccount();
-    private static final Account FEE_INCOME_ACCOUNT = ACCOUNT_HELPER.createIncomeAccount();
-    private static final Account FEE_CHARGE_OFF_ACCOUNT = ACCOUNT_HELPER.createIncomeAccount();
-    private static final Account RECOVERIES_ACCOUNT = ACCOUNT_HELPER.createIncomeAccount();
-    private static final Account INTEREST_INCOME_CHARGE_OFF_ACCOUNT = ACCOUNT_HELPER.createIncomeAccount();
+    private static Account interestIncomeAccount;
+    private static Account feeIncomeAccount;
+    private static Account feeChargeOffAccount;
+    private static Account recoveriesAccount;
+    private static Account interestIncomeChargeOffAccount;
     // expense
-    private static final Account CREDIT_LOSS_BAD_DEBT_ACCOUNT = ACCOUNT_HELPER.createExpenseAccount();
-    private static final Account CREDIT_LOSS_BAD_DEBT_FRAUD_ACCOUNT = ACCOUNT_HELPER.createExpenseAccount();
-    private static final Account WRITTEN_OFF_ACCOUNT = ACCOUNT_HELPER.createExpenseAccount();
-    private static final Account GOODWILL_EXPENSE_ACCOUNT = ACCOUNT_HELPER.createExpenseAccount();
-    private static final SchedulerJobHelper SCHEDULER_JOB_HELPER = new SchedulerJobHelper(REQUEST_SPEC);
-    private static final SavingsAccountHelper SAVINGS_ACCOUNT_HELPER = new SavingsAccountHelper(REQUEST_SPEC, RESPONSE_SPEC);
-    private static final AccountTransferHelper ACCOUNT_TRANSFER_HELPER = new AccountTransferHelper(REQUEST_SPEC, RESPONSE_SPEC);
-    private static final LoanProductHelper LOAN_PRODUCT_HELPER = new LoanProductHelper();
-    private static final String DATETIME_PATTERN = "dd MMMM yyyy";
-    private static final DateTimeFormatter DATE_TIME_FORMATTER = new DateTimeFormatterBuilder().appendPattern(DATETIME_PATTERN)
-            .toFormatter();
-    private static final BusinessDateHelper BUSINESS_DATE_HELPER = new BusinessDateHelper();
-    private static final ChargesHelper CHARGES_HELPER = new ChargesHelper();
-    private static final ClientHelper CLIENT_HELPER = new ClientHelper(REQUEST_SPEC, RESPONSE_SPEC);
+    private static Account creditLossBadDebtAccount;
+    private static Account creditLossBadDebtFraudAccount;
+    private static Account writtenOffAccount;
+    private static Account goodwillExpenseAccount;
 
-    private static RequestSpecification createRequestSpecification() {
-        RequestSpecification request = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
+    private static FeignCollateralHelper collateralHelper;
+    private static FeignSavingsHelper savingsHelper;
+    private static FeignSavingsProductHelper savingsProductHelper;
+    private static FeignAccountTransferHelper accountTransferHelper;
 
-        request.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        request.header("Fineract-Platform-TenantId", "default");
-        return request;
-    }
+    @BeforeAll
+    public static void setupClientLoanTest() {
+        loansReceivableAccount = accountHelper.createAssetAccount();
+        interestFeeReceivableAccount = accountHelper.createAssetAccount();
+        suspenseAccount = accountHelper.createAssetAccount();
 
-    private static ResponseSpecification createResponseSpecification(int statusCode) {
-        return new ResponseSpecBuilder().expectStatusCode(statusCode).build();
+        suspenseClearingAccount = accountHelper.createLiabilityAccount();
+        overpaymentAccount = accountHelper.createLiabilityAccount();
+
+        interestIncomeAccount = accountHelper.createIncomeAccount();
+        feeIncomeAccount = accountHelper.createIncomeAccount();
+        feeChargeOffAccount = accountHelper.createIncomeAccount();
+        recoveriesAccount = accountHelper.createIncomeAccount();
+        interestIncomeChargeOffAccount = accountHelper.createIncomeAccount();
+
+        creditLossBadDebtAccount = accountHelper.createExpenseAccount();
+        creditLossBadDebtFraudAccount = accountHelper.createExpenseAccount();
+        writtenOffAccount = accountHelper.createExpenseAccount();
+        goodwillExpenseAccount = accountHelper.createExpenseAccount();
+
+        collateralHelper = new FeignCollateralHelper(FineractFeignClientHelper.getFineractFeignClient());
+        savingsHelper = new FeignSavingsHelper(FineractFeignClientHelper.getFineractFeignClient());
+        savingsProductHelper = new FeignSavingsProductHelper(FineractFeignClientHelper.getFineractFeignClient());
+        accountTransferHelper = new FeignAccountTransferHelper(FineractFeignClientHelper.getFineractFeignClient());
     }
 
     @Test
     public void checkClientLoanCreateAndDisburseFlow() {
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
-        List<HashMap> collaterals = new ArrayList<>();
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long clientID = createClient();
 
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+        verifyClientCreatedOnServer(clientID);
 
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanProductID = createLoanProduct(false, NONE);
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, null, null, "12,000.00", collaterals);
-        final ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        final Long loanProductID = createLoanProduct(false, NONE);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID, null, null, "12,000.00", collaterals);
+        final List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
         verifyLoanRepaymentSchedule(loanSchedule);
     }
 
     @Test
     public void validateClientLoanWithUniqueExternalId() {
         // Given
-        final ResponseSpecification responseSpec403 = new ResponseSpecBuilder().expectStatusCode(403).build();
-
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        final Integer loanProductID = createLoanProduct(false, NONE);
+        final Long clientID = createClient();
+        final Long loanProductID = createLoanProduct(false, NONE);
 
         final String externalId = UUID.randomUUID().toString();
 
         // When
-        final Integer loanID = applyForLoanApplicationWithExternalId(REQUEST_SPEC, RESPONSE_SPEC, clientID, loanProductID, "12,000.00",
-                externalId);
+        final Long loanID = applyForLoanApplicationWithExternalId(clientID, loanProductID, "12,000.00", externalId);
 
         // Then
         assertNotNull(loanID);
-        applyForLoanApplicationWithExternalId(REQUEST_SPEC, responseSpec403, clientID, loanProductID, "12,000.00", externalId);
+        CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
+                () -> applyForLoanApplicationWithExternalId(clientID, loanProductID, "12,000.00", externalId));
+        assertEquals(403, exception.getStatus());
     }
 
     @Test
     public void testAddingLoanChargeIncludesLoanIdInTheResponse() {
         // given
-        Integer clientId = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        Integer loanProductId = createLoanProduct(false, NONE);
-        Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
-        Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientId), collateralId);
-        List<HashMap> collaterals = List.of(collaterals(clientCollateralId, BigDecimal.ONE));
+        Long clientId = createClient();
+        Long loanProductId = createLoanProduct(false, NONE);
+        Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
+        Long clientCollateralId = collateralHelper.createClientCollateral(clientId, collateralId).getResourceId();
+        List<PostLoansRequestCollateralData> collaterals = List.of(collateral(clientCollateralId, BigDecimal.ONE));
 
-        Integer chargeId = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanDisbursementJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1"));
-        List<HashMap> charges = List.of(charges(chargeId, "1", null));
+        Long chargeId = chargesHelper.createLoanDisbursementCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0).getResourceId();
+        List<PostLoansRequestChargeData> charges = List.of(charge(chargeId, 1.0, null));
         // when
-        Integer loanId = applyForLoanApplication(clientId, loanProductId, charges, null, "12,000.00", collaterals);
+        Long loanId = applyForLoanApplication(clientId, loanProductId, charges, null, "12,000.00", collaterals);
         // then
-        List<HashMap> loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanId);
-        Integer loanChargeId = (Integer) loanCharges.get(0).get("id");
-        HashMap loanChargeDetail = LOAN_TRANSACTION_HELPER.getLoanCharge(loanId, loanChargeId);
-        assertEquals(loanId, loanChargeDetail.get("loanId"));
+        List<GetLoansLoanIdChargesChargeIdResponse> loanCharges = getLoanCharges(loanId);
+        Long loanChargeId = loanCharges.get(0).getId();
+        GetLoansLoanIdChargesChargeIdResponse loanChargeDetail = getLoanCharge(loanId, loanChargeId);
+        assertEquals(loanId, loanChargeDetail.getLoanId());
     }
 
     @Test
     public void testLoanCharges_DISBURSEMENT_FEE() {
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProduct(false, NONE);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Long loanProductID = createLoanProduct(false, NONE);
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
         Assertions.assertNotNull(collateralId);
-        List<HashMap> collaterals = new ArrayList<>();
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
         Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        List<HashMap> charges = new ArrayList<>();
-        Integer flatDisbursement = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC, ChargesHelper.getLoanDisbursementJSON());
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
+        Long flatDisbursement = chargesHelper.createLoanDisbursementCharge(ChargeCalculationType.FLAT, 100.0).getResourceId();
 
-        Integer amountPercentage = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanDisbursementJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1"));
-        addCharges(charges, amountPercentage, "1", null);
-        Integer amountPlusInterestPercentage = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanDisbursementJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT_AND_INTEREST, "1"));
-        addCharges(charges, amountPlusInterestPercentage, "1", null);
-        Integer interestPercentage = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanDisbursementJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_INTEREST, "1"));
-        addCharges(charges, interestPercentage, "1", null);
+        Long amountPercentage = chargesHelper.createLoanDisbursementCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0).getResourceId();
+        addCharges(charges, amountPercentage, 1.0, null);
+        Long amountPlusInterestPercentage = chargesHelper
+                .createLoanDisbursementCharge(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST, 1.0).getResourceId();
+        addCharges(charges, amountPlusInterestPercentage, 1.0, null);
+        Long interestPercentage = chargesHelper.createLoanDisbursementCharge(ChargeCalculationType.PERCENT_OF_INTEREST, 1.0)
+                .getResourceId();
+        addCharges(charges, interestPercentage, 1.0, null);
 
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
         Assertions.assertNotNull(loanID);
 
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap disbursementDetail = loanSchedule.get(0);
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod disbursementDetail = loanSchedule.get(0);
 
-        List<HashMap> loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        List<GetLoansLoanIdChargesChargeIdResponse> loanCharges = getLoanCharges(loanID);
 
         validateCharge(amountPercentage, loanCharges, "1.0", "120.0", "0.0", "0.0");
         validateCharge(interestPercentage, loanCharges, "1.0", "6.06", "0.0", "0.0");
         validateCharge(amountPlusInterestPercentage, loanCharges, "1.0", "126.06", "0.0", "0.0");
 
-        validateNumberForEqual("252.12", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        validateNumberForEqual("252.12", String.valueOf(disbursementDetail.getFeeChargesDue()));
 
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID,
-                LoanTransactionHelper.getDisbursementChargesForLoanAsJSON(String.valueOf(flatDisbursement)));
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        addDisbursementCharge(loanID, flatDisbursement, 100.0);
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         disbursementDetail = loanSchedule.get(0);
 
         validateCharge(flatDisbursement, loanCharges, "100.0", "100.0", "0.0", "0.0");
-        validateNumberForEqual("352.12", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        validateNumberForEqual("352.12", String.valueOf(disbursementDetail.getFeeChargesDue()));
 
-        LOAN_TRANSACTION_HELPER.updateChargesForLoan(loanID, (Integer) getloanCharge(amountPercentage, loanCharges).get("id"),
-                LoanTransactionHelper.getUpdateChargesForLoanAsJSON("2"));
-        LOAN_TRANSACTION_HELPER.updateChargesForLoan(loanID, (Integer) getloanCharge(interestPercentage, loanCharges).get("id"),
-                LoanTransactionHelper.getUpdateChargesForLoanAsJSON("2"));
-        LOAN_TRANSACTION_HELPER.updateChargesForLoan(loanID, (Integer) getloanCharge(amountPlusInterestPercentage, loanCharges).get("id"),
-                LoanTransactionHelper.getUpdateChargesForLoanAsJSON("2"));
-        LOAN_TRANSACTION_HELPER.updateChargesForLoan(loanID, (Integer) getloanCharge(flatDisbursement, loanCharges).get("id"),
-                LoanTransactionHelper.getUpdateChargesForLoanAsJSON("150"));
+        updateLoanCharge(loanID, getloanCharge(amountPercentage, loanCharges).getId(),
+                new PutLoansLoanIdChargesChargeIdRequest().amount(2.0).locale(LOCALE).dateFormat(DATETIME_PATTERN));
+        updateLoanCharge(loanID, getloanCharge(interestPercentage, loanCharges).getId(),
+                new PutLoansLoanIdChargesChargeIdRequest().amount(2.0).locale(LOCALE).dateFormat(DATETIME_PATTERN));
+        updateLoanCharge(loanID, getloanCharge(amountPlusInterestPercentage, loanCharges).getId(),
+                new PutLoansLoanIdChargesChargeIdRequest().amount(2.0).locale(LOCALE).dateFormat(DATETIME_PATTERN));
+        updateLoanCharge(loanID, getloanCharge(flatDisbursement, loanCharges).getId(),
+                new PutLoansLoanIdChargesChargeIdRequest().amount(150.0).locale(LOCALE).dateFormat(DATETIME_PATTERN));
 
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         disbursementDetail = loanSchedule.get(0);
         validateCharge(amountPercentage, loanCharges, "2.0", "240.0", "0.0", "0.0");
         validateCharge(interestPercentage, loanCharges, "2.0", "12.12", "0.0", "0.0");
         validateCharge(amountPlusInterestPercentage, loanCharges, "2.0", "252.12", "0.0", "0.0");
         validateCharge(flatDisbursement, loanCharges, "150.0", "150.0", "0.0", "0.0");
-        validateNumberForEqual("654.24", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        validateNumberForEqual("654.24", String.valueOf(disbursementDetail.getFeeChargesDue()));
 
-        LOAN_TRANSACTION_HELPER.updateLoan(loanID,
-                updateLoanJson(clientID, loanProductID, copyChargesForUpdate(loanCharges, null, null), null, collaterals));
+        modifyLoanApplication(loanID, null,
+                updateLoanRequest(clientID, loanProductID, copyChargesForUpdate(loanCharges, null, null), null, collaterals));
 
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         disbursementDetail = loanSchedule.get(0);
         validateCharge(amountPercentage, loanCharges, "2.0", "200.0", "0.0", "0.0");
         validateCharge(interestPercentage, loanCharges, "2.0", "10.1", "0.0", "0.0");
         validateCharge(amountPlusInterestPercentage, loanCharges, "2.0", "210.1", "0.0", "0.0");
         validateCharge(flatDisbursement, loanCharges, "150.0", "150.0", "0.0", "0.0");
-        validateNumberForEqual("570.2", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        validateNumberForEqual("570.2", String.valueOf(disbursementDetail.getFeeChargesDue()));
 
-        LOAN_TRANSACTION_HELPER.updateLoan(loanID,
-                updateLoanJson(clientID, loanProductID, copyChargesForUpdate(loanCharges, flatDisbursement, "1"), null, collaterals));
+        modifyLoanApplication(loanID, null,
+                updateLoanRequest(clientID, loanProductID, copyChargesForUpdate(loanCharges, flatDisbursement, 1.0), null, collaterals));
 
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         disbursementDetail = loanSchedule.get(0);
         validateCharge(amountPercentage, loanCharges, "1.0", "100.0", "0.0", "0.0");
         validateCharge(interestPercentage, loanCharges, "1.0", "5.05", "0.0", "0.0");
         validateCharge(amountPlusInterestPercentage, loanCharges, "1.0", "105.05", "0.0", "0.0");
-        validateNumberForEqual("210.1", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        validateNumberForEqual("210.1", String.valueOf(disbursementDetail.getFeeChargesDue()));
 
         charges.clear();
-        addCharges(charges, flatDisbursement, "100", null);
-        LOAN_TRANSACTION_HELPER.updateLoan(loanID, updateLoanJson(clientID, loanProductID, charges, null, collaterals));
+        addCharges(charges, flatDisbursement, 100.0, null);
+        modifyLoanApplication(loanID, null, updateLoanRequest(clientID, loanProductID, toUpdateCharges(charges), null, collaterals));
 
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         disbursementDetail = loanSchedule.get(0);
         validateCharge(flatDisbursement, loanCharges, "100.0", "100.0", "0.0", "0.0");
-        validateNumberForEqual("100.0", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        validateNumberForEqual("100.0", String.valueOf(disbursementDetail.getFeeChargesDue()));
 
-        LOAN_TRANSACTION_HELPER.deleteChargesForLoan(loanID, (Integer) getloanCharge(flatDisbursement, loanCharges).get("id"));
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        deleteLoanCharge(loanID, getloanCharge(flatDisbursement, loanCharges).getId());
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         disbursementDetail = loanSchedule.get(0);
         Assertions.assertEquals(0, loanCharges.size());
-        validateNumberForEqual("0.0", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        validateNumberForEqual("0.0", String.valueOf(disbursementDetail.getFeeChargesDue()));
 
     }
 
     @Test
     public void testLoanCharges_DISBURSEMENT_FEE_WITH_AMOUNT_CHANGE() {
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProduct(false, NONE);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Long loanProductID = createLoanProduct(false, NONE);
 
-        List<HashMap> charges = new ArrayList<>();
-        Integer amountPercentage = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanDisbursementJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1"));
-        addCharges(charges, amountPercentage, "1", null);
-        Integer amountPlusInterestPercentage = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanDisbursementJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT_AND_INTEREST, "1"));
-        addCharges(charges, amountPlusInterestPercentage, "1", null);
-        Integer interestPercentage = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanDisbursementJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_INTEREST, "1"));
-        addCharges(charges, interestPercentage, "1", null);
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
+        Long amountPercentage = chargesHelper.createLoanDisbursementCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0).getResourceId();
+        addCharges(charges, amountPercentage, 1.0, null);
+        Long amountPlusInterestPercentage = chargesHelper
+                .createLoanDisbursementCharge(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST, 1.0).getResourceId();
+        addCharges(charges, amountPlusInterestPercentage, 1.0, null);
+        Long interestPercentage = chargesHelper.createLoanDisbursementCharge(ChargeCalculationType.PERCENT_OF_INTEREST, 1.0)
+                .getResourceId();
+        addCharges(charges, interestPercentage, 1.0, null);
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
         Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
         Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
         Assertions.assertNotNull(loanID);
 
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap disbursementDetail = loanSchedule.get(0);
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod disbursementDetail = loanSchedule.get(0);
 
-        List<HashMap> loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        List<GetLoansLoanIdChargesChargeIdResponse> loanCharges = getLoanCharges(loanID);
 
         validateCharge(amountPercentage, loanCharges, "1.0", "120.0", "0.0", "0.0");
         validateCharge(interestPercentage, loanCharges, "1.0", "6.06", "0.0", "0.0");
         validateCharge(amountPlusInterestPercentage, loanCharges, "1.0", "126.06", "0.0", "0.0");
-        validateNumberForEqual("252.12", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        validateNumberForEqual("252.12", String.valueOf(disbursementDetail.getFeeChargesDue()));
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("20 September 2011", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("20 September 2011", loanID));
 
         // DISBURSE
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("20 September 2011", loanID, "10000",
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LOG.info("DISBURSE {}", loanStatusHashMap.toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount("20 September 2011", loanID, "10000"));
 
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         disbursementDetail = loanSchedule.get(0);
 
         validateCharge(amountPercentage, loanCharges, "1.0", "0.0", "100.0", "0.0");
         validateCharge(interestPercentage, loanCharges, "1.0", "0.0", "5.05", "0.0");
         validateCharge(amountPlusInterestPercentage, loanCharges, "1.0", "0.0", "105.05", "0.0");
-        validateNumberForEqual("210.1", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        validateNumberForEqual("210.1", String.valueOf(disbursementDetail.getFeeChargesDue()));
 
     }
 
     @Test
     public void testLoanDisbursedTodayIsRetrieved() {
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProduct(false, NONE);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Long loanProductID = createLoanProduct(false, NONE);
 
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, "5", null);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID, 5, null);
         Assertions.assertNotNull(loanID);
 
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
         DateFormat dateFormat = new SimpleDateFormat(DATETIME_PATTERN, Locale.US);
         Calendar todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         final String LOAN_DISBURSEMENT_DATE = "2 June 2014";
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(LOAN_DISBURSEMENT_DATE, loanID));
 
         // DISBURSE on todays date so that loan can't be in arrears
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID, "10000",
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LOG.info("DISBURSE {}", loanStatusHashMap.toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-        loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID, "10000"));
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanID);
         // Test added because loans created without arrears were failing to be retrieved (associations=all) due to inner
         // join on m_loan_arrears_aging (now left join)
         Assertions.assertNotNull(loanDetails, "Empty Loan Details");
-        Assertions.assertNotNull(JsonPath.from(loanDetails).get("id"), "No id Found");
+        Assertions.assertNotNull(loanDetails.getId(), "No id Found");
 
     }
 
     @Test
     public void testLoanCharges_SPECIFIED_DUE_DATE_FEE() {
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProduct(false, NONE);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Long loanProductID = createLoanProduct(false, NONE);
 
-        List<HashMap> charges = new ArrayList<>();
-        Integer flat = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "100", false));
-        Integer flatAccTransfer = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateWithAccountTransferJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "100", false));
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
+        Long flat = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.FLAT, 100.0, false).getResourceId();
+        Long flatAccTransfer = chargesHelper.createLoanSpecifiedDueDateAccountTransferCharge(ChargeCalculationType.FLAT, 100.0, false)
+                .getResourceId();
 
-        Integer amountPercentage = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1", false));
-        addCharges(charges, amountPercentage, "1", "29 September 2011");
-        Integer amountPlusInterestPercentage = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC, ChargesHelper
-                .getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT_AND_INTEREST, "1", false));
-        addCharges(charges, amountPlusInterestPercentage, "1", "29 September 2011");
-        Integer interestPercentage = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_INTEREST, "1", false));
-        addCharges(charges, interestPercentage, "1", "29 September 2011");
+        Long amountPercentage = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0, false)
+                .getResourceId();
+        addCharges(charges, amountPercentage, 1.0, "29 September 2011");
+        Long amountPlusInterestPercentage = chargesHelper
+                .createLoanSpecifiedDueDateCharge(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST, 1.0, false).getResourceId();
+        addCharges(charges, amountPlusInterestPercentage, 1.0, "29 September 2011");
+        Long interestPercentage = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.PERCENT_OF_INTEREST, 1.0, false)
+                .getResourceId();
+        addCharges(charges, interestPercentage, 1.0, "29 September 2011");
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
         Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                clientID.toString(), collateralId);
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
         Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
         Assertions.assertNotNull(loanID);
 
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap firstInstallment = loanSchedule.get(1);
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod firstInstallment = loanSchedule.get(1);
 
-        List<HashMap> loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        List<GetLoansLoanIdChargesChargeIdResponse> loanCharges = getLoanCharges(loanID);
 
         validateCharge(amountPercentage, loanCharges, "1.0", "120.0", "0.0", "0.0");
         validateCharge(interestPercentage, loanCharges, "1.0", "6.06", "0.0", "0.0");
         validateCharge(amountPlusInterestPercentage, loanCharges, "1.0", "126.06", "0.0", "0.0");
 
-        validateNumberForEqual("252.12", String.valueOf(firstInstallment.get("feeChargesDue")));
+        validateNumberForEqual("252.12", String.valueOf(firstInstallment.getFeeChargesDue()));
 
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID,
-                LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flat), "29 September 2011", "100"));
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        addLoanCharge(loanID, flat, "29 September 2011", 100.0);
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         firstInstallment = loanSchedule.get(1);
 
         validateCharge(flat, loanCharges, "100.0", "100.0", "0.0", "0.0");
-        validateNumberForEqual("352.12", String.valueOf(firstInstallment.get("feeChargesDue")));
+        validateNumberForEqual("352.12", String.valueOf(firstInstallment.getFeeChargesDue()));
 
-        LOAN_TRANSACTION_HELPER.updateChargesForLoan(loanID, (Integer) getloanCharge(amountPercentage, loanCharges).get("id"),
-                LoanTransactionHelper.getUpdateChargesForLoanAsJSON("2"));
-        LOAN_TRANSACTION_HELPER.updateChargesForLoan(loanID, (Integer) getloanCharge(interestPercentage, loanCharges).get("id"),
-                LoanTransactionHelper.getUpdateChargesForLoanAsJSON("2"));
-        LOAN_TRANSACTION_HELPER.updateChargesForLoan(loanID, (Integer) getloanCharge(amountPlusInterestPercentage, loanCharges).get("id"),
-                LoanTransactionHelper.getUpdateChargesForLoanAsJSON("2"));
-        LOAN_TRANSACTION_HELPER.updateChargesForLoan(loanID, (Integer) getloanCharge(flat, loanCharges).get("id"),
-                LoanTransactionHelper.getUpdateChargesForLoanAsJSON("150"));
+        updateLoanCharge(loanID, getloanCharge(amountPercentage, loanCharges).getId(),
+                new PutLoansLoanIdChargesChargeIdRequest().amount(2.0).locale(LOCALE).dateFormat(DATETIME_PATTERN));
+        updateLoanCharge(loanID, getloanCharge(interestPercentage, loanCharges).getId(),
+                new PutLoansLoanIdChargesChargeIdRequest().amount(2.0).locale(LOCALE).dateFormat(DATETIME_PATTERN));
+        updateLoanCharge(loanID, getloanCharge(amountPlusInterestPercentage, loanCharges).getId(),
+                new PutLoansLoanIdChargesChargeIdRequest().amount(2.0).locale(LOCALE).dateFormat(DATETIME_PATTERN));
+        updateLoanCharge(loanID, getloanCharge(flat, loanCharges).getId(),
+                new PutLoansLoanIdChargesChargeIdRequest().amount(150.0).locale(LOCALE).dateFormat(DATETIME_PATTERN));
 
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         firstInstallment = loanSchedule.get(1);
         validateCharge(amountPercentage, loanCharges, "2.0", "240.0", "0.0", "0.0");
         validateCharge(interestPercentage, loanCharges, "2.0", "12.12", "0.0", "0.0");
         validateCharge(amountPlusInterestPercentage, loanCharges, "2.0", "252.12", "0.0", "0.0");
         validateCharge(flat, loanCharges, "150.0", "150.0", "0.0", "0.0");
-        validateNumberForEqual("654.24", String.valueOf(firstInstallment.get("feeChargesDue")));
+        validateNumberForEqual("654.24", String.valueOf(firstInstallment.getFeeChargesDue()));
 
-        final Integer savingsId = SavingsAccountHelper.openSavingsAccount(REQUEST_SPEC, RESPONSE_SPEC, clientID, MINIMUM_OPENING_BALANCE);
-        LOAN_TRANSACTION_HELPER.updateLoan(loanID, updateLoanJson(clientID, loanProductID, copyChargesForUpdate(loanCharges, null, null),
-                String.valueOf(savingsId), collaterals));
+        final Long savingsId = openSavingsAccountActivatedOnTransactionDate(clientID, MINIMUM_OPENING_BALANCE);
+        modifyLoanApplication(loanID, null,
+                updateLoanRequest(clientID, loanProductID, copyChargesForUpdate(loanCharges, null, null), savingsId, collaterals));
 
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         firstInstallment = loanSchedule.get(1);
         validateCharge(amountPercentage, loanCharges, "2.0", "200.0", "0.0", "0.0");
         validateCharge(interestPercentage, loanCharges, "2.0", "10.1", "0.0", "0.0");
         validateCharge(amountPlusInterestPercentage, loanCharges, "2.0", "210.1", "0.0", "0.0");
         validateCharge(flat, loanCharges, "150.0", "150.0", "0.0", "0.0");
-        validateNumberForEqual("570.2", String.valueOf(firstInstallment.get("feeChargesDue")));
+        validateNumberForEqual("570.2", String.valueOf(firstInstallment.getFeeChargesDue()));
 
-        LOAN_TRANSACTION_HELPER.updateLoan(loanID,
-                updateLoanJson(clientID, loanProductID, copyChargesForUpdate(loanCharges, flat, "1"), null, collaterals));
+        modifyLoanApplication(loanID, null,
+                updateLoanRequest(clientID, loanProductID, copyChargesForUpdate(loanCharges, flat, 1.0), null, collaterals));
 
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         firstInstallment = loanSchedule.get(1);
         validateCharge(amountPercentage, loanCharges, "1.0", "100.0", "0.0", "0.0");
         validateCharge(interestPercentage, loanCharges, "1.0", "5.05", "0.0", "0.0");
         validateCharge(amountPlusInterestPercentage, loanCharges, "1.0", "105.05", "0.0", "0.0");
-        validateNumberForEqual("210.1", String.valueOf(firstInstallment.get("feeChargesDue")));
+        validateNumberForEqual("210.1", String.valueOf(firstInstallment.getFeeChargesDue()));
 
         charges.clear();
-        addCharges(charges, flat, "100", "29 September 2011");
-        LOAN_TRANSACTION_HELPER.updateLoan(loanID, updateLoanJson(clientID, loanProductID, charges, null, collaterals));
+        addCharges(charges, flat, 100.0, "29 September 2011");
+        modifyLoanApplication(loanID, null, updateLoanRequest(clientID, loanProductID, toUpdateCharges(charges), null, collaterals));
 
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         firstInstallment = loanSchedule.get(1);
         validateCharge(flat, loanCharges, "100.0", "100.0", "0.0", "0.0");
-        validateNumberForEqual("100.0", String.valueOf(firstInstallment.get("feeChargesDue")));
+        validateNumberForEqual("100.0", String.valueOf(firstInstallment.getFeeChargesDue()));
 
-        LOAN_TRANSACTION_HELPER.deleteChargesForLoan(loanID, (Integer) getloanCharge(flat, loanCharges).get("id"));
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        deleteLoanCharge(loanID, getloanCharge(flat, loanCharges).getId());
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         firstInstallment = loanSchedule.get(1);
         Assertions.assertEquals(0, loanCharges.size());
-        validateNumberForEqual("0", String.valueOf(firstInstallment.get("feeChargesDue")));
+        validateNumberForEqual("0", String.valueOf(firstInstallment.getFeeChargesDue()));
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("20 September 2011", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("20 September 2011", loanID));
 
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID,
-                LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flatAccTransfer), "29 September 2011", "100"));
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        addLoanCharge(loanID, flatAccTransfer, "29 September 2011", 100.0);
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         firstInstallment = loanSchedule.get(1);
         validateCharge(flatAccTransfer, loanCharges, "100.0", "100.0", "0.0", "0.0");
-        validateNumberForEqual("100.0", String.valueOf(firstInstallment.get("feeChargesDue")));
+        validateNumberForEqual("100.0", String.valueOf(firstInstallment.getFeeChargesDue()));
 
         // DISBURSE
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("20 September 2011", loanID, "10000",
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LOG.info("DISBURSE {}", loanStatusHashMap.toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount("20 September 2011", loanID, "10000"));
 
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID,
-                LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(amountPercentage), "29 September 2011", "1"));
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        addLoanCharge(loanID, amountPercentage, "29 September 2011", 1.0);
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         firstInstallment = loanSchedule.get(1);
         validateCharge(amountPercentage, loanCharges, "1.0", "100.0", "0.0", "0.0");
         validateCharge(flatAccTransfer, loanCharges, "100.0", "100.0", "0.0", "0.0");
-        validateNumberForEqual("200.0", String.valueOf(firstInstallment.get("feeChargesDue")));
+        validateNumberForEqual("200.0", String.valueOf(firstInstallment.getFeeChargesDue()));
 
-        LOAN_TRANSACTION_HELPER.waiveChargesForLoan(loanID, (Integer) getloanCharge(amountPercentage, loanCharges).get("id"), "");
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        waiveWholeLoanCharge(loanID, getloanCharge(amountPercentage, loanCharges).getId());
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         firstInstallment = loanSchedule.get(1);
         validateCharge(amountPercentage, loanCharges, "1.0", "0.0", "0.0", "100.0");
         validateCharge(flatAccTransfer, loanCharges, "100.0", "100.0", "0.0", "0.0");
-        validateNumberForEqual("200.0", String.valueOf(firstInstallment.get("feeChargesDue")));
-        validateNumberForEqual("100.0", String.valueOf(firstInstallment.get("feeChargesOutstanding")));
-        validateNumberForEqual("100.0", String.valueOf(firstInstallment.get("feeChargesWaived")));
+        validateNumberForEqual("200.0", String.valueOf(firstInstallment.getFeeChargesDue()));
+        validateNumberForEqual("100.0", String.valueOf(firstInstallment.getFeeChargesOutstanding()));
+        validateNumberForEqual("100.0", String.valueOf(firstInstallment.getFeeChargesWaived()));
 
-        LOAN_TRANSACTION_HELPER.payChargesForLoan(loanID, (Integer) getloanCharge(flatAccTransfer, loanCharges).get("id"),
-                LoanTransactionHelper.getPayChargeJSON(SavingsAccountHelper.TRANSACTION_DATE, null));
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        payLoanCharge(loanID, getloanCharge(flatAccTransfer, loanCharges).getId(), new PostLoansLoanIdChargesChargeIdRequest()
+                .transactionDate(SAVINGS_TRANSACTION_DATE).locale(LOCALE).dateFormat(DATETIME_PATTERN));
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         firstInstallment = loanSchedule.get(1);
         validateCharge(amountPercentage, loanCharges, "1.0", "0.0", "0.0", "100.0");
         validateCharge(flatAccTransfer, loanCharges, "100.0", "0.0", "100.0", "0.0");
-        validateNumberForEqual("200.0", String.valueOf(firstInstallment.get("feeChargesDue")));
-        validateNumberForEqual("100.0", String.valueOf(firstInstallment.get("feeChargesWaived")));
-        validateNumberForEqual("100.0", String.valueOf(firstInstallment.get("feeChargesPaid")));
-        validateNumberForEqual("0.0", String.valueOf(firstInstallment.get("feeChargesOutstanding")));
+        validateNumberForEqual("200.0", String.valueOf(firstInstallment.getFeeChargesDue()));
+        validateNumberForEqual("100.0", String.valueOf(firstInstallment.getFeeChargesWaived()));
+        validateNumberForEqual("100.0", String.valueOf(firstInstallment.getFeeChargesPaid()));
+        validateNumberForEqual("0.0", String.valueOf(firstInstallment.getFeeChargesOutstanding()));
     }
 
     @Test
     public void testLoanCharges_INSTALMENT_FEE() {
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProduct(false, NONE);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Long loanProductID = createLoanProduct(false, NONE);
 
-        List<HashMap> charges = new ArrayList<>();
-        Integer flat = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "50", false));
-        Integer flatAccTransfer = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanInstallmentWithAccountTransferJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "50", false));
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
+        Long flat = chargesHelper.createLoanInstallmentCharge(ChargeCalculationType.FLAT, 50.0, false).getResourceId();
+        Long flatAccTransfer = chargesHelper.createLoanInstallmentAccountTransferCharge(ChargeCalculationType.FLAT, 50.0, false)
+                .getResourceId();
 
-        Integer amountPercentage = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1", false));
-        addCharges(charges, amountPercentage, "1", "29 September 2011");
-        Integer amountPlusInterestPercentage = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT_AND_INTEREST, "1", false));
-        addCharges(charges, amountPlusInterestPercentage, "1", "29 September 2011");
-        Integer interestPercentage = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_INTEREST, "1", false));
-        addCharges(charges, interestPercentage, "1", "29 September 2011");
+        Long amountPercentage = chargesHelper.createLoanInstallmentCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0, false)
+                .getResourceId();
+        addCharges(charges, amountPercentage, 1.0, "29 September 2011");
+        Long amountPlusInterestPercentage = chargesHelper
+                .createLoanInstallmentCharge(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST, 1.0, false).getResourceId();
+        addCharges(charges, amountPlusInterestPercentage, 1.0, "29 September 2011");
+        Long interestPercentage = chargesHelper.createLoanInstallmentCharge(ChargeCalculationType.PERCENT_OF_INTEREST, 1.0, false)
+                .getResourceId();
+        addCharges(charges, interestPercentage, 1.0, "29 September 2011");
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
 
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
         Assertions.assertNotNull(loanID);
 
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
         loanSchedule.remove(0);
-        List<HashMap> loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        List<GetLoansLoanIdChargesChargeIdResponse> loanCharges = getLoanCharges(loanID);
 
         Float totalPerOfAmout = 0F;
         Float totalPerOfAmoutPlusInt = 0F;
         Float totalPerOfint = 0F;
-        for (HashMap installment : loanSchedule) {
-            Float principalDue = (Float) installment.get("principalDue");
-            Float interestDue = (Float) installment.get("interestDue");
+        for (GetLoansLoanIdRepaymentPeriod installment : loanSchedule) {
+            Float principalDue = installment.getPrincipalDue().floatValue();
+            Float interestDue = installment.getInterestDue().floatValue();
             Float principalFee = principalDue / 100;
             Float interestFee = interestDue / 100;
             Float totalInstallmentFee = (principalFee * 2) + (interestFee * 2);
-            validateNumberForEqualExcludePrecission(String.valueOf(totalInstallmentFee), String.valueOf(installment.get("feeChargesDue")));
+            validateNumberForEqualExcludePrecission(String.valueOf(totalInstallmentFee), String.valueOf(installment.getFeeChargesDue()));
             totalPerOfAmout = totalPerOfAmout + principalFee;
             totalPerOfAmoutPlusInt = totalPerOfAmoutPlusInt + principalFee + interestFee;
             totalPerOfint = totalPerOfint + interestFee;
@@ -688,21 +668,20 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         validateChargeExcludePrecission(amountPlusInterestPercentage, loanCharges, "1.0", String.valueOf(totalPerOfAmoutPlusInt), "0.0",
                 "0.0");
 
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID,
-                LoanTransactionHelper.getInstallmentChargesForLoanAsJSON(String.valueOf(flat), "50"));
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        addLoanCharge(loanID, new PostLoansLoanIdChargesRequest().chargeId(flat).amount(50.0).locale(LOCALE).dateFormat(DATETIME_PATTERN));
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         loanSchedule.remove(0);
         totalPerOfAmout = 0F;
         totalPerOfAmoutPlusInt = 0F;
         totalPerOfint = 0F;
-        for (HashMap installment : loanSchedule) {
-            Float principalDue = (Float) installment.get("principalDue");
-            Float interestDue = (Float) installment.get("interestDue");
+        for (GetLoansLoanIdRepaymentPeriod installment : loanSchedule) {
+            Float principalDue = installment.getPrincipalDue().floatValue();
+            Float interestDue = installment.getInterestDue().floatValue();
             Float principalFee = principalDue / 100;
             Float interestFee = interestDue / 100;
             Float totalInstallmentFee = (principalFee * 2) + (interestFee * 2) + 50;
-            validateNumberForEqualExcludePrecission(String.valueOf(totalInstallmentFee), String.valueOf(installment.get("feeChargesDue")));
+            validateNumberForEqualExcludePrecission(String.valueOf(totalInstallmentFee), String.valueOf(installment.getFeeChargesDue()));
             totalPerOfAmout = totalPerOfAmout + principalFee;
             totalPerOfAmoutPlusInt = totalPerOfAmoutPlusInt + principalFee + interestFee;
             totalPerOfint = totalPerOfint + interestFee;
@@ -714,28 +693,28 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
                 "0.0");
         validateChargeExcludePrecission(flat, loanCharges, "50.0", "200", "0.0", "0.0");
 
-        LOAN_TRANSACTION_HELPER.updateChargesForLoan(loanID, (Integer) getloanCharge(amountPercentage, loanCharges).get("id"),
-                LoanTransactionHelper.getUpdateChargesForLoanAsJSON("2"));
-        LOAN_TRANSACTION_HELPER.updateChargesForLoan(loanID, (Integer) getloanCharge(interestPercentage, loanCharges).get("id"),
-                LoanTransactionHelper.getUpdateChargesForLoanAsJSON("2"));
-        LOAN_TRANSACTION_HELPER.updateChargesForLoan(loanID, (Integer) getloanCharge(amountPlusInterestPercentage, loanCharges).get("id"),
-                LoanTransactionHelper.getUpdateChargesForLoanAsJSON("2"));
-        LOAN_TRANSACTION_HELPER.updateChargesForLoan(loanID, (Integer) getloanCharge(flat, loanCharges).get("id"),
-                LoanTransactionHelper.getUpdateChargesForLoanAsJSON("100"));
+        updateLoanCharge(loanID, getloanCharge(amountPercentage, loanCharges).getId(),
+                new PutLoansLoanIdChargesChargeIdRequest().amount(2.0).locale(LOCALE).dateFormat(DATETIME_PATTERN));
+        updateLoanCharge(loanID, getloanCharge(interestPercentage, loanCharges).getId(),
+                new PutLoansLoanIdChargesChargeIdRequest().amount(2.0).locale(LOCALE).dateFormat(DATETIME_PATTERN));
+        updateLoanCharge(loanID, getloanCharge(amountPlusInterestPercentage, loanCharges).getId(),
+                new PutLoansLoanIdChargesChargeIdRequest().amount(2.0).locale(LOCALE).dateFormat(DATETIME_PATTERN));
+        updateLoanCharge(loanID, getloanCharge(flat, loanCharges).getId(),
+                new PutLoansLoanIdChargesChargeIdRequest().amount(100.0).locale(LOCALE).dateFormat(DATETIME_PATTERN));
 
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         loanSchedule.remove(0);
         totalPerOfAmout = 0F;
         totalPerOfAmoutPlusInt = 0F;
         totalPerOfint = 0F;
-        for (HashMap installment : loanSchedule) {
-            Float principalDue = (Float) installment.get("principalDue");
-            Float interestDue = (Float) installment.get("interestDue");
+        for (GetLoansLoanIdRepaymentPeriod installment : loanSchedule) {
+            Float principalDue = installment.getPrincipalDue().floatValue();
+            Float interestDue = installment.getInterestDue().floatValue();
             Float principalFee = principalDue * 2 / 100;
             Float interestFee = interestDue * 2 / 100;
             Float totalInstallmentFee = (principalFee * 2) + (interestFee * 2) + 100;
-            validateNumberForEqualExcludePrecission(String.valueOf(totalInstallmentFee), String.valueOf(installment.get("feeChargesDue")));
+            validateNumberForEqualExcludePrecission(String.valueOf(totalInstallmentFee), String.valueOf(installment.getFeeChargesDue()));
             totalPerOfAmout = totalPerOfAmout + principalFee;
             totalPerOfAmoutPlusInt = totalPerOfAmoutPlusInt + principalFee + interestFee;
             totalPerOfint = totalPerOfint + interestFee;
@@ -747,23 +726,23 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
                 "0.0");
         validateChargeExcludePrecission(flat, loanCharges, "100.0", "400", "0.0", "0.0");
 
-        final Integer savingsId = SavingsAccountHelper.openSavingsAccount(REQUEST_SPEC, RESPONSE_SPEC, clientID, MINIMUM_OPENING_BALANCE);
-        LOAN_TRANSACTION_HELPER.updateLoan(loanID, updateLoanJson(clientID, loanProductID, copyChargesForUpdate(loanCharges, null, null),
-                String.valueOf(savingsId), collaterals));
+        final Long savingsId = openSavingsAccountActivatedOnTransactionDate(clientID, MINIMUM_OPENING_BALANCE);
+        modifyLoanApplication(loanID, null,
+                updateLoanRequest(clientID, loanProductID, copyChargesForUpdate(loanCharges, null, null), savingsId, collaterals));
 
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         loanSchedule.remove(0);
         totalPerOfAmout = 0F;
         totalPerOfAmoutPlusInt = 0F;
         totalPerOfint = 0F;
-        for (HashMap installment : loanSchedule) {
-            Float principalDue = (Float) installment.get("principalDue");
-            Float interestDue = (Float) installment.get("interestDue");
+        for (GetLoansLoanIdRepaymentPeriod installment : loanSchedule) {
+            Float principalDue = installment.getPrincipalDue().floatValue();
+            Float interestDue = installment.getInterestDue().floatValue();
             Float principalFee = principalDue * 2 / 100;
             Float interestFee = interestDue * 2 / 100;
             Float totalInstallmentFee = (principalFee * 2) + (interestFee * 2) + 100;
-            validateNumberForEqualExcludePrecission(String.valueOf(totalInstallmentFee), String.valueOf(installment.get("feeChargesDue")));
+            validateNumberForEqualExcludePrecission(String.valueOf(totalInstallmentFee), String.valueOf(installment.getFeeChargesDue()));
             totalPerOfAmout = totalPerOfAmout + principalFee;
             totalPerOfAmoutPlusInt = totalPerOfAmoutPlusInt + principalFee + interestFee;
             totalPerOfint = totalPerOfint + interestFee;
@@ -775,22 +754,22 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
                 "0.0");
         validateChargeExcludePrecission(flat, loanCharges, "100.0", "400", "0.0", "0.0");
 
-        LOAN_TRANSACTION_HELPER.updateLoan(loanID,
-                updateLoanJson(clientID, loanProductID, copyChargesForUpdate(loanCharges, flat, "1"), null, collaterals));
+        modifyLoanApplication(loanID, null,
+                updateLoanRequest(clientID, loanProductID, copyChargesForUpdate(loanCharges, flat, 1.0), null, collaterals));
 
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         loanSchedule.remove(0);
         totalPerOfAmout = 0F;
         totalPerOfAmoutPlusInt = 0F;
         totalPerOfint = 0F;
-        for (HashMap installment : loanSchedule) {
-            Float principalDue = (Float) installment.get("principalDue");
-            Float interestDue = (Float) installment.get("interestDue");
+        for (GetLoansLoanIdRepaymentPeriod installment : loanSchedule) {
+            Float principalDue = installment.getPrincipalDue().floatValue();
+            Float interestDue = installment.getInterestDue().floatValue();
             Float principalFee = principalDue / 100;
             Float interestFee = interestDue / 100;
             Float totalInstallmentFee = (principalFee * 2) + (interestFee * 2);
-            validateNumberForEqualExcludePrecission(String.valueOf(totalInstallmentFee), String.valueOf(installment.get("feeChargesDue")));
+            validateNumberForEqualExcludePrecission(String.valueOf(totalInstallmentFee), String.valueOf(installment.getFeeChargesDue()));
             totalPerOfAmout = totalPerOfAmout + principalFee;
             totalPerOfAmoutPlusInt = totalPerOfAmoutPlusInt + principalFee + interestFee;
             totalPerOfint = totalPerOfint + interestFee;
@@ -802,84 +781,70 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
                 "0.0");
 
         charges.clear();
-        addCharges(charges, flat, "50", "29 September 2011");
-        LOAN_TRANSACTION_HELPER.updateLoan(loanID, updateLoanJson(clientID, loanProductID, charges, null, collaterals));
+        addCharges(charges, flat, 50.0, "29 September 2011");
+        modifyLoanApplication(loanID, null, updateLoanRequest(clientID, loanProductID, toUpdateCharges(charges), null, collaterals));
 
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         loanSchedule.remove(0);
-        for (HashMap installment : loanSchedule) {
-            validateNumberForEqualExcludePrecission("50", String.valueOf(installment.get("feeChargesDue")));
+        for (GetLoansLoanIdRepaymentPeriod installment : loanSchedule) {
+            validateNumberForEqualExcludePrecission("50", String.valueOf(installment.getFeeChargesDue()));
         }
         validateChargeExcludePrecission(flat, loanCharges, "50.0", "200", "0.0", "0.0");
 
-        LOAN_TRANSACTION_HELPER.deleteChargesForLoan(loanID, (Integer) getloanCharge(flat, loanCharges).get("id"));
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        deleteLoanCharge(loanID, getloanCharge(flat, loanCharges).getId());
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         loanSchedule.remove(0);
-        for (HashMap installment : loanSchedule) {
-            validateNumberForEqualExcludePrecission("0", String.valueOf(installment.get("feeChargesDue")));
+        for (GetLoansLoanIdRepaymentPeriod installment : loanSchedule) {
+            validateNumberForEqualExcludePrecission("0", String.valueOf(installment.getFeeChargesDue()));
         }
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("20 September 2011", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("20 September 2011", loanID));
 
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID,
-                LoanTransactionHelper.getInstallmentChargesForLoanAsJSON(String.valueOf(flatAccTransfer), "100"));
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        addLoanCharge(loanID,
+                new PostLoansLoanIdChargesRequest().chargeId(flatAccTransfer).amount(100.0).locale(LOCALE).dateFormat(DATETIME_PATTERN));
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         loanSchedule.remove(0);
-        for (HashMap installment : loanSchedule) {
-            validateNumberForEqualExcludePrecission("100", String.valueOf(installment.get("feeChargesDue")));
+        for (GetLoansLoanIdRepaymentPeriod installment : loanSchedule) {
+            validateNumberForEqualExcludePrecission("100", String.valueOf(installment.getFeeChargesDue()));
         }
         validateChargeExcludePrecission(flatAccTransfer, loanCharges, "100.0", "400", "0.0", "0.0");
 
         // DISBURSE
-        String loanDetail = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("20 September 2011", loanID, "10000",
-                JsonPath.from(loanDetail).get("netDisbursalAmount").toString());
+        GetLoansLoanIdResponse loanStatusHashMap = disburseLoanWithNetDisbursalAmount("20 September 2011", loanID, "10000");
         LOG.info("DISBURSE {}", loanStatusHashMap.toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(loanStatusHashMap);
 
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID,
-                LoanTransactionHelper.getInstallmentChargesForLoanAsJSON(String.valueOf(flat), "50"));
+        addLoanCharge(loanID, new PostLoansLoanIdChargesRequest().chargeId(flat).amount(50.0).locale(LOCALE).dateFormat(DATETIME_PATTERN));
 
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         loanSchedule.remove(0);
-        for (HashMap installment : loanSchedule) {
-            validateNumberForEqualExcludePrecission("150", String.valueOf(installment.get("feeChargesDue")));
+        for (GetLoansLoanIdRepaymentPeriod installment : loanSchedule) {
+            validateNumberForEqualExcludePrecission("150", String.valueOf(installment.getFeeChargesDue()));
         }
         validateChargeExcludePrecission(flatAccTransfer, loanCharges, "100.0", "400", "0.0", "0.0");
         validateChargeExcludePrecission(flat, loanCharges, "50.0", "200", "0.0", "0.0");
 
-        Integer waivePeriodnum = 1;
-        final Integer waivedChargeId = LOAN_TRANSACTION_HELPER.waiveChargesForLoan(loanID,
-                (Integer) getloanCharge(flat, loanCharges).get("id"),
-                LoanTransactionHelper.getWaiveChargeJSON(String.valueOf(waivePeriodnum)));
+        Long waivePeriodnum = 1L;
+        final Long waivedChargeId = waiveLoanCharge(loanID, getloanCharge(flat, loanCharges).getId(),
+                new PostLoansLoanIdChargesChargeIdRequest().installmentNumber(waivePeriodnum).locale(LOCALE)).getResourceId();
 
         // Get loan transaction details
-        ArrayList<HashMap> loanDetails = LOAN_TRANSACTION_HELPER.getLoanTransactionDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        Assertions.assertNotNull(loanDetails, "Empty Loan Details");
-        Gson gson = new Gson();
-        Integer transId = null;
-        Integer chargeId = null;
-        for (HashMap detail : loanDetails) {
-            String resultObject = gson.toJson(detail);
-            JsonObject reportObject = JsonParser.parseString(resultObject).getAsJsonObject();
-            JsonObject type = reportObject.getAsJsonObject("type");
-            final Integer transTypeId = type.get("id").getAsInt();
-            Assertions.assertNotNull(transTypeId);
-            if (Integer.valueOf(9).compareTo(transTypeId) == 0) {
-                transId = reportObject.get("id").getAsInt();
+        List<GetLoansLoanIdTransactions> loanTransactions = getLoanDetails(loanID).getTransactions();
+        Assertions.assertNotNull(loanTransactions, "Empty Loan Details");
+        Long transId = null;
+        Long chargeId = null;
+        for (GetLoansLoanIdTransactions transaction : loanTransactions) {
+            Assertions.assertNotNull(transaction.getType().getId());
+            if (Boolean.TRUE.equals(transaction.getType().getWaiveCharges())) {
+                transId = transaction.getId();
                 Assertions.assertNotNull(transId);
-                final HashMap<String, String> map = new HashMap<>();
-                map.put("id", transId.toString());
-                map.put("loanId", loanID.toString());
-                final String putBody = gson.toJson(map);
-                chargeId = LOAN_TRANSACTION_HELPER.undoWaiveChargesForLoanReturnResourceId(loanID, transId, putBody);
+                chargeId = undoWaiveLoanCharge(loanID, transId, new PutChargeTransactionChangesRequest().id(transId).loanId(loanID))
+                        .getResourceId();
                 break;
             }
         }
@@ -887,19 +852,14 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         Assertions.assertEquals(waivedChargeId, chargeId);
 
         // Validate the undo process
-        ArrayList<HashMap> loanTransactionDetails = LOAN_TRANSACTION_HELPER.getLoanTransactionDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        List<GetLoansLoanIdTransactions> loanTransactionDetails = getLoanDetails(loanID).getTransactions();
         Assertions.assertNotNull(loanTransactionDetails, "Empty Loan Transaction Details");
         for (int i = 0; i < loanTransactionDetails.size(); i++) {
-            String resultObject = gson.toJson(loanTransactionDetails.get(i));
-            JsonObject reportObject = JsonParser.parseString(resultObject).getAsJsonObject();
-            final Boolean isReversed = reportObject.get("manuallyReversed").getAsBoolean();
-            final Integer id = reportObject.get("id").getAsInt();
+            final Boolean isReversed = loanTransactionDetails.get(i).getManuallyReversed();
+            final Long id = loanTransactionDetails.get(i).getId();
 
             if (transId.compareTo(id) == 0) {
-                final HashMap chargeDetails = LOAN_TRANSACTION_HELPER.getLoanCharge(loanID, waivedChargeId);
-                String resultChargeObject = gson.toJson(chargeDetails);
-                JsonObject reportChargeObject = JsonParser.parseString(resultChargeObject).getAsJsonObject();
-                BigDecimal waiveAmount = reportChargeObject.get("amountWaived").getAsBigDecimal();
+                BigDecimal waiveAmount = BigDecimal.valueOf(getLoanCharge(loanID, waivedChargeId).getAmountWaived());
 
                 Assertions.assertEquals(true, isReversed);
                 Assertions.assertEquals(Double.valueOf(0), waiveAmount.doubleValue());
@@ -910,42 +870,42 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         }
 
         // Re-waive charge
-        LOAN_TRANSACTION_HELPER.waiveChargesForLoan(loanID, waivedChargeId,
-                LoanTransactionHelper.getWaiveChargeJSON(String.valueOf(waivePeriodnum)));
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        waiveLoanCharge(loanID, waivedChargeId,
+                new PostLoansLoanIdChargesChargeIdRequest().installmentNumber(waivePeriodnum).locale(LOCALE));
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         loanSchedule.remove(0);
-        for (HashMap installment : loanSchedule) {
-            validateNumberForEqualExcludePrecission("150", String.valueOf(installment.get("feeChargesDue")));
-            if (waivePeriodnum.equals(installment.get("period"))) {
-                validateNumberForEqualExcludePrecission("100.0", String.valueOf(installment.get("feeChargesOutstanding")));
-                validateNumberForEqualExcludePrecission("50.0", String.valueOf(installment.get("feeChargesWaived")));
+        for (GetLoansLoanIdRepaymentPeriod installment : loanSchedule) {
+            validateNumberForEqualExcludePrecission("150", String.valueOf(installment.getFeeChargesDue()));
+            if (isPeriod(installment, waivePeriodnum)) {
+                validateNumberForEqualExcludePrecission("100.0", String.valueOf(installment.getFeeChargesOutstanding()));
+                validateNumberForEqualExcludePrecission("50.0", String.valueOf(installment.getFeeChargesWaived()));
             } else {
-                validateNumberForEqualExcludePrecission("150.0", String.valueOf(installment.get("feeChargesOutstanding")));
-                validateNumberForEqualExcludePrecission("0.0", String.valueOf(installment.get("feeChargesWaived")));
+                validateNumberForEqualExcludePrecission("150.0", String.valueOf(installment.getFeeChargesOutstanding()));
+                validateNumberForEqualExcludePrecission("0.0", String.valueOf(installment.getFeeChargesWaived()));
 
             }
         }
         validateChargeExcludePrecission(flatAccTransfer, loanCharges, "100.0", "400", "0.0", "0.0");
         validateChargeExcludePrecission(flat, loanCharges, "50.0", "150", "0.0", "50.0");
 
-        Integer payPeriodnum = 2;
-        LOAN_TRANSACTION_HELPER.payChargesForLoan(loanID, (Integer) getloanCharge(flatAccTransfer, loanCharges).get("id"),
-                LoanTransactionHelper.getPayChargeJSON(SavingsAccountHelper.TRANSACTION_DATE, String.valueOf(payPeriodnum)));
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        Long payPeriodnum = 2L;
+        payLoanCharge(loanID, getloanCharge(flatAccTransfer, loanCharges).getId(), new PostLoansLoanIdChargesChargeIdRequest()
+                .transactionDate(SAVINGS_TRANSACTION_DATE).installmentNumber(payPeriodnum).locale(LOCALE).dateFormat(DATETIME_PATTERN));
+        loanCharges = getLoanCharges(loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         loanSchedule.remove(0);
-        for (HashMap installment : loanSchedule) {
-            validateNumberForEqualExcludePrecission("150", String.valueOf(installment.get("feeChargesDue")));
-            if (payPeriodnum.equals(installment.get("period"))) {
-                validateNumberForEqualExcludePrecission("50.0", String.valueOf(installment.get("feeChargesOutstanding")));
-                validateNumberForEqualExcludePrecission("100.0", String.valueOf(installment.get("feeChargesPaid")));
-            } else if (waivePeriodnum.equals(installment.get("period"))) {
-                validateNumberForEqualExcludePrecission("100.0", String.valueOf(installment.get("feeChargesOutstanding")));
-                validateNumberForEqualExcludePrecission("50.0", String.valueOf(installment.get("feeChargesWaived")));
+        for (GetLoansLoanIdRepaymentPeriod installment : loanSchedule) {
+            validateNumberForEqualExcludePrecission("150", String.valueOf(installment.getFeeChargesDue()));
+            if (isPeriod(installment, payPeriodnum)) {
+                validateNumberForEqualExcludePrecission("50.0", String.valueOf(installment.getFeeChargesOutstanding()));
+                validateNumberForEqualExcludePrecission("100.0", String.valueOf(installment.getFeeChargesPaid()));
+            } else if (isPeriod(installment, waivePeriodnum)) {
+                validateNumberForEqualExcludePrecission("100.0", String.valueOf(installment.getFeeChargesOutstanding()));
+                validateNumberForEqualExcludePrecission("50.0", String.valueOf(installment.getFeeChargesWaived()));
             } else {
-                validateNumberForEqualExcludePrecission("150.0", String.valueOf(installment.get("feeChargesOutstanding")));
-                validateNumberForEqualExcludePrecission("0.0", String.valueOf(installment.get("feeChargesPaid")));
+                validateNumberForEqualExcludePrecission("150.0", String.valueOf(installment.getFeeChargesOutstanding()));
+                validateNumberForEqualExcludePrecission("0.0", String.valueOf(installment.getFeeChargesPaid()));
 
             }
         }
@@ -953,90 +913,81 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         validateChargeExcludePrecission(flat, loanCharges, "50.0", "150", "0.0", "50.0");
 
         // Loan Charges with US Locale using the amount as a number in the JSON body
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID,
-                LoanTransactionHelper.getInstallmentChargesForLoanAsJSON(String.valueOf(flat), 50.05, Locale.US));
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        addInstallmentChargeWithLocale(loanID, flat, 50.05, Locale.US);
+        loanCharges = getLoanCharges(loanID);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         loanSchedule.remove(0);
-        for (HashMap installment : loanSchedule) {
-            validateNumberForEqualExcludePrecission("200.05", String.valueOf(installment.get("feeChargesDue")));
+        for (GetLoansLoanIdRepaymentPeriod installment : loanSchedule) {
+            validateNumberForEqualExcludePrecission("200.05", String.valueOf(installment.getFeeChargesDue()));
         }
 
         // Loan Charges with other Locale using comma (,) as decimal delimiter
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID,
-                LoanTransactionHelper.getInstallmentChargesForLoanAsJSON(String.valueOf(flat), "50,05", Locale.GERMAN));
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        addInstallmentChargeWithLocaleFormattedAmount(loanID, flat, "50,05", Locale.GERMAN);
+        loanCharges = getLoanCharges(loanID);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         loanSchedule.remove(0);
-        for (HashMap installment : loanSchedule) {
-            validateNumberForEqualExcludePrecission("250.10", String.valueOf(installment.get("feeChargesDue")));
+        for (GetLoansLoanIdRepaymentPeriod installment : loanSchedule) {
+            validateNumberForEqualExcludePrecission("250.10", String.valueOf(installment.getFeeChargesDue()));
         }
 
         // Loan Charges with German Locale (where the comma is the decimal delimiter) using the amount as a number in
         // the JSON body
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID,
-                LoanTransactionHelper.getInstallmentChargesForLoanAsJSON(String.valueOf(flat), 50.05, Locale.GERMAN));
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        addInstallmentChargeWithLocale(loanID, flat, 50.05, Locale.GERMAN);
+        loanCharges = getLoanCharges(loanID);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         loanSchedule.remove(0);
-        for (HashMap installment : loanSchedule) {
-            validateNumberForEqualExcludePrecission("300.15", String.valueOf(installment.get("feeChargesDue")));
+        for (GetLoansLoanIdRepaymentPeriod installment : loanSchedule) {
+            validateNumberForEqualExcludePrecission("300.15", String.valueOf(installment.getFeeChargesDue()));
         }
     }
 
     @Test
     public void testLoanCharges_DISBURSEMENT_TO_SAVINGS() {
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProduct(false, NONE);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Long loanProductID = createLoanProduct(false, NONE);
 
-        final Integer savingsId = SavingsAccountHelper.openSavingsAccount(REQUEST_SPEC, RESPONSE_SPEC, clientID, MINIMUM_OPENING_BALANCE);
+        final Long savingsId = openSavingsAccountActivatedOnTransactionDate(clientID, MINIMUM_OPENING_BALANCE);
 
-        List<HashMap> collaterals = new ArrayList<>();
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
         Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
         Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, null, savingsId.toString(), "12,000.00", collaterals);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID, null, savingsId, "12,000.00", collaterals);
         Assertions.assertNotNull(loanID);
 
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("20 September 2011", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("20 September 2011", loanID));
 
-        HashMap summary = SAVINGS_ACCOUNT_HELPER.getSavingsSummary(savingsId);
+        SavingsAccountSummaryData summary = savingsHelper.getSavingsSummary(savingsId);
         float balance = Float.parseFloat(MINIMUM_OPENING_BALANCE);
-        assertEquals(balance, summary.get("accountBalance"), "Verifying opening Balance");
+        assertEquals(balance, summary.getAccountBalance().floatValue(), "Verifying opening Balance");
 
         // DISBURSE
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanToSavings(SavingsAccountHelper.TRANSACTION_DATE, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
+        GetLoansLoanIdResponse loanStatusHashMap = disburseToSavingsWithNetDisbursalAmount(SAVINGS_TRANSACTION_DATE, loanID);
         LOG.info("DISBURSE {}", loanStatusHashMap.toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(loanStatusHashMap);
 
-        summary = SAVINGS_ACCOUNT_HELPER.getSavingsSummary(savingsId);
+        summary = savingsHelper.getSavingsSummary(savingsId);
         balance = Float.parseFloat(MINIMUM_OPENING_BALANCE) + Float.parseFloat("12000");
-        assertEquals(balance, summary.get("accountBalance"), "Verifying opening Balance");
+        assertEquals(balance, summary.getAccountBalance().floatValue(), "Verifying opening Balance");
 
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.undoDisbursal(loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        undoDisbursement(loanID);
+        loanStatusHashMap = getLoanDetails(loanID);
+        verifyLoanIsApprovedAndWaitingForDisbursal(loanStatusHashMap);
 
-        summary = SAVINGS_ACCOUNT_HELPER.getSavingsSummary(savingsId);
+        summary = savingsHelper.getSavingsSummary(savingsId);
         balance = Float.parseFloat(MINIMUM_OPENING_BALANCE);
-        assertEquals(balance, summary.get("accountBalance"), "Verifying opening Balance");
+        assertEquals(balance, summary.getAccountBalance().floatValue(), "Verifying opening Balance");
 
     }
 
@@ -1050,148 +1001,133 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         }
 
         String fourMonthsfromNow = Utils.convertDateToURLFormat(fourMonthsfromNowCalendar);
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProduct(false, NONE);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Long loanProductID = createLoanProduct(false, NONE);
 
-        List<HashMap> charges = new ArrayList<>();
-        Integer disbursementFee = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanDisbursementJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_INTEREST, "5"));
-        addCharges(charges, disbursementFee, "5", null);
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
+        Long disbursementFee = chargesHelper.createLoanDisbursementCharge(ChargeCalculationType.PERCENT_OF_INTEREST, 5.0).getResourceId();
+        addCharges(charges, disbursementFee, 5.0, null);
 
-        List<HashMap> collaterals = new ArrayList<>();
-        final Integer loanID = applyForLoanApplicationWithPaymentStrategyAndPastMonth(clientID, loanProductID, charges, null, "1000",
-                LoanApplicationTestBuilder.DEFAULT_STRATEGY, fourMonthsfromNow, collaterals);
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
+        final Long loanID = applyForLoanApplicationWithPaymentStrategyAndPastMonth(clientID, loanProductID, charges, null, "1000",
+                DEFAULT_STRATEGY, fourMonthsfromNow, collaterals);
         Assertions.assertNotNull(loanID);
 
-        LOAN_TRANSACTION_HELPER.approveLoan(fourMonthsfromNow, loanID);
+        approveLoan(fourMonthsfromNow, loanID);
 
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(fourMonthsfromNow, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanID);
+        disburseLoanWithNetDisbursalAmount(fourMonthsfromNow, loanID);
 
         // check for disbursement fee: Principal 1,000 with 24% Annual Rate for 6 Months we have Total Interest of:
         // 120.00
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap disbursementDetail = loanSchedule.get(0);
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod disbursementDetail = loanSchedule.get(0);
         // Disbursement Fee: 5% of 120.00 = 6.00
-        validateNumberForEqual("6.00", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        validateNumberForEqual("6.00", String.valueOf(disbursementDetail.getFeeChargesDue()));
     }
 
     @Test
     public void testLoanCharges_DISBURSEMENT_WITH_TRANCHES() {
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProduct(true, NONE);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Long loanProductID = createLoanProduct(true, NONE);
 
-        List<HashMap> tranches = new ArrayList<>();
+        List<PostLoansDisbursementData> tranches = new ArrayList<>();
         tranches.add(createTrancheDetail("01 March 2014", "25000"));
         tranches.add(createTrancheDetail("23 April 2014", "20000"));
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
         Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                clientID.toString(), collateralId);
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
         Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanID = applyForLoanApplicationWithTranches(clientID, loanProductID, null, null, "45,000.00", tranches, collaterals);
+        final Long loanID = applyForLoanApplicationWithTranches(clientID, loanProductID, null, null, "45,000.00", tranches, collaterals);
         Assertions.assertNotNull(loanID);
 
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("01 March 2014", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("01 March 2014", loanID));
 
         // DISBURSE first Tranche
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("20 March 2014", loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanID);
+        GetLoansLoanIdResponse loanStatusHashMap = disburseLoanWithNetDisbursalAmount("20 March 2014", loanID);
         LOG.info("DISBURSE {}", loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(loanStatusHashMap);
 
         // DISBURSE Second Tranche
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("23 April 2014", loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
+        loanStatusHashMap = disburseLoanWithNetDisbursalAmount("23 April 2014", loanID);
         LOG.info("DISBURSE {}", loanStatusHashMap.toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(loanStatusHashMap);
 
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.undoDisbursal(loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        undoDisbursement(loanID);
+        loanStatusHashMap = getLoanDetails(loanID);
+        verifyLoanIsApprovedAndWaitingForDisbursal(loanStatusHashMap);
 
     }
 
     @Test
     public void testLoanCharges_DISBURSEMENT_TO_SAVINGS_WITH_TRANCHES() {
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProduct(true, NONE);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Long loanProductID = createLoanProduct(true, NONE);
 
-        final Integer savingsId = SavingsAccountHelper.openSavingsAccount(REQUEST_SPEC, RESPONSE_SPEC, clientID, MINIMUM_OPENING_BALANCE);
+        final Long savingsId = openSavingsAccountActivatedOnTransactionDate(clientID, MINIMUM_OPENING_BALANCE);
 
-        List<HashMap> tranches = new ArrayList<>();
+        List<PostLoansDisbursementData> tranches = new ArrayList<>();
         tranches.add(createTrancheDetail("01 March 2014", "25000"));
         tranches.add(createTrancheDetail("23 April 2014", "20000"));
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
         Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
         Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanID = applyForLoanApplicationWithTranches(clientID, loanProductID, null, savingsId.toString(), "45,000.00",
-                tranches, collaterals);
+        final Long loanID = applyForLoanApplicationWithTranches(clientID, loanProductID, null, savingsId, "45,000.00", tranches,
+                collaterals);
         Assertions.assertNotNull(loanID);
 
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("01 March 2014", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("01 March 2014", loanID));
 
-        HashMap summary = SAVINGS_ACCOUNT_HELPER.getSavingsSummary(savingsId);
+        SavingsAccountSummaryData summary = savingsHelper.getSavingsSummary(savingsId);
         float balance = Float.parseFloat(MINIMUM_OPENING_BALANCE);
-        assertEquals(balance, summary.get("accountBalance"), "Verifying opening Balance");
+        assertEquals(balance, summary.getAccountBalance().floatValue(), "Verifying opening Balance");
 
         // DISBURSE first Tranche
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanToSavings("01 March 2014", loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
+        GetLoansLoanIdResponse loanStatusHashMap = disburseToSavingsWithNetDisbursalAmount("01 March 2014", loanID);
         LOG.info("DISBURSE {}", loanStatusHashMap.toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(loanStatusHashMap);
 
-        summary = SAVINGS_ACCOUNT_HELPER.getSavingsSummary(savingsId);
+        summary = savingsHelper.getSavingsSummary(savingsId);
         balance = Float.parseFloat(MINIMUM_OPENING_BALANCE) + Float.parseFloat("25000");
-        assertEquals(balance, summary.get("accountBalance"), "Verifying opening Balance");
+        assertEquals(balance, summary.getAccountBalance().floatValue(), "Verifying opening Balance");
 
         // DISBURSE Second Tranche
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanToSavings("23 April 2014", loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
+        loanStatusHashMap = disburseToSavingsWithNetDisbursalAmount("23 April 2014", loanID);
         LOG.info("DISBURSE {}", loanStatusHashMap.toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(loanStatusHashMap);
 
-        summary = SAVINGS_ACCOUNT_HELPER.getSavingsSummary(savingsId);
+        summary = savingsHelper.getSavingsSummary(savingsId);
         balance = Float.parseFloat(MINIMUM_OPENING_BALANCE) + Float.parseFloat("25000") + Float.parseFloat("20000");
-        assertEquals(balance, summary.get("accountBalance"), "Verifying opening Balance");
+        assertEquals(balance, summary.getAccountBalance().floatValue(), "Verifying opening Balance");
 
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.undoDisbursal(loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        undoDisbursement(loanID);
+        loanStatusHashMap = getLoanDetails(loanID);
+        verifyLoanIsApprovedAndWaitingForDisbursal(loanStatusHashMap);
 
-        summary = SAVINGS_ACCOUNT_HELPER.getSavingsSummary(savingsId);
+        summary = savingsHelper.getSavingsSummary(savingsId);
         balance = Float.parseFloat(MINIMUM_OPENING_BALANCE);
-        assertEquals(balance, summary.get("accountBalance"), "Verifying opening Balance");
+        assertEquals(balance, summary.getAccountBalance().floatValue(), "Verifying opening Balance");
 
     }
 
@@ -1201,184 +1137,174 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void loanWithFlatCahargesAndCashBasedAccountingEnabled() {
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
 
         // Add charges with payment mode regular
-        List<HashMap> charges = new ArrayList<>();
-        Integer flatDisbursement = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC, ChargesHelper.getLoanDisbursementJSON());
-        addCharges(charges, flatDisbursement, "100", null);
-        Integer flatSpecifiedDueDate = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "100", false));
-        addCharges(charges, flatSpecifiedDueDate, "100", "29 September 2011");
-        Integer flatInstallmentFee = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "50", false));
-        addCharges(charges, flatInstallmentFee, "50", null);
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
+        Long flatDisbursement = chargesHelper.createLoanDisbursementCharge(ChargeCalculationType.FLAT, 100.0).getResourceId();
+        addCharges(charges, flatDisbursement, 100.0, null);
+        Long flatSpecifiedDueDate = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.FLAT, 100.0, false)
+                .getResourceId();
+        addCharges(charges, flatSpecifiedDueDate, 100.0, "29 September 2011");
+        Long flatInstallmentFee = chargesHelper.createLoanInstallmentCharge(ChargeCalculationType.FLAT, 50.0, false).getResourceId();
+        addCharges(charges, flatInstallmentFee, 50.0, null);
 
-        final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-        final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-        final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-        final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+        final Account assetAccount = accountHelper.createAssetAccount();
+        final Account incomeAccount = accountHelper.createIncomeAccount();
+        final Account expenseAccount = accountHelper.createExpenseAccount();
+        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
 
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanProductID = createLoanProduct(false, CASH_BASED, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
+        final Long loanProductID = createLoanProduct(false, CASH_BASED, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
 
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
         verifyLoanRepaymentSchedule(loanSchedule);
 
-        List<HashMap> loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        List<GetLoansLoanIdChargesChargeIdResponse> loanCharges = getLoanCharges(loanID);
         validateCharge(flatDisbursement, loanCharges, "100", "100.00", "0.0", "0.0");
         validateCharge(flatSpecifiedDueDate, loanCharges, "100", "100.00", "0.0", "0.0");
         validateCharge(flatInstallmentFee, loanCharges, "50", "200.00", "0.0", "0.0");
 
         // check for disbursement fee
-        HashMap disbursementDetail = loanSchedule.get(0);
-        validateNumberForEqual("100.00", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod disbursementDetail = loanSchedule.get(0);
+        validateNumberForEqual("100.00", String.valueOf(disbursementDetail.getFeeChargesDue()));
 
         // check for charge at specified date and installment fee
-        HashMap firstInstallment = loanSchedule.get(1);
-        validateNumberForEqual("150.00", String.valueOf(firstInstallment.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod firstInstallment = loanSchedule.get(1);
+        validateNumberForEqual("150.00", String.valueOf(firstInstallment.getFeeChargesDue()));
 
         // check for installment fee
-        HashMap secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("50.00", String.valueOf(secondInstallment.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod secondInstallment = loanSchedule.get(2);
+        validateNumberForEqual("50.00", String.valueOf(secondInstallment.getFeeChargesDue()));
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("20 September 2011", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("20 September 2011", loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("20 September 2011", loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount("20 September 2011", loanID));
 
-        final JournalEntry[] assetAccountInitialEntry = { new JournalEntry(Float.parseFloat("100.00"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.DEBIT) };
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", assetAccountInitialEntry);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 September 2011",
-                new JournalEntry(Float.parseFloat("100.00"), JournalEntry.TransactionType.CREDIT));
+        final LoanTestData.Journal[] assetAccountInitialEntry = {
+                journalEntry(Float.parseFloat("100.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()) };
+        checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", assetAccountInitialEntry);
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 September 2011",
+                journalEntry(Float.parseFloat("100.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(flatDisbursement, loanCharges, "100", "0.00", "100.0", "0.0");
 
         LOG.info("-------------Make repayment 1-----------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 October 2011", Float.parseFloat("3301.49"), loanID);
+        makeRepayment("20 October 2011", Float.parseFloat("3301.49"), loanID);
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(flatDisbursement, loanCharges, "100", "0.00", "100.0", "0.0");
         validateCharge(flatSpecifiedDueDate, loanCharges, "100", "0.00", "100.0", "0.0");
         validateCharge(flatInstallmentFee, loanCharges, "50", "150.00", "50.0", "0.0");
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("3301.49"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("2911.49"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("150.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("240.00"), JournalEntry.TransactionType.CREDIT));
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flatSpecifiedDueDate), "29 October 2011", "100"));
+        checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("3301.49"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("2911.49"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("150.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("240.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
+        addLoanCharge(loanID, flatSpecifiedDueDate, "29 October 2011", 100.0);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
 
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("150.00", String.valueOf(secondInstallment.get("feeChargesDue")));
-        LOAN_TRANSACTION_HELPER.waiveChargesForLoan(loanID, (Integer) getloanCharge(flatInstallmentFee, loanCharges).get("id"),
-                LoanTransactionHelper.getWaiveChargeJSON(String.valueOf(2)));
+        validateNumberForEqual("150.00", String.valueOf(secondInstallment.getFeeChargesDue()));
+        waiveLoanCharge(loanID, getloanCharge(flatInstallmentFee, loanCharges).getId(),
+                new PostLoansLoanIdChargesChargeIdRequest().installmentNumber(2L).locale(LOCALE));
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(flatInstallmentFee, loanCharges, "50", "100.00", "50.0", "50.0");
 
         LOG.info("----------Make repayment 2------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3251.49"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("3251.49"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("2969.72"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("100.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("181.77"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 November 2011", Float.parseFloat("3251.49"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("3251.49"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("2969.72"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("100.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("181.77"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("0", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("--------------Waive interest---------------");
-        LOAN_TRANSACTION_HELPER.waiveInterest("20 December 2011", String.valueOf(61.79), loanID);
+        waiveInterestOnLoan(loanID, "20 December 2011", 61.79);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap thirdInstallment = loanSchedule.get(3);
-        validateNumberForEqual("60.59", String.valueOf(thirdInstallment.get("interestOutstanding")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod thirdInstallment = loanSchedule.get(3);
+        validateNumberForEqual("60.59", String.valueOf(thirdInstallment.getInterestOutstanding()));
 
-        Integer flatPenaltySpecifiedDueDate = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "100", true));
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flatPenaltySpecifiedDueDate), "29 September 2011", "100"));
+        Long flatPenaltySpecifiedDueDate = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.FLAT, 100.0, true)
+                .getResourceId();
+        addLoanCharge(loanID, flatPenaltySpecifiedDueDate, "29 September 2011", 100.0);
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(flatPenaltySpecifiedDueDate, loanCharges, "100", "0.00", "100.0", "0.0");
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("100", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("100", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("3301.49"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("2811.49"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("100.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("150.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("240"), JournalEntry.TransactionType.CREDIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("3301.49"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("2811.49"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("100.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("150.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("240"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         LOG.info("----------Make repayment 3 advance------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3301.49"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("3301.49"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3129.11"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("50.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("122.38"), JournalEntry.TransactionType.CREDIT));
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flatPenaltySpecifiedDueDate), "10 January 2012", "100"));
+        makeRepayment("20 November 2011", Float.parseFloat("3301.49"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("3301.49"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3129.11"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("50.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("122.38"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
+        addLoanCharge(loanID, flatPenaltySpecifiedDueDate, "10 January 2012", 100.0);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("100", String.valueOf(fourthInstallment.get("penaltyChargesOutstanding")));
-        validateNumberForEqual("3239.68", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod fourthInstallment = loanSchedule.get(4);
+        validateNumberForEqual("100", String.valueOf(fourthInstallment.getPenaltyChargesOutstanding()));
+        validateNumberForEqual("3239.68", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("----------Pay applied penalty ------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("100"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("100"), JournalEntry.TransactionType.DEBIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("100.00"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 January 2012", Float.parseFloat("100"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("100"), assetAccount, JournalEntry.TransactionType.DEBIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("100.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("0", String.valueOf(fourthInstallment.get("penaltyChargesOutstanding")));
-        validateNumberForEqual("3139.68", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0", String.valueOf(fourthInstallment.getPenaltyChargesOutstanding()));
+        validateNumberForEqual("3139.68", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("----------Make repayment 4 ------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("3139.68"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("3139.68"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3089.68"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("50.00"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 January 2012", Float.parseFloat("3139.68"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("3139.68"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3089.68"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("50.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
     }
 
     /***
@@ -1388,187 +1314,178 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void loanWithChargesOfTypeAmountPercentageAndCashBasedAccountingEnabled() {
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
 
         // Add charges with payment mode regular
-        List<HashMap> charges = new ArrayList<>();
-        Integer percentageDisbursementCharge = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanDisbursementJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1"));
-        addCharges(charges, percentageDisbursementCharge, "1", null);
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
+        Long percentageDisbursementCharge = chargesHelper.createLoanDisbursementCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0)
+                .getResourceId();
+        addCharges(charges, percentageDisbursementCharge, 1.0, null);
 
-        Integer percentageSpecifiedDueDateCharge = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1", false));
-        addCharges(charges, percentageSpecifiedDueDateCharge, "1", "29 September 2011");
+        Long percentageSpecifiedDueDateCharge = chargesHelper
+                .createLoanSpecifiedDueDateCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0, false).getResourceId();
+        addCharges(charges, percentageSpecifiedDueDateCharge, 1.0, "29 September 2011");
 
-        Integer percentageInstallmentFee = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1", false));
-        addCharges(charges, percentageInstallmentFee, "1", "29 September 2011");
+        Long percentageInstallmentFee = chargesHelper.createLoanInstallmentCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0, false)
+                .getResourceId();
+        addCharges(charges, percentageInstallmentFee, 1.0, "29 September 2011");
 
-        final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-        final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-        final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-        final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+        final Account assetAccount = accountHelper.createAssetAccount();
+        final Account incomeAccount = accountHelper.createIncomeAccount();
+        final Account expenseAccount = accountHelper.createExpenseAccount();
+        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
         Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                clientID.toString(), collateralId);
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
         Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanProductID = createLoanProduct(false, CASH_BASED, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
+        final Long loanProductID = createLoanProduct(false, CASH_BASED, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
         verifyLoanRepaymentSchedule(loanSchedule);
 
-        List<HashMap> loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        List<GetLoansLoanIdChargesChargeIdResponse> loanCharges = getLoanCharges(loanID);
         validateCharge(percentageDisbursementCharge, loanCharges, "1", "120.00", "0.0", "0.0");
         validateCharge(percentageSpecifiedDueDateCharge, loanCharges, "1", "120.00", "0.0", "0.0");
         validateCharge(percentageInstallmentFee, loanCharges, "1", "120.00", "0.0", "0.0");
 
         // check for disbursement fee
-        HashMap disbursementDetail = loanSchedule.get(0);
-        validateNumberForEqual("120.00", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod disbursementDetail = loanSchedule.get(0);
+        validateNumberForEqual("120.00", String.valueOf(disbursementDetail.getFeeChargesDue()));
 
         // check for charge at specified date and installment fee
-        HashMap firstInstallment = loanSchedule.get(1);
-        validateNumberForEqual("149.11", String.valueOf(firstInstallment.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod firstInstallment = loanSchedule.get(1);
+        validateNumberForEqual("149.11", String.valueOf(firstInstallment.getFeeChargesDue()));
 
         // check for installment fee
-        HashMap secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("29.70", String.valueOf(secondInstallment.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod secondInstallment = loanSchedule.get(2);
+        validateNumberForEqual("29.70", String.valueOf(secondInstallment.getFeeChargesDue()));
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("20 September 2011", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("20 September 2011", loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("20 September 2011", loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount("20 September 2011", loanID));
 
-        final JournalEntry[] assetAccountInitialEntry = { new JournalEntry(Float.parseFloat("120.00"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.DEBIT) };
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", assetAccountInitialEntry);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 September 2011",
-                new JournalEntry(Float.parseFloat("120.00"), JournalEntry.TransactionType.CREDIT));
+        final LoanTestData.Journal[] assetAccountInitialEntry = {
+                journalEntry(Float.parseFloat("120.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()) };
+        checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", assetAccountInitialEntry);
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 September 2011",
+                journalEntry(Float.parseFloat("120.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(percentageDisbursementCharge, loanCharges, "1", "0.0", "120.00", "0.0");
 
         LOG.info("-------------Make repayment 1-----------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 October 2011", Float.parseFloat("3300.60"), loanID);
+        makeRepayment("20 October 2011", Float.parseFloat("3300.60"), loanID);
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(percentageDisbursementCharge, loanCharges, "1", "0.00", "120.00", "0.0");
         validateCharge(percentageSpecifiedDueDateCharge, loanCharges, "1", "0.00", "120.0", "0.0");
         validateCharge(percentageInstallmentFee, loanCharges, "1", "90.89", "29.11", "0.0");
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("3300.60"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("2911.49"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("149.11"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("240.00"), JournalEntry.TransactionType.CREDIT));
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(percentageSpecifiedDueDateCharge), "29 October 2011", "1"));
+        checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("3300.60"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("2911.49"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("149.11"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("240.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
+        addLoanCharge(loanID, percentageSpecifiedDueDateCharge, "29 October 2011", 1.0);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
 
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("149.70", String.valueOf(secondInstallment.get("feeChargesDue")));
-        LOAN_TRANSACTION_HELPER.waiveChargesForLoan(loanID, (Integer) getloanCharge(percentageInstallmentFee, loanCharges).get("id"),
-                LoanTransactionHelper.getWaiveChargeJSON(String.valueOf(2)));
+        validateNumberForEqual("149.70", String.valueOf(secondInstallment.getFeeChargesDue()));
+        waiveLoanCharge(loanID, getloanCharge(percentageInstallmentFee, loanCharges).getId(),
+                new PostLoansLoanIdChargesChargeIdRequest().installmentNumber(2L).locale(LOCALE));
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(percentageInstallmentFee, loanCharges, "1", "61.19", "29.11", "29.70");
 
         LOG.info("----------Make repayment 2------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3271.49"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("3271.49"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("2969.72"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("120.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("181.77"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 November 2011", Float.parseFloat("3271.49"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("3271.49"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("2969.72"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("120.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("181.77"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("0", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("--------------Waive interest---------------");
-        LOAN_TRANSACTION_HELPER.waiveInterest("20 December 2011", String.valueOf(61.79), loanID);
+        waiveInterestOnLoan(loanID, "20 December 2011", 61.79);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap thirdInstallment = loanSchedule.get(3);
-        validateNumberForEqual("60.59", String.valueOf(thirdInstallment.get("interestOutstanding")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod thirdInstallment = loanSchedule.get(3);
+        validateNumberForEqual("60.59", String.valueOf(thirdInstallment.getInterestOutstanding()));
 
-        Integer percentagePenaltySpecifiedDueDate = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1", true));
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(percentagePenaltySpecifiedDueDate), "29 September 2011", "1"));
+        Long percentagePenaltySpecifiedDueDate = chargesHelper
+                .createLoanSpecifiedDueDateCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0, true).getResourceId();
+        addLoanCharge(loanID, percentagePenaltySpecifiedDueDate, "29 September 2011", 1.0);
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(percentagePenaltySpecifiedDueDate, loanCharges, "1", "0.00", "120.0", "0.0");
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("120", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("120", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("3300.60"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("2791.49"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("120.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("149.11"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("240"), JournalEntry.TransactionType.CREDIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("3300.60"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("2791.49"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("120.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("149.11"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("240"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         LOG.info("----------Make repayment 3 advance------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3301.78"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("3301.78"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3149.11"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("30.29"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("122.38"), JournalEntry.TransactionType.CREDIT));
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(percentagePenaltySpecifiedDueDate), "10 January 2012", "1"));
+        makeRepayment("20 November 2011", Float.parseFloat("3301.78"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("3301.78"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3149.11"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("30.29"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("122.38"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
+        addLoanCharge(loanID, percentagePenaltySpecifiedDueDate, "10 January 2012", 1.0);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("120", String.valueOf(fourthInstallment.get("penaltyChargesOutstanding")));
-        validateNumberForEqual("3240.58", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod fourthInstallment = loanSchedule.get(4);
+        validateNumberForEqual("120", String.valueOf(fourthInstallment.getPenaltyChargesOutstanding()));
+        validateNumberForEqual("3240.58", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("----------Pay applied penalty ------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("120"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("120"), JournalEntry.TransactionType.DEBIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("120.00"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 January 2012", Float.parseFloat("120"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("120"), assetAccount, JournalEntry.TransactionType.DEBIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("120.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("0", String.valueOf(fourthInstallment.get("penaltyChargesOutstanding")));
-        validateNumberForEqual("3120.58", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0", String.valueOf(fourthInstallment.getPenaltyChargesOutstanding()));
+        validateNumberForEqual("3120.58", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("----------Make repayment 4 ------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("3120.58"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("3120.58"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3089.68"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("30.90"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 January 2012", Float.parseFloat("3120.58"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("3120.58"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3089.68"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("30.90"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
     }
 
     /***
@@ -1578,189 +1495,179 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void loanWithChargesOfTypeAmountPlusInterestPercentageAndCashBasedAccountingEnabled() {
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
 
         // Add charges with payment mode regular
-        List<HashMap> charges = new ArrayList<>();
-        Integer amountPlusInterestPercentageDisbursementCharge = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanDisbursementJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT_AND_INTEREST, "1"));
-        addCharges(charges, amountPlusInterestPercentageDisbursementCharge, "1", null);
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
+        Long amountPlusInterestPercentageDisbursementCharge = chargesHelper
+                .createLoanDisbursementCharge(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST, 1.0).getResourceId();
+        addCharges(charges, amountPlusInterestPercentageDisbursementCharge, 1.0, null);
 
-        Integer amountPlusInterestPercentageSpecifiedDueDateCharge = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC, ChargesHelper
-                .getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT_AND_INTEREST, "1", false));
-        addCharges(charges, amountPlusInterestPercentageSpecifiedDueDateCharge, "1", "29 September 2011");
+        Long amountPlusInterestPercentageSpecifiedDueDateCharge = chargesHelper
+                .createLoanSpecifiedDueDateCharge(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST, 1.0, false).getResourceId();
+        addCharges(charges, amountPlusInterestPercentageSpecifiedDueDateCharge, 1.0, "29 September 2011");
 
-        Integer amountPlusInterestPercentageInstallmentFee = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT_AND_INTEREST, "1", false));
-        addCharges(charges, amountPlusInterestPercentageInstallmentFee, "1", "29 September 2011");
+        Long amountPlusInterestPercentageInstallmentFee = chargesHelper
+                .createLoanInstallmentCharge(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST, 1.0, false).getResourceId();
+        addCharges(charges, amountPlusInterestPercentageInstallmentFee, 1.0, "29 September 2011");
 
-        final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-        final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-        final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-        final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+        final Account assetAccount = accountHelper.createAssetAccount();
+        final Account incomeAccount = accountHelper.createIncomeAccount();
+        final Account expenseAccount = accountHelper.createExpenseAccount();
+        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
 
         Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                clientID.toString(), collateralId);
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
         Assertions.assertNotNull(collateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanProductID = createLoanProduct(false, CASH_BASED, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
+        final Long loanProductID = createLoanProduct(false, CASH_BASED, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
         verifyLoanRepaymentSchedule(loanSchedule);
 
-        List<HashMap> loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        List<GetLoansLoanIdChargesChargeIdResponse> loanCharges = getLoanCharges(loanID);
         validateCharge(amountPlusInterestPercentageDisbursementCharge, loanCharges, "1", "126.06", "0.0", "0.0");
         validateCharge(amountPlusInterestPercentageSpecifiedDueDateCharge, loanCharges, "1", "126.06", "0.0", "0.0");
         validateCharge(amountPlusInterestPercentageInstallmentFee, loanCharges, "1", "126.04", "0.0", "0.0");
 
         // check for disbursement fee
-        HashMap disbursementDetail = loanSchedule.get(0);
-        validateNumberForEqual("126.06", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod disbursementDetail = loanSchedule.get(0);
+        validateNumberForEqual("126.06", String.valueOf(disbursementDetail.getFeeChargesDue()));
 
         // check for charge at specified date and installment fee
-        HashMap firstInstallment = loanSchedule.get(1);
-        validateNumberForEqual("157.57", String.valueOf(firstInstallment.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod firstInstallment = loanSchedule.get(1);
+        validateNumberForEqual("157.57", String.valueOf(firstInstallment.getFeeChargesDue()));
 
         // check for installment fee
-        HashMap secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("31.51", String.valueOf(secondInstallment.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod secondInstallment = loanSchedule.get(2);
+        validateNumberForEqual("31.51", String.valueOf(secondInstallment.getFeeChargesDue()));
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("20 September 2011", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("20 September 2011", loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("20 September 2011", loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount("20 September 2011", loanID));
 
-        final JournalEntry[] assetAccountInitialEntry = { new JournalEntry(Float.parseFloat("126.06"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.DEBIT) };
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", assetAccountInitialEntry);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 September 2011",
-                new JournalEntry(Float.parseFloat("126.06"), JournalEntry.TransactionType.CREDIT));
+        final LoanTestData.Journal[] assetAccountInitialEntry = {
+                journalEntry(Float.parseFloat("126.06"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()) };
+        checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", assetAccountInitialEntry);
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 September 2011",
+                journalEntry(Float.parseFloat("126.06"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(amountPlusInterestPercentageDisbursementCharge, loanCharges, "1", "0.0", "126.06", "0.0");
 
         LOG.info("-------------Make repayment 1-----------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 October 2011", Float.parseFloat("3309.06"), loanID);
+        makeRepayment("20 October 2011", Float.parseFloat("3309.06"), loanID);
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(amountPlusInterestPercentageDisbursementCharge, loanCharges, "1", "0.00", "126.06", "0.0");
         validateCharge(amountPlusInterestPercentageSpecifiedDueDateCharge, loanCharges, "1", "0.00", "126.06", "0.0");
         validateCharge(amountPlusInterestPercentageInstallmentFee, loanCharges, "1", "94.53", "31.51", "0.0");
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("3309.06"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("2911.49"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("157.57"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("240.00"), JournalEntry.TransactionType.CREDIT));
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(
-                String.valueOf(amountPlusInterestPercentageSpecifiedDueDateCharge), "29 October 2011", "1"));
+        checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("3309.06"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("2911.49"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("157.57"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("240.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
+        addLoanCharge(loanID, amountPlusInterestPercentageSpecifiedDueDateCharge, "29 October 2011", 1.0);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
 
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("157.57", String.valueOf(secondInstallment.get("feeChargesDue")));
-        LOAN_TRANSACTION_HELPER.waiveChargesForLoan(loanID,
-                (Integer) getloanCharge(amountPlusInterestPercentageInstallmentFee, loanCharges).get("id"),
-                LoanTransactionHelper.getWaiveChargeJSON(String.valueOf(2)));
+        validateNumberForEqual("157.57", String.valueOf(secondInstallment.getFeeChargesDue()));
+        waiveLoanCharge(loanID, getloanCharge(amountPlusInterestPercentageInstallmentFee, loanCharges).getId(),
+                new PostLoansLoanIdChargesChargeIdRequest().installmentNumber(2L).locale(LOCALE));
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(amountPlusInterestPercentageInstallmentFee, loanCharges, "1", "63.02", "31.51", "31.51");
 
         LOG.info("----------Make repayment 2------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3277.55"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("3277.55"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("2969.72"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("126.06"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("181.77"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 November 2011", Float.parseFloat("3277.55"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("3277.55"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("2969.72"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("126.06"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("181.77"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("0", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("--------------Waive interest---------------");
-        LOAN_TRANSACTION_HELPER.waiveInterest("20 December 2011", String.valueOf(61.79), loanID);
+        waiveInterestOnLoan(loanID, "20 December 2011", 61.79);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap thirdInstallment = loanSchedule.get(3);
-        validateNumberForEqual("60.59", String.valueOf(thirdInstallment.get("interestOutstanding")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod thirdInstallment = loanSchedule.get(3);
+        validateNumberForEqual("60.59", String.valueOf(thirdInstallment.getInterestOutstanding()));
 
-        Integer amountPlusInterestPercentagePenaltySpecifiedDueDate = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1", true));
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(
-                String.valueOf(amountPlusInterestPercentagePenaltySpecifiedDueDate), "29 September 2011", "1"));
+        Long amountPlusInterestPercentagePenaltySpecifiedDueDate = chargesHelper
+                .createLoanSpecifiedDueDateCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0, true).getResourceId();
+        addLoanCharge(loanID, amountPlusInterestPercentagePenaltySpecifiedDueDate, "29 September 2011", 1.0);
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(amountPlusInterestPercentagePenaltySpecifiedDueDate, loanCharges, "1", "0.0", "120.0", "0.0");
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("120", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("120", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("3309.06"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("2791.49"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("120.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("157.57"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("240"), JournalEntry.TransactionType.CREDIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("3309.06"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("2791.49"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("120.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("157.57"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("240"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         LOG.info("----------Make repayment 3 advance------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3303"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("3303"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3149.11"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("31.51"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("122.38"), JournalEntry.TransactionType.CREDIT));
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(
-                String.valueOf(amountPlusInterestPercentagePenaltySpecifiedDueDate), "10 January 2012", "1"));
+        makeRepayment("20 November 2011", Float.parseFloat("3303"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("3303"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3149.11"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("31.51"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("122.38"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
+        addLoanCharge(loanID, amountPlusInterestPercentagePenaltySpecifiedDueDate, "10 January 2012", 1.0);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("120", String.valueOf(fourthInstallment.get("penaltyChargesOutstanding")));
-        validateNumberForEqual("3241.19", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod fourthInstallment = loanSchedule.get(4);
+        validateNumberForEqual("120", String.valueOf(fourthInstallment.getPenaltyChargesOutstanding()));
+        validateNumberForEqual("3241.19", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("----------Pay applied penalty ------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("120"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("120"), JournalEntry.TransactionType.DEBIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("120.00"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 January 2012", Float.parseFloat("120"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("120"), assetAccount, JournalEntry.TransactionType.DEBIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("120.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("0", String.valueOf(fourthInstallment.get("penaltyChargesOutstanding")));
-        validateNumberForEqual("3121.19", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0", String.valueOf(fourthInstallment.getPenaltyChargesOutstanding()));
+        validateNumberForEqual("3121.19", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("----------Make repayment 4 ------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("3121.19"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("3121.19"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3089.68"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("31.51"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 January 2012", Float.parseFloat("3121.19"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("3121.19"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3089.68"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("31.51"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
     }
 
     /***
@@ -1769,201 +1676,190 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void loanWithFlatCahargesAndUpfrontAccrualAccountingEnabled() {
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
 
         // Add charges with payment mode regular
-        List<HashMap> charges = new ArrayList<>();
-        Integer flatDisbursement = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC, ChargesHelper.getLoanDisbursementJSON());
-        addCharges(charges, flatDisbursement, "100", null);
-        Integer flatSpecifiedDueDate = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "100", false));
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
+        Long flatDisbursement = chargesHelper.createLoanDisbursementCharge(ChargeCalculationType.FLAT, 100.0).getResourceId();
+        addCharges(charges, flatDisbursement, 100.0, null);
+        Long flatSpecifiedDueDate = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.FLAT, 100.0, false)
+                .getResourceId();
 
-        Integer flatInstallmentFee = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "50", false));
-        addCharges(charges, flatInstallmentFee, "50", null);
+        Long flatInstallmentFee = chargesHelper.createLoanInstallmentCharge(ChargeCalculationType.FLAT, 50.0, false).getResourceId();
+        addCharges(charges, flatInstallmentFee, 50.0, null);
 
-        final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-        final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-        final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-        final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+        final Account assetAccount = accountHelper.createAssetAccount();
+        final Account incomeAccount = accountHelper.createIncomeAccount();
+        final Account expenseAccount = accountHelper.createExpenseAccount();
+        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
         Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
         Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanProductID = createLoanProduct(false, ACCRUAL_UPFRONT, assetAccount, incomeAccount, expenseAccount,
+        final Long loanProductID = createLoanProduct(false, ACCRUAL_UPFRONT, assetAccount, incomeAccount, expenseAccount,
                 overpaymentAccount);
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
         verifyLoanRepaymentSchedule(loanSchedule);
 
-        List<HashMap> loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        List<GetLoansLoanIdChargesChargeIdResponse> loanCharges = getLoanCharges(loanID);
         validateCharge(flatDisbursement, loanCharges, "100", "100.00", "0.0", "0.0");
         validateCharge(flatInstallmentFee, loanCharges, "50", "200.00", "0.0", "0.0");
 
         // check for disbursement fee
-        HashMap disbursementDetail = loanSchedule.get(0);
-        validateNumberForEqual("100.00", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod disbursementDetail = loanSchedule.get(0);
+        validateNumberForEqual("100.00", String.valueOf(disbursementDetail.getFeeChargesDue()));
 
         // check for charge at specified date and installment fee
-        HashMap firstInstallment = loanSchedule.get(1);
-        validateNumberForEqual("50.00", String.valueOf(firstInstallment.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod firstInstallment = loanSchedule.get(1);
+        validateNumberForEqual("50.00", String.valueOf(firstInstallment.getFeeChargesDue()));
 
         // check for installment fee
-        HashMap secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("50.00", String.valueOf(secondInstallment.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod secondInstallment = loanSchedule.get(2);
+        validateNumberForEqual("50.00", String.valueOf(secondInstallment.getFeeChargesDue()));
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("20 September 2011", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("20 September 2011", loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("20 September 2011", loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount("20 September 2011", loanID));
 
-        final JournalEntry[] assetAccountInitialEntry = { new JournalEntry(Float.parseFloat("605.94"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("100.00"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("200.00"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.DEBIT) };
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", assetAccountInitialEntry);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 September 2011",
-                new JournalEntry(Float.parseFloat("605.94"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("100.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("200.00"), JournalEntry.TransactionType.CREDIT));
+        final LoanTestData.Journal[] assetAccountInitialEntry = {
+                journalEntry(Float.parseFloat("605.94"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("100.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("200.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()) };
+        checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", assetAccountInitialEntry);
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 September 2011",
+                journalEntry(Float.parseFloat("605.94"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("100.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("200.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
 
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flatSpecifiedDueDate), "29 September 2011", "100"));
+        addLoanCharge(loanID, flatSpecifiedDueDate, "29 September 2011", 100.0);
 
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(flatDisbursement, loanCharges, "100", "0.00", "100.0", "0.0");
         validateCharge(flatSpecifiedDueDate, loanCharges, "100", "100.00", "0.0", "0.0");
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "29 September 2011",
-                new JournalEntry(Float.parseFloat("100.00"), JournalEntry.TransactionType.DEBIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "29 September 2011",
-                new JournalEntry(Float.parseFloat("100.00"), JournalEntry.TransactionType.CREDIT));
+        checkJournalEntryForAssetAccount(assetAccount, "29 September 2011",
+                journalEntry(Float.parseFloat("100.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "29 September 2011",
+                journalEntry(Float.parseFloat("100.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         LOG.info("-------------Make repayment 1-----------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 October 2011", Float.parseFloat("3301.49"), loanID);
+        makeRepayment("20 October 2011", Float.parseFloat("3301.49"), loanID);
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(flatDisbursement, loanCharges, "100", "0.00", "100.0", "0.0");
         validateCharge(flatSpecifiedDueDate, loanCharges, "100", "0.00", "100.0", "0.0");
         validateCharge(flatInstallmentFee, loanCharges, "50", "150.00", "50.0", "0.0");
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("3301.49"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3301.49"), JournalEntry.TransactionType.CREDIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("3301.49"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3301.49"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flatSpecifiedDueDate), "29 October 2011", "100"));
+        addLoanCharge(loanID, flatSpecifiedDueDate, "29 October 2011", 100.0);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
 
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("150.00", String.valueOf(secondInstallment.get("feeChargesDue")));
+        validateNumberForEqual("150.00", String.valueOf(secondInstallment.getFeeChargesDue()));
         LOG.info("----------- Waive installment charge for 2nd installment ---------");
-        LOAN_TRANSACTION_HELPER.waiveChargesForLoan(loanID, (Integer) getloanCharge(flatInstallmentFee, loanCharges).get("id"),
-                LoanTransactionHelper.getWaiveChargeJSON(String.valueOf(2)));
+        waiveLoanCharge(loanID, getloanCharge(flatInstallmentFee, loanCharges).getId(),
+                new PostLoansLoanIdChargesChargeIdRequest().installmentNumber(2L).locale(LOCALE));
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(flatInstallmentFee, loanCharges, "50", "100.00", "50.0", "50.0");
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("50.0"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForExpenseAccount(expenseAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("50.0"), JournalEntry.TransactionType.DEBIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("50.0"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForExpenseAccount(expenseAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("50.0"), expenseAccount, JournalEntry.TransactionType.DEBIT.name()));
 
         LOG.info("----------Make repayment 2------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3251.49"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("3251.49"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3251.49"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 November 2011", Float.parseFloat("3251.49"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("3251.49"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3251.49"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("0", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("--------------Waive interest---------------");
-        LOAN_TRANSACTION_HELPER.waiveInterest("20 December 2011", String.valueOf(61.79), loanID);
+        waiveInterestOnLoan(loanID, "20 December 2011", 61.79);
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap thirdInstallment = loanSchedule.get(3);
-        validateNumberForEqual("60.59", String.valueOf(thirdInstallment.get("interestOutstanding")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod thirdInstallment = loanSchedule.get(3);
+        validateNumberForEqual("60.59", String.valueOf(thirdInstallment.getInterestOutstanding()));
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 December 2011",
-                new JournalEntry(Float.parseFloat("61.79"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForExpenseAccount(expenseAccount, "20 December 2011",
-                new JournalEntry(Float.parseFloat("61.79"), JournalEntry.TransactionType.DEBIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 December 2011",
+                journalEntry(Float.parseFloat("61.79"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForExpenseAccount(expenseAccount, "20 December 2011",
+                journalEntry(Float.parseFloat("61.79"), expenseAccount, JournalEntry.TransactionType.DEBIT.name()));
 
-        Integer flatPenaltySpecifiedDueDate = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "100", true));
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flatPenaltySpecifiedDueDate), "29 September 2011", "100"));
+        Long flatPenaltySpecifiedDueDate = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.FLAT, 100.0, true)
+                .getResourceId();
+        addLoanCharge(loanID, flatPenaltySpecifiedDueDate, "29 September 2011", 100.0);
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(flatPenaltySpecifiedDueDate, loanCharges, "100", "0.00", "100.0", "0.0");
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("100", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("100", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
         // checking the journal entry as applied penalty has been collected
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("3301.49"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3301.49"), JournalEntry.TransactionType.CREDIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("3301.49"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3301.49"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         LOG.info("----------Make repayment 3 advance------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3301.49"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("3301.49"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3301.49"), JournalEntry.TransactionType.CREDIT));
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flatPenaltySpecifiedDueDate), "10 January 2012", "100"));
+        makeRepayment("20 November 2011", Float.parseFloat("3301.49"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("3301.49"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3301.49"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        addLoanCharge(loanID, flatPenaltySpecifiedDueDate, "10 January 2012", 100.0);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("100", String.valueOf(fourthInstallment.get("penaltyChargesOutstanding")));
-        validateNumberForEqual("3239.68", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod fourthInstallment = loanSchedule.get(4);
+        validateNumberForEqual("100", String.valueOf(fourthInstallment.getPenaltyChargesOutstanding()));
+        validateNumberForEqual("3239.68", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("----------Pay applied penalty ------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("100"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("100"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("100"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 January 2012", Float.parseFloat("100"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("100"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("100"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("0", String.valueOf(fourthInstallment.get("penaltyChargesOutstanding")));
-        validateNumberForEqual("3139.68", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0", String.valueOf(fourthInstallment.getPenaltyChargesOutstanding()));
+        validateNumberForEqual("3139.68", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("----------Make over payment for repayment 4 ------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("3220.60"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("3220.60"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3139.68"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForLiabilityAccount(overpaymentAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("80.92"), JournalEntry.TransactionType.CREDIT));
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "status");
-        LoanStatusChecker.verifyLoanAccountIsOverPaid(loanStatusHashMap);
+        makeRepayment("20 January 2012", Float.parseFloat("3220.60"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("3220.60"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3139.68"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForLiabilityAccount(overpaymentAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("80.92"), overpaymentAccount, JournalEntry.TransactionType.CREDIT.name()));
+        GetLoansLoanIdResponse loanStatusHashMap = getLoanDetails(loanID);
+        verifyLoanStatus(loanStatusHashMap, GetLoansLoanIdStatus::getOverpaid);
     }
 
     /***
@@ -1973,197 +1869,188 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void loanWithCahargesAndUpfrontAccrualAccountingEnabled() {
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
 
         // Add charges with payment mode regular
-        List<HashMap> charges = new ArrayList<>();
-        Integer percentageDisbursementCharge = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanDisbursementJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1"));
-        addCharges(charges, percentageDisbursementCharge, "1", null);
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
+        Long percentageDisbursementCharge = chargesHelper.createLoanDisbursementCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0)
+                .getResourceId();
+        addCharges(charges, percentageDisbursementCharge, 1.0, null);
 
-        Integer percentageSpecifiedDueDateCharge = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1", false));
-        addCharges(charges, percentageSpecifiedDueDateCharge, "1", "29 September 2011");
+        Long percentageSpecifiedDueDateCharge = chargesHelper
+                .createLoanSpecifiedDueDateCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0, false).getResourceId();
+        addCharges(charges, percentageSpecifiedDueDateCharge, 1.0, "29 September 2011");
 
-        Integer percentageInstallmentFee = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1", false));
-        addCharges(charges, percentageInstallmentFee, "1", "29 September 2011");
+        Long percentageInstallmentFee = chargesHelper.createLoanInstallmentCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0, false)
+                .getResourceId();
+        addCharges(charges, percentageInstallmentFee, 1.0, "29 September 2011");
 
-        final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-        final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-        final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-        final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+        final Account assetAccount = accountHelper.createAssetAccount();
+        final Account incomeAccount = accountHelper.createIncomeAccount();
+        final Account expenseAccount = accountHelper.createExpenseAccount();
+        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
         Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
         Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanProductID = createLoanProduct(false, ACCRUAL_UPFRONT, assetAccount, incomeAccount, expenseAccount,
+        final Long loanProductID = createLoanProduct(false, ACCRUAL_UPFRONT, assetAccount, incomeAccount, expenseAccount,
                 overpaymentAccount);
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
         verifyLoanRepaymentSchedule(loanSchedule);
 
-        List<HashMap> loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        List<GetLoansLoanIdChargesChargeIdResponse> loanCharges = getLoanCharges(loanID);
         validateCharge(percentageDisbursementCharge, loanCharges, "1", "120.00", "0.0", "0.0");
         validateCharge(percentageSpecifiedDueDateCharge, loanCharges, "1", "120.00", "0.0", "0.0");
         validateCharge(percentageInstallmentFee, loanCharges, "1", "120.00", "0.0", "0.0");
 
         // check for disbursement fee
-        HashMap disbursementDetail = loanSchedule.get(0);
-        validateNumberForEqual("120.00", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod disbursementDetail = loanSchedule.get(0);
+        validateNumberForEqual("120.00", String.valueOf(disbursementDetail.getFeeChargesDue()));
 
         // check for charge at specified date and installment fee
-        HashMap firstInstallment = loanSchedule.get(1);
-        validateNumberForEqual("149.11", String.valueOf(firstInstallment.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod firstInstallment = loanSchedule.get(1);
+        validateNumberForEqual("149.11", String.valueOf(firstInstallment.getFeeChargesDue()));
 
         // check for installment fee
-        HashMap secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("29.70", String.valueOf(secondInstallment.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod secondInstallment = loanSchedule.get(2);
+        validateNumberForEqual("29.70", String.valueOf(secondInstallment.getFeeChargesDue()));
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("20 September 2011", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("20 September 2011", loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("20 September 2011", loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount("20 September 2011", loanID));
 
-        final JournalEntry[] assetAccountInitialEntry = { new JournalEntry(Float.parseFloat("605.94"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("120.00"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("120.00"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("120.00"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.DEBIT) };
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", assetAccountInitialEntry);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 September 2011",
-                new JournalEntry(Float.parseFloat("605.94"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("120.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("120.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("120.00"), JournalEntry.TransactionType.CREDIT));
+        final LoanTestData.Journal[] assetAccountInitialEntry = {
+                journalEntry(Float.parseFloat("605.94"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("120.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("120.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("120.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()) };
+        checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", assetAccountInitialEntry);
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 September 2011",
+                journalEntry(Float.parseFloat("605.94"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("120.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("120.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("120.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(percentageDisbursementCharge, loanCharges, "1", "0.0", "120.00", "0.0");
 
         LOG.info("-------------Make repayment 1-----------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 October 2011", Float.parseFloat("3300.60"), loanID);
+        makeRepayment("20 October 2011", Float.parseFloat("3300.60"), loanID);
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(percentageDisbursementCharge, loanCharges, "1", "0.00", "120.00", "0.0");
         validateCharge(percentageSpecifiedDueDateCharge, loanCharges, "1", "0.00", "120.0", "0.0");
         validateCharge(percentageInstallmentFee, loanCharges, "1", "90.89", "29.11", "0.0");
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("3300.60"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3300.60"), JournalEntry.TransactionType.CREDIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("3300.60"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3300.60"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(percentageSpecifiedDueDateCharge), "29 October 2011", "1"));
+        addLoanCharge(loanID, percentageSpecifiedDueDateCharge, "29 October 2011", 1.0);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
 
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("149.70", String.valueOf(secondInstallment.get("feeChargesDue")));
+        validateNumberForEqual("149.70", String.valueOf(secondInstallment.getFeeChargesDue()));
         LOG.info("----------- Waive installment charge for 2nd installment ---------");
-        LOAN_TRANSACTION_HELPER.waiveChargesForLoan(loanID, (Integer) getloanCharge(percentageInstallmentFee, loanCharges).get("id"),
-                LoanTransactionHelper.getWaiveChargeJSON(String.valueOf(2)));
+        waiveLoanCharge(loanID, getloanCharge(percentageInstallmentFee, loanCharges).getId(),
+                new PostLoansLoanIdChargesChargeIdRequest().installmentNumber(2L).locale(LOCALE));
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(percentageInstallmentFee, loanCharges, "1", "61.19", "29.11", "29.70");
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("29.7"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForExpenseAccount(expenseAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("29.7"), JournalEntry.TransactionType.DEBIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("29.7"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForExpenseAccount(expenseAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("29.7"), expenseAccount, JournalEntry.TransactionType.DEBIT.name()));
 
         LOG.info("----------Make repayment 2------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3271.49"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("3271.49"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3271.49"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 November 2011", Float.parseFloat("3271.49"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("3271.49"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3271.49"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("0", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("--------------Waive interest---------------");
-        LOAN_TRANSACTION_HELPER.waiveInterest("20 December 2011", String.valueOf(61.79), loanID);
+        waiveInterestOnLoan(loanID, "20 December 2011", 61.79);
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap thirdInstallment = loanSchedule.get(3);
-        validateNumberForEqual("60.59", String.valueOf(thirdInstallment.get("interestOutstanding")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod thirdInstallment = loanSchedule.get(3);
+        validateNumberForEqual("60.59", String.valueOf(thirdInstallment.getInterestOutstanding()));
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 December 2011",
-                new JournalEntry(Float.parseFloat("61.79"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForExpenseAccount(expenseAccount, "20 December 2011",
-                new JournalEntry(Float.parseFloat("61.79"), JournalEntry.TransactionType.DEBIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 December 2011",
+                journalEntry(Float.parseFloat("61.79"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForExpenseAccount(expenseAccount, "20 December 2011",
+                journalEntry(Float.parseFloat("61.79"), expenseAccount, JournalEntry.TransactionType.DEBIT.name()));
 
-        Integer percentagePenaltySpecifiedDueDate = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1", true));
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(percentagePenaltySpecifiedDueDate), "29 September 2011", "1"));
+        Long percentagePenaltySpecifiedDueDate = chargesHelper
+                .createLoanSpecifiedDueDateCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0, true).getResourceId();
+        addLoanCharge(loanID, percentagePenaltySpecifiedDueDate, "29 September 2011", 1.0);
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(percentagePenaltySpecifiedDueDate, loanCharges, "1", "0.00", "120.0", "0.0");
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("120", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("120", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
         // checking the journal entry as applied penalty has been collected
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("3300.60"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3300.60"), JournalEntry.TransactionType.CREDIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("3300.60"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3300.60"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         LOG.info("----------Make repayment 3 advance------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3301.78"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("3301.78"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3301.78"), JournalEntry.TransactionType.CREDIT));
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(percentagePenaltySpecifiedDueDate), "10 January 2012", "1"));
+        makeRepayment("20 November 2011", Float.parseFloat("3301.78"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("3301.78"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3301.78"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        addLoanCharge(loanID, percentagePenaltySpecifiedDueDate, "10 January 2012", 1.0);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("120", String.valueOf(fourthInstallment.get("penaltyChargesOutstanding")));
-        validateNumberForEqual("3240.58", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod fourthInstallment = loanSchedule.get(4);
+        validateNumberForEqual("120", String.valueOf(fourthInstallment.getPenaltyChargesOutstanding()));
+        validateNumberForEqual("3240.58", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("----------Pay applied penalty ------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("120"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("120"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("120"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 January 2012", Float.parseFloat("120"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("120"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("120"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("0", String.valueOf(fourthInstallment.get("penaltyChargesOutstanding")));
-        validateNumberForEqual("3120.58", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0", String.valueOf(fourthInstallment.getPenaltyChargesOutstanding()));
+        validateNumberForEqual("3120.58", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("----------Make over payment for repayment 4 ------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("3220.58"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("3220.58"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3120.58"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForLiabilityAccount(overpaymentAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("100.00"), JournalEntry.TransactionType.CREDIT));
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "status");
-        LoanStatusChecker.verifyLoanAccountIsOverPaid(loanStatusHashMap);
+        makeRepayment("20 January 2012", Float.parseFloat("3220.58"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("3220.58"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3120.58"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForLiabilityAccount(overpaymentAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("100.00"), overpaymentAccount, JournalEntry.TransactionType.CREDIT.name()));
+        GetLoansLoanIdResponse loanStatusHashMap = getLoanDetails(loanID);
+        verifyLoanStatus(loanStatusHashMap, GetLoansLoanIdStatus::getOverpaid);
     }
 
     /***
@@ -2173,203 +2060,192 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void loanWithCahargesOfTypeAmountPlusInterestPercentageAndUpfrontAccrualAccountingEnabled() {
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
 
         // Add charges with payment mode regular
-        List<HashMap> charges = new ArrayList<>();
-        Integer amountPlusInterestPercentageDisbursementCharge = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanDisbursementJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT_AND_INTEREST, "1"));
-        addCharges(charges, amountPlusInterestPercentageDisbursementCharge, "1", null);
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
+        Long amountPlusInterestPercentageDisbursementCharge = chargesHelper
+                .createLoanDisbursementCharge(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST, 1.0).getResourceId();
+        addCharges(charges, amountPlusInterestPercentageDisbursementCharge, 1.0, null);
 
-        Integer amountPlusInterestPercentageSpecifiedDueDateCharge = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC, ChargesHelper
-                .getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT_AND_INTEREST, "1", false));
+        Long amountPlusInterestPercentageSpecifiedDueDateCharge = chargesHelper
+                .createLoanSpecifiedDueDateCharge(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST, 1.0, false).getResourceId();
 
-        Integer amountPlusInterestPercentageInstallmentFee = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT_AND_INTEREST, "1", false));
-        addCharges(charges, amountPlusInterestPercentageInstallmentFee, "1", "29 September 2011");
+        Long amountPlusInterestPercentageInstallmentFee = chargesHelper
+                .createLoanInstallmentCharge(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST, 1.0, false).getResourceId();
+        addCharges(charges, amountPlusInterestPercentageInstallmentFee, 1.0, "29 September 2011");
 
-        final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-        final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-        final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-        final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+        final Account assetAccount = accountHelper.createAssetAccount();
+        final Account incomeAccount = accountHelper.createIncomeAccount();
+        final Account expenseAccount = accountHelper.createExpenseAccount();
+        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
 
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanProductID = createLoanProduct(false, ACCRUAL_UPFRONT, assetAccount, incomeAccount, expenseAccount,
+        final Long loanProductID = createLoanProduct(false, ACCRUAL_UPFRONT, assetAccount, incomeAccount, expenseAccount,
                 overpaymentAccount);
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
         verifyLoanRepaymentSchedule(loanSchedule);
 
-        List<HashMap> loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        List<GetLoansLoanIdChargesChargeIdResponse> loanCharges = getLoanCharges(loanID);
         validateCharge(amountPlusInterestPercentageDisbursementCharge, loanCharges, "1", "126.06", "0.0", "0.0");
         validateCharge(amountPlusInterestPercentageInstallmentFee, loanCharges, "1", "126.04", "0.0", "0.0");
 
         // check for disbursement fee
-        HashMap disbursementDetail = loanSchedule.get(0);
-        validateNumberForEqual("126.06", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod disbursementDetail = loanSchedule.get(0);
+        validateNumberForEqual("126.06", String.valueOf(disbursementDetail.getFeeChargesDue()));
 
         // check for charge at specified date and installment fee
-        HashMap firstInstallment = loanSchedule.get(1);
-        validateNumberForEqual("31.51", String.valueOf(firstInstallment.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod firstInstallment = loanSchedule.get(1);
+        validateNumberForEqual("31.51", String.valueOf(firstInstallment.getFeeChargesDue()));
 
         // check for installment fee
-        HashMap secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("31.51", String.valueOf(secondInstallment.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod secondInstallment = loanSchedule.get(2);
+        validateNumberForEqual("31.51", String.valueOf(secondInstallment.getFeeChargesDue()));
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("20 September 2011", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("20 September 2011", loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("20 September 2011", loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount("20 September 2011", loanID));
 
-        final JournalEntry[] assetAccountInitialEntry = { new JournalEntry(Float.parseFloat("605.94"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("126.06"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("126.04"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.DEBIT) };
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", assetAccountInitialEntry);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 September 2011",
-                new JournalEntry(Float.parseFloat("605.94"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("126.06"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("126.04"), JournalEntry.TransactionType.CREDIT));
+        final LoanTestData.Journal[] assetAccountInitialEntry = {
+                journalEntry(Float.parseFloat("605.94"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("126.06"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("126.04"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()) };
+        checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", assetAccountInitialEntry);
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 September 2011",
+                journalEntry(Float.parseFloat("605.94"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("126.06"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("126.04"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
 
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(
-                String.valueOf(amountPlusInterestPercentageSpecifiedDueDateCharge), "29 September 2011", "1"));
+        addLoanCharge(loanID, amountPlusInterestPercentageSpecifiedDueDateCharge, "29 September 2011", 1.0);
 
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(amountPlusInterestPercentageDisbursementCharge, loanCharges, "1", "0.0", "126.06", "0.0");
         validateCharge(amountPlusInterestPercentageSpecifiedDueDateCharge, loanCharges, "1", "126.06", "0.0", "0.0");
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "29 September 2011",
-                new JournalEntry(Float.parseFloat("126.06"), JournalEntry.TransactionType.DEBIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "29 September 2011",
-                new JournalEntry(Float.parseFloat("126.06"), JournalEntry.TransactionType.CREDIT));
+        checkJournalEntryForAssetAccount(assetAccount, "29 September 2011",
+                journalEntry(Float.parseFloat("126.06"), assetAccount, JournalEntry.TransactionType.DEBIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, "29 September 2011",
+                journalEntry(Float.parseFloat("126.06"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         LOG.info("-------------Make repayment 1-----------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 October 2011", Float.parseFloat("3309.06"), loanID);
+        makeRepayment("20 October 2011", Float.parseFloat("3309.06"), loanID);
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(amountPlusInterestPercentageDisbursementCharge, loanCharges, "1", "0.00", "126.06", "0.0");
         validateCharge(amountPlusInterestPercentageSpecifiedDueDateCharge, loanCharges, "1", "0.00", "126.06", "0.0");
         validateCharge(amountPlusInterestPercentageInstallmentFee, loanCharges, "1", "94.53", "31.51", "0.0");
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("3309.06"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3309.06"), JournalEntry.TransactionType.CREDIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("3309.06"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3309.06"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(
-                String.valueOf(amountPlusInterestPercentageSpecifiedDueDateCharge), "29 October 2011", "1"));
+        addLoanCharge(loanID, amountPlusInterestPercentageSpecifiedDueDateCharge, "29 October 2011", 1.0);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
 
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("157.57", String.valueOf(secondInstallment.get("feeChargesDue")));
+        validateNumberForEqual("157.57", String.valueOf(secondInstallment.getFeeChargesDue()));
         LOG.info("----------- Waive installment charge for 2nd installment ---------");
-        LOAN_TRANSACTION_HELPER.waiveChargesForLoan(loanID,
-                (Integer) getloanCharge(amountPlusInterestPercentageInstallmentFee, loanCharges).get("id"),
-                LoanTransactionHelper.getWaiveChargeJSON(String.valueOf(2)));
+        waiveLoanCharge(loanID, getloanCharge(amountPlusInterestPercentageInstallmentFee, loanCharges).getId(),
+                new PostLoansLoanIdChargesChargeIdRequest().installmentNumber(2L).locale(LOCALE));
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(amountPlusInterestPercentageInstallmentFee, loanCharges, "1", "63.02", "31.51", "31.51");
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("31.51"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForExpenseAccount(expenseAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("31.51"), JournalEntry.TransactionType.DEBIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("31.51"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForExpenseAccount(expenseAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("31.51"), expenseAccount, JournalEntry.TransactionType.DEBIT.name()));
 
         LOG.info("----------Make repayment 2------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3277.55"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("3277.55"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3277.55"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 November 2011", Float.parseFloat("3277.55"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("3277.55"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3277.55"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("0", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("--------------Waive interest---------------");
-        LOAN_TRANSACTION_HELPER.waiveInterest("20 December 2011", String.valueOf(61.79), loanID);
+        waiveInterestOnLoan(loanID, "20 December 2011", 61.79);
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap thirdInstallment = loanSchedule.get(3);
-        validateNumberForEqual("60.59", String.valueOf(thirdInstallment.get("interestOutstanding")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod thirdInstallment = loanSchedule.get(3);
+        validateNumberForEqual("60.59", String.valueOf(thirdInstallment.getInterestOutstanding()));
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 December 2011",
-                new JournalEntry(Float.parseFloat("61.79"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForExpenseAccount(expenseAccount, "20 December 2011",
-                new JournalEntry(Float.parseFloat("61.79"), JournalEntry.TransactionType.DEBIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 December 2011",
+                journalEntry(Float.parseFloat("61.79"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForExpenseAccount(expenseAccount, "20 December 2011",
+                journalEntry(Float.parseFloat("61.79"), expenseAccount, JournalEntry.TransactionType.DEBIT.name()));
 
-        Integer amountPlusInterestPercentagePenaltySpecifiedDueDate = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1", true));
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(
-                String.valueOf(amountPlusInterestPercentagePenaltySpecifiedDueDate), "29 September 2011", "1"));
+        Long amountPlusInterestPercentagePenaltySpecifiedDueDate = chargesHelper
+                .createLoanSpecifiedDueDateCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0, true).getResourceId();
+        addLoanCharge(loanID, amountPlusInterestPercentagePenaltySpecifiedDueDate, "29 September 2011", 1.0);
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(amountPlusInterestPercentagePenaltySpecifiedDueDate, loanCharges, "1", "0.0", "120.0", "0.0");
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("120", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("120", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
         // checking the journal entry as applied penalty has been collected
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("3309.06"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3309.06"), JournalEntry.TransactionType.CREDIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("3309.06"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3309.06"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         LOG.info("----------Make repayment 3 advance------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3303"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("3303"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3303"), JournalEntry.TransactionType.CREDIT));
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(
-                String.valueOf(amountPlusInterestPercentagePenaltySpecifiedDueDate), "10 January 2012", "1"));
+        makeRepayment("20 November 2011", Float.parseFloat("3303"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("3303"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3303"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        addLoanCharge(loanID, amountPlusInterestPercentagePenaltySpecifiedDueDate, "10 January 2012", 1.0);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("120", String.valueOf(fourthInstallment.get("penaltyChargesOutstanding")));
-        validateNumberForEqual("3241.19", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod fourthInstallment = loanSchedule.get(4);
+        validateNumberForEqual("120", String.valueOf(fourthInstallment.getPenaltyChargesOutstanding()));
+        validateNumberForEqual("3241.19", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("----------Pay applied penalty ------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("120"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("120"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("120"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 January 2012", Float.parseFloat("120"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("120"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("120"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("0", String.valueOf(fourthInstallment.get("penaltyChargesOutstanding")));
-        validateNumberForEqual("3121.19", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0", String.valueOf(fourthInstallment.getPenaltyChargesOutstanding()));
+        validateNumberForEqual("3121.19", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("----------Make over payment for repayment 4 ------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("3221.61"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("3221.61"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3121.19"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForLiabilityAccount(overpaymentAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("100.42"), JournalEntry.TransactionType.CREDIT));
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "status");
-        LoanStatusChecker.verifyLoanAccountIsOverPaid(loanStatusHashMap);
+        makeRepayment("20 January 2012", Float.parseFloat("3221.61"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("3221.61"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3121.19"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForLiabilityAccount(overpaymentAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("100.42"), overpaymentAccount, JournalEntry.TransactionType.CREDIT.name()));
+        GetLoansLoanIdResponse loanStatusHashMap = getLoanDetails(loanID);
+        verifyLoanStatus(loanStatusHashMap, GetLoansLoanIdStatus::getOverpaid);
     }
 
     /***
@@ -2378,195 +2254,185 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void loanWithFlatChargesAndPeriodicAccrualAccountingEnabled() throws InterruptedException {
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
 
         // Add charges with payment mode regular
-        List<HashMap> charges = new ArrayList<>();
-        Integer flatDisbursement = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC, ChargesHelper.getLoanDisbursementJSON());
-        addCharges(charges, flatDisbursement, "100", null);
-        Integer flatSpecifiedDueDate = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "100", false));
-        addCharges(charges, flatSpecifiedDueDate, "100", "29 September 2011");
-        Integer flatInstallmentFee = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "50", false));
-        addCharges(charges, flatInstallmentFee, "50", null);
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
+        Long flatDisbursement = chargesHelper.createLoanDisbursementCharge(ChargeCalculationType.FLAT, 100.0).getResourceId();
+        addCharges(charges, flatDisbursement, 100.0, null);
+        Long flatSpecifiedDueDate = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.FLAT, 100.0, false)
+                .getResourceId();
+        addCharges(charges, flatSpecifiedDueDate, 100.0, "29 September 2011");
+        Long flatInstallmentFee = chargesHelper.createLoanInstallmentCharge(ChargeCalculationType.FLAT, 50.0, false).getResourceId();
+        addCharges(charges, flatInstallmentFee, 50.0, null);
 
-        final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-        final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-        final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-        final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+        final Account assetAccount = accountHelper.createAssetAccount();
+        final Account incomeAccount = accountHelper.createIncomeAccount();
+        final Account expenseAccount = accountHelper.createExpenseAccount();
+        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
 
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanProductID = createLoanProduct(false, ACCRUAL_PERIODIC, assetAccount, incomeAccount, expenseAccount,
+        final Long loanProductID = createLoanProduct(false, ACCRUAL_PERIODIC, assetAccount, incomeAccount, expenseAccount,
                 overpaymentAccount);
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
         verifyLoanRepaymentSchedule(loanSchedule);
 
-        List<HashMap> loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        List<GetLoansLoanIdChargesChargeIdResponse> loanCharges = getLoanCharges(loanID);
         validateCharge(flatDisbursement, loanCharges, "100", "100.00", "0.0", "0.0");
         validateCharge(flatSpecifiedDueDate, loanCharges, "100", "100.00", "0.0", "0.0");
         validateCharge(flatInstallmentFee, loanCharges, "50", "200.00", "0.0", "0.0");
 
         // check for disbursement fee
-        HashMap disbursementDetail = loanSchedule.get(0);
-        validateNumberForEqual("100.00", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod disbursementDetail = loanSchedule.get(0);
+        validateNumberForEqual("100.00", String.valueOf(disbursementDetail.getFeeChargesDue()));
 
         // check for charge at specified date and installment fee
-        HashMap firstInstallment = loanSchedule.get(1);
-        validateNumberForEqual("150.00", String.valueOf(firstInstallment.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod firstInstallment = loanSchedule.get(1);
+        validateNumberForEqual("150.00", String.valueOf(firstInstallment.getFeeChargesDue()));
 
         // check for installment fee
-        HashMap secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("50.00", String.valueOf(secondInstallment.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod secondInstallment = loanSchedule.get(2);
+        validateNumberForEqual("50.00", String.valueOf(secondInstallment.getFeeChargesDue()));
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("20 September 2011", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("20 September 2011", loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("20 September 2011", loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount("20 September 2011", loanID));
 
-        final JournalEntry[] assetAccountInitialEntry = { new JournalEntry(Float.parseFloat("100.00"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.DEBIT) };
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", assetAccountInitialEntry);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 September 2011",
-                new JournalEntry(Float.parseFloat("100.00"), JournalEntry.TransactionType.CREDIT));
+        final LoanTestData.Journal[] assetAccountInitialEntry = {
+                journalEntry(Float.parseFloat("100.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()) };
+        checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", assetAccountInitialEntry);
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 September 2011",
+                journalEntry(Float.parseFloat("100.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(flatDisbursement, loanCharges, "100", "0.00", "100.0", "0.0");
 
         LOG.info("-------------Make repayment 1-----------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 October 2011", Float.parseFloat("3301.49"), loanID);
+        makeRepayment("20 October 2011", Float.parseFloat("3301.49"), loanID);
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(flatDisbursement, loanCharges, "100", "0.00", "100.0", "0.0");
         validateCharge(flatSpecifiedDueDate, loanCharges, "100", "0.00", "100.0", "0.0");
         validateCharge(flatInstallmentFee, loanCharges, "50", "150.00", "50.0", "0.0");
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("3301.49"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3301.49"), JournalEntry.TransactionType.CREDIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("3301.49"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3301.49"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flatSpecifiedDueDate), "29 October 2011", "100"));
+        addLoanCharge(loanID, flatSpecifiedDueDate, "29 October 2011", 100.0);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
 
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("150.00", String.valueOf(secondInstallment.get("feeChargesDue")));
+        validateNumberForEqual("150.00", String.valueOf(secondInstallment.getFeeChargesDue()));
         LOG.info("----------- Waive installment charge for 2nd installment ---------");
-        LOAN_TRANSACTION_HELPER.waiveChargesForLoan(loanID, (Integer) getloanCharge(flatInstallmentFee, loanCharges).get("id"),
-                LoanTransactionHelper.getWaiveChargeJSON(String.valueOf(2)));
+        waiveLoanCharge(loanID, getloanCharge(flatInstallmentFee, loanCharges).getId(),
+                new PostLoansLoanIdChargesChargeIdRequest().installmentNumber(2L).locale(LOCALE));
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(flatInstallmentFee, loanCharges, "50", "100.00", "50.0", "50.0");
 
         /*
-         * JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount( assetAccount, "20 September 2011", new
+         * checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", new
          * JournalEntry(Float.parseFloat("50.0"), JournalEntry.TransactionType.CREDIT));
-         * JOURNAL_ENTRY_HELPER.checkJournalEntryForExpenseAccount (expenseAccount, "20 September 2011", new
+         * journalHelper.checkJournalEntryForExpenseAccount (expenseAccount, "20 September 2011", new
          * JournalEntry(Float.parseFloat("50.0"), JournalEntry.TransactionType.DEBIT));
          */
         final String jobName = "Add Accrual Transactions";
 
-        SCHEDULER_JOB_HELPER.executeAndAwaitJob(jobName);
+        schedulerHelper.executeAndAwaitJob(jobName);
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         checkAccrualTransactions(loanSchedule, loanID);
 
         LOG.info("----------Make repayment 2------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3251.49"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("3251.49"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3251.49"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 November 2011", Float.parseFloat("3251.49"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("3251.49"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3251.49"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("0", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("--------------Waive interest---------------");
-        LOAN_TRANSACTION_HELPER.waiveInterest("20 December 2011", String.valueOf(61.79), loanID);
+        waiveInterestOnLoan(loanID, "20 December 2011", 61.79);
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap thirdInstallment = loanSchedule.get(3);
-        validateNumberForEqual("60.59", String.valueOf(thirdInstallment.get("interestOutstanding")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod thirdInstallment = loanSchedule.get(3);
+        validateNumberForEqual("60.59", String.valueOf(thirdInstallment.getInterestOutstanding()));
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 December 2011",
-                new JournalEntry(Float.parseFloat("61.79"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForExpenseAccount(expenseAccount, "20 December 2011",
-                new JournalEntry(Float.parseFloat("61.79"), JournalEntry.TransactionType.DEBIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 December 2011",
+                journalEntry(Float.parseFloat("61.79"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForExpenseAccount(expenseAccount, "20 December 2011",
+                journalEntry(Float.parseFloat("61.79"), expenseAccount, JournalEntry.TransactionType.DEBIT.name()));
 
-        Integer flatPenaltySpecifiedDueDate = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "100", true));
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flatPenaltySpecifiedDueDate), "29 September 2011", "100"));
+        Long flatPenaltySpecifiedDueDate = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.FLAT, 100.0, true)
+                .getResourceId();
+        addLoanCharge(loanID, flatPenaltySpecifiedDueDate, "29 September 2011", 100.0);
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(flatPenaltySpecifiedDueDate, loanCharges, "100", "0.00", "100.0", "0.0");
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("100", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("100", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
         // checking the journal entry as applied penalty has been collected
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("3301.49"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3301.49"), JournalEntry.TransactionType.CREDIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("3301.49"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3301.49"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         LOG.info("----------Make repayment 3 advance------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3301.49"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("3301.49"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3301.49"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 November 2011", Float.parseFloat("3301.49"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("3301.49"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3301.49"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flatPenaltySpecifiedDueDate), "10 January 2012", "100"));
+        addLoanCharge(loanID, flatPenaltySpecifiedDueDate, "10 January 2012", 100.0);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("100", String.valueOf(fourthInstallment.get("penaltyChargesOutstanding")));
-        validateNumberForEqual("3239.68", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod fourthInstallment = loanSchedule.get(4);
+        validateNumberForEqual("100", String.valueOf(fourthInstallment.getPenaltyChargesOutstanding()));
+        validateNumberForEqual("3239.68", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("----------Pay applied penalty ------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("100"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("100"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("100"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 January 2012", Float.parseFloat("100"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("100"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("100"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("0", String.valueOf(fourthInstallment.get("penaltyChargesOutstanding")));
-        validateNumberForEqual("3139.68", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0", String.valueOf(fourthInstallment.getPenaltyChargesOutstanding()));
+        validateNumberForEqual("3139.68", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("----------Make repayment 4 ------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("3139.68"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("3139.68"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3139.68"), JournalEntry.TransactionType.CREDIT));
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "status");
-        LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
+        makeRepayment("20 January 2012", Float.parseFloat("3139.68"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("3139.68"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3139.68"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        GetLoansLoanIdResponse loanStatusHashMap = getLoanDetails(loanID);
+        verifyLoanStatus(loanStatusHashMap, GetLoansLoanIdStatus::getClosed);
     }
 
     /**
@@ -2577,202 +2443,191 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
     public void loanWithChargesOfTypeAmountPercentageAndPeriodicAccrualAccountingEnabled() throws InterruptedException {
         try {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-            ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+            final Long clientID = createClient();
+            verifyClientCreatedOnServer(clientID);
 
             // Add charges with payment mode regular
-            List<HashMap> charges = new ArrayList<>();
-            Integer percentageDisbursementCharge = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                    ChargesHelper.getLoanDisbursementJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1"));
-            addCharges(charges, percentageDisbursementCharge, "1", null);
+            List<PostLoansRequestChargeData> charges = new ArrayList<>();
+            Long percentageDisbursementCharge = chargesHelper.createLoanDisbursementCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0)
+                    .getResourceId();
+            addCharges(charges, percentageDisbursementCharge, 1.0, null);
 
-            Integer percentageSpecifiedDueDateCharge = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1", false));
-            addCharges(charges, percentageSpecifiedDueDateCharge, "1", "29 September 2011");
+            Long percentageSpecifiedDueDateCharge = chargesHelper
+                    .createLoanSpecifiedDueDateCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0, false).getResourceId();
+            addCharges(charges, percentageSpecifiedDueDateCharge, 1.0, "29 September 2011");
 
-            Integer percentageInstallmentFee = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                    ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1", false));
-            addCharges(charges, percentageInstallmentFee, "1", "29 September 2011");
+            Long percentageInstallmentFee = chargesHelper.createLoanInstallmentCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0, false)
+                    .getResourceId();
+            addCharges(charges, percentageInstallmentFee, 1.0, "29 September 2011");
 
-            final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-            final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-            final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-            final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+            final Account assetAccount = accountHelper.createAssetAccount();
+            final Account incomeAccount = accountHelper.createIncomeAccount();
+            final Account expenseAccount = accountHelper.createExpenseAccount();
+            final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-            List<HashMap> collaterals = new ArrayList<>();
+            List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-            final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+            final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
 
-            final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                    String.valueOf(clientID), collateralId);
-            addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+            final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
+            collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-            final Integer loanProductID = createLoanProduct(false, ACCRUAL_PERIODIC, assetAccount, incomeAccount, expenseAccount,
+            final Long loanProductID = createLoanProduct(false, ACCRUAL_PERIODIC, assetAccount, incomeAccount, expenseAccount,
                     overpaymentAccount);
-            final Integer loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
+            final Long loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
             Assertions.assertNotNull(loanID);
-            HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+            verifyLoanIsPending(loanID);
 
-            ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+            List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
             verifyLoanRepaymentSchedule(loanSchedule);
 
-            List<HashMap> loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+            List<GetLoansLoanIdChargesChargeIdResponse> loanCharges = getLoanCharges(loanID);
             validateCharge(percentageDisbursementCharge, loanCharges, "1", "120.00", "0.0", "0.0");
             validateCharge(percentageSpecifiedDueDateCharge, loanCharges, "1", "120.00", "0.0", "0.0");
             validateCharge(percentageInstallmentFee, loanCharges, "1", "120.00", "0.0", "0.0");
 
             // check for disbursement fee
-            HashMap disbursementDetail = loanSchedule.get(0);
-            validateNumberForEqual("120.00", String.valueOf(disbursementDetail.get("feeChargesDue")));
+            GetLoansLoanIdRepaymentPeriod disbursementDetail = loanSchedule.get(0);
+            validateNumberForEqual("120.00", String.valueOf(disbursementDetail.getFeeChargesDue()));
 
             // check for charge at specified date and installment fee
-            HashMap firstInstallment = loanSchedule.get(1);
-            validateNumberForEqual("149.11", String.valueOf(firstInstallment.get("feeChargesDue")));
+            GetLoansLoanIdRepaymentPeriod firstInstallment = loanSchedule.get(1);
+            validateNumberForEqual("149.11", String.valueOf(firstInstallment.getFeeChargesDue()));
 
             // check for installment fee
-            HashMap secondInstallment = loanSchedule.get(2);
-            validateNumberForEqual("29.70", String.valueOf(secondInstallment.get("feeChargesDue")));
+            GetLoansLoanIdRepaymentPeriod secondInstallment = loanSchedule.get(2);
+            validateNumberForEqual("29.70", String.valueOf(secondInstallment.getFeeChargesDue()));
 
             LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("20 September 2011", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-            LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+            verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("20 September 2011", loanID));
 
             LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-            String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("20 September 2011", loanID,
-                    JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+            verifyLoanIsActive(disburseLoanWithNetDisbursalAmount("20 September 2011", loanID));
 
-            ArrayList<HashMap> loanTransactionDetails = LOAN_TRANSACTION_HELPER.getLoanTransactionDetails(REQUEST_SPEC, RESPONSE_SPEC,
-                    loanID);
-            final JournalEntry[] assetAccountInitialEntry = {
-                    new JournalEntry(Float.parseFloat("120.00"), JournalEntry.TransactionType.DEBIT),
-                    new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.CREDIT),
-                    new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.DEBIT) };
-            JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", assetAccountInitialEntry);
-            JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 September 2011",
-                    new JournalEntry(Float.parseFloat("120.00"), JournalEntry.TransactionType.CREDIT));
+            List<GetLoansLoanIdTransactions> loanTransactionDetails = getLoanDetails(loanID).getTransactions();
+            final LoanTestData.Journal[] assetAccountInitialEntry = {
+                    journalEntry(Float.parseFloat("120.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                    journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                    journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()) };
+            checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", assetAccountInitialEntry);
+            checkJournalEntryForIncomeAccount(incomeAccount, "20 September 2011",
+                    journalEntry(Float.parseFloat("120.00"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
             loanCharges.clear();
-            loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+            loanCharges = getLoanCharges(loanID);
             validateCharge(percentageDisbursementCharge, loanCharges, "1", "0.0", "120.00", "0.0");
 
             LOG.info("-------------Make repayment 1-----------");
-            LOAN_TRANSACTION_HELPER.makeRepayment("20 October 2011", Float.parseFloat("3300.60"), loanID);
+            makeRepayment("20 October 2011", Float.parseFloat("3300.60"), loanID);
             loanCharges.clear();
-            loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+            loanCharges = getLoanCharges(loanID);
             validateCharge(percentageDisbursementCharge, loanCharges, "1", "0.00", "120.00", "0.0");
             validateCharge(percentageSpecifiedDueDateCharge, loanCharges, "1", "0.00", "120.0", "0.0");
             validateCharge(percentageInstallmentFee, loanCharges, "1", "90.89", "29.11", "0.0");
 
-            JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
-                    new JournalEntry(Float.parseFloat("3300.60"), JournalEntry.TransactionType.DEBIT),
-                    new JournalEntry(Float.parseFloat("3300.60"), JournalEntry.TransactionType.CREDIT));
+            checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
+                    journalEntry(Float.parseFloat("3300.60"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                    journalEntry(Float.parseFloat("3300.60"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
-            LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                    .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(percentageSpecifiedDueDateCharge), "29 October 2011", "1"));
+            addLoanCharge(loanID, percentageSpecifiedDueDateCharge, "29 October 2011", 1.0);
             loanSchedule.clear();
-            loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+            loanSchedule = getLoanRepaymentSchedule(loanID);
 
             secondInstallment = loanSchedule.get(2);
-            validateNumberForEqual("149.70", String.valueOf(secondInstallment.get("feeChargesDue")));
+            validateNumberForEqual("149.70", String.valueOf(secondInstallment.getFeeChargesDue()));
             LOG.info("----------- Waive installment charge for 2nd installment ---------");
-            LOAN_TRANSACTION_HELPER.waiveChargesForLoan(loanID, (Integer) getloanCharge(percentageInstallmentFee, loanCharges).get("id"),
-                    LoanTransactionHelper.getWaiveChargeJSON(String.valueOf(2)));
+            waiveLoanCharge(loanID, getloanCharge(percentageInstallmentFee, loanCharges).getId(),
+                    new PostLoansLoanIdChargesChargeIdRequest().installmentNumber(2L).locale(LOCALE));
             loanCharges.clear();
-            loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+            loanCharges = getLoanCharges(loanID);
             validateCharge(percentageInstallmentFee, loanCharges, "1", "61.19", "29.11", "29.70");
 
             /*
-             * JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount( assetAccount, "20 September 2011", new
+             * checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", new
              * JournalEntry(Float.parseFloat("29.7"), JournalEntry.TransactionType.CREDIT));
-             * JOURNAL_ENTRY_HELPER.checkJournalEntryForExpenseAccount (expenseAccount, "20 September 2011", new
+             * journalHelper.checkJournalEntryForExpenseAccount (expenseAccount, "20 September 2011", new
              * JournalEntry(Float.parseFloat("29.7"), JournalEntry.TransactionType.DEBIT));
              */
 
             final String jobName = "Add Accrual Transactions";
 
-            SCHEDULER_JOB_HELPER.executeAndAwaitJob(jobName);
+            schedulerHelper.executeAndAwaitJob(jobName);
 
             loanSchedule.clear();
-            loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+            loanSchedule = getLoanRepaymentSchedule(loanID);
             checkAccrualTransactions(loanSchedule, loanID);
 
             LOG.info("----------Make repayment 2------------");
-            LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3271.49"), loanID);
-            JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                    new JournalEntry(Float.parseFloat("3271.49"), JournalEntry.TransactionType.DEBIT),
-                    new JournalEntry(Float.parseFloat("3271.49"), JournalEntry.TransactionType.CREDIT));
+            makeRepayment("20 November 2011", Float.parseFloat("3271.49"), loanID);
+            checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                    journalEntry(Float.parseFloat("3271.49"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                    journalEntry(Float.parseFloat("3271.49"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
             loanSchedule.clear();
-            loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+            loanSchedule = getLoanRepaymentSchedule(loanID);
             secondInstallment = loanSchedule.get(2);
-            validateNumberForEqual("0", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+            validateNumberForEqual("0", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
             LOG.info("--------------Waive interest---------------");
-            LOAN_TRANSACTION_HELPER.waiveInterest("20 December 2011", String.valueOf(61.79), loanID);
+            waiveInterestOnLoan(loanID, "20 December 2011", 61.79);
 
             loanSchedule.clear();
-            loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            HashMap thirdInstallment = loanSchedule.get(3);
-            validateNumberForEqual("60.59", String.valueOf(thirdInstallment.get("interestOutstanding")));
+            loanSchedule = getLoanRepaymentSchedule(loanID);
+            GetLoansLoanIdRepaymentPeriod thirdInstallment = loanSchedule.get(3);
+            validateNumberForEqual("60.59", String.valueOf(thirdInstallment.getInterestOutstanding()));
 
-            JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 December 2011",
-                    new JournalEntry(Float.parseFloat("61.79"), JournalEntry.TransactionType.CREDIT));
-            JOURNAL_ENTRY_HELPER.checkJournalEntryForExpenseAccount(expenseAccount, "20 December 2011",
-                    new JournalEntry(Float.parseFloat("61.79"), JournalEntry.TransactionType.DEBIT));
+            checkJournalEntryForAssetAccount(assetAccount, "20 December 2011",
+                    journalEntry(Float.parseFloat("61.79"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+            checkJournalEntryForExpenseAccount(expenseAccount, "20 December 2011",
+                    journalEntry(Float.parseFloat("61.79"), expenseAccount, JournalEntry.TransactionType.DEBIT.name()));
 
-            Integer percentagePenaltySpecifiedDueDate = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1", true));
-            LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                    .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(percentagePenaltySpecifiedDueDate), "29 September 2011", "1"));
+            Long percentagePenaltySpecifiedDueDate = chargesHelper
+                    .createLoanSpecifiedDueDateCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0, true).getResourceId();
+            addLoanCharge(loanID, percentagePenaltySpecifiedDueDate, "29 September 2011", 1.0);
             loanCharges.clear();
-            loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+            loanCharges = getLoanCharges(loanID);
             validateCharge(percentagePenaltySpecifiedDueDate, loanCharges, "1", "0.00", "120.0", "0.0");
 
             loanSchedule.clear();
-            loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+            loanSchedule = getLoanRepaymentSchedule(loanID);
             secondInstallment = loanSchedule.get(2);
-            validateNumberForEqual("120", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+            validateNumberForEqual("120", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
             // checking the journal entry as applied penalty has been collected
-            JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
-                    new JournalEntry(Float.parseFloat("3300.60"), JournalEntry.TransactionType.DEBIT),
-                    new JournalEntry(Float.parseFloat("3300.60"), JournalEntry.TransactionType.CREDIT));
+            checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
+                    journalEntry(Float.parseFloat("3300.60"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                    journalEntry(Float.parseFloat("3300.60"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
             LOG.info("----------Make repayment 3 advance------------");
-            LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3301.78"), loanID);
-            JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                    new JournalEntry(Float.parseFloat("3301.78"), JournalEntry.TransactionType.DEBIT),
-                    new JournalEntry(Float.parseFloat("3301.78"), JournalEntry.TransactionType.CREDIT));
+            makeRepayment("20 November 2011", Float.parseFloat("3301.78"), loanID);
+            checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                    journalEntry(Float.parseFloat("3301.78"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                    journalEntry(Float.parseFloat("3301.78"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
-            LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                    .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(percentagePenaltySpecifiedDueDate), "10 January 2012", "1"));
+            addLoanCharge(loanID, percentagePenaltySpecifiedDueDate, "10 January 2012", 1.0);
             loanSchedule.clear();
-            loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            HashMap fourthInstallment = loanSchedule.get(4);
-            validateNumberForEqual("120", String.valueOf(fourthInstallment.get("penaltyChargesOutstanding")));
-            validateNumberForEqual("3240.58", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
+            loanSchedule = getLoanRepaymentSchedule(loanID);
+            GetLoansLoanIdRepaymentPeriod fourthInstallment = loanSchedule.get(4);
+            validateNumberForEqual("120", String.valueOf(fourthInstallment.getPenaltyChargesOutstanding()));
+            validateNumberForEqual("3240.58", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
 
             LOG.info("----------Pay applied penalty ------------");
-            LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("120"), loanID);
-            JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
-                    new JournalEntry(Float.parseFloat("120"), JournalEntry.TransactionType.DEBIT),
-                    new JournalEntry(Float.parseFloat("120"), JournalEntry.TransactionType.CREDIT));
+            makeRepayment("20 January 2012", Float.parseFloat("120"), loanID);
+            checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
+                    journalEntry(Float.parseFloat("120"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                    journalEntry(Float.parseFloat("120"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
             loanSchedule.clear();
-            loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+            loanSchedule = getLoanRepaymentSchedule(loanID);
             fourthInstallment = loanSchedule.get(4);
-            validateNumberForEqual("0", String.valueOf(fourthInstallment.get("penaltyChargesOutstanding")));
-            validateNumberForEqual("3120.58", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
+            validateNumberForEqual("0", String.valueOf(fourthInstallment.getPenaltyChargesOutstanding()));
+            validateNumberForEqual("3120.58", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
 
             LOG.info("----------Make repayment 4 ------------");
-            LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("3120.58"), loanID);
-            JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
-                    new JournalEntry(Float.parseFloat("3120.58"), JournalEntry.TransactionType.DEBIT),
-                    new JournalEntry(Float.parseFloat("3120.58"), JournalEntry.TransactionType.CREDIT));
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "status");
-            LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
+            makeRepayment("20 January 2012", Float.parseFloat("3120.58"), loanID);
+            checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
+                    journalEntry(Float.parseFloat("3120.58"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                    journalEntry(Float.parseFloat("3120.58"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+            GetLoansLoanIdResponse loanStatusHashMap = getLoanDetails(loanID);
+            verifyLoanStatus(loanStatusHashMap, GetLoansLoanIdStatus::getClosed);
         } finally {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, false);
         }
@@ -2785,220 +2640,209 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void loanWithChargesOfTypeAmountPlusInterestPercentageAndPeriodicAccrualAccountingEnabled() throws InterruptedException {
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
 
         // Add charges with payment mode regular
-        List<HashMap> charges = new ArrayList<>();
-        Integer amountPlusInterestPercentageDisbursementCharge = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanDisbursementJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT_AND_INTEREST, "1"));
-        addCharges(charges, amountPlusInterestPercentageDisbursementCharge, "1", null);
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
+        Long amountPlusInterestPercentageDisbursementCharge = chargesHelper
+                .createLoanDisbursementCharge(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST, 1.0).getResourceId();
+        addCharges(charges, amountPlusInterestPercentageDisbursementCharge, 1.0, null);
 
-        Integer amountPlusInterestPercentageSpecifiedDueDateCharge = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC, ChargesHelper
-                .getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT_AND_INTEREST, "1", false));
-        addCharges(charges, amountPlusInterestPercentageSpecifiedDueDateCharge, "1", "29 September 2011");
+        Long amountPlusInterestPercentageSpecifiedDueDateCharge = chargesHelper
+                .createLoanSpecifiedDueDateCharge(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST, 1.0, false).getResourceId();
+        addCharges(charges, amountPlusInterestPercentageSpecifiedDueDateCharge, 1.0, "29 September 2011");
 
-        Integer amountPlusInterestPercentageInstallmentFee = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT_AND_INTEREST, "1", false));
-        addCharges(charges, amountPlusInterestPercentageInstallmentFee, "1", "29 September 2011");
+        Long amountPlusInterestPercentageInstallmentFee = chargesHelper
+                .createLoanInstallmentCharge(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST, 1.0, false).getResourceId();
+        addCharges(charges, amountPlusInterestPercentageInstallmentFee, 1.0, "29 September 2011");
 
-        final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-        final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-        final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-        final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+        final Account assetAccount = accountHelper.createAssetAccount();
+        final Account incomeAccount = accountHelper.createIncomeAccount();
+        final Account expenseAccount = accountHelper.createExpenseAccount();
+        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
         Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
         Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanProductID = createLoanProduct(false, ACCRUAL_PERIODIC, assetAccount, incomeAccount, expenseAccount,
+        final Long loanProductID = createLoanProduct(false, ACCRUAL_PERIODIC, assetAccount, incomeAccount, expenseAccount,
                 overpaymentAccount);
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "12,000.00", collaterals);
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
         verifyLoanRepaymentSchedule(loanSchedule);
 
-        List<HashMap> loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        List<GetLoansLoanIdChargesChargeIdResponse> loanCharges = getLoanCharges(loanID);
         validateCharge(amountPlusInterestPercentageDisbursementCharge, loanCharges, "1", "126.06", "0.0", "0.0");
         validateCharge(amountPlusInterestPercentageSpecifiedDueDateCharge, loanCharges, "1", "126.06", "0.0", "0.0");
         validateCharge(amountPlusInterestPercentageInstallmentFee, loanCharges, "1", "126.04", "0.0", "0.0");
 
         // check for disbursement fee
-        HashMap disbursementDetail = loanSchedule.get(0);
-        validateNumberForEqual("126.06", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod disbursementDetail = loanSchedule.get(0);
+        validateNumberForEqual("126.06", String.valueOf(disbursementDetail.getFeeChargesDue()));
 
         // check for charge at specified date and installment fee
-        HashMap firstInstallment = loanSchedule.get(1);
-        validateNumberForEqual("157.57", String.valueOf(firstInstallment.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod firstInstallment = loanSchedule.get(1);
+        validateNumberForEqual("157.57", String.valueOf(firstInstallment.getFeeChargesDue()));
 
         // check for installment fee
-        HashMap secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("31.51", String.valueOf(secondInstallment.get("feeChargesDue")));
+        GetLoansLoanIdRepaymentPeriod secondInstallment = loanSchedule.get(2);
+        validateNumberForEqual("31.51", String.valueOf(secondInstallment.getFeeChargesDue()));
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("20 September 2011", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("20 September 2011", loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("20 September 2011", loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount("20 September 2011", loanID));
 
-        final JournalEntry[] assetAccountInitialEntry = { new JournalEntry(Float.parseFloat("126.06"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.DEBIT) };
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", assetAccountInitialEntry);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, "20 September 2011",
-                new JournalEntry(Float.parseFloat("126.06"), JournalEntry.TransactionType.CREDIT));
+        final LoanTestData.Journal[] assetAccountInitialEntry = {
+                journalEntry(Float.parseFloat("126.06"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()) };
+        checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", assetAccountInitialEntry);
+        checkJournalEntryForIncomeAccount(incomeAccount, "20 September 2011",
+                journalEntry(Float.parseFloat("126.06"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(amountPlusInterestPercentageDisbursementCharge, loanCharges, "1", "0.0", "126.06", "0.0");
 
         LOG.info("-------------Make repayment 1-----------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 October 2011", Float.parseFloat("3309.06"), loanID);
+        makeRepayment("20 October 2011", Float.parseFloat("3309.06"), loanID);
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(amountPlusInterestPercentageDisbursementCharge, loanCharges, "1", "0.00", "126.06", "0.0");
         validateCharge(amountPlusInterestPercentageSpecifiedDueDateCharge, loanCharges, "1", "0.00", "126.06", "0.0");
         validateCharge(amountPlusInterestPercentageInstallmentFee, loanCharges, "1", "94.53", "31.51", "0.0");
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("3309.06"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3309.06"), JournalEntry.TransactionType.CREDIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("3309.06"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3309.06"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(
-                String.valueOf(amountPlusInterestPercentageSpecifiedDueDateCharge), "29 October 2011", "1"));
+        addLoanCharge(loanID, amountPlusInterestPercentageSpecifiedDueDateCharge, "29 October 2011", 1.0);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
 
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("157.57", String.valueOf(secondInstallment.get("feeChargesDue")));
+        validateNumberForEqual("157.57", String.valueOf(secondInstallment.getFeeChargesDue()));
         LOG.info("----------- Waive installment charge for 2nd installment ---------");
-        LOAN_TRANSACTION_HELPER.waiveChargesForLoan(loanID,
-                (Integer) getloanCharge(amountPlusInterestPercentageInstallmentFee, loanCharges).get("id"),
-                LoanTransactionHelper.getWaiveChargeJSON(String.valueOf(2)));
+        waiveLoanCharge(loanID, getloanCharge(amountPlusInterestPercentageInstallmentFee, loanCharges).getId(),
+                new PostLoansLoanIdChargesChargeIdRequest().installmentNumber(2L).locale(LOCALE));
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(amountPlusInterestPercentageInstallmentFee, loanCharges, "1", "63.02", "31.51", "31.51");
 
         /*
-         * JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount( assetAccount, "20 September 2011", new JournalEntry(
-         * Float.parseFloat("31.51"), JournalEntry.TransactionType.CREDIT));
-         * JOURNAL_ENTRY_HELPER.checkJournalEntryForExpenseAccount (expenseAccount, "20 September 2011", new
-         * JournalEntry(Float.parseFloat("31.51"), JournalEntry.TransactionType.DEBIT));
+         * checkJournalEntryForAssetAccount(assetAccount, "20 September 2011", journalEntry(* Float.parseFloat("31.51"),
+         * assetAccount, JournalEntry.TransactionType.CREDIT.name())); journalHelper.checkJournalEntryForExpenseAccount
+         * (expenseAccount, "20 September 2011", new JournalEntry(Float.parseFloat("31.51"),
+         * JournalEntry.TransactionType.DEBIT));
          */
 
         final String jobName = "Add Accrual Transactions";
 
-        SCHEDULER_JOB_HELPER.executeAndAwaitJob(jobName);
+        schedulerHelper.executeAndAwaitJob(jobName);
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         checkAccrualTransactions(loanSchedule, loanID);
 
         LOG.info("----------Make repayment 2------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3277.55"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("3277.55"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3277.55"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 November 2011", Float.parseFloat("3277.55"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("3277.55"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3277.55"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("0", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("--------------Waive interest---------------");
-        LOAN_TRANSACTION_HELPER.waiveInterest("20 December 2011", String.valueOf(61.79), loanID);
+        waiveInterestOnLoan(loanID, "20 December 2011", 61.79);
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap thirdInstallment = loanSchedule.get(3);
-        validateNumberForEqual("60.59", String.valueOf(thirdInstallment.get("interestOutstanding")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod thirdInstallment = loanSchedule.get(3);
+        validateNumberForEqual("60.59", String.valueOf(thirdInstallment.getInterestOutstanding()));
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 December 2011",
-                new JournalEntry(Float.parseFloat("61.79"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForExpenseAccount(expenseAccount, "20 December 2011",
-                new JournalEntry(Float.parseFloat("61.79"), JournalEntry.TransactionType.DEBIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 December 2011",
+                journalEntry(Float.parseFloat("61.79"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForExpenseAccount(expenseAccount, "20 December 2011",
+                journalEntry(Float.parseFloat("61.79"), expenseAccount, JournalEntry.TransactionType.DEBIT.name()));
 
-        Integer amountPlusInterestPercentagePenaltySpecifiedDueDate = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "1", true));
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(
-                String.valueOf(amountPlusInterestPercentagePenaltySpecifiedDueDate), "29 September 2011", "1"));
+        Long amountPlusInterestPercentagePenaltySpecifiedDueDate = chargesHelper
+                .createLoanSpecifiedDueDateCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 1.0, true).getResourceId();
+        addLoanCharge(loanID, amountPlusInterestPercentagePenaltySpecifiedDueDate, "29 September 2011", 1.0);
         loanCharges.clear();
-        loanCharges = LOAN_TRANSACTION_HELPER.getLoanCharges(loanID);
+        loanCharges = getLoanCharges(loanID);
         validateCharge(amountPlusInterestPercentagePenaltySpecifiedDueDate, loanCharges, "1", "0.0", "120.0", "0.0");
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("120", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("120", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
         // checking the journal entry as applied penalty has been collected
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
-                new JournalEntry(Float.parseFloat("3309.06"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3309.06"), JournalEntry.TransactionType.CREDIT));
+        checkJournalEntryForAssetAccount(assetAccount, "20 October 2011",
+                journalEntry(Float.parseFloat("3309.06"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3309.06"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         LOG.info("----------Make repayment 3 advance------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3303"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
-                new JournalEntry(Float.parseFloat("3303"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3303"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 November 2011", Float.parseFloat("3303"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 November 2011",
+                journalEntry(Float.parseFloat("3303"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3303"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
-        LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(
-                String.valueOf(amountPlusInterestPercentagePenaltySpecifiedDueDate), "10 January 2012", "1"));
+        addLoanCharge(loanID, amountPlusInterestPercentagePenaltySpecifiedDueDate, "10 January 2012", 1.0);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("120", String.valueOf(fourthInstallment.get("penaltyChargesOutstanding")));
-        validateNumberForEqual("3241.19", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod fourthInstallment = loanSchedule.get(4);
+        validateNumberForEqual("120", String.valueOf(fourthInstallment.getPenaltyChargesOutstanding()));
+        validateNumberForEqual("3241.19", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("----------Pay applied penalty ------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("120"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("120"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("120"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment("20 January 2012", Float.parseFloat("120"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("120"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("120"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("0", String.valueOf(fourthInstallment.get("penaltyChargesOutstanding")));
-        validateNumberForEqual("3121.19", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0", String.valueOf(fourthInstallment.getPenaltyChargesOutstanding()));
+        validateNumberForEqual("3121.19", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
 
         LOG.info("----------Make repayment 4 ------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("3121.19"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
-                new JournalEntry(Float.parseFloat("3121.19"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("3121.19"), JournalEntry.TransactionType.CREDIT));
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "status");
-        LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
+        makeRepayment("20 January 2012", Float.parseFloat("3121.19"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, "20 January 2012",
+                journalEntry(Float.parseFloat("3121.19"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("3121.19"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        GetLoansLoanIdResponse loanStatusHashMap = getLoanDetails(loanID);
+        verifyLoanStatus(loanStatusHashMap, GetLoansLoanIdStatus::getClosed);
     }
 
     @Test
     public void testClientLoanScheduleWithCurrencyDetails() {
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
 
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanProductID = createLoanProduct("100", "0", LoanProductTestBuilder.DEFAULT_STRATEGY);
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, null, collaterals);
-        final ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        final Long loanProductID = createLoanProduct(100, 0, DEFAULT_STRATEGY);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID, null, collaterals);
+        final List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
         verifyLoanRepaymentScheduleForEqualPrincipal(loanSchedule);
 
     }
@@ -3006,20 +2850,19 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void testClientLoanScheduleWithCurrencyDetails_with_grace() {
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
 
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanProductID = createLoanProduct("100", "0", LoanProductTestBuilder.DEFAULT_STRATEGY);
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, "5", collaterals);
-        final ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        final Long loanProductID = createLoanProduct(100, 0, DEFAULT_STRATEGY);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID, 5, collaterals);
+        final List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
         verifyLoanRepaymentScheduleForEqualPrincipalWithGrace(loanSchedule);
 
     }
@@ -3030,82 +2873,75 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void testRBIPaymentStrategy() {
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
 
         /***
          * Create loan product with RBI strategy
          */
-        final Integer loanProductID = createLoanProduct("100", "0", LoanProductTestBuilder.RBI_INDIA_STRATEGY);
+        final Long loanProductID = createLoanProduct(100, 0, RBI_INDIA_STRATEGY);
         Assertions.assertNotNull(loanProductID);
 
         /***
          * Apply for loan application and verify loan status
          */
-        final String savingsId = null;
+        final Long savingsId = null;
         final String principal = "12,000.00";
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
 
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanID = applyForLoanApplicationWithPaymentStrategy(clientID, loanProductID, null, savingsId, principal,
-                LoanApplicationTestBuilder.RBI_INDIA_STRATEGY, collaterals);
+        final Long loanID = applyForLoanApplicationWithPaymentStrategy(clientID, loanProductID, null, savingsId, principal,
+                RBI_INDIA_STRATEGY, collaterals);
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("20 September 2011", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("20 September 2011", loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("20 September 2011", loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount("20 September 2011", loanID));
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap firstInstallment = loanSchedule.get(1);
-        validateNumberForEqual("3200", String.valueOf(firstInstallment.get("totalOutstandingForPeriod")));
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod firstInstallment = loanSchedule.get(1);
+        validateNumberForEqual("3200", String.valueOf(firstInstallment.getTotalOutstandingForPeriod()));
 
         /***
          * Make payment for installment #1
          */
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 October 2011", Float.parseFloat("3200"), loanID);
+        makeRepayment("20 October 2011", Float.parseFloat("3200"), loanID);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         firstInstallment = loanSchedule.get(1);
-        validateNumberForEqual("0.00", String.valueOf(firstInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0.00", String.valueOf(firstInstallment.getTotalOutstandingForPeriod()));
 
         /***
          * Verify 2nd and 3rd repayments dues before making excess payment for installment no 2
          */
-        HashMap secondInstallment = loanSchedule.get(2);
-        HashMap thirdInstallment = loanSchedule.get(3);
+        GetLoansLoanIdRepaymentPeriod secondInstallment = loanSchedule.get(2);
+        GetLoansLoanIdRepaymentPeriod thirdInstallment = loanSchedule.get(3);
 
-        validateNumberForEqual("3200", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
-        validateNumberForEqual("3200", String.valueOf(thirdInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("3200", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
+        validateNumberForEqual("3200", String.valueOf(thirdInstallment.getTotalOutstandingForPeriod()));
 
-        validateNumberForEqual("3000", String.valueOf(secondInstallment.get("principalOutstanding")));
-        validateNumberForEqual("3100", String.valueOf(thirdInstallment.get("principalOutstanding")));
+        validateNumberForEqual("3000", String.valueOf(secondInstallment.getPrincipalOutstanding()));
+        validateNumberForEqual("3100", String.valueOf(thirdInstallment.getPrincipalOutstanding()));
 
         /***
          * Make payment for installment #2
          */
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 November 2011", Float.parseFloat("3200"), loanID);
+        makeRepayment("20 November 2011", Float.parseFloat("3200"), loanID);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         /***
          * Verify 2nd and 3rd repayments after making excess payment for installment no 2
          */
         secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("0.00", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0.00", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
         /***
          * According to RBI Excess payment should go to principal portion of next installment, but as interest
@@ -3113,95 +2949,87 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
          * payment, so excess payments will behave the same as regular payment with the excess amount
          */
         thirdInstallment = loanSchedule.get(3);
-        validateNumberForEqual("3200", String.valueOf(thirdInstallment.get("totalOutstandingForPeriod")));
-        validateNumberForEqual("3100", String.valueOf(thirdInstallment.get("principalOutstanding")));
-        validateNumberForEqual("0", String.valueOf(thirdInstallment.get("principalPaid")));
-        validateNumberForEqual("0", String.valueOf(thirdInstallment.get("interestPaid")));
-        validateNumberForEqual("100.00", String.valueOf(thirdInstallment.get("interestOutstanding")));
+        validateNumberForEqual("3200", String.valueOf(thirdInstallment.getTotalOutstandingForPeriod()));
+        validateNumberForEqual("3100", String.valueOf(thirdInstallment.getPrincipalOutstanding()));
+        validateNumberForEqual("0", String.valueOf(thirdInstallment.getPrincipalPaid()));
+        validateNumberForEqual("0", String.valueOf(thirdInstallment.getInterestPaid()));
+        validateNumberForEqual("100.00", String.valueOf(thirdInstallment.getInterestOutstanding()));
 
         /***
          * Make payment with due amount of 3rd installment on 4th installment date
          */
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("3200"), loanID);
+        makeRepayment("20 January 2012", Float.parseFloat("3200"), loanID);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
 
         /***
          * Verify overdue interests are deducted first and then remaining amount for interest portion of due installment
          */
         thirdInstallment = loanSchedule.get(3);
-        HashMap fourthInstallment = loanSchedule.get(4);
+        GetLoansLoanIdRepaymentPeriod fourthInstallment = loanSchedule.get(4);
 
-        validateNumberForEqual("100", String.valueOf(thirdInstallment.get("totalOutstandingForPeriod")));
-        validateNumberForEqual("100", String.valueOf(thirdInstallment.get("principalOutstanding")));
+        validateNumberForEqual("100", String.valueOf(thirdInstallment.getTotalOutstandingForPeriod()));
+        validateNumberForEqual("100", String.valueOf(thirdInstallment.getPrincipalOutstanding()));
 
-        validateNumberForEqual("2900", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
-        validateNumberForEqual("100", String.valueOf(fourthInstallment.get("interestPaid")));
-        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.get("interestOutstanding")));
+        validateNumberForEqual("2900", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
+        validateNumberForEqual("100", String.valueOf(fourthInstallment.getInterestPaid()));
+        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.getInterestOutstanding()));
 
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 January 2012", Float.parseFloat("3000"), loanID);
+        makeRepayment("20 January 2012", Float.parseFloat("3000"), loanID);
 
         /***
          * verify loan is closed as we paid full amount
          */
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
+        verifyLoanAccountIsClosed(loanID);
 
     }
 
     @Test
     public void testLoanPrePaymentWithMultiplePayments() {
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
 
         // Create a loan product
-        Integer loanProductId = createLoanProduct(false, NONE);
-        Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
-        Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
-        List<HashMap> collaterals = List.of(collaterals(clientCollateralId, BigDecimal.ONE));
+        Long loanProductId = createLoanProduct(false, NONE);
+        Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
+        Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
+        List<PostLoansRequestCollateralData> collaterals = List.of(collateral(clientCollateralId, BigDecimal.ONE));
 
         // Apply for a loan
         final String disbursementDate = "1 May 2023";
         final String approvalDate = "1 April 2023";
         final String submissionDate = "1 March 2023";
         final String interestRate = "7";
-        final Integer loanID = applyForLoanApplication(clientID, loanProductId, disbursementDate, submissionDate, interestRate, null, null,
+        final Long loanID = applyForLoanApplication(clientID, loanProductId, disbursementDate, submissionDate, interestRate, null, null,
                 "1000", collaterals);
         Assertions.assertNotNull(loanID);
 
         // Check loan status
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
         // Approve the loan
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(approvalDate, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(approvalDate, loanID));
 
         // Disburse the loan
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(disbursementDate, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(disbursementDate, loanID));
 
         // Make the first partial repayment
         LOG.info("------------------------MAKE FIRST PARTIAL REPAYMENT-----------------------------------");
         Float firstRepaymentAmount = 500.0f; // First partial repayment
         String firstRepaymentDate = "1 June 2023";
-        LOAN_TRANSACTION_HELPER.makeRepayment(firstRepaymentDate, firstRepaymentAmount, loanID);
+        makeRepayment(firstRepaymentDate, firstRepaymentAmount, loanID);
 
         // Verify the prepayment amount after the first partial repayment
         LOG.info("------------------------GET PREPAYMENT AMOUNT AFTER FIRST PAYMENT-----------------------");
-        HashMap<String, Object> prepayAmount = loanTransactionHelper.getPrepayAmount(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        GetLoansLoanIdTransactionsTemplateResponse prepayAmount = getPrepayAmount(loanID);
         Assertions.assertNotNull(prepayAmount);
 
         // Extract the principal and interest portions
-        Float totalPrepayAmount = (Float) prepayAmount.get("amount");
-        Float principalAmount = (Float) prepayAmount.get("principalPortion");
-        Float interestAmount = (Float) prepayAmount.get("interestPortion");
+        Float totalPrepayAmount = prepayAmount.getAmount().floatValue();
+        Float principalAmount = prepayAmount.getPrincipalPortion().floatValue();
+        Float interestAmount = prepayAmount.getInterestPortion().floatValue();
 
         // Expected values after the first partial repayment
         Float expectedTotalPrepayAmount = 606.18f;
@@ -3217,24 +3045,23 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         LOG.info("------------------------MAKE SECOND PARTIAL REPAYMENT----------------------------------");
         Float secondRepaymentAmount = 606.18f;
         String secondRepaymentDate = "1 July 2023";
-        LOAN_TRANSACTION_HELPER.makeRepayment(secondRepaymentDate, secondRepaymentAmount, loanID);
+        makeRepayment(secondRepaymentDate, secondRepaymentAmount, loanID);
 
         // Recheck the prepayment amount
         LOG.info("------------------------RECHECK PREPAYMENT AMOUNT AFTER FULL REPAYMENT------------------");
-        HashMap<String, Object> postPrepayAmount = loanTransactionHelper.getPrepayAmount(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        GetLoansLoanIdTransactionsTemplateResponse postPrepayAmount = getPrepayAmount(loanID);
         Assertions.assertNotNull(postPrepayAmount);
 
         // Verify that the principal and interest portions are zero
-        Float postPrincipalAmount = (Float) postPrepayAmount.get("principalPortion");
-        Float postInterestAmount = (Float) postPrepayAmount.get("interestPortion");
+        Float postPrincipalAmount = postPrepayAmount.getPrincipalPortion().floatValue();
+        Float postInterestAmount = postPrepayAmount.getInterestPortion().floatValue();
 
         validateNumberForEqual("0.0", String.valueOf(postPrincipalAmount));
         validateNumberForEqual("0.0", String.valueOf(postInterestAmount));
 
         // Check the loan status after repayment
         LOG.info("------------------------CHECK LOAN STATUS---------------------------------------------");
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
+        verifyLoanAccountIsClosed(loanID);
     }
 
     @Test
@@ -3247,23 +3074,21 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         todaysDate.add(Calendar.DAY_OF_MONTH, -14);
         final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todaysDate.getTime());
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProductWithInterestRecalculation(LoanProductTestBuilder.DEFAULT_STRATEGY,
-                LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_NONE,
-                LoanProductTestBuilder.RECALCULATION_STRATEGY_REDUCE_EMI_AMOUN,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_SAME_AS_REPAYMENT_PERIOD, "0", null,
-                LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE, null, null, null);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Long loanProductID = createLoanProductWithInterestRecalculation(DEFAULT_STRATEGY,
+                LoanTestData.InterestRecalculationCompoundingMethod.NONE, LoanTestData.RescheduleStrategyMethod.REDUCE_EMI_AMOUNT,
+                LoanTestData.RecalculationRestFrequencyType.SAME_AS_REPAYMENT_PERIOD, 0,
+                LoanTestData.PreClosureInterestCalculationStrategy.TILL_PRE_CLOSE_DATE, null, null, null);
 
-        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE, null,
-                LoanApplicationTestBuilder.DEFAULT_STRATEGY, new ArrayList<>(0));
+        final Long loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
+                DEFAULT_STRATEGY, new ArrayList<>(0));
 
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        List<Map<String, Object>> expectedvalues = new ArrayList<>();
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        List<ExpectedInstallment> expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2494.22", "34.69", "0.0", "0.0");
@@ -3272,17 +3097,12 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(LOAN_DISBURSEMENT_DATE, loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID));
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
@@ -3295,10 +3115,10 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -7);
         final String LOAN_FIRST_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
-        Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        Float totalDueForCurrentPeriod = loanSchedule.get(1).getTotalDueForPeriod().floatValue();
+        makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
@@ -3311,8 +3131,8 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -5);
         final String LOAN_SECOND_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_SECOND_REPAYMENT_DATE, earlyPayment, loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        makeRepayment(LOAN_SECOND_REPAYMENT_DATE, earlyPayment, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
@@ -3321,19 +3141,18 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "1780.05", "8.22", "0.0", "0.0");
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
-        HashMap prepayDetail = LOAN_TRANSACTION_HELPER.getPrepayAmount(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        String prepayAmount = String.valueOf(prepayDetail.get("amount"));
+        GetLoansLoanIdTransactionsTemplateResponse prepayDetail = getPrepayAmount(loanID);
+        String prepayAmount = String.valueOf(prepayDetail.getAmount());
         validateNumberForEqualWithMsg("verify pre-close amount", "3551.93", prepayAmount);
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         final String loanRepaymentDate = dateFormat.format(todaysDate.getTime());
-        LOAN_TRANSACTION_HELPER.makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanID);
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
+        makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanID);
+        verifyLoanAccountIsClosed(loanID);
     }
 
     @Test
     public void testLoanScheduleWithInterestRecalculation_WITH_REST_SAME_AS_REPAYMENT_INTEREST_COMPOUND_NONE_STRATEGY_REDUCE_EMI_PRE_CLOSE_INTEREST_PRE_CLOSE_DATE() {
-        String preCloseInterestStrategy = LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE;
+        Integer preCloseInterestStrategy = LoanTestData.PreClosureInterestCalculationStrategy.TILL_PRE_CLOSE_DATE;
         String preCloseAmount = "7561.84";
         testLoanScheduleWithInterestRecalculation_WITH_REST_SAME_AS_REPAYMENT_INTEREST_COMPOUND_NONE_STRATEGY_REDUCE_EMI_PRE_CLOSE_INTEREST(
                 preCloseInterestStrategy, preCloseAmount);
@@ -3341,7 +3160,7 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
     @Test
     public void testLoanScheduleWithInterestRecalculation_WITH_REST_SAME_AS_REPAYMENT_INTEREST_COMPOUND_NONE_STRATEGY_REDUCE_EMI_PRE_CLOSE_INTEREST_REST_DATE() {
-        String preCloseInterestStrategy = LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_REST_DATE;
+        Integer preCloseInterestStrategy = LoanTestData.PreClosureInterestCalculationStrategy.TILL_REST_FREQUENCY_DATE;
         String preCloseAmount = "7586.62";
         testLoanScheduleWithInterestRecalculation_WITH_REST_SAME_AS_REPAYMENT_INTEREST_COMPOUND_NONE_STRATEGY_REDUCE_EMI_PRE_CLOSE_INTEREST(
                 preCloseInterestStrategy, preCloseAmount);
@@ -3357,27 +3176,25 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         todaysDate.add(Calendar.DAY_OF_MONTH, -14);
         final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todaysDate.getTime());
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProductWithInterestRecalculation(LoanProductTestBuilder.DEFAULT_STRATEGY,
-                LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_NONE,
-                LoanProductTestBuilder.RECALCULATION_STRATEGY_REDUCE_EMI_AMOUN,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_SAME_AS_REPAYMENT_PERIOD, "0", null,
-                LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE, null, null, null);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Long loanProductID = createLoanProductWithInterestRecalculation(DEFAULT_STRATEGY,
+                LoanTestData.InterestRecalculationCompoundingMethod.NONE, LoanTestData.RescheduleStrategyMethod.REDUCE_EMI_AMOUNT,
+                LoanTestData.RecalculationRestFrequencyType.SAME_AS_REPAYMENT_PERIOD, 0,
+                LoanTestData.PreClosureInterestCalculationStrategy.TILL_PRE_CLOSE_DATE, null, null, null);
 
-        List<HashMap> charges = new ArrayList<>();
-        Integer installmentCharge = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_INTEREST, "10", false));
-        addCharges(charges, installmentCharge, "10", null);
-        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE, null,
-                LoanApplicationTestBuilder.DEFAULT_STRATEGY, charges);
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
+        Long installmentCharge = chargesHelper.createLoanInstallmentCharge(ChargeCalculationType.PERCENT_OF_INTEREST, 10.0, false)
+                .getResourceId();
+        addCharges(charges, installmentCharge, 10.0, null);
+        final Long loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
+                DEFAULT_STRATEGY, charges);
 
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        List<Map<String, Object>> expectedvalues = new ArrayList<>();
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        List<ExpectedInstallment> expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "4.62", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2494.22", "34.69", "3.47", "0.0");
@@ -3386,17 +3203,12 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(LOAN_DISBURSEMENT_DATE, loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID));
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "4.62", "0.0");
@@ -3409,10 +3221,10 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -7);
         final String LOAN_FIRST_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
-        Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        Float totalDueForCurrentPeriod = loanSchedule.get(1).getTotalDueForPeriod().floatValue();
+        makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "4.62", "0.0");
@@ -3425,8 +3237,8 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -5);
         final String LOAN_SECOND_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_SECOND_REPAYMENT_DATE, earlyPayment, loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        makeRepayment(LOAN_SECOND_REPAYMENT_DATE, earlyPayment, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "4.62", "0.0");
@@ -3435,13 +3247,12 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "1781.79", "8.22", "0.82", "0.0");
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
-        HashMap prepayDetail = LOAN_TRANSACTION_HELPER.getPrepayAmount(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        String prepayAmount = String.valueOf(prepayDetail.get("amount"));
+        GetLoansLoanIdTransactionsTemplateResponse prepayDetail = getPrepayAmount(loanID);
+        String prepayAmount = String.valueOf(prepayDetail.getAmount());
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         final String loanRepaymentDate = dateFormat.format(todaysDate.getTime());
-        LOAN_TRANSACTION_HELPER.makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanID);
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
+        makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanID);
+        verifyLoanAccountIsClosed(loanID);
     }
 
     @Test
@@ -3455,24 +3266,22 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todaysDate.getTime());
         Integer dayOfWeek = getDayOfWeek(todaysDate);
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProductWithInterestRecalculationAndCompoundingDetails(
-                LoanProductTestBuilder.RBI_INDIA_STRATEGY, LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_INTEREST,
-                LoanProductTestBuilder.RECALCULATION_STRATEGY_REDUCE_NUMBER_OF_INSTALLMENTS,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_DAILY, "1", LOAN_DISBURSEMENT_DATE,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_WEEKLY, "1", LOAN_DISBURSEMENT_DATE,
-                LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE, null, null, dayOfWeek, null, dayOfWeek);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Long loanProductID = createLoanProductWithInterestRecalculationAndCompoundingDetails(RBI_INDIA_STRATEGY,
+                LoanTestData.InterestRecalculationCompoundingMethod.INTEREST,
+                LoanTestData.RescheduleStrategyMethod.REDUCE_NUMBER_OF_INSTALLMENTS, LoanTestData.RecalculationRestFrequencyType.DAILY, 1,
+                LoanTestData.RecalculationRestFrequencyType.WEEKLY, 1,
+                LoanTestData.PreClosureInterestCalculationStrategy.TILL_PRE_CLOSE_DATE, null, null, dayOfWeek, null, dayOfWeek);
 
-        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
-                LoanApplicationTestBuilder.RBI_INDIA_STRATEGY, new ArrayList<>(0));
+        final Long loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
+                RBI_INDIA_STRATEGY, new ArrayList<>(0));
 
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        List<Map<String, Object>> expectedvalues = new ArrayList<>();
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        List<ExpectedInstallment> expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2494.22", "34.69", "0.0", "0.0");
@@ -3482,17 +3291,12 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(LOAN_DISBURSEMENT_DATE, loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID));
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
@@ -3502,7 +3306,7 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanFutureRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanFutureRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, 0, false, "4965.3", "92.52", "0.0", "0.0");
@@ -3514,10 +3318,10 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -7);
         final String LOAN_FIRST_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
-        Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        Float totalDueForCurrentPeriod = loanSchedule.get(1).getTotalDueForPeriod().floatValue();
+        makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
@@ -3530,30 +3334,24 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -5);
         final String LOAN_SECOND_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_SECOND_REPAYMENT_DATE, earlyPayment, loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        makeRepayment(LOAN_SECOND_REPAYMENT_DATE, earlyPayment, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         Calendar today = Calendar.getInstance(Utils.getTimeZoneOfTenant());
-        Map<String, Object> paymentday = new HashMap<>(3);
-        paymentday.put("dueDate", getDateAsArray(today, -5, Calendar.DAY_OF_MONTH));
-        paymentday.put("principalDue", "3990.09");
-        paymentday.put("interestDue", "9.91");
-        paymentday.put("feeChargesDue", "0");
-        paymentday.put("penaltyChargesDue", "0");
+        ExpectedInstallment paymentday = new ExpectedInstallment(addDays(today, -5), "3990.09", "9.91", "0", "0");
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
         expectedvalues.add(paymentday);
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2517.31", "11.6", "0.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "1009.84", "4.66", "0.0", "0.0");
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
-        HashMap prepayDetail = LOAN_TRANSACTION_HELPER.getPrepayAmount(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        String prepayAmount = String.valueOf(prepayDetail.get("amount"));
+        GetLoansLoanIdTransactionsTemplateResponse prepayDetail = getPrepayAmount(loanID);
+        String prepayAmount = String.valueOf(prepayDetail.getAmount());
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         final String loanRepaymentDate = dateFormat.format(todaysDate.getTime());
-        LOAN_TRANSACTION_HELPER.makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanID);
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
+        makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanID);
+        verifyLoanAccountIsClosed(loanID);
 
     }
 
@@ -3575,42 +3373,34 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             String firstRepayment = dateFormat.format(firstRepaymentDate.getTime());
 
             final String loanDisbursementDate = dateFormat.format(startDate.getTime());
-            final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-            ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-            final Integer loanProductID = createLoanProductWithInterestRecalculationAndCompoundingDetails(
-                    LoanProductTestBuilder.INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY,
-                    LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_NONE,
-                    LoanProductTestBuilder.RECALCULATION_STRATEGY_REDUCE_NUMBER_OF_INSTALLMENTS,
-                    LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_SAME_AS_REPAYMENT_PERIOD,
-                    LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE, null, "12");
+            final Long clientID = createClient();
+            verifyClientCreatedOnServer(clientID);
+            final Long loanProductID = createLoanProductWithInterestRecalculationAndInstallmentAmount(
+                    INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY, LoanTestData.InterestRecalculationCompoundingMethod.NONE,
+                    LoanTestData.RescheduleStrategyMethod.REDUCE_NUMBER_OF_INSTALLMENTS,
+                    LoanTestData.PreClosureInterestCalculationStrategy.TILL_PRE_CLOSE_DATE, null, 12);
 
-            final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, loanDisbursementDate,
-                    LoanApplicationTestBuilder.INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY, firstRepayment);
+            final Long loanID = applyForLoanApplicationForInterestRecalculationWithFirstRepaymentDate(clientID, loanProductID,
+                    loanDisbursementDate, INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY, firstRepayment);
 
             Assertions.assertNotNull(loanID);
-            HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+            verifyLoanIsPending(loanID);
 
             LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(loanDisbursementDate, loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-            LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+            verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(loanDisbursementDate, loanID));
 
             LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-            String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(loanDisbursementDate, loanID,
-                    JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+            verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(loanDisbursementDate, loanID));
 
-            ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+            List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
             Assertions.assertNotNull(loanSchedule);
             startDate.add(Calendar.DAY_OF_MONTH, 2);
             String loanFirstRepaymentDate = dateFormat.format(startDate.getTime());
 
             Float earlyPayment = Float.parseFloat("3000");
-            String accountNo = JsonPath.from(loanDetails).get("accountNo").toString();
+            String accountNo = getLoanDetails(loanID).getAccountNo();
 
-            HashMap loanRepayment = LOAN_TRANSACTION_HELPER.makeRepaymentWithAccountNo(loanFirstRepaymentDate, earlyPayment, accountNo);
+            String loanRepayment = makeRepaymentByAccountNo(accountNo, loanFirstRepaymentDate, earlyPayment);
             assertNotNull(loanRepayment);
         } finally {
             globalConfigurationHelper.updateGlobalConfiguration(
@@ -3641,34 +3431,31 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         final String LOAN_FLAT_CHARGE_DATE = dateFormat.format(todaysDate.getTime());
         todaysDate.add(Calendar.DAY_OF_MONTH, 14);
         final String LOAN_INTEREST_CHARGE_DATE = dateFormat.format(todaysDate.getTime());
-        List<HashMap> charges = new ArrayList<>(2);
-        Integer flat = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "100", false));
-        Integer principalPercentage = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "2", false));
+        List<PostLoansRequestChargeData> charges = new ArrayList<>(2);
+        Long flat = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.FLAT, 100.0, false).getResourceId();
+        Long principalPercentage = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 2.0, false)
+                .getResourceId();
 
-        addCharges(charges, flat, "100", LOAN_FLAT_CHARGE_DATE);
-        addCharges(charges, principalPercentage, "2", LOAN_INTEREST_CHARGE_DATE);
+        addCharges(charges, flat, 100.0, LOAN_FLAT_CHARGE_DATE);
+        addCharges(charges, principalPercentage, 2.0, LOAN_INTEREST_CHARGE_DATE);
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProductWithInterestRecalculationAndCompoundingDetails(
-                LoanProductTestBuilder.DEFAULT_STRATEGY, LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_INTEREST_AND_FEE,
-                LoanProductTestBuilder.RECALCULATION_STRATEGY_RESCHEDULE_NEXT_REPAYMENTS,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_WEEKLY, "1", REST_START_DATE,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_WEEKLY, "1", LOAN_DISBURSEMENT_DATE,
-                LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE, null, compoundingDayOfMonth, compoundingDayOfWeek,
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Long loanProductID = createLoanProductWithInterestRecalculationAndCompoundingDetails(DEFAULT_STRATEGY,
+                LoanTestData.InterestRecalculationCompoundingMethod.INTEREST_AND_FEE,
+                LoanTestData.RescheduleStrategyMethod.RESCHEDULE_NEXT_REPAYMENTS, LoanTestData.RecalculationRestFrequencyType.WEEKLY, 1,
+                LoanTestData.RecalculationRestFrequencyType.WEEKLY, 1,
+                LoanTestData.PreClosureInterestCalculationStrategy.TILL_PRE_CLOSE_DATE, null, compoundingDayOfMonth, compoundingDayOfWeek,
                 restDayOfMonth, restDayOfWeek);
 
-        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
-                LOAN_DISBURSEMENT_DATE, LoanApplicationTestBuilder.DEFAULT_STRATEGY, charges);
+        final Long loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
+                DEFAULT_STRATEGY, charges);
 
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        List<Map<String, Object>> expectedvalues = new ArrayList<>();
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        List<ExpectedInstallment> expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "100.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2494.22", "34.69", "0.0", "0.0");
@@ -3677,17 +3464,12 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(LOAN_DISBURSEMENT_DATE, loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID));
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "100.0", "0.0");
@@ -3700,10 +3482,10 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         Calendar repaymentDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         repaymentDate.add(Calendar.DAY_OF_MONTH, -7);
         final String LOAN_FIRST_REPAYMENT_DATE = dateFormat.format(repaymentDate.getTime());
-        Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        Float totalDueForCurrentPeriod = loanSchedule.get(1).getTotalDueForPeriod().floatValue();
+        makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "100.0", "0.0");
@@ -3716,9 +3498,9 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         repaymentDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         repaymentDate.add(Calendar.DAY_OF_MONTH, -5);
         final String LOAN_SECOND_REPAYMENT_DATE = dateFormat.format(repaymentDate.getTime());
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_SECOND_REPAYMENT_DATE, earlyPayment, loanID);
+        makeRepayment(LOAN_SECOND_REPAYMENT_DATE, earlyPayment, loanID);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "100.0", "0.0");
@@ -3727,19 +3509,18 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2451.93", "11.32", "0.0", "0.0");
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
-        HashMap prepayDetail = LOAN_TRANSACTION_HELPER.getPrepayAmount(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        String prepayAmount = String.valueOf(prepayDetail.get("amount"));
+        GetLoansLoanIdTransactionsTemplateResponse prepayDetail = getPrepayAmount(loanID);
+        String prepayAmount = String.valueOf(prepayDetail.getAmount());
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         final String loanRepaymentDate = dateFormat.format(todaysDate.getTime());
-        LOAN_TRANSACTION_HELPER.makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanID);
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
+        makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanID);
+        verifyLoanAccountIsClosed(loanID);
 
     }
 
     @Test
     public void testLoanScheduleWithInterestRecalculation_WITH_REST_WEEKLY_INTEREST_COMPOUND_INTEREST_FEE_STRATEGY_REDUCE_NEXT_INSTALLMENTS_PRE_CLOSE_INTEREST_PRE_CLOSE_DATE() {
-        String preCloseInterestStrategy = LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE;
+        Integer preCloseInterestStrategy = LoanTestData.PreClosureInterestCalculationStrategy.TILL_PRE_CLOSE_DATE;
         String preCloseAmount = "7761.89";
         testLoanScheduleWithInterestRecalculation_WITH_REST_WEEKLY_INTEREST_COMPOUND_INTEREST_FEE_STRATEGY_REDUCE_NEXT_INSTALLMENTS_PRE_CLOSE_INTEREST(
                 preCloseInterestStrategy, preCloseAmount);
@@ -3748,7 +3529,7 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
     @Test
     public void testLoanScheduleWithInterestRecalculation_WITH_REST_WEEKLY_INTEREST_COMPOUND_INTEREST_FEE_STRATEGY_REDUCE_NEXT_INSTALLMENTS_PRE_CLOSE_INTEREST_REST_DATE() {
-        String preCloseInterestStrategy = LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_REST_DATE;
+        Integer preCloseInterestStrategy = LoanTestData.PreClosureInterestCalculationStrategy.TILL_REST_FREQUENCY_DATE;
         String preCloseAmount = "7786.79";
         testLoanScheduleWithInterestRecalculation_WITH_REST_WEEKLY_INTEREST_COMPOUND_INTEREST_FEE_STRATEGY_REDUCE_NEXT_INSTALLMENTS_PRE_CLOSE_INTEREST(
                 preCloseInterestStrategy, preCloseAmount);
@@ -3768,31 +3549,28 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         todaysDate.add(Calendar.DAY_OF_MONTH, -2);
         final String REST_START_DATE = dateFormat.format(todaysDate.getTime());
 
-        Integer overdueFeeChargeId = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("10"));
+        Long overdueFeeChargeId = chargesHelper.createCharge(ChargeRequestBuilders.loanOverdueFeePercentageOfAmountAndInterest(10.0))
+                .getResourceId();
         Assertions.assertNotNull(overdueFeeChargeId);
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final String recalculationCompoundingFrequencyInterval = null;
-        final String recalculationCompoundingFrequencyDate = null;
-        final Integer loanProductID = createLoanProductWithInterestRecalculation(LoanProductTestBuilder.DEFAULT_STRATEGY,
-                LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_INTEREST_AND_FEE,
-                LoanProductTestBuilder.RECALCULATION_STRATEGY_RESCHEDULE_NEXT_REPAYMENTS,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_DAILY, "1", REST_START_DATE,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_SAME_AS_REPAYMENT_PERIOD, recalculationCompoundingFrequencyInterval,
-                recalculationCompoundingFrequencyDate, LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE, null,
-                overdueFeeChargeId.toString(), false, null, null, null, null);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Integer recalculationCompoundingFrequencyInterval = null;
+        final Long loanProductID = createLoanProductWithInterestRecalculation(DEFAULT_STRATEGY,
+                LoanTestData.InterestRecalculationCompoundingMethod.INTEREST_AND_FEE,
+                LoanTestData.RescheduleStrategyMethod.RESCHEDULE_NEXT_REPAYMENTS, LoanTestData.RecalculationRestFrequencyType.DAILY, 1,
+                LoanTestData.RecalculationRestFrequencyType.SAME_AS_REPAYMENT_PERIOD, recalculationCompoundingFrequencyInterval,
+                LoanTestData.PreClosureInterestCalculationStrategy.TILL_PRE_CLOSE_DATE, null, overdueFeeChargeId, false, null, null, null,
+                null);
 
-        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
-                REST_START_DATE, LoanApplicationTestBuilder.DEFAULT_STRATEGY, null);
+        final Long loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
+                DEFAULT_STRATEGY, null);
 
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        List<Map<String, Object>> expectedvalues = new ArrayList<>();
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        List<ExpectedInstallment> expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -2, false, "2482.76", "46.15", "0.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2494.22", "34.69", "0.0", "0.0");
@@ -3801,17 +3579,12 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(LOAN_DISBURSEMENT_DATE, loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID));
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
 
@@ -3823,9 +3596,9 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         String JobName = "Apply penalty to overdue loans";
-        SCHEDULER_JOB_HELPER.executeAndAwaitJob(JobName);
+        schedulerHelper.executeAndAwaitJob(JobName);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -2, false, "2482.76", "46.15", "0.0", "252.89");
@@ -3837,11 +3610,11 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         Calendar repaymentDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         repaymentDate.add(Calendar.DAY_OF_MONTH, -7 * 2);
         final String LOAN_FIRST_REPAYMENT_DATE = dateFormat.format(repaymentDate.getTime());
-        Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
+        Float totalDueForCurrentPeriod = loanSchedule.get(1).getTotalDueForPeriod().floatValue();
         totalDueForCurrentPeriod = totalDueForCurrentPeriod - Float.parseFloat("252.89");
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -2, false, "2482.76", "46.15", "0.0", "252.89");
@@ -3853,10 +3626,10 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         repaymentDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         repaymentDate.add(Calendar.DAY_OF_MONTH, -3);
         final String LOAN_SECOND_REPAYMENT_DATE = dateFormat.format(repaymentDate.getTime());
-        totalDueForCurrentPeriod = (Float) loanSchedule.get(2).get("totalDueForPeriod");
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_SECOND_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        totalDueForCurrentPeriod = loanSchedule.get(2).getTotalDueForPeriod().floatValue();
+        makeRepayment(LOAN_SECOND_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -2, false, "2482.76", "46.15", "0.0", "252.89");
@@ -3873,34 +3646,32 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         DateFormat dateFormat = new SimpleDateFormat(DATETIME_PATTERN, Locale.US);
         dateFormat.setTimeZone(Utils.getTimeZoneOfTenant());
 
-        final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-        final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-        final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-        final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+        final Account assetAccount = accountHelper.createAssetAccount();
+        final Account incomeAccount = accountHelper.createIncomeAccount();
+        final Account expenseAccount = accountHelper.createExpenseAccount();
+        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
         Calendar todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         LOG.info("Disbursal Date Calendar {}", todaysDate.getTime());
         todaysDate.add(Calendar.DAY_OF_MONTH, -14);
         final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todaysDate.getTime());
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
         Account[] accounts = { assetAccount, incomeAccount, expenseAccount, overpaymentAccount };
-        final Integer loanProductID = createLoanProductWithInterestRecalculation(LoanProductTestBuilder.DEFAULT_STRATEGY,
-                LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_NONE,
-                LoanProductTestBuilder.RECALCULATION_STRATEGY_REDUCE_EMI_AMOUN,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_SAME_AS_REPAYMENT_PERIOD, "0", null,
-                LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE, accounts, null, null);
+        final Long loanProductID = createLoanProductWithInterestRecalculation(DEFAULT_STRATEGY,
+                LoanTestData.InterestRecalculationCompoundingMethod.NONE, LoanTestData.RescheduleStrategyMethod.REDUCE_EMI_AMOUNT,
+                LoanTestData.RecalculationRestFrequencyType.SAME_AS_REPAYMENT_PERIOD, 0,
+                LoanTestData.PreClosureInterestCalculationStrategy.TILL_PRE_CLOSE_DATE, accounts, null, null);
 
-        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE, null,
-                LoanApplicationTestBuilder.DEFAULT_STRATEGY, new ArrayList<>(0));
+        final Long loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
+                DEFAULT_STRATEGY, new ArrayList<>(0));
 
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        List<Map<String, Object>> expectedvalues = new ArrayList<>();
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        List<ExpectedInstallment> expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         LOG.info("Date during repayment schedule {}", todaysDate.getTime());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
@@ -3910,17 +3681,12 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(LOAN_DISBURSEMENT_DATE, loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID));
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
@@ -3930,23 +3696,24 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
-        final JournalEntry[] assetAccountInitialEntry = { new JournalEntry(10000.0f, JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(10000.0f, JournalEntry.TransactionType.DEBIT), };
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, LOAN_DISBURSEMENT_DATE, assetAccountInitialEntry);
+        final LoanTestData.Journal[] assetAccountInitialEntry = {
+                journalEntry(10000.0f, assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(10000.0f, assetAccount, JournalEntry.TransactionType.DEBIT.name()), };
+        checkJournalEntryForAssetAccount(assetAccount, LOAN_DISBURSEMENT_DATE, assetAccountInitialEntry);
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         String runOndate = dateFormat.format(todaysDate.getTime());
         LOG.info("runOndate : {}", runOndate);
-        PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting(runOndate);
-        LOAN_TRANSACTION_HELPER.checkAccrualTransactionForRepayment(Utils.getLocalDateOfTenant().minusDays(7), 46.15f, 0f, 0f, loanID);
-        LOAN_TRANSACTION_HELPER.checkAccrualTransactionForRepayment(Utils.getLocalDateOfTenant(), 46.15f, 0f, 0f, loanID);
+        runPeriodicAccrualAccounting(runOndate);
+        checkAccrualTransactionForRepayment(Utils.getLocalDateOfTenant().minusDays(7), 46.15f, 0f, 0f, loanID);
+        checkAccrualTransactionForRepayment(Utils.getLocalDateOfTenant(), 46.15f, 0f, 0f, loanID);
 
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -7);
         final String LOAN_FIRST_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
-        Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        Float totalDueForCurrentPeriod = loanSchedule.get(1).getTotalDueForPeriod().floatValue();
+        makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
@@ -3955,20 +3722,19 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2517.29", "11.62", "0.0", "0.0");
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
-        PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting(runOndate);
-        LOAN_TRANSACTION_HELPER.checkAccrualTransactionForRepayment(Utils.getLocalDateOfTenant().minusDays(7), 46.15f, 0f, 0f, loanID);
-        LOAN_TRANSACTION_HELPER.checkAccrualTransactionForRepayment(Utils.getLocalDateOfTenant(), 34.69f, 0f, 0f, loanID);
+        runPeriodicAccrualAccounting(runOndate);
+        checkAccrualTransactionForRepayment(Utils.getLocalDateOfTenant().minusDays(7), 46.15f, 0f, 0f, loanID);
+        checkAccrualTransactionForRepayment(Utils.getLocalDateOfTenant(), 34.69f, 0f, 0f, loanID);
 
-        HashMap prepayDetail = LOAN_TRANSACTION_HELPER.getPrepayAmount(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        String prepayAmount = String.valueOf(prepayDetail.get("amount"));
+        GetLoansLoanIdTransactionsTemplateResponse prepayDetail = getPrepayAmount(loanID);
+        String prepayAmount = String.valueOf(prepayDetail.getAmount());
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         final String loanRepaymentDate = dateFormat.format(todaysDate.getTime());
-        LOAN_TRANSACTION_HELPER.makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanID);
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
+        makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanID);
+        verifyLoanAccountIsClosed(loanID);
 
-        LOAN_TRANSACTION_HELPER.checkAccrualTransactionForRepayment(Utils.getLocalDateOfTenant().minusDays(7), 46.15f, 0f, 0f, loanID);
-        LOAN_TRANSACTION_HELPER.checkAccrualTransactionForRepayment(Utils.getLocalDateOfTenant(), 34.69f, 0f, 0f, loanID);
+        checkAccrualTransactionForRepayment(Utils.getLocalDateOfTenant().minusDays(7), 46.15f, 0f, 0f, loanID);
+        checkAccrualTransactionForRepayment(Utils.getLocalDateOfTenant(), 34.69f, 0f, 0f, loanID);
 
     }
 
@@ -3982,25 +3748,23 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         todaysDate.add(Calendar.DAY_OF_MONTH, -14);
         final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todaysDate.getTime());
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProductWithInterestRecalculationAndCompoundingDetails(
-                LoanProductTestBuilder.RBI_INDIA_STRATEGY, LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_INTEREST,
-                LoanProductTestBuilder.RECALCULATION_STRATEGY_RESCHEDULE_NEXT_REPAYMENTS,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_DAILY, "1", LOAN_DISBURSEMENT_DATE,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_SAME_AS_REPAYMENT_PERIOD, "1", LOAN_DISBURSEMENT_DATE,
-                LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE, null, getDayOfMonth(todaysDate),
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Long loanProductID = createLoanProductWithInterestRecalculationAndCompoundingDetails(RBI_INDIA_STRATEGY,
+                LoanTestData.InterestRecalculationCompoundingMethod.INTEREST,
+                LoanTestData.RescheduleStrategyMethod.RESCHEDULE_NEXT_REPAYMENTS, LoanTestData.RecalculationRestFrequencyType.DAILY, 1,
+                LoanTestData.RecalculationRestFrequencyType.SAME_AS_REPAYMENT_PERIOD, 1,
+                LoanTestData.PreClosureInterestCalculationStrategy.TILL_PRE_CLOSE_DATE, null, getDayOfMonth(todaysDate),
                 getDayOfWeek(todaysDate), getDayOfMonth(todaysDate), getDayOfWeek(todaysDate));
 
-        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
-                LOAN_DISBURSEMENT_DATE, LoanApplicationTestBuilder.RBI_INDIA_STRATEGY, new ArrayList<>(0));
+        final Long loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
+                RBI_INDIA_STRATEGY, new ArrayList<>(0));
 
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        List<Map<String, Object>> expectedvalues = new ArrayList<>();
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        List<ExpectedInstallment> expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2494.22", "34.69", "0.0", "0.0");
@@ -4010,17 +3774,12 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(LOAN_DISBURSEMENT_DATE, loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID));
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
@@ -4031,25 +3790,19 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -7);
-        HashMap loanSummary = LOAN_TRANSACTION_HELPER.getLoanSummary(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        List dates = (List) loanSummary.get("overdueSinceDate");
-        assertEquals(todaysDate.get(Calendar.YEAR), dates.get(0));
-        assertEquals(todaysDate.get(Calendar.MONTH) + 1, dates.get(1));
-        assertEquals(todaysDate.get(Calendar.DAY_OF_MONTH), dates.get(2));
+        GetLoansLoanIdSummary loanSummary = getLoanDetails(loanID).getSummary();
+        assertEquals(toLocalDate(todaysDate), loanSummary.getOverdueSinceDate());
 
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -8);
         final String LOAN_FIRST_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
-        Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        Float totalDueForCurrentPeriod = loanSchedule.get(1).getTotalDueForPeriod().floatValue();
+        makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
 
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -7);
-        loanSummary = LOAN_TRANSACTION_HELPER.getLoanSummary(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        dates = (List) loanSummary.get("overdueSinceDate");
-        assertEquals(todaysDate.get(Calendar.YEAR), dates.get(0));
-        assertEquals(todaysDate.get(Calendar.MONTH) + 1, dates.get(1));
-        assertEquals(todaysDate.get(Calendar.DAY_OF_MONTH), dates.get(2));
+        loanSummary = getLoanDetails(loanID).getSummary();
+        assertEquals(toLocalDate(todaysDate), loanSummary.getOverdueSinceDate());
 
     }
 
@@ -4064,27 +3817,24 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         todaysDate.add(Calendar.DAY_OF_MONTH, -14);
         final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todaysDate.getTime());
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final String recalculationCompoundingFrequencyInterval = null;
-        final String recalculationCompoundingFrequencyDate = null;
-        final Integer loanProductID = createLoanProductWithInterestRecalculation(LoanProductTestBuilder.RBI_INDIA_STRATEGY,
-                LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_INTEREST,
-                LoanProductTestBuilder.RECALCULATION_STRATEGY_RESCHEDULE_NEXT_REPAYMENTS,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_DAILY, "1", LOAN_DISBURSEMENT_DATE,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_SAME_AS_REPAYMENT_PERIOD, recalculationCompoundingFrequencyInterval,
-                recalculationCompoundingFrequencyDate, LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE, null, null,
-                true, null, null, getDayOfMonth(todaysDate), getDayOfWeek(todaysDate));
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Integer recalculationCompoundingFrequencyInterval = null;
+        final Long loanProductID = createLoanProductWithInterestRecalculation(RBI_INDIA_STRATEGY,
+                LoanTestData.InterestRecalculationCompoundingMethod.INTEREST,
+                LoanTestData.RescheduleStrategyMethod.RESCHEDULE_NEXT_REPAYMENTS, LoanTestData.RecalculationRestFrequencyType.DAILY, 1,
+                LoanTestData.RecalculationRestFrequencyType.SAME_AS_REPAYMENT_PERIOD, recalculationCompoundingFrequencyInterval,
+                LoanTestData.PreClosureInterestCalculationStrategy.TILL_PRE_CLOSE_DATE, null, null, true, null, null,
+                getDayOfMonth(todaysDate), getDayOfWeek(todaysDate));
 
-        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
-                LOAN_DISBURSEMENT_DATE, LoanApplicationTestBuilder.RBI_INDIA_STRATEGY, new ArrayList<>(0));
+        final Long loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
+                RBI_INDIA_STRATEGY, new ArrayList<>(0));
 
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        List<Map<String, Object>> expectedvalues = new ArrayList<>();
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        List<ExpectedInstallment> expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2494.22", "34.69", "0.0", "0.0");
@@ -4094,17 +3844,12 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(LOAN_DISBURSEMENT_DATE, loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID));
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
@@ -4115,36 +3860,32 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -7);
-        HashMap loanSummary = LOAN_TRANSACTION_HELPER.getLoanSummary(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        List dates = (List) loanSummary.get("overdueSinceDate");
-        assertEquals(todaysDate.get(Calendar.YEAR), dates.get(0));
-        assertEquals(todaysDate.get(Calendar.MONTH) + 1, dates.get(1));
-        assertEquals(todaysDate.get(Calendar.DAY_OF_MONTH), dates.get(2));
+        GetLoansLoanIdSummary loanSummary = getLoanDetails(loanID).getSummary();
+        assertEquals(toLocalDate(todaysDate), loanSummary.getOverdueSinceDate());
 
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -8);
         final String LOAN_FIRST_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
-        Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        Float totalDueForCurrentPeriod = loanSchedule.get(1).getTotalDueForPeriod().floatValue();
+        makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
 
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -7);
-        loanSummary = LOAN_TRANSACTION_HELPER.getLoanSummary(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        dates = (List) loanSummary.get("overdueSinceDate");
-        Assertions.assertNull(dates);
+        loanSummary = getLoanDetails(loanID).getSummary();
+        Assertions.assertNull(loanSummary.getOverdueSinceDate());
 
     }
 
     @Test
     public void testLoanScheduleWithInterestRecalculation_FOR_PRE_CLOSE_WITH_MORATORIUM_INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE() {
         testLoanScheduleWithInterestRecalculation_FOR_PRE_CLOSE_WITH_MORATORIUM(
-                LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE, "10006.59");
+                LoanTestData.PreClosureInterestCalculationStrategy.TILL_PRE_CLOSE_DATE, "10006.59");
     }
 
     @Test
     public void testLoanScheduleWithInterestRecalculation_FOR_PRE_CLOSE_WITH_MORATORIUM_INTEREST_APPLICABLE_STRATEGY_REST_DATE() {
         testLoanScheduleWithInterestRecalculation_FOR_PRE_CLOSE_WITH_MORATORIUM(
-                LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_REST_DATE, "10046.15");
+                LoanTestData.PreClosureInterestCalculationStrategy.TILL_REST_FREQUENCY_DATE, "10046.15");
     }
 
     /***
@@ -4166,68 +3907,60 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
         String fourMonthsfromNow = Utils.convertDateToURLFormat(fourMonthsfromNowCalendar);
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
 
         /***
          * Create loan product with Default STYLE strategy
          */
 
-        final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-        final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-        final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-        final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+        final Account assetAccount = accountHelper.createAssetAccount();
+        final Account incomeAccount = accountHelper.createIncomeAccount();
+        final Account expenseAccount = accountHelper.createExpenseAccount();
+        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-        final Integer loanProductID = createLoanProduct("0", "0", LoanProductTestBuilder.DEFAULT_STRATEGY, CASH_BASED, assetAccount,
-                incomeAccount, expenseAccount, overpaymentAccount);
+        final Long loanProductID = createLoanProduct(0, 0, DEFAULT_STRATEGY, CASH_BASED, assetAccount, incomeAccount, expenseAccount,
+                overpaymentAccount);
         Assertions.assertNotNull(loanProductID);
 
         /***
          * Apply for loan application and verify loan status
          */
-        final String savingsId = null;
+        final Long savingsId = null;
         final String principal = "12,000.00";
 
         // Add charges with payment mode regular
-        List<HashMap> charges = new ArrayList<>();
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
 
-        Integer flatInstallmentFee = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "50", false));
-        addCharges(charges, flatInstallmentFee, "50", null);
+        Long flatInstallmentFee = chargesHelper.createLoanInstallmentCharge(ChargeCalculationType.FLAT, 50.0, false).getResourceId();
+        addCharges(charges, flatInstallmentFee, 50.0, null);
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
 
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanID = applyForLoanApplicationWithPaymentStrategyAndPastMonth(clientID, loanProductID, charges, savingsId,
-                principal, LoanApplicationTestBuilder.DEFAULT_STRATEGY, fourMonthsfromNow, collaterals);
+        final Long loanID = applyForLoanApplicationWithPaymentStrategyAndPastMonth(clientID, loanProductID, charges, savingsId, principal,
+                DEFAULT_STRATEGY, fourMonthsfromNow, collaterals);
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(fourMonthsfromNow, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(fourMonthsfromNow, loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(fourMonthsfromNow, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(fourMonthsfromNow, loanID));
 
-        final JournalEntry[] assetAccountInitialEntry = {
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.DEBIT) };
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, fourMonthsfromNow, assetAccountInitialEntry);
+        final LoanTestData.Journal[] assetAccountInitialEntry = {
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()) };
+        checkJournalEntryForAssetAccount(assetAccount, fourMonthsfromNow, assetAccountInitialEntry);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap firstInstallment = loanSchedule.get(1);
-        validateNumberForEqual("2290", String.valueOf(firstInstallment.get("totalOutstandingForPeriod")));
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod firstInstallment = loanSchedule.get(1);
+        validateNumberForEqual("2290", String.valueOf(firstInstallment.getTotalOutstandingForPeriod()));
 
         // Make payment for installment #1
 
@@ -4235,29 +3968,29 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
         final String threeMonthsfromNow = Utils.convertDateToURLFormat(fourMonthsfromNowCalendar);
 
-        LOAN_TRANSACTION_HELPER.makeRepayment(threeMonthsfromNow, Float.parseFloat("2290"), loanID);
+        makeRepayment(threeMonthsfromNow, Float.parseFloat("2290"), loanID);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         firstInstallment = loanSchedule.get(1);
-        validateNumberForEqual("0.00", String.valueOf(firstInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0.00", String.valueOf(firstInstallment.getTotalOutstandingForPeriod()));
 
         // Make payment for installment #2
         fourMonthsfromNowCalendar.add(Calendar.MONTH, 1);
 
         final String twoMonthsfromNow = Utils.convertDateToURLFormat(fourMonthsfromNowCalendar);
 
-        LOAN_TRANSACTION_HELPER.makeRepayment(twoMonthsfromNow, Float.parseFloat("2290"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, twoMonthsfromNow,
-                new JournalEntry(Float.parseFloat("2290"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("2000"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, twoMonthsfromNow,
-                new JournalEntry(Float.parseFloat("50"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("240"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment(twoMonthsfromNow, Float.parseFloat("2290"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, twoMonthsfromNow,
+                journalEntry(Float.parseFloat("2290"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("2000"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, twoMonthsfromNow,
+                journalEntry(Float.parseFloat("50"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("240"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        Map secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("0.00", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod secondInstallment = loanSchedule.get(2);
+        validateNumberForEqual("0.00", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
         // Make payment for installment #3
         // Pay 2290 more than expected
@@ -4265,18 +3998,18 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
         final String oneMonthfromNow = Utils.convertDateToURLFormat(fourMonthsfromNowCalendar);
 
-        LOAN_TRANSACTION_HELPER.makeRepayment(oneMonthfromNow, Float.parseFloat("4580"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, oneMonthfromNow,
-                new JournalEntry(Float.parseFloat("4580"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("4000"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, oneMonthfromNow,
-                new JournalEntry(Float.parseFloat("100"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("480"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment(oneMonthfromNow, Float.parseFloat("4580"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, oneMonthfromNow,
+                journalEntry(Float.parseFloat("4580"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("4000"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, oneMonthfromNow,
+                journalEntry(Float.parseFloat("100"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("480"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap thirdInstallment = loanSchedule.get(3);
-        validateNumberForEqual("0.00", String.valueOf(thirdInstallment.get("totalOutstandingForPeriod")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod thirdInstallment = loanSchedule.get(3);
+        validateNumberForEqual("0.00", String.valueOf(thirdInstallment.getTotalOutstandingForPeriod()));
 
         // Make refund of 20
         // max 2290 to refund. Pay 20 means only principal
@@ -4290,39 +4023,39 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         fourMonthsfromNowCalendar.setTime(Date.from(Utils.getLocalDateOfTenant().atStartOfDay(Utils.getZoneIdOfTenant()).toInstant()));
         final String now = Utils.convertDateToURLFormat(fourMonthsfromNowCalendar);
 
-        LOAN_TRANSACTION_HELPER.makeRefundByCash(now, Float.parseFloat("20"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, now,
-                new JournalEntry(Float.parseFloat("20"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("20"), JournalEntry.TransactionType.DEBIT));
+        makeRefundByCash(now, Float.parseFloat("20"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, now,
+                journalEntry(Float.parseFloat("20"), assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("20"), assetAccount, JournalEntry.TransactionType.DEBIT.name()));
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("20.00", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
-        validateNumberForEqual("20.00", String.valueOf(fourthInstallment.get("principalOutstanding")));
-        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.get("interestOutstanding")));
-        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.get("feeChargesOutstanding")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod fourthInstallment = loanSchedule.get(4);
+        validateNumberForEqual("20.00", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
+        validateNumberForEqual("20.00", String.valueOf(fourthInstallment.getPrincipalOutstanding()));
+        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.getInterestOutstanding()));
+        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.getFeeChargesOutstanding()));
 
         // Make refund of 2000
         // max 2270 to refund. Pay 2000 means only principal
         // paid: principal 1980, interest 240, fees 50, penalty 0
         // refund 2000 means paid: principal 0, interest 220, fees 50, penalty 0
 
-        LOAN_TRANSACTION_HELPER.makeRefundByCash(now, Float.parseFloat("2000"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, now,
-                new JournalEntry(Float.parseFloat("2000"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("1980"), JournalEntry.TransactionType.DEBIT));
+        makeRefundByCash(now, Float.parseFloat("2000"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, now,
+                journalEntry(Float.parseFloat("2000"), assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("1980"), assetAccount, JournalEntry.TransactionType.DEBIT.name()));
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, now,
-                new JournalEntry(Float.parseFloat("20"), JournalEntry.TransactionType.DEBIT));
+        checkJournalEntryForIncomeAccount(incomeAccount, now,
+                journalEntry(Float.parseFloat("20"), incomeAccount, JournalEntry.TransactionType.DEBIT.name()));
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("2020.00", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
-        validateNumberForEqual("2000.00", String.valueOf(fourthInstallment.get("principalOutstanding")));
-        validateNumberForEqual("20.00", String.valueOf(fourthInstallment.get("interestOutstanding")));
-        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.get("feeChargesOutstanding")));
+        validateNumberForEqual("2020.00", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
+        validateNumberForEqual("2000.00", String.valueOf(fourthInstallment.getPrincipalOutstanding()));
+        validateNumberForEqual("20.00", String.valueOf(fourthInstallment.getInterestOutstanding()));
+        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.getFeeChargesOutstanding()));
 
     }
 
@@ -4344,20 +4077,20 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
         String fourMonthsfromNow = Utils.convertDateToURLFormat(fourMonthsfromNowCalendar);
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
 
         /***
          * Create loan product with Default STYLE strategy
          */
 
-        final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-        final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-        final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-        final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+        final Account assetAccount = accountHelper.createAssetAccount();
+        final Account incomeAccount = accountHelper.createIncomeAccount();
+        final Account expenseAccount = accountHelper.createExpenseAccount();
+        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-        final Integer loanProductID = createLoanProduct("0", "0", LoanProductTestBuilder.DEFAULT_STRATEGY, ACCRUAL_UPFRONT, assetAccount,
-                incomeAccount, expenseAccount, overpaymentAccount);// ,
+        final Long loanProductID = createLoanProduct(0, 0, DEFAULT_STRATEGY, ACCRUAL_UPFRONT, assetAccount, incomeAccount, expenseAccount,
+                overpaymentAccount);// ,
         // LoanProductTestBuilder.EQUAL_INSTALLMENTS,
         // LoanProductTestBuilder.FLAT_BALANCE);
         Assertions.assertNotNull(loanProductID);
@@ -4365,51 +4098,44 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         /***
          * Apply for loan application and verify loan status
          */
-        final String savingsId = null;
+        final Long savingsId = null;
         final String principal = "12,000.00";
 
         // Add charges with payment mode regular
-        List<HashMap> charges = new ArrayList<>();
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
 
-        Integer flatInstallmentFee = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "50", false));
-        addCharges(charges, flatInstallmentFee, "50", null);
+        Long flatInstallmentFee = chargesHelper.createLoanInstallmentCharge(ChargeCalculationType.FLAT, 50.0, false).getResourceId();
+        addCharges(charges, flatInstallmentFee, 50.0, null);
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
         Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
         Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanID = applyForLoanApplicationWithPaymentStrategyAndPastMonth(clientID, loanProductID, charges, savingsId,
-                principal, LoanApplicationTestBuilder.DEFAULT_STRATEGY, fourMonthsfromNow, collaterals);
+        final Long loanID = applyForLoanApplicationWithPaymentStrategyAndPastMonth(clientID, loanProductID, charges, savingsId, principal,
+                DEFAULT_STRATEGY, fourMonthsfromNow, collaterals);
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(fourMonthsfromNow, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(fourMonthsfromNow, loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(fourMonthsfromNow, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(fourMonthsfromNow, loanID));
 
-        final JournalEntry[] assetAccountInitialEntry = { new JournalEntry(Float.parseFloat("1440"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("300.00"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.DEBIT) };
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, fourMonthsfromNow, assetAccountInitialEntry);
+        final LoanTestData.Journal[] assetAccountInitialEntry = {
+                journalEntry(Float.parseFloat("1440"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("300.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()) };
+        checkJournalEntryForAssetAccount(assetAccount, fourMonthsfromNow, assetAccountInitialEntry);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap firstInstallment = loanSchedule.get(1);
-        validateNumberForEqual("2290", String.valueOf(firstInstallment.get("totalOutstandingForPeriod")));
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod firstInstallment = loanSchedule.get(1);
+        validateNumberForEqual("2290", String.valueOf(firstInstallment.getTotalOutstandingForPeriod()));
 
         // Make payment for installment #1
 
@@ -4417,26 +4143,26 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
         final String threeMonthsfromNow = Utils.convertDateToURLFormat(fourMonthsfromNowCalendar);
 
-        LOAN_TRANSACTION_HELPER.makeRepayment(threeMonthsfromNow, Float.parseFloat("2290"), loanID);
+        makeRepayment(threeMonthsfromNow, Float.parseFloat("2290"), loanID);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         firstInstallment = loanSchedule.get(1);
-        validateNumberForEqual("0.00", String.valueOf(firstInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0.00", String.valueOf(firstInstallment.getTotalOutstandingForPeriod()));
 
         // Make payment for installment #2
         fourMonthsfromNowCalendar.add(Calendar.MONTH, 1);
 
         final String twoMonthsfromNow = Utils.convertDateToURLFormat(fourMonthsfromNowCalendar);
 
-        LOAN_TRANSACTION_HELPER.makeRepayment(twoMonthsfromNow, Float.parseFloat("2290"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, twoMonthsfromNow,
-                new JournalEntry(Float.parseFloat("2290"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("2290"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment(twoMonthsfromNow, Float.parseFloat("2290"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, twoMonthsfromNow,
+                journalEntry(Float.parseFloat("2290"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("2290"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        Map secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("0.00", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod secondInstallment = loanSchedule.get(2);
+        validateNumberForEqual("0.00", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
         // Make payment for installment #3
         // Pay 2290 more than expected
@@ -4444,15 +4170,15 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
         final String oneMonthfromNow = Utils.convertDateToURLFormat(fourMonthsfromNowCalendar);
 
-        LOAN_TRANSACTION_HELPER.makeRepayment(oneMonthfromNow, Float.parseFloat("4580"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, oneMonthfromNow,
-                new JournalEntry(Float.parseFloat("4580"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("4580"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment(oneMonthfromNow, Float.parseFloat("4580"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, oneMonthfromNow,
+                journalEntry(Float.parseFloat("4580"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("4580"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap thirdInstallment = loanSchedule.get(3);
-        validateNumberForEqual("0.00", String.valueOf(thirdInstallment.get("totalOutstandingForPeriod")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod thirdInstallment = loanSchedule.get(3);
+        validateNumberForEqual("0.00", String.valueOf(thirdInstallment.getTotalOutstandingForPeriod()));
 
         // Make refund of 20
         // max 2290 to refund. Pay 20 means only principal
@@ -4466,39 +4192,39 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         fourMonthsfromNowCalendar.setTime(Date.from(Utils.getLocalDateOfTenant().atStartOfDay(Utils.getZoneIdOfTenant()).toInstant()));
         final String now = Utils.convertDateToURLFormat(fourMonthsfromNowCalendar);
 
-        LOAN_TRANSACTION_HELPER.makeRefundByCash(now, Float.parseFloat("20"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, now,
-                new JournalEntry(Float.parseFloat("20"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("20"), JournalEntry.TransactionType.DEBIT));
+        makeRefundByCash(now, Float.parseFloat("20"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, now,
+                journalEntry(Float.parseFloat("20"), assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("20"), assetAccount, JournalEntry.TransactionType.DEBIT.name()));
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("20.00", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
-        validateNumberForEqual("20.00", String.valueOf(fourthInstallment.get("principalOutstanding")));
-        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.get("interestOutstanding")));
-        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.get("feeChargesOutstanding")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod fourthInstallment = loanSchedule.get(4);
+        validateNumberForEqual("20.00", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
+        validateNumberForEqual("20.00", String.valueOf(fourthInstallment.getPrincipalOutstanding()));
+        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.getInterestOutstanding()));
+        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.getFeeChargesOutstanding()));
 
         // Make refund of 2000
         // max 2270 to refund. Pay 2000 means only principal
         // paid: principal 1980, interest 240, fees 50, penalty 0
         // refund 2000 means paid: principal 0, interest 220, fees 50, penalty 0
 
-        LOAN_TRANSACTION_HELPER.makeRefundByCash(now, Float.parseFloat("2000"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, now,
-                new JournalEntry(Float.parseFloat("2000"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("1980"), JournalEntry.TransactionType.DEBIT));
+        makeRefundByCash(now, Float.parseFloat("2000"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, now,
+                journalEntry(Float.parseFloat("2000"), assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("1980"), assetAccount, JournalEntry.TransactionType.DEBIT.name()));
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, now,
-                new JournalEntry(Float.parseFloat("20"), JournalEntry.TransactionType.DEBIT));
+        checkJournalEntryForIncomeAccount(incomeAccount, now,
+                journalEntry(Float.parseFloat("20"), incomeAccount, JournalEntry.TransactionType.DEBIT.name()));
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("2020.00", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
-        validateNumberForEqual("2000.00", String.valueOf(fourthInstallment.get("principalOutstanding")));
-        validateNumberForEqual("20.00", String.valueOf(fourthInstallment.get("interestOutstanding")));
-        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.get("feeChargesOutstanding")));
+        validateNumberForEqual("2020.00", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
+        validateNumberForEqual("2000.00", String.valueOf(fourthInstallment.getPrincipalOutstanding()));
+        validateNumberForEqual("20.00", String.valueOf(fourthInstallment.getInterestOutstanding()));
+        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.getFeeChargesOutstanding()));
 
     }
 
@@ -4518,38 +4244,37 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
         String fourMonthsfromNow = Utils.convertDateToURLFormat(fourMonthsfromNowCalendar);
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
 
-        final Integer savingsProductID = createSavingsProduct(MINIMUM_OPENING_BALANCE);
+        final Long savingsProductID = createSavingsProduct(MINIMUM_OPENING_BALANCE);
         Assertions.assertNotNull(savingsProductID);
 
-        final Integer savingsId = SAVINGS_ACCOUNT_HELPER.applyForSavingsApplication(clientID, savingsProductID, ACCOUNT_TYPE_INDIVIDUAL);
-        Assertions.assertNotNull(savingsProductID);
+        final Long savingsId = savingsHelper.submitApplication(clientID, savingsProductID, SAVINGS_CREATED_DATE).getSavingsId();
+        Assertions.assertNotNull(savingsId);
 
-        HashMap modifications = SAVINGS_ACCOUNT_HELPER.updateSavingsAccount(clientID, savingsProductID, savingsId, ACCOUNT_TYPE_INDIVIDUAL);
-        assertTrue(modifications.containsKey("submittedOnDate"));
+        assertTrue(updateSavingsSubmittedOnDate(savingsId, clientID, savingsProductID, SAVINGS_CREATED_DATE_PLUS_ONE),
+                "Expected submittedOnDate to be reported as modified");
 
-        HashMap savingsStatusHashMap = SavingsStatusChecker.getStatusOfSavings(REQUEST_SPEC, RESPONSE_SPEC, savingsId);
-        SavingsStatusChecker.verifySavingsIsPending(savingsStatusHashMap);
+        assertTrue(savingsHelper.getSavingsDetails(savingsId).getStatus().getSubmittedAndPendingApproval());
 
-        savingsStatusHashMap = SAVINGS_ACCOUNT_HELPER.approveSavings(savingsId);
-        SavingsStatusChecker.verifySavingsIsApproved(savingsStatusHashMap);
+        savingsHelper.approveSavings(savingsId, SAVINGS_TRANSACTION_DATE);
+        assertTrue(savingsHelper.getSavingsDetails(savingsId).getStatus().getApproved());
 
-        savingsStatusHashMap = SAVINGS_ACCOUNT_HELPER.activateSavings(savingsId);
-        SavingsStatusChecker.verifySavingsIsActive(savingsStatusHashMap);
+        savingsHelper.activateSavings(savingsId, SAVINGS_TRANSACTION_DATE);
+        assertTrue(savingsHelper.getSavingsDetails(savingsId).getStatus().getActive());
 
         /***
          * Create loan product with Default STYLE strategy
          */
 
-        final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-        final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-        final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-        final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+        final Account assetAccount = accountHelper.createAssetAccount();
+        final Account incomeAccount = accountHelper.createIncomeAccount();
+        final Account expenseAccount = accountHelper.createExpenseAccount();
+        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-        final Integer loanProductID = createLoanProduct("0", "0", LoanProductTestBuilder.DEFAULT_STRATEGY, CASH_BASED, assetAccount,
-                incomeAccount, expenseAccount, overpaymentAccount);
+        final Long loanProductID = createLoanProduct(0, 0, DEFAULT_STRATEGY, CASH_BASED, assetAccount, incomeAccount, expenseAccount,
+                overpaymentAccount);
         Assertions.assertNotNull(loanProductID);
 
         /***
@@ -4559,46 +4284,38 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         final String principal = "12,000.00";
 
         // Add charges with payment mode regular
-        List<HashMap> charges = new ArrayList<>();
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
 
-        Integer flatInstallmentFee = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "50", false));
-        addCharges(charges, flatInstallmentFee, "50", null);
+        Long flatInstallmentFee = chargesHelper.createLoanInstallmentCharge(ChargeCalculationType.FLAT, 50.0, false).getResourceId();
+        addCharges(charges, flatInstallmentFee, 50.0, null);
 
-        List<HashMap> collaterals = new ArrayList<>();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
         Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                clientID.toString(), collateralId);
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
         Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanID = applyForLoanApplicationWithPaymentStrategyAndPastMonth(clientID, loanProductID, charges, null, principal,
-                LoanApplicationTestBuilder.DEFAULT_STRATEGY, fourMonthsfromNow, collaterals);
+        final Long loanID = applyForLoanApplicationWithPaymentStrategyAndPastMonth(clientID, loanProductID, charges, null, principal,
+                DEFAULT_STRATEGY, fourMonthsfromNow, collaterals);
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(fourMonthsfromNow, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(fourMonthsfromNow, loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(fourMonthsfromNow, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(fourMonthsfromNow, loanID));
 
-        final JournalEntry[] assetAccountInitialEntry = {
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("12000.00"), JournalEntry.TransactionType.DEBIT) };
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, fourMonthsfromNow, assetAccountInitialEntry);
+        final LoanTestData.Journal[] assetAccountInitialEntry = {
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("12000.00"), assetAccount, JournalEntry.TransactionType.DEBIT.name()) };
+        checkJournalEntryForAssetAccount(assetAccount, fourMonthsfromNow, assetAccountInitialEntry);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap firstInstallment = loanSchedule.get(1);
-        validateNumberForEqual("2290", String.valueOf(firstInstallment.get("totalOutstandingForPeriod")));
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod firstInstallment = loanSchedule.get(1);
+        validateNumberForEqual("2290", String.valueOf(firstInstallment.getTotalOutstandingForPeriod()));
 
         // Make payment for installment #1
 
@@ -4606,29 +4323,29 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
         final String threeMonthsfromNow = Utils.convertDateToURLFormat(fourMonthsfromNowCalendar);
 
-        LOAN_TRANSACTION_HELPER.makeRepayment(threeMonthsfromNow, Float.parseFloat("2290"), loanID);
+        makeRepayment(threeMonthsfromNow, Float.parseFloat("2290"), loanID);
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         firstInstallment = loanSchedule.get(1);
-        validateNumberForEqual("0.00", String.valueOf(firstInstallment.get("totalOutstandingForPeriod")));
+        validateNumberForEqual("0.00", String.valueOf(firstInstallment.getTotalOutstandingForPeriod()));
 
         // Make payment for installment #2
         fourMonthsfromNowCalendar.add(Calendar.MONTH, 1);
 
         final String twoMonthsfromNow = Utils.convertDateToURLFormat(fourMonthsfromNowCalendar);
 
-        LOAN_TRANSACTION_HELPER.makeRepayment(twoMonthsfromNow, Float.parseFloat("2290"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, twoMonthsfromNow,
-                new JournalEntry(Float.parseFloat("2290"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("2000"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, twoMonthsfromNow,
-                new JournalEntry(Float.parseFloat("50"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("240"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment(twoMonthsfromNow, Float.parseFloat("2290"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, twoMonthsfromNow,
+                journalEntry(Float.parseFloat("2290"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("2000"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, twoMonthsfromNow,
+                journalEntry(Float.parseFloat("50"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("240"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        Map secondInstallment = loanSchedule.get(2);
-        validateNumberForEqual("0.00", String.valueOf(secondInstallment.get("totalOutstandingForPeriod")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod secondInstallment = loanSchedule.get(2);
+        validateNumberForEqual("0.00", String.valueOf(secondInstallment.getTotalOutstandingForPeriod()));
 
         // Make payment for installment #3
         // Pay 2290 more than expected
@@ -4636,18 +4353,18 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
         final String oneMonthfromNow = Utils.convertDateToURLFormat(fourMonthsfromNowCalendar);
 
-        LOAN_TRANSACTION_HELPER.makeRepayment(oneMonthfromNow, Float.parseFloat("4580"), loanID);
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, oneMonthfromNow,
-                new JournalEntry(Float.parseFloat("4580"), JournalEntry.TransactionType.DEBIT),
-                new JournalEntry(Float.parseFloat("4000"), JournalEntry.TransactionType.CREDIT));
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, oneMonthfromNow,
-                new JournalEntry(Float.parseFloat("100"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("480"), JournalEntry.TransactionType.CREDIT));
+        makeRepayment(oneMonthfromNow, Float.parseFloat("4580"), loanID);
+        checkJournalEntryForAssetAccount(assetAccount, oneMonthfromNow,
+                journalEntry(Float.parseFloat("4580"), assetAccount, JournalEntry.TransactionType.DEBIT.name()),
+                journalEntry(Float.parseFloat("4000"), assetAccount, JournalEntry.TransactionType.CREDIT.name()));
+        checkJournalEntryForIncomeAccount(incomeAccount, oneMonthfromNow,
+                journalEntry(Float.parseFloat("100"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("480"), incomeAccount, JournalEntry.TransactionType.CREDIT.name()));
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap thirdInstallment = loanSchedule.get(3);
-        validateNumberForEqual("0.00", String.valueOf(thirdInstallment.get("totalOutstandingForPeriod")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod thirdInstallment = loanSchedule.get(3);
+        validateNumberForEqual("0.00", String.valueOf(thirdInstallment.getTotalOutstandingForPeriod()));
 
         // Make refund of 20
         // max 2290 to refund. Pay 20 means only principal
@@ -4666,30 +4383,29 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         final String FROM_LOAN_ACCOUNT_TYPE = "1";
         final String TO_SAVINGS_ACCOUNT_TYPE = "2";
 
-        ACCOUNT_TRANSFER_HELPER.refundLoanByTransfer(now, clientID, loanID, clientID, savingsId, FROM_LOAN_ACCOUNT_TYPE,
-                TO_SAVINGS_ACCOUNT_TYPE, transferAmountValue.toString());
+        accountTransferHelper.refundLoanByTransfer(now, clientID, loanID, savingsId, transferAmountValue.toString());
 
         Float toSavingsBalance = Float.parseFloat(MINIMUM_OPENING_BALANCE);
 
-        HashMap toSavingsSummaryAfter = SAVINGS_ACCOUNT_HELPER.getSavingsSummary(savingsId);
+        SavingsAccountSummaryData toSavingsSummaryAfter = savingsHelper.getSavingsSummary(savingsId);
 
         toSavingsBalance += transferAmountValue;
 
         // Verifying toSavings Account Balance after Account Transfer
-        assertEquals(toSavingsBalance, toSavingsSummaryAfter.get("accountBalance"),
+        assertEquals(toSavingsBalance, toSavingsSummaryAfter.getAccountBalance().floatValue(),
                 "Verifying From Savings Account Balance after Account Transfer");
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, now,
-                new JournalEntry(Float.parseFloat("20"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("20"), JournalEntry.TransactionType.DEBIT));
+        checkJournalEntryForAssetAccount(assetAccount, now,
+                journalEntry(Float.parseFloat("20"), assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("20"), assetAccount, JournalEntry.TransactionType.DEBIT.name()));
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("20.00", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
-        validateNumberForEqual("20.00", String.valueOf(fourthInstallment.get("principalOutstanding")));
-        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.get("interestOutstanding")));
-        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.get("feeChargesOutstanding")));
+        loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod fourthInstallment = loanSchedule.get(4);
+        validateNumberForEqual("20.00", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
+        validateNumberForEqual("20.00", String.valueOf(fourthInstallment.getPrincipalOutstanding()));
+        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.getInterestOutstanding()));
+        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.getFeeChargesOutstanding()));
 
         // Make refund of 2000
         // max 2270 to refund. Pay 2000 means only principal
@@ -4699,58 +4415,45 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
         transferAmountValue = 2000f;
 
-        ACCOUNT_TRANSFER_HELPER.refundLoanByTransfer(now, clientID, loanID, clientID, savingsId, FROM_LOAN_ACCOUNT_TYPE,
-                TO_SAVINGS_ACCOUNT_TYPE, transferAmountValue.toString());
+        accountTransferHelper.refundLoanByTransfer(now, clientID, loanID, savingsId, transferAmountValue.toString());
 
-        toSavingsSummaryAfter = SAVINGS_ACCOUNT_HELPER.getSavingsSummary(savingsId);
+        toSavingsSummaryAfter = savingsHelper.getSavingsSummary(savingsId);
 
         toSavingsBalance += transferAmountValue;
 
         // Verifying toSavings Account Balance after Account Transfer
-        assertEquals(toSavingsBalance, toSavingsSummaryAfter.get("accountBalance"),
+        assertEquals(toSavingsBalance, toSavingsSummaryAfter.getAccountBalance().floatValue(),
                 "Verifying From Savings Account Balance after Account Transfer");
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForAssetAccount(assetAccount, now,
-                new JournalEntry(Float.parseFloat("2000"), JournalEntry.TransactionType.CREDIT),
-                new JournalEntry(Float.parseFloat("1980"), JournalEntry.TransactionType.DEBIT));
+        checkJournalEntryForAssetAccount(assetAccount, now,
+                journalEntry(Float.parseFloat("2000"), assetAccount, JournalEntry.TransactionType.CREDIT.name()),
+                journalEntry(Float.parseFloat("1980"), assetAccount, JournalEntry.TransactionType.DEBIT.name()));
 
-        JOURNAL_ENTRY_HELPER.checkJournalEntryForIncomeAccount(incomeAccount, now,
-                new JournalEntry(Float.parseFloat("20"), JournalEntry.TransactionType.DEBIT));
+        checkJournalEntryForIncomeAccount(incomeAccount, now,
+                journalEntry(Float.parseFloat("20"), incomeAccount, JournalEntry.TransactionType.DEBIT.name()));
 
         loanSchedule.clear();
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         fourthInstallment = loanSchedule.get(4);
-        validateNumberForEqual("2020.00", String.valueOf(fourthInstallment.get("totalOutstandingForPeriod")));
-        validateNumberForEqual("2000.00", String.valueOf(fourthInstallment.get("principalOutstanding")));
-        validateNumberForEqual("20.00", String.valueOf(fourthInstallment.get("interestOutstanding")));
-        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.get("feeChargesOutstanding")));
+        validateNumberForEqual("2020.00", String.valueOf(fourthInstallment.getTotalOutstandingForPeriod()));
+        validateNumberForEqual("2000.00", String.valueOf(fourthInstallment.getPrincipalOutstanding()));
+        validateNumberForEqual("20.00", String.valueOf(fourthInstallment.getInterestOutstanding()));
+        validateNumberForEqual("0.00", String.valueOf(fourthInstallment.getFeeChargesOutstanding()));
 
     }
 
     @Test
     public void testLoanProductConfiguration() {
         final String proposedAmount = "5000";
-        JsonObject loanProductConfigurationAsTrue = new JsonObject();
-        loanProductConfigurationAsTrue = createLoanProductConfigurationDetail(loanProductConfigurationAsTrue, true);
 
-        JsonObject loanProductConfigurationAsFalse = new JsonObject();
-        loanProductConfigurationAsFalse = createLoanProductConfigurationDetail(loanProductConfigurationAsFalse, false);
-
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC, "01 January 2012");
-        Integer loanProductID = LOAN_TRANSACTION_HELPER
-                .getLoanProductId(new LoanProductTestBuilder().withAmortizationTypeAsEqualInstallments().withRepaymentTypeAsMonth()
-                        .withRepaymentAfterEvery("1").withRepaymentStrategy(LoanProductTestBuilder.DEFAULT_STRATEGY)
-                        .withInterestTypeAsDecliningBalance().withInterestCalculationPeriodTypeAsDays().withInArrearsTolerance("10")
-                        .withMoratorium("2", "3").withLoanProductConfiguration(loanProductConfigurationAsTrue).build(null));
+        final Long clientID = createClient("01 January 2012");
+        Long loanProductID = createLoanProductWithAttributeOverrides(true);
         LOG.info("-----------------------LOAN PRODUCT CREATED WITH ATTRIBUTE CONFIGURATION AS TRUE-------------------------- {}",
                 loanProductID);
-        Integer loanID = applyForLoanApplicationWithProductConfigurationAsTrue(clientID, loanProductID, proposedAmount);
+        Long loanID = applyForLoanApplicationWithProductConfigurationAsTrue(clientID, loanProductID, proposedAmount);
         LOG.info("------------------------LOAN CREATED WITH ID------------------------------{}", loanID);
 
-        loanProductID = LOAN_TRANSACTION_HELPER.getLoanProductId(new LoanProductTestBuilder().withAmortizationTypeAsEqualInstallments()
-                .withRepaymentTypeAsMonth().withRepaymentAfterEvery("1").withRepaymentStrategy(LoanProductTestBuilder.DEFAULT_STRATEGY)
-                .withInterestTypeAsDecliningBalance().withInterestCalculationPeriodTypeAsDays().withInArrearsTolerance("10")
-                .withMoratorium("2", "3").withLoanProductConfiguration(loanProductConfigurationAsFalse).build(null));
+        loanProductID = createLoanProductWithAttributeOverrides(false);
         LOG.info("-------------------LOAN PRODUCT CREATED WITH ATTRIBUTE CONFIGURATION AS FALSE---------------------- {}", loanProductID);
         /*
          * Try to override attribute values in loan account when attribute configurations are set to false at product
@@ -4767,59 +4470,51 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void testLoanForeclosure() {
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProduct(false, NONE);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Long loanProductID = createLoanProduct(false, NONE);
 
-        List<HashMap> charges = new ArrayList<>();
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
 
-        Integer flatAmountChargeOne = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "50", false));
-        addCharges(charges, flatAmountChargeOne, "50", "01 October 2011");
-        Integer flatAmountChargeTwo = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "100", true));
-        addCharges(charges, flatAmountChargeTwo, "100", "15 December 2011");
+        Long flatAmountChargeOne = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.FLAT, 50.0, false).getResourceId();
+        addCharges(charges, flatAmountChargeOne, 50.0, "01 October 2011");
+        Long flatAmountChargeTwo = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.FLAT, 100.0, true).getResourceId();
+        addCharges(charges, flatAmountChargeTwo, 100.0, "15 December 2011");
 
-        List<HashMap> collaterals = new ArrayList<>();
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
         Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientID, collateralId).getResourceId();
         Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "10,000.00", collaterals);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID, charges, null, "10,000.00", collaterals);
         Assertions.assertNotNull(loanID);
 
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
         LOG.info("----------------------------------- APPROVE LOAN -----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("20 September 2011", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("20 September 2011", loanID));
 
         LOG.info("----------------------------------- DISBURSE LOAN ----------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("20 September 2011", loanID, "10,000.00",
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanID);
+        GetLoansLoanIdResponse loanStatusHashMap = disburseLoanWithNetDisbursalAmount("20 September 2011", loanID, "10,000.00");
         LOG.info("DISBURSE {}", loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(loanStatusHashMap);
 
         LOG.info("---------------------------------- Make repayment 1 --------------------------------------");
-        LOAN_TRANSACTION_HELPER.makeRepayment("20 October 2011", Float.parseFloat("2676.24"), loanID);
+        makeRepayment("20 October 2011", Float.parseFloat("2676.24"), loanID);
 
         LOG.info("---------------------------------- FORECLOSE LOAN ----------------------------------------");
-        LOAN_TRANSACTION_HELPER.forecloseLoan("08 November 2011", loanID);
+        forecloseLoan(loanID, new PostLoansLoanIdTransactionsRequest().transactionDate("08 November 2011").dateFormat(DATETIME_PATTERN)
+                .locale(LOCALE).note("Foreclosure"));
 
         // retrieving the loan status
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanStatusHashMap = getLoanDetails(loanID);
         // verifying the loan status is closed
-        LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
-        // retrieving the loan sub-status
-        loanStatusHashMap = LoanStatusChecker.getSubStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        verifyLoanStatus(loanStatusHashMap, GetLoansLoanIdStatus::getClosed);
         // verifying the loan sub-status is foreclosed
-        LoanStatusChecker.verifyLoanAccountForeclosed(loanStatusHashMap);
+        assertEquals("Foreclosed", loanStatusHashMap.getSubStatus().getValue());
 
     }
 
@@ -4834,25 +4529,22 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todaysDate.getTime());
         Integer dayOfWeek = getDayOfWeek(todaysDate);
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProductWithInterestRecalculationAndCompoundingDetails(
-                LoanProductTestBuilder.INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY,
-                LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_INTEREST,
-                LoanProductTestBuilder.RECALCULATION_STRATEGY_REDUCE_NUMBER_OF_INSTALLMENTS,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_DAILY, "1", LOAN_DISBURSEMENT_DATE,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_WEEKLY, "1", LOAN_DISBURSEMENT_DATE,
-                LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE, null, null, dayOfWeek, null, dayOfWeek);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Long loanProductID = createLoanProductWithInterestRecalculationAndCompoundingDetails(
+                INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY, LoanTestData.InterestRecalculationCompoundingMethod.INTEREST,
+                LoanTestData.RescheduleStrategyMethod.REDUCE_NUMBER_OF_INSTALLMENTS, LoanTestData.RecalculationRestFrequencyType.DAILY, 1,
+                LoanTestData.RecalculationRestFrequencyType.WEEKLY, 1,
+                LoanTestData.PreClosureInterestCalculationStrategy.TILL_PRE_CLOSE_DATE, null, null, dayOfWeek, null, dayOfWeek);
 
-        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
-                LoanApplicationTestBuilder.INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY, new ArrayList<HashMap>(0));
+        final Long loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
+                INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY, Collections.emptyList());
 
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        List<Map<String, Object>> expectedvalues = new ArrayList<>();
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        List<ExpectedInstallment> expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2494.22", "34.69", "0.0", "0.0");
@@ -4862,17 +4554,12 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(LOAN_DISBURSEMENT_DATE, loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID));
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
@@ -4882,7 +4569,7 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanFutureRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanFutureRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, 0, false, "4965.3", "92.52", "0.0", "0.0");
@@ -4894,10 +4581,10 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -7);
         final String LOAN_FIRST_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
-        Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        Float totalDueForCurrentPeriod = loanSchedule.get(1).getTotalDueForPeriod().floatValue();
+        makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
@@ -4910,30 +4597,24 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -5);
         final String LOAN_SECOND_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_SECOND_REPAYMENT_DATE, earlyPayment, loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        makeRepayment(LOAN_SECOND_REPAYMENT_DATE, earlyPayment, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         Calendar today = Calendar.getInstance(Utils.getTimeZoneOfTenant());
-        Map<String, Object> paymentday = new HashMap<>(3);
-        paymentday.put("dueDate", getDateAsArray(today, -5, Calendar.DAY_OF_MONTH));
-        paymentday.put("principalDue", "3990.09");
-        paymentday.put("interestDue", "9.91");
-        paymentday.put("feeChargesDue", "0");
-        paymentday.put("penaltyChargesDue", "0");
+        ExpectedInstallment paymentday = new ExpectedInstallment(addDays(today, -5), "3990.09", "9.91", "0", "0");
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
         expectedvalues.add(paymentday);
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2517.31", "11.6", "0.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "1009.84", "4.66", "0.0", "0.0");
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
-        HashMap prepayDetail = LOAN_TRANSACTION_HELPER.getPrepayAmount(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        String prepayAmount = String.valueOf(prepayDetail.get("amount"));
+        GetLoansLoanIdTransactionsTemplateResponse prepayDetail = getPrepayAmount(loanID);
+        String prepayAmount = String.valueOf(prepayDetail.getAmount());
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         final String loanRepaymentDate = dateFormat.format(todaysDate.getTime());
-        LOAN_TRANSACTION_HELPER.makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanID);
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
+        makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanID);
+        verifyLoanAccountIsClosed(loanID);
 
     }
 
@@ -4948,25 +4629,22 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todaysDate.getTime());
         Integer dayOfWeek = getDayOfWeek(todaysDate);
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProductWithInterestRecalculationAndCompoundingDetails(
-                LoanProductTestBuilder.INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY,
-                LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_INTEREST,
-                LoanProductTestBuilder.RECALCULATION_STRATEGY_REDUCE_NUMBER_OF_INSTALLMENTS,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_DAILY, "1", LOAN_DISBURSEMENT_DATE,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_WEEKLY, "1", LOAN_DISBURSEMENT_DATE,
-                LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE, null, null, dayOfWeek, null, dayOfWeek);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Long loanProductID = createLoanProductWithInterestRecalculationAndCompoundingDetails(
+                INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY, LoanTestData.InterestRecalculationCompoundingMethod.INTEREST,
+                LoanTestData.RescheduleStrategyMethod.REDUCE_NUMBER_OF_INSTALLMENTS, LoanTestData.RecalculationRestFrequencyType.DAILY, 1,
+                LoanTestData.RecalculationRestFrequencyType.WEEKLY, 1,
+                LoanTestData.PreClosureInterestCalculationStrategy.TILL_PRE_CLOSE_DATE, null, null, dayOfWeek, null, dayOfWeek);
 
-        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
-                LoanApplicationTestBuilder.INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY, new ArrayList<HashMap>(0));
+        final Long loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
+                INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY, Collections.emptyList());
 
         Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        List<Map<String, Object>> expectedvalues = new ArrayList<>();
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        List<ExpectedInstallment> expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2494.22", "34.69", "0.0", "0.0");
@@ -4976,17 +4654,12 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(LOAN_DISBURSEMENT_DATE, loanID));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID));
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
@@ -4996,7 +4669,7 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanFutureRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanFutureRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, 0, false, "4965.3", "92.52", "0.0", "0.0");
@@ -5008,10 +4681,10 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -7);
         final String LOAN_FIRST_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
-        Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        Float totalDueForCurrentPeriod = loanSchedule.get(1).getTotalDueForPeriod().floatValue();
+        makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -1, false, "2482.76", "46.15", "0.0", "0.0");
@@ -5025,8 +4698,8 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -2);
         final String LOAN_SECOND_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_SECOND_REPAYMENT_DATE, earlyPayment, loanID);
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        makeRepayment(LOAN_SECOND_REPAYMENT_DATE, earlyPayment, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         Calendar today = Calendar.getInstance(Utils.getTimeZoneOfTenant());
@@ -5038,13 +4711,12 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2490.78", "11.5", "0.0", "0.0");
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
-        HashMap prepayDetail = LOAN_TRANSACTION_HELPER.getPrepayAmount(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        String prepayAmount = String.valueOf(prepayDetail.get("amount"));
+        GetLoansLoanIdTransactionsTemplateResponse prepayDetail = getPrepayAmount(loanID);
+        String prepayAmount = String.valueOf(prepayDetail.getAmount());
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         final String loanRepaymentDate = dateFormat.format(todaysDate.getTime());
-        LOAN_TRANSACTION_HELPER.makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanID);
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
+        makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanID);
+        verifyLoanAccountIsClosed(loanID);
 
     }
 
@@ -5067,47 +4739,38 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             String firstRepayment = dateFormat.format(firstRepaymentDate.getTime());
 
             final String loanDisbursementDate = dateFormat.format(startDate.getTime());
-            final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-            ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-            final Integer loanProductID = createLoanProductWithInterestRecalculationAndCompoundingDetails(
-                    LoanProductTestBuilder.INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY,
-                    LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_NONE,
-                    LoanProductTestBuilder.RECALCULATION_STRATEGY_REDUCE_NUMBER_OF_INSTALLMENTS,
-                    LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_SAME_AS_REPAYMENT_PERIOD,
-                    LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE, null, "12");
+            final Long clientID = createClient();
+            verifyClientCreatedOnServer(clientID);
+            final Long loanProductID = createLoanProductWithInterestRecalculationAndInstallmentAmount(
+                    INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY, LoanTestData.InterestRecalculationCompoundingMethod.NONE,
+                    LoanTestData.RescheduleStrategyMethod.REDUCE_NUMBER_OF_INSTALLMENTS,
+                    LoanTestData.PreClosureInterestCalculationStrategy.TILL_PRE_CLOSE_DATE, null, 12);
 
-            final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, loanDisbursementDate,
-                    LoanApplicationTestBuilder.INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY, firstRepayment);
+            final Long loanID = applyForLoanApplicationForInterestRecalculationWithFirstRepaymentDate(clientID, loanProductID,
+                    loanDisbursementDate, INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY, firstRepayment);
 
             Assertions.assertNotNull(loanID);
-            HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+            verifyLoanIsPending(loanID);
 
             LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(loanDisbursementDate, loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-            LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+            verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(loanDisbursementDate, loanID));
 
             LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-            String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(loanDisbursementDate, loanID,
-                    JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+            verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(loanDisbursementDate, loanID));
 
-            ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+            List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
             Assertions.assertNotNull(loanSchedule);
             startDate.add(Calendar.DAY_OF_MONTH, 2);
             String loanFirstRepaymentDate = dateFormat.format(startDate.getTime());
             //
             Float earlyPayment = Float.parseFloat("3000");
-            LOAN_TRANSACTION_HELPER.makeRepayment(loanFirstRepaymentDate, earlyPayment, loanID);
+            makeRepayment(loanFirstRepaymentDate, earlyPayment, loanID);
 
-            HashMap prepayDetail = LOAN_TRANSACTION_HELPER.getPrepayAmount(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            String prepayAmount = String.valueOf(prepayDetail.get("amount"));
+            GetLoansLoanIdTransactionsTemplateResponse prepayDetail = getPrepayAmount(loanID);
+            String prepayAmount = String.valueOf(prepayDetail.getAmount());
             String loanPrepaymentDate = dateFormat.format(currentDate.getTime());
-            LOAN_TRANSACTION_HELPER.makeRepayment(loanPrepaymentDate, Float.parseFloat(prepayAmount), loanID);
-            loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
+            makeRepayment(loanPrepaymentDate, Float.parseFloat(prepayAmount), loanID);
+            verifyLoanAccountIsClosed(loanID);
         } finally {
             globalConfigurationHelper.updateGlobalConfiguration(
                     GlobalConfigurationConstants.IS_INTEREST_TO_BE_RECOVERED_FIRST_WHEN_GREATER_THAN_EMI,
@@ -5118,8 +4781,6 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void testLoanScheduleWithInterestRecalculationMakeAdvancePaymentTillSettlement() {
         try {
-            final ResponseSpecification errorResponse = new ResponseSpecBuilder().expectStatusCode(403).build();
-            final LoanTransactionHelper validationErrorHelper = new LoanTransactionHelper(REQUEST_SPEC, errorResponse);
             DateFormat dateFormat = new SimpleDateFormat(DATETIME_PATTERN, Locale.US);
             dateFormat.setTimeZone(Utils.getTimeZoneOfTenant());
             globalConfigurationHelper.updateGlobalConfiguration(
@@ -5136,34 +4797,26 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             String firstRepayment = dateFormat.format(firstRepaymentDate.getTime());
 
             final String loanDisbursementDate = dateFormat.format(startDate.getTime());
-            final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-            ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-            final Integer loanProductID = createLoanProductWithInterestRecalculationAndCompoundingDetails(
-                    LoanProductTestBuilder.INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY,
-                    LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_NONE,
-                    LoanProductTestBuilder.RECALCULATION_STRATEGY_REDUCE_NUMBER_OF_INSTALLMENTS,
-                    LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_SAME_AS_REPAYMENT_PERIOD,
-                    LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE, null, "12");
+            final Long clientID = createClient();
+            verifyClientCreatedOnServer(clientID);
+            final Long loanProductID = createLoanProductWithInterestRecalculationAndInstallmentAmount(
+                    INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY, LoanTestData.InterestRecalculationCompoundingMethod.NONE,
+                    LoanTestData.RescheduleStrategyMethod.REDUCE_NUMBER_OF_INSTALLMENTS,
+                    LoanTestData.PreClosureInterestCalculationStrategy.TILL_PRE_CLOSE_DATE, null, 12);
 
-            final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, loanDisbursementDate,
-                    LoanApplicationTestBuilder.INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY, firstRepayment);
+            final Long loanID = applyForLoanApplicationForInterestRecalculationWithFirstRepaymentDate(clientID, loanProductID,
+                    loanDisbursementDate, INTEREST_PRINCIPAL_PENALTIES_FEES_ORDER_STRATEGY, firstRepayment);
 
             Assertions.assertNotNull(loanID);
-            HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+            verifyLoanIsPending(loanID);
 
             LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(loanDisbursementDate, loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-            LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+            verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(loanDisbursementDate, loanID));
 
             LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-            String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(loanDisbursementDate, loanID,
-                    JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+            verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(loanDisbursementDate, loanID));
 
-            ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+            List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
             Assertions.assertNotNull(loanSchedule);
             Calendar repaymentDate = (Calendar) firstRepaymentDate.clone();
             startDate.add(Calendar.DAY_OF_MONTH, 2);
@@ -5172,22 +4825,25 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             Float earlyPayment = Float.parseFloat("3000");
             String retrieveDueDate = null;
             Float amount = null;
-            LOAN_TRANSACTION_HELPER.makeRepayment(loanFirstRepaymentDate, earlyPayment, loanID);
+            makeRepayment(loanFirstRepaymentDate, earlyPayment, loanID);
             for (int i = 1; i < loanSchedule.size(); i++) {
 
                 retrieveDueDate = dateFormat.format(repaymentDate.getTime());
-                amount = ((Number) loanSchedule.get(i).get("principalOriginalDue")).floatValue()
-                        + ((Number) loanSchedule.get(i).get("interestOriginalDue")).floatValue();
+                amount = ((Number) loanSchedule.get(i).getPrincipalOriginalDue()).floatValue()
+                        + ((Number) loanSchedule.get(i).getInterestOriginalDue()).floatValue();
                 if (currentDate.after(repaymentDate)) {
-                    LOAN_TRANSACTION_HELPER.makeRepayment(retrieveDueDate, amount, loanID);
+                    makeRepayment(retrieveDueDate, amount, loanID);
                 } else {
                     break;
                 }
                 repaymentDate.add(Calendar.MONTH, 1);
             }
-            HashMap savingsAccountErrorData = validationErrorHelper.makeRepayment(retrieveDueDate, amount, loanID);
-            ArrayList<HashMap> error = (ArrayList<HashMap>) savingsAccountErrorData.get("errors");
-            assertEquals("error.msg.loan.transaction.cannot.be.a.future.date", error.get(0).get("userMessageGlobalisationCode"));
+            final String futureRepaymentDate = retrieveDueDate;
+            final Float futureRepaymentAmount = amount;
+            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
+                    () -> makeRepayment(futureRepaymentDate, futureRepaymentAmount, loanID));
+            assertEquals(403, exception.getStatus());
+            assertTrue(exception.getMessage().contains("error.msg.loan.transaction.cannot.be.a.future.date"));
         } finally {
             globalConfigurationHelper.updateGlobalConfiguration(
                     GlobalConfigurationConstants.IS_INTEREST_TO_BE_RECOVERED_FIRST_WHEN_GREATER_THAN_EMI,
@@ -5199,112 +4855,103 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
     public void testCollateralDataIsAvailableWhenRequested() {
         // given
 
-        Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
-        List<HashMap> collaterals = new ArrayList<>();
-        Integer clientId = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientId);
+        Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
+        Long clientId = createClient();
+        verifyClientCreatedOnServer(clientId);
 
-        Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientId), collateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
+        Long clientCollateralId = collateralHelper.createClientCollateral(clientId, collateralId).getResourceId();
+        collaterals.add(collateral(clientCollateralId, BigDecimal.ONE));
 
-        Integer loanProductId = createLoanProduct(false, NONE);
+        Long loanProductId = createLoanProduct(false, NONE);
 
         // when
-        Integer loanId = applyForLoanApplication(clientId, loanProductId, null, null, "12,000.00", collaterals);
+        Long loanId = applyForLoanApplication(clientId, loanProductId, null, null, "12,000.00", collaterals);
 
         // then
-        List<Integer> clientCollateralIds = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanId,
-                "collateral.clientCollateralId");
-        Integer clientCollateralIdResult = clientCollateralIds.get(0);
-        assertEquals(clientCollateralId, clientCollateralIdResult);
+        List<GetLoansLoanIdCollateralData> loanCollateral = getLoanDetails(loanId).getCollateral();
+        assertEquals(clientCollateralId, loanCollateral.get(0).getClientCollateralId());
     }
 
     @Test
     public void undoWaivedChargeTransactionDoesNotExist() {
-        LoanTransactionHelper loanTransactionHelper = new LoanTransactionHelper(REQUEST_SPEC, createResponseSpecification(404));
-        HashMap response = loanTransactionHelper.undoWaiveChargesForLoan(-1, -2, "");
-        assertEquals("error.msg.loan.transaction.id.invalid",
-                ((Map) ((List) response.get("errors")).get(0)).get("userMessageGlobalisationCode"));
-        assertEquals("Transaction with identifier -2 does not exist for loan with identifier -1.",
-                ((Map) ((List) response.get("errors")).get(0)).get("defaultUserMessage"));
+        CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
+                () -> undoWaiveLoanCharge(-1L, -2L, new PutChargeTransactionChangesRequest().id(-2L).loanId(-1L)));
+        assertEquals(404, exception.getStatus());
+        assertTrue(exception.getMessage().contains("error.msg.loan.transaction.id.invalid"));
+        assertTrue(exception.getMessage().contains("Transaction with identifier -2 does not exist for loan with identifier -1."));
     }
 
     @Test
     public void chargeAdjustmentChargeWrongParams() {
         CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                () -> LOAN_TRANSACTION_HELPER.chargeAdjustment(0L, 0L, new PostLoansLoanIdChargesChargeIdRequest().amount(0.0)));
-        assertEquals(400, exception.getResponse().code());
+                () -> chargeAdjustment(0L, 0L, new PostLoansLoanIdChargesChargeIdRequest().amount(0.0)));
+        assertEquals(400, exception.getStatus());
         assertTrue(exception.getMessage().contains("validation.msg.loan.charge.adjustment.request.amount.not.greater.than.zero"));
         assertTrue(exception.getMessage().contains("validation.msg.loan.charge.adjustment.request.loanId.not.greater.than.zero"));
         assertTrue(exception.getMessage().contains("validation.msg.loan.charge.adjustment.request.loanChargeId.not.greater.than.zero"));
         exception = assertThrows(CallFailedRuntimeException.class,
-                () -> LOAN_TRANSACTION_HELPER.chargeAdjustment(1L, 0L, new PostLoansLoanIdChargesChargeIdRequest().amount(0.0)));
-        assertEquals(400, exception.getResponse().code());
+                () -> chargeAdjustment(1L, 0L, new PostLoansLoanIdChargesChargeIdRequest().amount(0.0)));
+        assertEquals(400, exception.getStatus());
         assertTrue(exception.getMessage().contains("validation.msg.loan.charge.adjustment.request.amount.not.greater.than.zero"));
         assertTrue(exception.getMessage().contains("validation.msg.loan.charge.adjustment.request.loanChargeId.not.greater.than.zero"));
         exception = assertThrows(CallFailedRuntimeException.class,
-                () -> LOAN_TRANSACTION_HELPER.chargeAdjustment(1L, 1L, new PostLoansLoanIdChargesChargeIdRequest().amount(0.0)));
-        assertEquals(400, exception.getResponse().code());
+                () -> chargeAdjustment(1L, 1L, new PostLoansLoanIdChargesChargeIdRequest().amount(0.0)));
+        assertEquals(400, exception.getStatus());
         assertTrue(exception.getMessage().contains("validation.msg.loan.charge.adjustment.request.amount.not.greater.than.zero"));
     }
 
     @Test
     public void chargeAdjustmentChargeDoesNotExist() {
-        final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-        final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-        final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-        final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+        final Account assetAccount = accountHelper.createAssetAccount();
+        final Account incomeAccount = accountHelper.createIncomeAccount();
+        final Account expenseAccount = accountHelper.createExpenseAccount();
+        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-        final Integer loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount, expenseAccount,
+        final Long loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount, expenseAccount,
                 overpaymentAccount);
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC, "01 January 2011");
+        final Long clientID = createClient("01 January 2011");
 
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID);
 
         CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                () -> LOAN_TRANSACTION_HELPER.chargeAdjustment((long) loanID, 1L, new PostLoansLoanIdChargesChargeIdRequest().amount(1.0)));
-        assertEquals(404, exception.getResponse().code());
+                () -> chargeAdjustment((long) loanID, 1L, new PostLoansLoanIdChargesChargeIdRequest().amount(1.0)));
+        assertEquals(404, exception.getStatus());
         assertTrue(exception.getMessage().contains("error.msg.loanCharge.id.invalid"));
     }
 
     @Test
     public void chargeAdjustmentChargeDoesNotExistForLoan() {
-        final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-        final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-        final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-        final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+        final Account assetAccount = accountHelper.createAssetAccount();
+        final Account incomeAccount = accountHelper.createIncomeAccount();
+        final Account expenseAccount = accountHelper.createExpenseAccount();
+        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-        final Integer loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount, expenseAccount,
+        final Long loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount, expenseAccount,
                 overpaymentAccount);
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC, "01 January 2011");
+        final Long clientID = createClient("01 January 2011");
 
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID);
 
-        HashMap<String, Object> loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("02 September 2022", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("02 September 2022", loanID));
 
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        GetLoansLoanIdResponse loanStatusHashMap = disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
+        verifyLoanIsActive(loanStatusHashMap);
 
-        Integer penalty = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", true));
+        Long penalty = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.FLAT, 10.0, true).getResourceId();
         LocalDate targetDate = LocalDate.of(2022, 9, 7);
-        final String penaltyCharge1AddedDate = DATE_TIME_FORMATTER.format(targetDate);
-        Integer penalty1LoanChargeId = LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID,
-                LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), penaltyCharge1AddedDate, "10"));
+        final String penaltyCharge1AddedDate = dateTimeFormatter.format(targetDate);
+        Long penalty1LoanChargeId = addLoanCharge(loanID, penalty, penaltyCharge1AddedDate, 10.0).getResourceId();
 
-        final Integer loanID2 = applyForLoanApplication(clientID, loanProductID);
+        final Long loanID2 = applyForLoanApplication(clientID, loanProductID);
 
-        CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class, () -> LOAN_TRANSACTION_HELPER
-                .chargeAdjustment((long) loanID2, (long) penalty1LoanChargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(1.0)));
-        assertEquals(404, exception.getResponse().code());
+        CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
+                () -> chargeAdjustment(loanID2, penalty1LoanChargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(1.0)));
+        assertEquals(404, exception.getStatus());
         assertTrue(exception.getMessage().contains("error.msg.loanCharge.id.invalid.for.given.loan"));
     }
 
@@ -5313,82 +4960,75 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         try {
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
-            BUSINESS_DATE_HELPER.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("01 November 2022").dateFormat(DATETIME_PATTERN).locale("en"));
-            final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-            final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-            final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-            final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+            updateBusinessDate("01 November 2022");
+            final Account assetAccount = accountHelper.createAssetAccount();
+            final Account incomeAccount = accountHelper.createIncomeAccount();
+            final Account expenseAccount = accountHelper.createExpenseAccount();
+            final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-            Integer penalty = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", true));
-            final Integer loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount,
-                    expenseAccount, overpaymentAccount);
+            Long penalty = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.FLAT, 10.0, true).getResourceId();
+            final Long loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount, expenseAccount,
+                    overpaymentAccount);
 
-            final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC, "01 January 2011");
+            final Long clientID = createClient("01 January 2011");
 
-            final Integer loanID = applyForLoanApplication(clientID, loanProductID);
+            final Long loanID = applyForLoanApplication(clientID, loanProductID);
 
-            HashMap<String, Object> loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+            verifyLoanIsPending(loanID);
 
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("02 September 2022", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-            LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+            verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("02 September 2022", loanID));
 
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+            GetLoansLoanIdResponse loanStatusHashMap = disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
+            verifyLoanIsActive(loanStatusHashMap);
 
-            ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+            List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
             assertEquals(2, loanSchedule.size());
-            assertEquals(0, loanSchedule.get(1).get("penaltyChargesDue"));
-            assertEquals(0, loanSchedule.get(1).get("penaltyChargesOutstanding"));
-            assertEquals(1000.0f, loanSchedule.get(1).get("totalDueForPeriod"));
-            assertEquals(1000.0f, loanSchedule.get(1).get("totalOutstandingForPeriod"));
+            assertEquals(0.0f, loanSchedule.get(1).getPenaltyChargesDue().floatValue());
+            assertEquals(0.0f, loanSchedule.get(1).getPenaltyChargesOutstanding().floatValue());
+            assertEquals(1000.0f, loanSchedule.get(1).getTotalDueForPeriod().floatValue());
+            assertEquals(1000.0f, loanSchedule.get(1).getTotalOutstandingForPeriod().floatValue());
             LocalDate targetDate = LocalDate.of(2022, 9, 7);
-            final String penaltyCharge1AddedDate = DATE_TIME_FORMATTER.format(targetDate);
-            Integer penalty1LoanChargeId = LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), penaltyCharge1AddedDate, "10"));
+            final String penaltyCharge1AddedDate = dateTimeFormatter.format(targetDate);
+            Long penalty1LoanChargeId = addLoanCharge(loanID, penalty, penaltyCharge1AddedDate, 10.0).getResourceId();
 
-            LOAN_TRANSACTION_HELPER.noAccrualTransactionForRepayment(loanID);
+            assertNoAccrualTransactions(loanID);
 
-            loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+            loanSchedule = getLoanRepaymentSchedule(loanID);
             assertEquals(2, loanSchedule.size());
-            assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesDue"));
-            assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesOutstanding"));
-            assertEquals(1010.0f, loanSchedule.get(1).get("totalDueForPeriod"));
-            assertEquals(1010.0f, loanSchedule.get(1).get("totalOutstandingForPeriod"));
-            assertEquals(0, loanSchedule.get(1).get("totalWaivedForPeriod"));
+            assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesDue().floatValue());
+            assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesOutstanding().floatValue());
+            assertEquals(1010.0f, loanSchedule.get(1).getTotalDueForPeriod().floatValue());
+            assertEquals(1010.0f, loanSchedule.get(1).getTotalOutstandingForPeriod().floatValue());
+            assertEquals(0, loanSchedule.get(1).getTotalWaivedForPeriod().floatValue());
 
-            HashMap loanSummary = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "summary");
-            assertEquals(10.0f, loanSummary.get("penaltyChargesCharged"));
-            assertEquals(10.0f, loanSummary.get("penaltyChargesOutstanding"));
-            assertEquals(0.0f, loanSummary.get("penaltyChargesWaived"));
-            assertEquals(1010.0f, loanSummary.get("totalOutstanding"));
-            assertEquals(0.0f, loanSummary.get("totalWaived"));
+            GetLoansLoanIdSummary loanSummary = getLoanDetails(loanID).getSummary();
+            assertEquals(10.0f, loanSummary.getPenaltyChargesCharged().floatValue());
+            assertEquals(10.0f, loanSummary.getPenaltyChargesOutstanding().floatValue());
+            assertEquals(0.0f, loanSummary.getPenaltyChargesWaived().floatValue());
+            assertEquals(1010.0f, loanSummary.getTotalOutstanding().floatValue());
+            assertEquals(0.0f, loanSummary.getTotalWaived().floatValue());
 
             String externalId = UUID.randomUUID().toString();
-            PostLoansLoanIdChargesChargeIdResponse chargeAdjustmentResponse = LOAN_TRANSACTION_HELPER.chargeAdjustment((long) loanID,
-                    (long) penalty1LoanChargeId,
+            PostLoansLoanIdChargesChargeIdResponse chargeAdjustmentResponse = chargeAdjustment((long) loanID, (long) penalty1LoanChargeId,
                     new PostLoansLoanIdChargesChargeIdRequest().amount(10.0).externalId(externalId).paymentTypeId(1L));
 
-            loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+            loanSchedule = getLoanRepaymentSchedule(loanID);
             assertEquals(2, loanSchedule.size());
-            assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesDue"));
-            assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesPaid"));
-            assertEquals(0.0f, loanSchedule.get(1).get("penaltyChargesOutstanding"));
-            assertEquals(1010.0f, loanSchedule.get(1).get("totalDueForPeriod"));
-            assertEquals(1000.0f, loanSchedule.get(1).get("totalOutstandingForPeriod"));
-            assertEquals(10.0f, loanSchedule.get(1).get("totalPaidForPeriod"));
+            assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesDue().floatValue());
+            assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesPaid().floatValue());
+            assertEquals(0.0f, loanSchedule.get(1).getPenaltyChargesOutstanding().floatValue());
+            assertEquals(1010.0f, loanSchedule.get(1).getTotalDueForPeriod().floatValue());
+            assertEquals(1000.0f, loanSchedule.get(1).getTotalOutstandingForPeriod().floatValue());
+            assertEquals(10.0f, loanSchedule.get(1).getTotalPaidForPeriod().floatValue());
 
-            loanSummary = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "summary");
-            assertEquals(10.0f, loanSummary.get("penaltyChargesCharged"));
-            assertEquals(0.0f, loanSummary.get("penaltyChargesOutstanding"));
-            assertEquals(10.0f, loanSummary.get("penaltyChargesPaid"));
-            assertEquals(1000.0f, loanSummary.get("totalOutstanding"));
+            loanSummary = getLoanDetails(loanID).getSummary();
+            assertEquals(10.0f, loanSummary.getPenaltyChargesCharged().floatValue());
+            assertEquals(0.0f, loanSummary.getPenaltyChargesOutstanding().floatValue());
+            assertEquals(10.0f, loanSummary.getPenaltyChargesPaid().floatValue());
+            assertEquals(1000.0f, loanSummary.getTotalOutstanding().floatValue());
 
-            GetLoansLoanIdTransactionsTransactionIdResponse chargeAdjustmentTransaction = LOAN_TRANSACTION_HELPER
-                    .getLoanTransactionDetails((long) loanID, chargeAdjustmentResponse.getSubResourceId());
+            GetLoansLoanIdTransactionsTransactionIdResponse chargeAdjustmentTransaction = getLoanTransactionDetails(loanID,
+                    chargeAdjustmentResponse.getSubResourceId());
             assertEquals(10.0, chargeAdjustmentTransaction.getAmount());
             assertEquals(10.0, chargeAdjustmentTransaction.getPenaltyChargesPortion());
             assertEquals("loanTransactionType.chargeAdjustment", chargeAdjustmentTransaction.getType().getCode());
@@ -5399,32 +5039,31 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals("CHARGE_ADJUSTMENT", transactionRelation.getRelationType());
             assertEquals(1L, chargeAdjustmentTransaction.getPaymentDetailData().getPaymentType().getId());
 
-            PostLoansLoanIdTransactionsResponse repaymentResult = LOAN_TRANSACTION_HELPER.makeLoanRepayment((long) loanID,
-                    new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate("06 September 2022").locale("en")
-                            .transactionAmount(5.0));
+            PostLoansLoanIdTransactionsResponse repaymentResult = makeLoanRepayment((long) loanID, new PostLoansLoanIdTransactionsRequest()
+                    .dateFormat(DATETIME_PATTERN).transactionDate("06 September 2022").locale("en").transactionAmount(5.0));
 
-            loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+            loanSchedule = getLoanRepaymentSchedule(loanID);
             assertEquals(2, loanSchedule.size());
-            assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesDue"));
-            assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesPaid"));
-            assertEquals(0.0f, loanSchedule.get(1).get("penaltyChargesOutstanding"));
-            assertEquals(1000.0f, loanSchedule.get(1).get("principalDue"));
-            assertEquals(5.0f, loanSchedule.get(1).get("principalPaid"));
-            assertEquals(995.0f, loanSchedule.get(1).get("principalOutstanding"));
-            assertEquals(1010.0f, loanSchedule.get(1).get("totalDueForPeriod"));
-            assertEquals(995.0f, loanSchedule.get(1).get("totalOutstandingForPeriod"));
-            assertEquals(15.0f, loanSchedule.get(1).get("totalPaidForPeriod"));
+            assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesDue().floatValue());
+            assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesPaid().floatValue());
+            assertEquals(0.0f, loanSchedule.get(1).getPenaltyChargesOutstanding().floatValue());
+            assertEquals(1000.0f, loanSchedule.get(1).getPrincipalDue().floatValue());
+            assertEquals(5.0f, loanSchedule.get(1).getPrincipalPaid().floatValue());
+            assertEquals(995.0f, loanSchedule.get(1).getPrincipalOutstanding().floatValue());
+            assertEquals(1010.0f, loanSchedule.get(1).getTotalDueForPeriod().floatValue());
+            assertEquals(995.0f, loanSchedule.get(1).getTotalOutstandingForPeriod().floatValue());
+            assertEquals(15.0f, loanSchedule.get(1).getTotalPaidForPeriod().floatValue());
 
-            loanSummary = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "summary");
-            assertEquals(10.0f, loanSummary.get("penaltyChargesCharged"));
-            assertEquals(0.0f, loanSummary.get("penaltyChargesOutstanding"));
-            assertEquals(10.0f, loanSummary.get("penaltyChargesPaid"));
-            assertEquals(1000.0f, loanSummary.get("principalDisbursed"));
-            assertEquals(995.0f, loanSummary.get("principalOutstanding"));
-            assertEquals(5.0f, loanSummary.get("principalPaid"));
-            assertEquals(995.0f, loanSummary.get("totalOutstanding"));
+            loanSummary = getLoanDetails(loanID).getSummary();
+            assertEquals(10.0f, loanSummary.getPenaltyChargesCharged().floatValue());
+            assertEquals(0.0f, loanSummary.getPenaltyChargesOutstanding().floatValue());
+            assertEquals(10.0f, loanSummary.getPenaltyChargesPaid().floatValue());
+            assertEquals(1000.0f, loanSummary.getPrincipalDisbursed().floatValue());
+            assertEquals(995.0f, loanSummary.getPrincipalOutstanding().floatValue());
+            assertEquals(5.0f, loanSummary.getPrincipalPaid().floatValue());
+            assertEquals(995.0f, loanSummary.getTotalOutstanding().floatValue());
 
-            GetLoansLoanIdResponse loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanID);
             GetLoansLoanIdTransactions replayedTransaction = loanDetails.getTransactions().stream()
                     .filter(t -> externalId.equals(t.getExternalId())).findFirst().get();
 
@@ -5443,36 +5082,36 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             }
 
             String uuid = UUID.randomUUID().toString();
-            LOAN_TRANSACTION_HELPER.reverseLoanTransaction((long) loanID, replayedTransaction.getId(),
+            reverseLoanTransaction((long) loanID, replayedTransaction.getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("08 September 2022")
                             .transactionAmount(0.0).locale("en").reversalExternalId(uuid));
 
             // Should fail due to external id collusion
             assertThrows(CallFailedRuntimeException.class,
-                    () -> LOAN_TRANSACTION_HELPER.reverseLoanTransaction((long) loanID, repaymentResult.getResourceId(),
+                    () -> reverseLoanTransaction((long) loanID, repaymentResult.getResourceId(),
                             new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN)
                                     .transactionDate("08 September 2022").transactionAmount(0.0).locale("en").reversalExternalId(uuid)));
 
-            loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+            loanSchedule = getLoanRepaymentSchedule(loanID);
             assertEquals(2, loanSchedule.size());
-            assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesDue"));
-            assertEquals(5.0f, loanSchedule.get(1).get("penaltyChargesPaid"));
-            assertEquals(5.0f, loanSchedule.get(1).get("penaltyChargesOutstanding"));
-            assertEquals(1000.0f, loanSchedule.get(1).get("principalDue"));
-            assertEquals(0, loanSchedule.get(1).get("principalPaid"));
-            assertEquals(1000.0f, loanSchedule.get(1).get("principalOutstanding"));
-            assertEquals(1010.0f, loanSchedule.get(1).get("totalDueForPeriod"));
-            assertEquals(1005.0f, loanSchedule.get(1).get("totalOutstandingForPeriod"));
-            assertEquals(5.0f, loanSchedule.get(1).get("totalPaidForPeriod"));
+            assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesDue().floatValue());
+            assertEquals(5.0f, loanSchedule.get(1).getPenaltyChargesPaid().floatValue());
+            assertEquals(5.0f, loanSchedule.get(1).getPenaltyChargesOutstanding().floatValue());
+            assertEquals(1000.0f, loanSchedule.get(1).getPrincipalDue().floatValue());
+            assertEquals(0.0f, loanSchedule.get(1).getPrincipalPaid().floatValue());
+            assertEquals(1000.0f, loanSchedule.get(1).getPrincipalOutstanding().floatValue());
+            assertEquals(1010.0f, loanSchedule.get(1).getTotalDueForPeriod().floatValue());
+            assertEquals(1005.0f, loanSchedule.get(1).getTotalOutstandingForPeriod().floatValue());
+            assertEquals(5.0f, loanSchedule.get(1).getTotalPaidForPeriod().floatValue());
 
-            loanSummary = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "summary");
-            assertEquals(10.0f, loanSummary.get("penaltyChargesCharged"));
-            assertEquals(5.0f, loanSummary.get("penaltyChargesOutstanding"));
-            assertEquals(5.0f, loanSummary.get("penaltyChargesPaid"));
-            assertEquals(1000.0f, loanSummary.get("principalDisbursed"));
-            assertEquals(1000.0f, loanSummary.get("principalOutstanding"));
-            assertEquals(0.0f, loanSummary.get("principalPaid"));
-            assertEquals(1005.0f, loanSummary.get("totalOutstanding"));
+            loanSummary = getLoanDetails(loanID).getSummary();
+            assertEquals(10.0f, loanSummary.getPenaltyChargesCharged().floatValue());
+            assertEquals(5.0f, loanSummary.getPenaltyChargesOutstanding().floatValue());
+            assertEquals(5.0f, loanSummary.getPenaltyChargesPaid().floatValue());
+            assertEquals(1000.0f, loanSummary.getPrincipalDisbursed().floatValue());
+            assertEquals(1000.0f, loanSummary.getPrincipalOutstanding().floatValue());
+            assertEquals(0.0f, loanSummary.getPrincipalPaid().floatValue());
+            assertEquals(1005.0f, loanSummary.getTotalOutstanding().floatValue());
         } finally {
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(false));
@@ -5484,62 +5123,71 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         try {
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
-            BUSINESS_DATE_HELPER.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("01 November 2022").dateFormat(DATETIME_PATTERN).locale("en"));
-            final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-            final Account assetFeeAndPenaltyAccount = ACCOUNT_HELPER.createAssetAccount();
-            final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-            final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-            final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
-            final PostGLAccountsResponse uniqueIncomeAccountForFee = ACCOUNT_HELPER.createGLAccount(new PostGLAccountsRequest()
+            updateBusinessDate("01 November 2022");
+            final Account assetAccount = accountHelper.createAssetAccount();
+            final Account assetFeeAndPenaltyAccount = accountHelper.createAssetAccount();
+            final Account incomeAccount = accountHelper.createIncomeAccount();
+            final Account expenseAccount = accountHelper.createExpenseAccount();
+            final Account overpaymentAccount = accountHelper.createLiabilityAccount();
+            final PostGLAccountsResponse uniqueIncomeAccountForFee = accountHelper.createGLAccount(new PostGLAccountsRequest()
                     .type(GLAccountType.INCOME.getValue())
                     .glCode(Utils.uniqueRandomStringGenerator("UNIQUE_FEE_INCOME" + Calendar.getInstance().getTimeInMillis(), 5))
                     .manualEntriesAllowed(true)
                     .name(Utils.uniqueRandomStringGenerator("UNIQUE_FEE_INCOME" + Calendar.getInstance().getTimeInMillis(), 5)).usage(1));
-            final PostGLAccountsResponse uniqueIncomeAccountForPenalty = ACCOUNT_HELPER.createGLAccount(new PostGLAccountsRequest()
+            final PostGLAccountsResponse uniqueIncomeAccountForPenalty = accountHelper.createGLAccount(new PostGLAccountsRequest()
                     .type(GLAccountType.INCOME.getValue())
                     .glCode(Utils.uniqueRandomStringGenerator("UNIQUE_PENALTY_INCOME" + Calendar.getInstance().getTimeInMillis(), 5))
                     .manualEntriesAllowed(true)
                     .name(Utils.uniqueRandomStringGenerator("UNIQUE_PENALTY_INCOME" + Calendar.getInstance().getTimeInMillis(), 5))
                     .usage(1));
 
-            PostChargesResponse penaltyCharge = CHARGES_HELPER.createCharges(new ChargeRequest().penalty(true).amount(10.0)
+            PostChargesResponse penaltyCharge = chargesHelper.createCharge(new ChargeRequest().penalty(true).amount(10.0)
                     .chargeCalculationType(ChargeCalculationType.FLAT.getValue())
                     .chargeTimeType(ChargeTimeType.SPECIFIED_DUE_DATE.getValue()).chargePaymentMode(ChargePaymentMode.REGULAR.getValue())
                     .currencyCode("USD").name(Utils.randomStringGenerator("PENALTY_" + Calendar.getInstance().getTimeInMillis(), 5))
                     .chargeAppliesTo(1).locale("en").active(true));
 
-            PostChargesResponse feeCharge = CHARGES_HELPER.createCharges(new ChargeRequest().penalty(false).amount(9.0)
+            PostChargesResponse feeCharge = chargesHelper.createCharge(new ChargeRequest().penalty(false).amount(9.0)
                     .chargeCalculationType(ChargeCalculationType.FLAT.getValue())
                     .chargeTimeType(ChargeTimeType.SPECIFIED_DUE_DATE.getValue()).chargePaymentMode(ChargePaymentMode.REGULAR.getValue())
                     .currencyCode("USD").name(Utils.randomStringGenerator("FEE_" + Calendar.getInstance().getTimeInMillis(), 5))
                     .chargeAppliesTo(1).locale("en").active(true));
 
-            final String loanProductJSON = new LoanProductTestBuilder().withPrincipal("1000").withRepaymentTypeAsMonth()
-                    .withRepaymentAfterEvery("1").withNumberOfRepayments("1").withRepaymentTypeAsMonth().withinterestRatePerPeriod("0")
-                    .withInterestRateFrequencyTypeAsMonths().withAmortizationTypeAsEqualPrincipalPayment().withInterestTypeAsFlat()
-                    .withAccountingRulePeriodicAccrual(new Account[] { assetAccount, incomeAccount, expenseAccount, overpaymentAccount })
-                    .withDaysInMonth("30").withDaysInYear("365").withMoratorium("0", "0")
-                    .withFeeToIncomeAccountMapping(feeCharge.getResourceId(), uniqueIncomeAccountForFee.getResourceId())
-                    .withPenaltyToIncomeAccountMapping(penaltyCharge.getResourceId(), uniqueIncomeAccountForPenalty.getResourceId())
-                    .withFeeAndPenaltyAssetAccount(assetFeeAndPenaltyAccount).build(null);
-            final Integer loanProductID = LOAN_TRANSACTION_HELPER.getLoanProductId(loanProductJSON);
+            PostLoanProductsRequest product = baseLoanProduct()//
+                    .principal(1000.00)//
+                    .numberOfRepayments(1)//
+                    .repaymentEvery(1)//
+                    .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS_L)//
+                    .interestRatePerPeriod(0.0)//
+                    .interestRateFrequencyType(LoanTestData.InterestRateFrequencyType.MONTHS)//
+                    .amortizationType(LoanTestData.AmortizationType.EQUAL_PRINCIPAL)//
+                    .interestType(LoanTestData.InterestType.FLAT)//
+                    .daysInMonthType(30)//
+                    .daysInYearType(365)//
+                    .graceOnPrincipalPayment(0)//
+                    .graceOnInterestPayment(0)//
+                    .feeToIncomeAccountMappings(List.of(new LoanProductChargeToGLAccountMapper().chargeId(feeCharge.getResourceId())
+                            .incomeAccountId(uniqueIncomeAccountForFee.getResourceId())))//
+                    .penaltyToIncomeAccountMappings(List.of(new LoanProductChargeToGLAccountMapper().chargeId(penaltyCharge.getResourceId())
+                            .incomeAccountId(uniqueIncomeAccountForPenalty.getResourceId())));
+            withAccounting(product, ACCRUAL_PERIODIC, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
+            // withFeeAndPenaltyAssetAccount: fee and penalty receivables point at a dedicated asset account
+            product.receivableFeeAccountId(assetFeeAndPenaltyAccount.getAccountID().longValue())//
+                    .receivablePenaltyAccountId(assetFeeAndPenaltyAccount.getAccountID().longValue());
+            final Long loanProductID = createLoanProduct(product);
 
-            final PostClientsResponse client = CLIENT_HELPER.createClient(ClientHelper.defaultClientCreationRequest());
+            final Long clientID = createClient();
 
-            final Integer loanID = applyForLoanApplication(client.getClientId().intValue(), loanProductID);
+            final Long loanID = applyForLoanApplication(clientID, loanProductID);
 
-            HashMap<String, Object> loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+            verifyLoanIsPending(loanID);
 
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("02 September 2022", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-            LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+            verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("02 September 2022", loanID));
 
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+            GetLoansLoanIdResponse loanStatusHashMap = disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
+            verifyLoanIsActive(loanStatusHashMap);
 
-            GetLoansLoanIdResponse loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanID);
             List<GetLoansLoanIdRepaymentPeriod> loanSchedulePeriods = loanDetails.getRepaymentSchedule().getPeriods();
             assertEquals(2, loanSchedulePeriods.size());
             assertEquals(0.0, Utils.getDoubleValue(loanSchedulePeriods.get(1).getPenaltyChargesDue()));
@@ -5548,27 +5196,27 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(1000.0, Utils.getDoubleValue(loanSchedulePeriods.get(1).getTotalOutstandingForPeriod()));
 
             LocalDate targetDate = LocalDate.of(2022, 9, 7);
-            final String penaltyCharge1AddedDate = DATE_TIME_FORMATTER.format(targetDate);
-            Integer penaltyLoanChargeId = LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                    .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penaltyCharge.getResourceId()), penaltyCharge1AddedDate, "10"));
+            final String penaltyCharge1AddedDate = dateTimeFormatter.format(targetDate);
+            Long penaltyLoanChargeId = addLoanCharge(loanID, penaltyCharge.getResourceId(), penaltyCharge1AddedDate, 10.0).getResourceId();
 
-            final String penalty1LoanChargeDate = DATE_TIME_FORMATTER.format(targetDate);
-            PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting(penalty1LoanChargeDate);
+            final String penalty1LoanChargeDate = dateTimeFormatter.format(targetDate);
+            runPeriodicAccrualAccounting(penalty1LoanChargeDate);
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
             List<GetLoansLoanIdTransactions> transactions = loanDetails.getTransactions();
             assertEquals(10.0, Utils.getDoubleValue(transactions.get(1).getAmount()));
             assertTrue(transactions.get(1).getType().getAccrual());
             assertEquals(10.0, Utils.getDoubleValue(transactions.get(1).getPenaltyChargesPortion()));
             Long accrualTransactionId = transactions.get(1).getId();
 
-            List<HashMap> journalEntries = JOURNAL_ENTRY_HELPER.getJournalEntriesByTransactionId("L" + accrualTransactionId);
-            assertEquals(10.0f, (float) journalEntries.get(0).get("amount"));
-            assertEquals(assetFeeAndPenaltyAccount.getAccountID(), (int) journalEntries.get(0).get("glAccountId"));
-            assertEquals("DEBIT", ((HashMap) journalEntries.get(0).get("entryType")).get("value"));
-            assertEquals(10.0f, (float) journalEntries.get(1).get("amount"));
-            assertEquals(uniqueIncomeAccountForPenalty.getResourceId(), (int) journalEntries.get(1).get("glAccountId"));
-            assertEquals("CREDIT", ((HashMap) journalEntries.get(1).get("entryType")).get("value"));
+            List<JournalEntryTransactionItem> journalEntries = journalHelper.getJournalEntriesByTransactionId("L" + accrualTransactionId)
+                    .getPageItems();
+            assertEquals(10.0f, journalEntries.get(0).getAmount().floatValue());
+            assertEquals(assetFeeAndPenaltyAccount.getAccountID(), journalEntries.get(0).getGlAccountId().intValue());
+            assertEquals("DEBIT", journalEntries.get(0).getEntryType().getValue());
+            assertEquals(10.0f, journalEntries.get(1).getAmount().floatValue());
+            assertEquals(uniqueIncomeAccountForPenalty.getResourceId(), journalEntries.get(1).getGlAccountId().intValue());
+            assertEquals("CREDIT", journalEntries.get(1).getEntryType().getValue());
 
             loanSchedulePeriods = loanDetails.getRepaymentSchedule().getPeriods();
             assertEquals(2, loanSchedulePeriods.size());
@@ -5583,10 +5231,10 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(1010.0, Utils.getDoubleValue(loanSummary.getTotalOutstanding()));
 
             String externalId = UUID.randomUUID().toString();
-            PostLoansLoanIdChargesChargeIdResponse chargeAdjustmentResponse = LOAN_TRANSACTION_HELPER.chargeAdjustment((long) loanID,
-                    (long) penaltyLoanChargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(10.0).externalId(externalId));
+            PostLoansLoanIdChargesChargeIdResponse chargeAdjustmentResponse = chargeAdjustment((long) loanID, (long) penaltyLoanChargeId,
+                    new PostLoansLoanIdChargesChargeIdRequest().amount(10.0).externalId(externalId));
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
 
             loanSchedulePeriods = loanDetails.getRepaymentSchedule().getPeriods();
             assertEquals(2, loanSchedulePeriods.size());
@@ -5609,43 +5257,42 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(10.0, Utils.getDoubleValue(transactions.get(2).getPenaltyChargesPortion()));
             Long chargeAdjustmentTransactionId = transactions.get(2).getId();
 
-            journalEntries = JOURNAL_ENTRY_HELPER.getJournalEntriesByTransactionId("L" + chargeAdjustmentTransactionId);
-            assertEquals(10.0f, (float) journalEntries.get(0).get("amount"));
-            assertEquals(uniqueIncomeAccountForPenalty.getResourceId().intValue(), (int) journalEntries.get(0).get("glAccountId"));
-            assertEquals("DEBIT", ((HashMap) journalEntries.get(0).get("entryType")).get("value"));
-            assertEquals(10.0f, (float) journalEntries.get(1).get("amount"));
-            assertEquals(assetFeeAndPenaltyAccount.getAccountID(), (int) journalEntries.get(1).get("glAccountId"));
-            assertEquals("CREDIT", ((HashMap) journalEntries.get(1).get("entryType")).get("value"));
+            journalEntries = journalHelper.getJournalEntriesByTransactionId("L" + chargeAdjustmentTransactionId).getPageItems();
+            assertEquals(10.0f, journalEntries.get(0).getAmount().floatValue());
+            assertEquals(uniqueIncomeAccountForPenalty.getResourceId().intValue(), journalEntries.get(0).getGlAccountId().intValue());
+            assertEquals("DEBIT", journalEntries.get(0).getEntryType().getValue());
+            assertEquals(10.0f, journalEntries.get(1).getAmount().floatValue());
+            assertEquals(assetFeeAndPenaltyAccount.getAccountID(), journalEntries.get(1).getGlAccountId().intValue());
+            assertEquals("CREDIT", journalEntries.get(1).getEntryType().getValue());
 
             String uuid = UUID.randomUUID().toString();
-            LOAN_TRANSACTION_HELPER.reverseLoanTransaction((long) loanID, chargeAdjustmentTransactionId,
+            reverseLoanTransaction((long) loanID, chargeAdjustmentTransactionId,
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("08 September 2022")
                             .transactionAmount(0.0).locale("en").reversalExternalId(uuid));
 
-            journalEntries = JOURNAL_ENTRY_HELPER.getJournalEntriesByTransactionId("L" + chargeAdjustmentTransactionId);
-            assertEquals(10.0f, (float) journalEntries.get(0).get("amount"));
-            assertEquals(uniqueIncomeAccountForPenalty.getResourceId().intValue(), (int) journalEntries.get(0).get("glAccountId"));
-            assertEquals("CREDIT", ((HashMap) journalEntries.get(0).get("entryType")).get("value"));
-            assertEquals(10.0f, (float) journalEntries.get(1).get("amount"));
-            assertEquals(assetFeeAndPenaltyAccount.getAccountID(), (int) journalEntries.get(1).get("glAccountId"));
-            assertEquals("DEBIT", ((HashMap) journalEntries.get(1).get("entryType")).get("value"));
-            assertEquals(10.0f, (float) journalEntries.get(2).get("amount"));
-            assertEquals(uniqueIncomeAccountForPenalty.getResourceId().intValue(), (int) journalEntries.get(2).get("glAccountId"));
-            assertEquals("DEBIT", ((HashMap) journalEntries.get(2).get("entryType")).get("value"));
-            assertEquals(10.0f, (float) journalEntries.get(3).get("amount"));
-            assertEquals(assetFeeAndPenaltyAccount.getAccountID(), (int) journalEntries.get(3).get("glAccountId"));
-            assertEquals("CREDIT", ((HashMap) journalEntries.get(3).get("entryType")).get("value"));
+            journalEntries = journalHelper.getJournalEntriesByTransactionId("L" + chargeAdjustmentTransactionId).getPageItems();
+            assertEquals(10.0f, journalEntries.get(0).getAmount().floatValue());
+            assertEquals(uniqueIncomeAccountForPenalty.getResourceId().intValue(), journalEntries.get(0).getGlAccountId().intValue());
+            assertEquals("CREDIT", journalEntries.get(0).getEntryType().getValue());
+            assertEquals(10.0f, journalEntries.get(1).getAmount().floatValue());
+            assertEquals(assetFeeAndPenaltyAccount.getAccountID(), journalEntries.get(1).getGlAccountId().intValue());
+            assertEquals("DEBIT", journalEntries.get(1).getEntryType().getValue());
+            assertEquals(10.0f, journalEntries.get(2).getAmount().floatValue());
+            assertEquals(uniqueIncomeAccountForPenalty.getResourceId().intValue(), journalEntries.get(2).getGlAccountId().intValue());
+            assertEquals("DEBIT", journalEntries.get(2).getEntryType().getValue());
+            assertEquals(10.0f, journalEntries.get(3).getAmount().floatValue());
+            assertEquals(assetFeeAndPenaltyAccount.getAccountID(), journalEntries.get(3).getGlAccountId().intValue());
+            assertEquals("CREDIT", journalEntries.get(3).getEntryType().getValue());
 
             targetDate = LocalDate.of(2022, 9, 10);
-            final String feeCharge1AddedDate = DATE_TIME_FORMATTER.format(targetDate);
-            Integer feeLoanChargeId = LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                    .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(feeCharge.getResourceId()), feeCharge1AddedDate, "3"));
+            final String feeCharge1AddedDate = dateTimeFormatter.format(targetDate);
+            Long feeLoanChargeId = addLoanCharge(loanID, feeCharge.getResourceId(), feeCharge1AddedDate, 3.0).getResourceId();
 
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            final String feeLoanChargeDate = DATE_TIME_FORMATTER.format(targetDate);
-            PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting(feeLoanChargeDate);
+            final String feeLoanChargeDate = dateTimeFormatter.format(targetDate);
+            runPeriodicAccrualAccounting(feeLoanChargeDate);
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
             transactions = loanDetails.getTransactions();
             assertEquals(3.0, Utils.getDoubleValue(transactions.get(2).getAmount()));
             assertTrue(transactions.get(2).getType().getAccrual());
@@ -5653,14 +5300,14 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertTrue(StringUtils.isNotBlank(transactions.get(2).getExternalId()));
             accrualTransactionId = transactions.get(2).getId();
 
-            journalEntries = JOURNAL_ENTRY_HELPER.getJournalEntriesByTransactionId("L" + accrualTransactionId);
+            journalEntries = journalHelper.getJournalEntriesByTransactionId("L" + accrualTransactionId).getPageItems();
             // FINERACT-2323: Journal entry order changed - DEBIT entries come first, then CREDIT entries
-            assertEquals(3.0f, (float) journalEntries.get(0).get("amount"));
-            assertEquals(assetFeeAndPenaltyAccount.getAccountID(), (int) journalEntries.get(0).get("glAccountId"));
-            assertEquals("DEBIT", ((HashMap) journalEntries.get(0).get("entryType")).get("value"));
-            assertEquals(3.0f, (float) journalEntries.get(1).get("amount"));
-            assertEquals(uniqueIncomeAccountForFee.getResourceId().intValue(), (int) journalEntries.get(1).get("glAccountId"));
-            assertEquals("CREDIT", ((HashMap) journalEntries.get(1).get("entryType")).get("value"));
+            assertEquals(3.0f, journalEntries.get(0).getAmount().floatValue());
+            assertEquals(assetFeeAndPenaltyAccount.getAccountID(), journalEntries.get(0).getGlAccountId().intValue());
+            assertEquals("DEBIT", journalEntries.get(0).getEntryType().getValue());
+            assertEquals(3.0f, journalEntries.get(1).getAmount().floatValue());
+            assertEquals(uniqueIncomeAccountForFee.getResourceId().intValue(), journalEntries.get(1).getGlAccountId().intValue());
+            assertEquals("CREDIT", journalEntries.get(1).getEntryType().getValue());
 
             loanSchedulePeriods = loanDetails.getRepaymentSchedule().getPeriods();
             assertEquals(2, loanSchedulePeriods.size());
@@ -5678,14 +5325,14 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(3.0, Utils.getDoubleValue(loanSummary.getFeeChargesOutstanding()));
             assertEquals(1013.0, Utils.getDoubleValue(loanSummary.getTotalOutstanding()));
 
-            LOAN_TRANSACTION_HELPER.makeLoanRepayment((long) loanID, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+            makeLoanRepayment((long) loanID, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
                     .transactionDate("11 September 2022").locale("en").transactionAmount(5.0));
 
             externalId = UUID.randomUUID().toString();
-            chargeAdjustmentResponse = LOAN_TRANSACTION_HELPER.chargeAdjustment((long) loanID, (long) feeLoanChargeId,
+            chargeAdjustmentResponse = chargeAdjustment((long) loanID, (long) feeLoanChargeId,
                     new PostLoansLoanIdChargesChargeIdRequest().amount(2.0).externalId(externalId));
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
 
             loanSchedulePeriods = loanDetails.getRepaymentSchedule().getPeriods();
             assertEquals(2, loanSchedulePeriods.size());
@@ -5722,19 +5369,19 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(0.0, Utils.getDoubleValue(transactions.get(5).getPrincipalPortion()));
             chargeAdjustmentTransactionId = transactions.get(5).getId();
 
-            journalEntries = JOURNAL_ENTRY_HELPER.getJournalEntriesByTransactionId("L" + chargeAdjustmentTransactionId);
-            assertEquals(2.0f, (float) journalEntries.get(0).get("amount"));
-            assertEquals(uniqueIncomeAccountForFee.getResourceId().intValue(), (int) journalEntries.get(0).get("glAccountId"));
-            assertEquals("DEBIT", ((HashMap) journalEntries.get(0).get("entryType")).get("value"));
-            assertEquals(2.0f, (float) journalEntries.get(1).get("amount"));
-            assertEquals(assetFeeAndPenaltyAccount.getAccountID(), (int) journalEntries.get(1).get("glAccountId"));
-            assertEquals("CREDIT", ((HashMap) journalEntries.get(1).get("entryType")).get("value"));
+            journalEntries = journalHelper.getJournalEntriesByTransactionId("L" + chargeAdjustmentTransactionId).getPageItems();
+            assertEquals(2.0f, journalEntries.get(0).getAmount().floatValue());
+            assertEquals(uniqueIncomeAccountForFee.getResourceId().intValue(), journalEntries.get(0).getGlAccountId().intValue());
+            assertEquals("DEBIT", journalEntries.get(0).getEntryType().getValue());
+            assertEquals(2.0f, journalEntries.get(1).getAmount().floatValue());
+            assertEquals(assetFeeAndPenaltyAccount.getAccountID(), journalEntries.get(1).getGlAccountId().intValue());
+            assertEquals("CREDIT", journalEntries.get(1).getEntryType().getValue());
 
             externalId = UUID.randomUUID().toString();
-            chargeAdjustmentResponse = LOAN_TRANSACTION_HELPER.chargeAdjustment((long) loanID, (long) penaltyLoanChargeId,
+            chargeAdjustmentResponse = chargeAdjustment((long) loanID, (long) penaltyLoanChargeId,
                     new PostLoansLoanIdChargesChargeIdRequest().amount(7.0).externalId(externalId));
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
 
             loanSchedulePeriods = loanDetails.getRepaymentSchedule().getPeriods();
             assertEquals(2, loanSchedulePeriods.size());
@@ -5771,36 +5418,36 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(1.0, Utils.getDoubleValue(transactions.get(6).getPrincipalPortion()));
             chargeAdjustmentTransactionId = transactions.get(6).getId();
 
-            journalEntries = JOURNAL_ENTRY_HELPER.getJournalEntriesByTransactionId("L" + chargeAdjustmentTransactionId);
-            assertEquals(7.0f, (float) journalEntries.get(0).get("amount"));
-            assertEquals(uniqueIncomeAccountForPenalty.getResourceId().intValue(), (int) journalEntries.get(0).get("glAccountId"));
-            assertEquals("DEBIT", ((HashMap) journalEntries.get(0).get("entryType")).get("value"));
-            if (assetAccount.getAccountID() == (int) journalEntries.get(1).get("glAccountId")) {
-                assertEquals(1.0f, (float) journalEntries.get(1).get("amount"));
-                assertEquals(assetAccount.getAccountID(), (int) journalEntries.get(1).get("glAccountId"));
-                assertEquals("CREDIT", ((HashMap) journalEntries.get(1).get("entryType")).get("value"));
+            journalEntries = journalHelper.getJournalEntriesByTransactionId("L" + chargeAdjustmentTransactionId).getPageItems();
+            assertEquals(7.0f, journalEntries.get(0).getAmount().floatValue());
+            assertEquals(uniqueIncomeAccountForPenalty.getResourceId().intValue(), journalEntries.get(0).getGlAccountId().intValue());
+            assertEquals("DEBIT", journalEntries.get(0).getEntryType().getValue());
+            if (assetAccount.getAccountID() == journalEntries.get(1).getGlAccountId().intValue()) {
+                assertEquals(1.0f, journalEntries.get(1).getAmount().floatValue());
+                assertEquals(assetAccount.getAccountID(), journalEntries.get(1).getGlAccountId().intValue());
+                assertEquals("CREDIT", journalEntries.get(1).getEntryType().getValue());
 
-                assertEquals(6.0f, (float) journalEntries.get(2).get("amount"));
-                assertEquals(assetFeeAndPenaltyAccount.getAccountID(), (int) journalEntries.get(2).get("glAccountId"));
-                assertEquals("CREDIT", ((HashMap) journalEntries.get(2).get("entryType")).get("value"));
+                assertEquals(6.0f, journalEntries.get(2).getAmount().floatValue());
+                assertEquals(assetFeeAndPenaltyAccount.getAccountID(), journalEntries.get(2).getGlAccountId().intValue());
+                assertEquals("CREDIT", journalEntries.get(2).getEntryType().getValue());
             } else {
-                assertEquals(1.0f, (float) journalEntries.get(2).get("amount"));
-                assertEquals(assetAccount.getAccountID(), (int) journalEntries.get(2).get("glAccountId"));
-                assertEquals("CREDIT", ((HashMap) journalEntries.get(2).get("entryType")).get("value"));
+                assertEquals(1.0f, journalEntries.get(2).getAmount().floatValue());
+                assertEquals(assetAccount.getAccountID(), journalEntries.get(2).getGlAccountId().intValue());
+                assertEquals("CREDIT", journalEntries.get(2).getEntryType().getValue());
 
-                assertEquals(6.0f, (float) journalEntries.get(1).get("amount"));
-                assertEquals(assetFeeAndPenaltyAccount.getAccountID(), (int) journalEntries.get(1).get("glAccountId"));
-                assertEquals("CREDIT", ((HashMap) journalEntries.get(1).get("entryType")).get("value"));
+                assertEquals(6.0f, journalEntries.get(1).getAmount().floatValue());
+                assertEquals(assetFeeAndPenaltyAccount.getAccountID(), journalEntries.get(1).getGlAccountId().intValue());
+                assertEquals("CREDIT", journalEntries.get(1).getEntryType().getValue());
             }
 
-            LOAN_TRANSACTION_HELPER.makeLoanRepayment((long) loanID, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+            makeLoanRepayment((long) loanID, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
                     .transactionDate("13 September 2022").locale("en").transactionAmount(998.0));
 
             externalId = UUID.randomUUID().toString();
-            chargeAdjustmentResponse = LOAN_TRANSACTION_HELPER.chargeAdjustment((long) loanID, (long) feeLoanChargeId,
+            chargeAdjustmentResponse = chargeAdjustment((long) loanID, (long) feeLoanChargeId,
                     new PostLoansLoanIdChargesChargeIdRequest().amount(1.0).externalId(externalId));
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
 
             loanSchedulePeriods = loanDetails.getRepaymentSchedule().getPeriods();
             assertEquals(2, loanSchedulePeriods.size());
@@ -5837,21 +5484,21 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(1.0, Utils.getDoubleValue(transactions.get(8).getPrincipalPortion()));
             chargeAdjustmentTransactionId = transactions.get(8).getId();
 
-            journalEntries = JOURNAL_ENTRY_HELPER.getJournalEntriesByTransactionId("L" + chargeAdjustmentTransactionId);
-            assertEquals(1.0f, (float) journalEntries.get(0).get("amount"));
-            assertEquals(uniqueIncomeAccountForFee.getResourceId().intValue(), (int) journalEntries.get(0).get("glAccountId"));
-            assertEquals("DEBIT", ((HashMap) journalEntries.get(0).get("entryType")).get("value"));
-            assertEquals(1.0f, (float) journalEntries.get(1).get("amount"));
-            assertEquals(assetAccount.getAccountID(), (int) journalEntries.get(1).get("glAccountId"));
-            assertEquals("CREDIT", ((HashMap) journalEntries.get(1).get("entryType")).get("value"));
+            journalEntries = journalHelper.getJournalEntriesByTransactionId("L" + chargeAdjustmentTransactionId).getPageItems();
+            assertEquals(1.0f, journalEntries.get(0).getAmount().floatValue());
+            assertEquals(uniqueIncomeAccountForFee.getResourceId().intValue(), journalEntries.get(0).getGlAccountId().intValue());
+            assertEquals("DEBIT", journalEntries.get(0).getEntryType().getValue());
+            assertEquals(1.0f, journalEntries.get(1).getAmount().floatValue());
+            assertEquals(assetAccount.getAccountID(), journalEntries.get(1).getGlAccountId().intValue());
+            assertEquals("CREDIT", journalEntries.get(1).getEntryType().getValue());
 
             assertTrue(loanDetails.getStatus().getClosedObligationsMet());
 
             externalId = UUID.randomUUID().toString();
-            chargeAdjustmentResponse = LOAN_TRANSACTION_HELPER.chargeAdjustment((long) loanID, (long) penaltyLoanChargeId,
+            chargeAdjustmentResponse = chargeAdjustment((long) loanID, (long) penaltyLoanChargeId,
                     new PostLoansLoanIdChargesChargeIdRequest().amount(1.0).externalId(externalId));
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
 
             transactions = loanDetails.getTransactions();
             assertEquals(1.0, Utils.getDoubleValue(transactions.get(9).getAmount()));
@@ -5862,13 +5509,13 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(1.0, Utils.getDoubleValue(transactions.get(9).getOverpaymentPortion()));
             chargeAdjustmentTransactionId = transactions.get(9).getId();
 
-            journalEntries = JOURNAL_ENTRY_HELPER.getJournalEntriesByTransactionId("L" + chargeAdjustmentTransactionId);
-            assertEquals(1.0f, (float) journalEntries.get(0).get("amount"));
-            assertEquals(uniqueIncomeAccountForPenalty.getResourceId().intValue(), (int) journalEntries.get(0).get("glAccountId"));
-            assertEquals("DEBIT", ((HashMap) journalEntries.get(0).get("entryType")).get("value"));
-            assertEquals(1.0f, (float) journalEntries.get(1).get("amount"));
-            assertEquals(overpaymentAccount.getAccountID(), (int) journalEntries.get(1).get("glAccountId"));
-            assertEquals("CREDIT", ((HashMap) journalEntries.get(1).get("entryType")).get("value"));
+            journalEntries = journalHelper.getJournalEntriesByTransactionId("L" + chargeAdjustmentTransactionId).getPageItems();
+            assertEquals(1.0f, journalEntries.get(0).getAmount().floatValue());
+            assertEquals(uniqueIncomeAccountForPenalty.getResourceId().intValue(), journalEntries.get(0).getGlAccountId().intValue());
+            assertEquals("DEBIT", journalEntries.get(0).getEntryType().getValue());
+            assertEquals(1.0f, journalEntries.get(1).getAmount().floatValue());
+            assertEquals(overpaymentAccount.getAccountID(), journalEntries.get(1).getGlAccountId().intValue());
+            assertEquals("CREDIT", journalEntries.get(1).getEntryType().getValue());
 
             assertTrue(loanDetails.getStatus().getOverpaid());
         } finally {
@@ -5880,292 +5527,283 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
 
     @Test
     public void undoWaivedChargeWaiveTransactionDoesNotExist() {
-        final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-        final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-        final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-        final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+        final Account assetAccount = accountHelper.createAssetAccount();
+        final Account incomeAccount = accountHelper.createIncomeAccount();
+        final Account expenseAccount = accountHelper.createExpenseAccount();
+        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-        final Integer loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount, expenseAccount,
+        final Long loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount, expenseAccount,
                 overpaymentAccount);
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC, "01 January 2011");
+        final Long clientID = createClient("01 January 2011");
 
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID);
 
-        HashMap<String, Object> loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("02 September 2022", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("02 September 2022", loanID));
 
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        final Integer loanTransactionId = (Integer) ((Map) ((List) JsonPath.from(loanDetails).get("transactions")).get(0)).get("id");
-        LoanTransactionHelper loanTransactionHelper = new LoanTransactionHelper(REQUEST_SPEC, createResponseSpecification(403));
-        HashMap response = loanTransactionHelper.undoWaiveChargesForLoan(loanID, loanTransactionId, "");
-        assertEquals("error.msg.loan.transaction.undo.waive.charge",
-                ((Map) ((List) response.get("errors")).get(0)).get("userMessageGlobalisationCode"));
-        assertEquals("Transaction is not a waive charge type.", ((Map) ((List) response.get("errors")).get(0)).get("defaultUserMessage"));
+        GetLoansLoanIdResponse loanStatusHashMap = disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
+        verifyLoanIsActive(loanStatusHashMap);
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanID);
+        final Long loanTransactionId = loanDetails.getTransactions().get(0).getId();
+        CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class, () -> undoWaiveLoanCharge(loanID,
+                loanTransactionId, new PutChargeTransactionChangesRequest().id(loanTransactionId).loanId(loanID)));
+        assertEquals(403, exception.getStatus());
+        assertTrue(exception.getMessage().contains("error.msg.loan.transaction.undo.waive.charge"));
+        assertTrue(exception.getMessage().contains("Transaction is not a waive charge type."));
     }
 
     @Test
     public void undoWaivedCharge() {
-        final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-        final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-        final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-        final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+        final Account assetAccount = accountHelper.createAssetAccount();
+        final Account incomeAccount = accountHelper.createIncomeAccount();
+        final Account expenseAccount = accountHelper.createExpenseAccount();
+        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-        Integer penalty = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", true));
-        final Integer loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount, expenseAccount,
+        Long penalty = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.FLAT, 10.0, true).getResourceId();
+        final Long loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount, expenseAccount,
                 overpaymentAccount);
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC, "01 January 2011");
+        final Long clientID = createClient("01 January 2011");
 
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID);
+        final Long loanID = applyForLoanApplication(clientID, loanProductID);
 
-        HashMap<String, Object> loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        verifyLoanIsPending(loanID);
 
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("02 September 2022", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("02 September 2022", loanID));
 
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        GetLoansLoanIdResponse loanStatusHashMap = disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
+        verifyLoanIsActive(loanStatusHashMap);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
         assertEquals(2, loanSchedule.size());
-        assertEquals(0, loanSchedule.get(1).get("feeChargesDue"));
-        assertEquals(0, loanSchedule.get(1).get("feeChargesOutstanding"));
-        assertEquals(0, loanSchedule.get(1).get("penaltyChargesDue"));
-        assertEquals(0, loanSchedule.get(1).get("penaltyChargesOutstanding"));
-        assertEquals(1000.0f, loanSchedule.get(1).get("totalDueForPeriod"));
-        assertEquals(1000.0f, loanSchedule.get(1).get("totalOutstandingForPeriod"));
+        assertEquals(0.0f, loanSchedule.get(1).getFeeChargesDue().floatValue());
+        assertEquals(0.0f, loanSchedule.get(1).getFeeChargesOutstanding().floatValue());
+        assertEquals(0.0f, loanSchedule.get(1).getPenaltyChargesDue().floatValue());
+        assertEquals(0.0f, loanSchedule.get(1).getPenaltyChargesOutstanding().floatValue());
+        assertEquals(1000.0f, loanSchedule.get(1).getTotalDueForPeriod().floatValue());
+        assertEquals(1000.0f, loanSchedule.get(1).getTotalOutstandingForPeriod().floatValue());
         LocalDate targetDate = LocalDate.of(2022, 9, 7);
-        final String penaltyCharge1AddedDate = DATE_TIME_FORMATTER.format(targetDate);
-        Integer penalty1LoanChargeId = LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID,
-                LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), penaltyCharge1AddedDate, "10"));
+        final String penaltyCharge1AddedDate = dateTimeFormatter.format(targetDate);
+        Long penalty1LoanChargeId = addLoanCharge(loanID, penalty, penaltyCharge1AddedDate, 10.0).getResourceId();
 
-        LOAN_TRANSACTION_HELPER.noAccrualTransactionForRepayment(loanID);
+        assertNoAccrualTransactions(loanID);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         assertEquals(2, loanSchedule.size());
-        assertEquals(0, loanSchedule.get(1).get("feeChargesDue"));
-        assertEquals(0, loanSchedule.get(1).get("feeChargesOutstanding"));
-        assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesDue"));
-        assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesOutstanding"));
-        assertEquals(1010.0f, loanSchedule.get(1).get("totalDueForPeriod"));
-        assertEquals(1010.0f, loanSchedule.get(1).get("totalOutstandingForPeriod"));
-        assertEquals(0, loanSchedule.get(1).get("totalWaivedForPeriod"));
+        assertEquals(0.0f, loanSchedule.get(1).getFeeChargesDue().floatValue());
+        assertEquals(0.0f, loanSchedule.get(1).getFeeChargesOutstanding().floatValue());
+        assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesDue().floatValue());
+        assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesOutstanding().floatValue());
+        assertEquals(1010.0f, loanSchedule.get(1).getTotalDueForPeriod().floatValue());
+        assertEquals(1010.0f, loanSchedule.get(1).getTotalOutstandingForPeriod().floatValue());
+        assertEquals(0, loanSchedule.get(1).getTotalWaivedForPeriod().floatValue());
 
-        HashMap loanSummary = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "summary");
-        assertEquals(10.0f, loanSummary.get("penaltyChargesCharged"));
-        assertEquals(10.0f, loanSummary.get("penaltyChargesOutstanding"));
-        assertEquals(0.0f, loanSummary.get("penaltyChargesWaived"));
-        assertEquals(0.0f, loanSummary.get("feeChargesCharged"));
-        assertEquals(0.0f, loanSummary.get("feeChargesOutstanding"));
-        assertEquals(0.0f, loanSummary.get("feeChargesWaived"));
-        assertEquals(1010.0f, loanSummary.get("totalOutstanding"));
-        assertEquals(0.0f, loanSummary.get("totalWaived"));
+        GetLoansLoanIdSummary loanSummary = getLoanDetails(loanID).getSummary();
+        assertEquals(10.0f, loanSummary.getPenaltyChargesCharged().floatValue());
+        assertEquals(10.0f, loanSummary.getPenaltyChargesOutstanding().floatValue());
+        assertEquals(0.0f, loanSummary.getPenaltyChargesWaived().floatValue());
+        assertEquals(0.0f, loanSummary.getFeeChargesCharged().floatValue());
+        assertEquals(0.0f, loanSummary.getFeeChargesOutstanding().floatValue());
+        assertEquals(0.0f, loanSummary.getFeeChargesWaived().floatValue());
+        assertEquals(1010.0f, loanSummary.getTotalOutstanding().floatValue());
+        assertEquals(0.0f, loanSummary.getTotalWaived().floatValue());
 
-        LOAN_TRANSACTION_HELPER.waiveChargesForLoan(loanID, penalty1LoanChargeId, "");
+        waiveWholeLoanCharge(loanID, penalty1LoanChargeId);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         assertEquals(2, loanSchedule.size());
-        assertEquals(0, loanSchedule.get(1).get("feeChargesDue"));
-        assertEquals(0, loanSchedule.get(1).get("feeChargesOutstanding"));
-        assertEquals(0, loanSchedule.get(1).get("feeChargesWaived"));
-        assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesDue"));
-        assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesWaived"));
-        assertEquals(0.0f, loanSchedule.get(1).get("penaltyChargesOutstanding"));
-        assertEquals(1010.0f, loanSchedule.get(1).get("totalDueForPeriod"));
-        assertEquals(1000.0f, loanSchedule.get(1).get("totalOutstandingForPeriod"));
-        assertEquals(10.0f, loanSchedule.get(1).get("totalWaivedForPeriod"));
+        assertEquals(0.0f, loanSchedule.get(1).getFeeChargesDue().floatValue());
+        assertEquals(0.0f, loanSchedule.get(1).getFeeChargesOutstanding().floatValue());
+        assertEquals(0.0f, loanSchedule.get(1).getFeeChargesWaived().floatValue());
+        assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesDue().floatValue());
+        assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesWaived().floatValue());
+        assertEquals(0.0f, loanSchedule.get(1).getPenaltyChargesOutstanding().floatValue());
+        assertEquals(1010.0f, loanSchedule.get(1).getTotalDueForPeriod().floatValue());
+        assertEquals(1000.0f, loanSchedule.get(1).getTotalOutstandingForPeriod().floatValue());
+        assertEquals(10.0f, loanSchedule.get(1).getTotalWaivedForPeriod().floatValue());
 
-        loanSummary = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "summary");
-        assertEquals(10.0f, loanSummary.get("penaltyChargesCharged"));
-        assertEquals(0.0f, loanSummary.get("penaltyChargesOutstanding"));
-        assertEquals(10.0f, loanSummary.get("penaltyChargesWaived"));
-        assertEquals(0.0f, loanSummary.get("feeChargesCharged"));
-        assertEquals(0.0f, loanSummary.get("feeChargesOutstanding"));
-        assertEquals(0.0f, loanSummary.get("feeChargesWaived"));
-        assertEquals(1000.0f, loanSummary.get("totalOutstanding"));
-        assertEquals(10.0f, loanSummary.get("totalWaived"));
+        loanSummary = getLoanDetails(loanID).getSummary();
+        assertEquals(10.0f, loanSummary.getPenaltyChargesCharged().floatValue());
+        assertEquals(0.0f, loanSummary.getPenaltyChargesOutstanding().floatValue());
+        assertEquals(10.0f, loanSummary.getPenaltyChargesWaived().floatValue());
+        assertEquals(0.0f, loanSummary.getFeeChargesCharged().floatValue());
+        assertEquals(0.0f, loanSummary.getFeeChargesOutstanding().floatValue());
+        assertEquals(0.0f, loanSummary.getFeeChargesWaived().floatValue());
+        assertEquals(1000.0f, loanSummary.getTotalOutstanding().floatValue());
+        assertEquals(10.0f, loanSummary.getTotalWaived().floatValue());
 
-        List<HashMap> transactions = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "transactions");
-        assertEquals(10.0f, (float) transactions.get(1).get("amount"));
-        assertEquals(9, (int) ((HashMap) transactions.get(1).get("type")).get("id"));
-        Integer waiveTransactionId = (int) transactions.get(1).get("id");
-        LOAN_TRANSACTION_HELPER.undoWaiveChargesForLoan(loanID, waiveTransactionId, "");
+        List<GetLoansLoanIdTransactions> transactions = getLoanDetails(loanID).getTransactions();
+        assertEquals(10.0f, transactions.get(1).getAmount().floatValue());
+        assertEquals(9, transactions.get(1).getType().getId().intValue());
+        Long waiveTransactionId = transactions.get(1).getId();
+        undoWaiveLoanCharge(loanID, waiveTransactionId, new PutChargeTransactionChangesRequest().id(waiveTransactionId).loanId(loanID));
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         assertEquals(2, loanSchedule.size());
-        assertEquals(0, loanSchedule.get(1).get("feeChargesDue"));
-        assertEquals(0, loanSchedule.get(1).get("feeChargesOutstanding"));
-        assertEquals(0, loanSchedule.get(1).get("feeChargesWaived"));
-        assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesDue"));
-        assertEquals(0, loanSchedule.get(1).get("penaltyChargesWaived"));
-        assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesOutstanding"));
-        assertEquals(1010.0f, loanSchedule.get(1).get("totalDueForPeriod"));
-        assertEquals(1010.0f, loanSchedule.get(1).get("totalOutstandingForPeriod"));
-        assertEquals(0, loanSchedule.get(1).get("totalWaivedForPeriod"));
+        assertEquals(0.0f, loanSchedule.get(1).getFeeChargesDue().floatValue());
+        assertEquals(0.0f, loanSchedule.get(1).getFeeChargesOutstanding().floatValue());
+        assertEquals(0.0f, loanSchedule.get(1).getFeeChargesWaived().floatValue());
+        assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesDue().floatValue());
+        assertEquals(0.0f, loanSchedule.get(1).getPenaltyChargesWaived().floatValue());
+        assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesOutstanding().floatValue());
+        assertEquals(1010.0f, loanSchedule.get(1).getTotalDueForPeriod().floatValue());
+        assertEquals(1010.0f, loanSchedule.get(1).getTotalOutstandingForPeriod().floatValue());
+        assertEquals(0, loanSchedule.get(1).getTotalWaivedForPeriod().floatValue());
 
-        loanSummary = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "summary");
-        assertEquals(10.0f, loanSummary.get("penaltyChargesCharged"));
-        assertEquals(10.0f, loanSummary.get("penaltyChargesOutstanding"));
-        assertEquals(0.0f, loanSummary.get("penaltyChargesWaived"));
-        assertEquals(0.0f, loanSummary.get("feeChargesCharged"));
-        assertEquals(0.0f, loanSummary.get("feeChargesOutstanding"));
-        assertEquals(0.0f, loanSummary.get("feeChargesWaived"));
-        assertEquals(1010.0f, loanSummary.get("totalOutstanding"));
-        assertEquals(0.0f, loanSummary.get("totalWaived"));
+        loanSummary = getLoanDetails(loanID).getSummary();
+        assertEquals(10.0f, loanSummary.getPenaltyChargesCharged().floatValue());
+        assertEquals(10.0f, loanSummary.getPenaltyChargesOutstanding().floatValue());
+        assertEquals(0.0f, loanSummary.getPenaltyChargesWaived().floatValue());
+        assertEquals(0.0f, loanSummary.getFeeChargesCharged().floatValue());
+        assertEquals(0.0f, loanSummary.getFeeChargesOutstanding().floatValue());
+        assertEquals(0.0f, loanSummary.getFeeChargesWaived().floatValue());
+        assertEquals(1010.0f, loanSummary.getTotalOutstanding().floatValue());
+        assertEquals(0.0f, loanSummary.getTotalWaived().floatValue());
 
-        transactions = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "transactions");
-        assertEquals(10.0f, (float) transactions.get(1).get("amount"));
-        assertEquals(9, (int) ((HashMap) transactions.get(1).get("type")).get("id"));
-        assertEquals(true, transactions.get(1).get("manuallyReversed"));
+        transactions = getLoanDetails(loanID).getTransactions();
+        assertEquals(10.0f, transactions.get(1).getAmount().floatValue());
+        assertEquals(9, transactions.get(1).getType().getId().intValue());
+        assertEquals(true, transactions.get(1).getManuallyReversed());
 
-        Integer fee = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", false));
+        Long fee = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.FLAT, 10.0, false).getResourceId();
 
-        final String feeCharge1AddedDate = DATE_TIME_FORMATTER.format(targetDate);
-        Integer fee1LoanChargeId = LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID,
-                LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(fee), feeCharge1AddedDate, "10"));
+        final String feeCharge1AddedDate = dateTimeFormatter.format(targetDate);
+        Long fee1LoanChargeId = addLoanCharge(loanID, fee, feeCharge1AddedDate, 10.0).getResourceId();
 
-        PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting(feeCharge1AddedDate);
+        runPeriodicAccrualAccounting(feeCharge1AddedDate);
 
-        transactions = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "transactions");
-        assertEquals(10, (int) ((HashMap) transactions.get(2).get("type")).get("id"));
-        assertEquals(20.0f, (float) transactions.get(2).get("amount"));
-        Integer accrualTransactionId = (int) transactions.get(2).get("id");
+        transactions = getLoanDetails(loanID).getTransactions();
+        assertEquals(10, transactions.get(2).getType().getId().intValue());
+        assertEquals(20.0f, transactions.get(2).getAmount().floatValue());
+        Long accrualTransactionId = transactions.get(2).getId();
 
-        List<HashMap> journalEntries = JOURNAL_ENTRY_HELPER.getJournalEntriesByTransactionId("L" + accrualTransactionId);
+        List<JournalEntryTransactionItem> journalEntries = journalHelper.getJournalEntriesByTransactionId("L" + accrualTransactionId)
+                .getPageItems();
         // FINERACT-2323: Due to multiple legs for journal entries, the system now uses charge-specific GL accounts
         // instead of product-level defaults. The journal entry structure has changed with alternating DEBIT/CREDIT
         // pairs.
         // This transaction accrues both penalty (10) and fee (10) charges.
         // Entry 0: DEBIT for penalty receivable
-        assertEquals(10.0f, (float) journalEntries.get(0).get("amount"));
-        assertEquals(assetAccount.getAccountID(), (int) journalEntries.get(0).get("glAccountId"));
-        assertEquals("DEBIT", ((HashMap) journalEntries.get(0).get("entryType")).get("value"));
+        assertEquals(10.0f, journalEntries.get(0).getAmount().floatValue());
+        assertEquals(assetAccount.getAccountID(), journalEntries.get(0).getGlAccountId().intValue());
+        assertEquals("DEBIT", journalEntries.get(0).getEntryType().getValue());
         // Entry 1: CREDIT for penalty income
-        assertEquals(10.0f, (float) journalEntries.get(1).get("amount"));
-        assertEquals(incomeAccount.getAccountID(), (int) journalEntries.get(1).get("glAccountId"));
-        assertEquals("CREDIT", ((HashMap) journalEntries.get(1).get("entryType")).get("value"));
+        assertEquals(10.0f, journalEntries.get(1).getAmount().floatValue());
+        assertEquals(incomeAccount.getAccountID(), journalEntries.get(1).getGlAccountId().intValue());
+        assertEquals("CREDIT", journalEntries.get(1).getEntryType().getValue());
         // Entry 2: DEBIT for fee receivable (uses charge-specific or fallback account due to FINERACT-2323)
-        assertEquals(10.0f, (float) journalEntries.get(2).get("amount"));
+        assertEquals(10.0f, journalEntries.get(2).getAmount().floatValue());
         // Due to FINERACT-2323, the fee uses a different asset account
-        assertEquals(assetAccount.getAccountID(), (int) journalEntries.get(2).get("glAccountId"));
-        assertEquals("DEBIT", ((HashMap) journalEntries.get(2).get("entryType")).get("value"));
+        assertEquals(assetAccount.getAccountID(), journalEntries.get(2).getGlAccountId().intValue());
+        assertEquals("DEBIT", journalEntries.get(2).getEntryType().getValue());
         // Entry 3: CREDIT for fee income
-        assertEquals(10.0f, (float) journalEntries.get(3).get("amount"));
-        assertEquals(incomeAccount.getAccountID(), (int) journalEntries.get(3).get("glAccountId"));
-        assertEquals("CREDIT", ((HashMap) journalEntries.get(3).get("entryType")).get("value"));
+        assertEquals(10.0f, journalEntries.get(3).getAmount().floatValue());
+        assertEquals(incomeAccount.getAccountID(), journalEntries.get(3).getGlAccountId().intValue());
+        assertEquals("CREDIT", journalEntries.get(3).getEntryType().getValue());
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         assertEquals(2, loanSchedule.size());
-        assertEquals(10.0f, loanSchedule.get(1).get("feeChargesDue"));
-        assertEquals(10.0f, loanSchedule.get(1).get("feeChargesOutstanding"));
-        assertEquals(0, loanSchedule.get(1).get("feeChargesWaived"));
-        assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesDue"));
-        assertEquals(0, loanSchedule.get(1).get("penaltyChargesWaived"));
-        assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesOutstanding"));
-        assertEquals(1020.0f, loanSchedule.get(1).get("totalDueForPeriod"));
-        assertEquals(1020.0f, loanSchedule.get(1).get("totalOutstandingForPeriod"));
-        assertEquals(0, loanSchedule.get(1).get("totalWaivedForPeriod"));
+        assertEquals(10.0f, loanSchedule.get(1).getFeeChargesDue().floatValue());
+        assertEquals(10.0f, loanSchedule.get(1).getFeeChargesOutstanding().floatValue());
+        assertEquals(0.0f, loanSchedule.get(1).getFeeChargesWaived().floatValue());
+        assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesDue().floatValue());
+        assertEquals(0.0f, loanSchedule.get(1).getPenaltyChargesWaived().floatValue());
+        assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesOutstanding().floatValue());
+        assertEquals(1020.0f, loanSchedule.get(1).getTotalDueForPeriod().floatValue());
+        assertEquals(1020.0f, loanSchedule.get(1).getTotalOutstandingForPeriod().floatValue());
+        assertEquals(0, loanSchedule.get(1).getTotalWaivedForPeriod().floatValue());
 
-        loanSummary = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "summary");
-        assertEquals(10.0f, loanSummary.get("penaltyChargesCharged"));
-        assertEquals(10.0f, loanSummary.get("penaltyChargesOutstanding"));
-        assertEquals(0.0f, loanSummary.get("penaltyChargesWaived"));
-        assertEquals(10.0f, loanSummary.get("feeChargesCharged"));
-        assertEquals(10.0f, loanSummary.get("feeChargesOutstanding"));
-        assertEquals(0.0f, loanSummary.get("feeChargesWaived"));
-        assertEquals(1020.0f, loanSummary.get("totalOutstanding"));
-        assertEquals(0.0f, loanSummary.get("totalWaived"));
+        loanSummary = getLoanDetails(loanID).getSummary();
+        assertEquals(10.0f, loanSummary.getPenaltyChargesCharged().floatValue());
+        assertEquals(10.0f, loanSummary.getPenaltyChargesOutstanding().floatValue());
+        assertEquals(0.0f, loanSummary.getPenaltyChargesWaived().floatValue());
+        assertEquals(10.0f, loanSummary.getFeeChargesCharged().floatValue());
+        assertEquals(10.0f, loanSummary.getFeeChargesOutstanding().floatValue());
+        assertEquals(0.0f, loanSummary.getFeeChargesWaived().floatValue());
+        assertEquals(1020.0f, loanSummary.getTotalOutstanding().floatValue());
+        assertEquals(0.0f, loanSummary.getTotalWaived().floatValue());
 
-        LOAN_TRANSACTION_HELPER.waiveChargesForLoan(loanID, fee1LoanChargeId, "");
+        waiveWholeLoanCharge(loanID, fee1LoanChargeId);
 
-        transactions = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "transactions");
-        assertEquals(10.0f, (float) transactions.get(3).get("amount"));
-        assertEquals(9, (int) ((HashMap) transactions.get(3).get("type")).get("id"));
-        Integer waive2TransactionId = (int) transactions.get(3).get("id");
+        transactions = getLoanDetails(loanID).getTransactions();
+        assertEquals(10.0f, transactions.get(3).getAmount().floatValue());
+        assertEquals(9, transactions.get(3).getType().getId().intValue());
+        Long waive2TransactionId = transactions.get(3).getId();
 
-        journalEntries = JOURNAL_ENTRY_HELPER.getJournalEntriesByTransactionId("L" + waive2TransactionId);
-        assertEquals(10.0f, (float) journalEntries.get(0).get("amount"));
-        assertEquals(expenseAccount.getAccountID(), (int) journalEntries.get(0).get("glAccountId"));
-        assertEquals("DEBIT", ((HashMap) journalEntries.get(0).get("entryType")).get("value"));
-        assertEquals(10.0f, (float) journalEntries.get(1).get("amount"));
-        assertEquals(assetAccount.getAccountID(), (int) journalEntries.get(1).get("glAccountId"));
-        assertEquals("CREDIT", ((HashMap) journalEntries.get(1).get("entryType")).get("value"));
+        journalEntries = journalHelper.getJournalEntriesByTransactionId("L" + waive2TransactionId).getPageItems();
+        assertEquals(10.0f, journalEntries.get(0).getAmount().floatValue());
+        assertEquals(expenseAccount.getAccountID(), journalEntries.get(0).getGlAccountId().intValue());
+        assertEquals("DEBIT", journalEntries.get(0).getEntryType().getValue());
+        assertEquals(10.0f, journalEntries.get(1).getAmount().floatValue());
+        assertEquals(assetAccount.getAccountID(), journalEntries.get(1).getGlAccountId().intValue());
+        assertEquals("CREDIT", journalEntries.get(1).getEntryType().getValue());
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         assertEquals(2, loanSchedule.size());
-        assertEquals(10.0f, loanSchedule.get(1).get("feeChargesDue"));
-        assertEquals(0.0f, loanSchedule.get(1).get("feeChargesOutstanding"));
-        assertEquals(10.0f, loanSchedule.get(1).get("feeChargesWaived"));
-        assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesDue"));
-        assertEquals(0, loanSchedule.get(1).get("penaltyChargesWaived"));
-        assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesOutstanding"));
-        assertEquals(1020.0f, loanSchedule.get(1).get("totalDueForPeriod"));
-        assertEquals(1010.0f, loanSchedule.get(1).get("totalOutstandingForPeriod"));
-        assertEquals(10.0f, loanSchedule.get(1).get("totalWaivedForPeriod"));
+        assertEquals(10.0f, loanSchedule.get(1).getFeeChargesDue().floatValue());
+        assertEquals(0.0f, loanSchedule.get(1).getFeeChargesOutstanding().floatValue());
+        assertEquals(10.0f, loanSchedule.get(1).getFeeChargesWaived().floatValue());
+        assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesDue().floatValue());
+        assertEquals(0.0f, loanSchedule.get(1).getPenaltyChargesWaived().floatValue());
+        assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesOutstanding().floatValue());
+        assertEquals(1020.0f, loanSchedule.get(1).getTotalDueForPeriod().floatValue());
+        assertEquals(1010.0f, loanSchedule.get(1).getTotalOutstandingForPeriod().floatValue());
+        assertEquals(10.0f, loanSchedule.get(1).getTotalWaivedForPeriod().floatValue());
 
-        loanSummary = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "summary");
-        assertEquals(10.0f, loanSummary.get("penaltyChargesCharged"));
-        assertEquals(10.0f, loanSummary.get("penaltyChargesOutstanding"));
-        assertEquals(0.0f, loanSummary.get("penaltyChargesWaived"));
-        assertEquals(10.0f, loanSummary.get("feeChargesCharged"));
-        assertEquals(0.0f, loanSummary.get("feeChargesOutstanding"));
-        assertEquals(10.0f, loanSummary.get("feeChargesWaived"));
-        assertEquals(1010.0f, loanSummary.get("totalOutstanding"));
-        assertEquals(10.0f, loanSummary.get("totalWaived"));
+        loanSummary = getLoanDetails(loanID).getSummary();
+        assertEquals(10.0f, loanSummary.getPenaltyChargesCharged().floatValue());
+        assertEquals(10.0f, loanSummary.getPenaltyChargesOutstanding().floatValue());
+        assertEquals(0.0f, loanSummary.getPenaltyChargesWaived().floatValue());
+        assertEquals(10.0f, loanSummary.getFeeChargesCharged().floatValue());
+        assertEquals(0.0f, loanSummary.getFeeChargesOutstanding().floatValue());
+        assertEquals(10.0f, loanSummary.getFeeChargesWaived().floatValue());
+        assertEquals(1010.0f, loanSummary.getTotalOutstanding().floatValue());
+        assertEquals(10.0f, loanSummary.getTotalWaived().floatValue());
 
-        LOAN_TRANSACTION_HELPER.undoWaiveChargesForLoan(loanID, waive2TransactionId, "");
+        undoWaiveLoanCharge(loanID, waive2TransactionId, new PutChargeTransactionChangesRequest().id(waive2TransactionId).loanId(loanID));
 
-        transactions = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "transactions");
-        assertEquals(10.0f, (float) transactions.get(3).get("amount"));
-        assertEquals(9, (int) ((HashMap) transactions.get(3).get("type")).get("id"));
-        assertEquals(true, transactions.get(3).get("manuallyReversed"));
+        transactions = getLoanDetails(loanID).getTransactions();
+        assertEquals(10.0f, transactions.get(3).getAmount().floatValue());
+        assertEquals(9, transactions.get(3).getType().getId().intValue());
+        assertEquals(true, transactions.get(3).getManuallyReversed());
 
-        journalEntries = JOURNAL_ENTRY_HELPER.getJournalEntriesByTransactionId("L" + waive2TransactionId);
-        assertEquals(10.0f, (float) journalEntries.get(0).get("amount"));
-        assertEquals(expenseAccount.getAccountID(), (int) journalEntries.get(0).get("glAccountId"));
-        assertEquals("CREDIT", ((HashMap) journalEntries.get(0).get("entryType")).get("value"));
-        assertEquals(10.0f, (float) journalEntries.get(1).get("amount"));
-        assertEquals(assetAccount.getAccountID(), (int) journalEntries.get(1).get("glAccountId"));
-        assertEquals("DEBIT", ((HashMap) journalEntries.get(1).get("entryType")).get("value"));
-        assertEquals(10.0f, (float) journalEntries.get(2).get("amount"));
-        assertEquals(expenseAccount.getAccountID(), (int) journalEntries.get(2).get("glAccountId"));
-        assertEquals("DEBIT", ((HashMap) journalEntries.get(2).get("entryType")).get("value"));
-        assertEquals(10.0f, (float) journalEntries.get(3).get("amount"));
-        assertEquals(assetAccount.getAccountID(), (int) journalEntries.get(3).get("glAccountId"));
-        assertEquals("CREDIT", ((HashMap) journalEntries.get(3).get("entryType")).get("value"));
+        journalEntries = journalHelper.getJournalEntriesByTransactionId("L" + waive2TransactionId).getPageItems();
+        assertEquals(10.0f, journalEntries.get(0).getAmount().floatValue());
+        assertEquals(expenseAccount.getAccountID(), journalEntries.get(0).getGlAccountId().intValue());
+        assertEquals("CREDIT", journalEntries.get(0).getEntryType().getValue());
+        assertEquals(10.0f, journalEntries.get(1).getAmount().floatValue());
+        assertEquals(assetAccount.getAccountID(), journalEntries.get(1).getGlAccountId().intValue());
+        assertEquals("DEBIT", journalEntries.get(1).getEntryType().getValue());
+        assertEquals(10.0f, journalEntries.get(2).getAmount().floatValue());
+        assertEquals(expenseAccount.getAccountID(), journalEntries.get(2).getGlAccountId().intValue());
+        assertEquals("DEBIT", journalEntries.get(2).getEntryType().getValue());
+        assertEquals(10.0f, journalEntries.get(3).getAmount().floatValue());
+        assertEquals(assetAccount.getAccountID(), journalEntries.get(3).getGlAccountId().intValue());
+        assertEquals("CREDIT", journalEntries.get(3).getEntryType().getValue());
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanID);
         assertEquals(2, loanSchedule.size());
-        assertEquals(10.0f, loanSchedule.get(1).get("feeChargesDue"));
-        assertEquals(10.0f, loanSchedule.get(1).get("feeChargesOutstanding"));
-        assertEquals(0, loanSchedule.get(1).get("feeChargesWaived"));
-        assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesDue"));
-        assertEquals(0, loanSchedule.get(1).get("penaltyChargesWaived"));
-        assertEquals(10.0f, loanSchedule.get(1).get("penaltyChargesOutstanding"));
-        assertEquals(1020.0f, loanSchedule.get(1).get("totalDueForPeriod"));
-        assertEquals(1020.0f, loanSchedule.get(1).get("totalOutstandingForPeriod"));
-        assertEquals(0, loanSchedule.get(1).get("totalWaivedForPeriod"));
+        assertEquals(10.0f, loanSchedule.get(1).getFeeChargesDue().floatValue());
+        assertEquals(10.0f, loanSchedule.get(1).getFeeChargesOutstanding().floatValue());
+        assertEquals(0.0f, loanSchedule.get(1).getFeeChargesWaived().floatValue());
+        assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesDue().floatValue());
+        assertEquals(0.0f, loanSchedule.get(1).getPenaltyChargesWaived().floatValue());
+        assertEquals(10.0f, loanSchedule.get(1).getPenaltyChargesOutstanding().floatValue());
+        assertEquals(1020.0f, loanSchedule.get(1).getTotalDueForPeriod().floatValue());
+        assertEquals(1020.0f, loanSchedule.get(1).getTotalOutstandingForPeriod().floatValue());
+        assertEquals(0, loanSchedule.get(1).getTotalWaivedForPeriod().floatValue());
 
-        loanSummary = LOAN_TRANSACTION_HELPER.getLoanDetail(REQUEST_SPEC, RESPONSE_SPEC, loanID, "summary");
-        assertEquals(10.0f, loanSummary.get("penaltyChargesCharged"));
-        assertEquals(10.0f, loanSummary.get("penaltyChargesOutstanding"));
-        assertEquals(0.0f, loanSummary.get("penaltyChargesWaived"));
-        assertEquals(10.0f, loanSummary.get("feeChargesCharged"));
-        assertEquals(10.0f, loanSummary.get("feeChargesOutstanding"));
-        assertEquals(0.0f, loanSummary.get("feeChargesWaived"));
-        assertEquals(1020.0f, loanSummary.get("totalOutstanding"));
-        assertEquals(0.0f, loanSummary.get("totalWaived"));
+        loanSummary = getLoanDetails(loanID).getSummary();
+        assertEquals(10.0f, loanSummary.getPenaltyChargesCharged().floatValue());
+        assertEquals(10.0f, loanSummary.getPenaltyChargesOutstanding().floatValue());
+        assertEquals(0.0f, loanSummary.getPenaltyChargesWaived().floatValue());
+        assertEquals(10.0f, loanSummary.getFeeChargesCharged().floatValue());
+        assertEquals(10.0f, loanSummary.getFeeChargesOutstanding().floatValue());
+        assertEquals(0.0f, loanSummary.getFeeChargesWaived().floatValue());
+        assertEquals(1020.0f, loanSummary.getTotalOutstanding().floatValue());
+        assertEquals(0.0f, loanSummary.getTotalWaived().floatValue());
     }
 
     @Test
@@ -6175,60 +5813,48 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
                     new PutGlobalConfigurationsRequest().enabled(true));
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
-            BUSINESS_DATE_HELPER.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("04 September 2022").dateFormat(DATETIME_PATTERN).locale("en"));
-            final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-            final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-            final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-            final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+            updateBusinessDate("04 September 2022");
+            final Account assetAccount = accountHelper.createAssetAccount();
+            final Account incomeAccount = accountHelper.createIncomeAccount();
+            final Account expenseAccount = accountHelper.createExpenseAccount();
+            final Account overpaymentAccount = accountHelper.createLiabilityAccount();
             String randomText = UUID.randomUUID().toString();
-            Integer chargeOffReasonId = CodeHelper.createChargeOffCodeValue(REQUEST_SPEC, RESPONSE_SPEC, randomText, 1);
-            final Integer loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterestMultiDisbursement(assetAccount,
+            Long chargeOffReasonId = codeHelper.createChargeOffCodeValue(randomText, 1);
+            final Long loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterestMultiDisbursement(assetAccount,
                     incomeAccount, expenseAccount, overpaymentAccount);
 
-            final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC, "01 January 2011");
+            final Long clientID = createClient("01 January 2011");
 
-            final Integer loanID = applyForLoanApplication(clientID, loanProductID);
+            final Long loanID = applyForLoanApplication(clientID, loanProductID);
 
-            HashMap<String, Object> loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
-
-            ResponseSpecification errorResponseSpec = new ResponseSpecBuilder().expectStatusCode(403).build();
-            LoanTransactionHelper errorLoanTransactionHelper = new LoanTransactionHelper(REQUEST_SPEC, errorResponseSpec);
+            verifyLoanIsPending(loanID);
 
             CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class, () -> {
-                errorLoanTransactionHelper.chargeOffLoan((long) loanID,
-                        new PostLoansLoanIdTransactionsRequest().transactionDate("4 September 2022").locale("en")
-                                .dateFormat(DATETIME_PATTERN).externalId(UUID.randomUUID().toString())
-                                .chargeOffReasonId((long) chargeOffReasonId));
+                chargeOffLoan(loanID, new PostLoansLoanIdTransactionsRequest().transactionDate("4 September 2022").locale("en")
+                        .dateFormat(DATETIME_PATTERN).externalId(UUID.randomUUID().toString()).chargeOffReasonId(chargeOffReasonId));
             });
 
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("error.msg.loan.is.not.active"));
 
-            exception = assertThrows(CallFailedRuntimeException.class, () -> {
-                LOAN_TRANSACTION_HELPER.undoChargeOffLoan((long) loanID, new PostLoansLoanIdTransactionsRequest());
-            });
-            assertEquals(403, exception.getResponse().code());
+            exception = assertThrows(CallFailedRuntimeException.class, () -> undoChargeOffLoan(loanID));
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("error.msg.loan.is.not.active"));
 
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("02 September 2022", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-            LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+            verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("02 September 2022", loanID));
 
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithTransactionAmount("02 September 2022", loanID, "1000");
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithTransactionAmount("03 September 2022", loanID, "1000");
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+            GetLoansLoanIdResponse loanStatusHashMap = disburseLoanWithTransactionAmount(loanID, "02 September 2022", "1000");
+            loanStatusHashMap = disburseLoanWithTransactionAmount(loanID, "03 September 2022", "1000");
+            verifyLoanIsActive(loanStatusHashMap);
 
             exception = assertThrows(CallFailedRuntimeException.class, () -> {
-                LOAN_TRANSACTION_HELPER.chargeOffLoan((long) loanID,
-                        new PostLoansLoanIdTransactionsRequest().transactionDate("1 October 2022").locale("en").dateFormat(DATETIME_PATTERN)
-                                .chargeOffReasonId((long) chargeOffReasonId));
+                chargeOffLoan((long) loanID, new PostLoansLoanIdTransactionsRequest().transactionDate("1 October 2022").locale("en")
+                        .dateFormat(DATETIME_PATTERN).chargeOffReasonId(chargeOffReasonId));
             });
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("error.msg.loan.transaction.cannot.be.a.future.date"));
 
-            GetLoansLoanIdResponse loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanID);
             assertTrue(loanDetails.getStatus().getActive());
             assertEquals(2000.0, Utils.getDoubleValue(loanDetails.getSummary().getTotalOutstanding()));
             assertFalse(loanDetails.getChargedOff());
@@ -6239,22 +5865,19 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertNull(loanDetails.getTimeline().getChargedOffByFirstname());
             assertNull(loanDetails.getTimeline().getChargedOffByLastname());
 
-            Integer flatPenaltySpecifiedDueDate = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "3", true));
-            LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                    .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flatPenaltySpecifiedDueDate), "04 September 2022", "3"));
-            Integer chargeId = LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID, LoanTransactionHelper
-                    .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flatPenaltySpecifiedDueDate), "04 September 2022", "5"));
+            Long flatPenaltySpecifiedDueDate = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.FLAT, 3.0, true)
+                    .getResourceId();
+            addLoanCharge(loanID, flatPenaltySpecifiedDueDate, "04 September 2022", 3.0);
+            Long chargeId = addLoanCharge(loanID, flatPenaltySpecifiedDueDate, "04 September 2022", 5.0).getResourceId();
 
-            PostLoansLoanIdChargesChargeIdResponse waiveChargeResponse = LOAN_TRANSACTION_HELPER.waiveLoanCharge((long) loanID,
-                    (long) chargeId, new PostLoansLoanIdChargesChargeIdRequest());
+            PostLoansLoanIdChargesChargeIdResponse waiveChargeResponse = waiveLoanCharge((long) loanID, (long) chargeId,
+                    new PostLoansLoanIdChargesChargeIdRequest().locale(LOCALE));
 
             String transactionExternalId = UUID.randomUUID().toString();
-            LOAN_TRANSACTION_HELPER.chargeOffLoan((long) loanID,
-                    new PostLoansLoanIdTransactionsRequest().transactionDate("4 September 2022").locale("en").dateFormat(DATETIME_PATTERN)
-                            .externalId(transactionExternalId).chargeOffReasonId((long) chargeOffReasonId));
+            chargeOffLoan((long) loanID, new PostLoansLoanIdTransactionsRequest().transactionDate("4 September 2022").locale("en")
+                    .dateFormat(DATETIME_PATTERN).externalId(transactionExternalId).chargeOffReasonId((long) chargeOffReasonId));
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
             assertTrue(loanDetails.getStatus().getActive());
             assertEquals(2003.0, Utils.getDoubleValue(loanDetails.getSummary().getTotalOutstanding()));
             assertTrue(loanDetails.getChargedOff());
@@ -6272,30 +5895,26 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(3.0, Utils.getDoubleValue(chargeOffTransaction.getPenaltyChargesPortion()));
 
             exception = assertThrows(CallFailedRuntimeException.class, () -> {
-                errorLoanTransactionHelper.chargeOffLoan((long) loanID,
-                        new PostLoansLoanIdTransactionsRequest().transactionDate("4 September 2022").locale("en")
-                                .dateFormat(DATETIME_PATTERN).externalId(UUID.randomUUID().toString())
-                                .chargeOffReasonId((long) chargeOffReasonId));
+                chargeOffLoan(loanID, new PostLoansLoanIdTransactionsRequest().transactionDate("4 September 2022").locale("en")
+                        .dateFormat(DATETIME_PATTERN).externalId(UUID.randomUUID().toString()).chargeOffReasonId(chargeOffReasonId));
             });
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("error.msg.loan.is.already.charged.off"));
 
-            HashMap chargeAddingError = errorLoanTransactionHelper.addChargesForLoanGetFullResponse(loanID, LoanTransactionHelper
-                    .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flatPenaltySpecifiedDueDate), "04 September 2022", "3"));
-
-            assertEquals("error.msg.loan.is.charged.off",
-                    ((Map) ((List) chargeAddingError.get("errors")).get(0)).get("userMessageGlobalisationCode"));
+            CallFailedRuntimeException chargeAddingError = assertThrows(CallFailedRuntimeException.class,
+                    () -> addLoanCharge(loanID, flatPenaltySpecifiedDueDate, "04 September 2022", 3.0));
+            assertEquals(403, chargeAddingError.getStatus());
+            assertTrue(chargeAddingError.getMessage().contains("error.msg.loan.is.charged.off"));
 
             exception = assertThrows(CallFailedRuntimeException.class, () -> {
-                errorLoanTransactionHelper.undoWaiveLoanCharge((long) loanID, waiveChargeResponse.getSubResourceId(),
-                        new PutChargeTransactionChangesRequest());
+                undoWaiveLoanCharge(loanID, waiveChargeResponse.getSubResourceId(), new PutChargeTransactionChangesRequest());
             });
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("error.msg.transaction.date.cannot.be.earlier.than.charge.off.date"));
 
-            LOAN_TRANSACTION_HELPER.undoChargeOffLoan((long) loanID, new PostLoansLoanIdTransactionsRequest());
+            undoChargeOffLoan(loanID);
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
             assertFalse(loanDetails.getChargedOff());
             assertNull(loanDetails.getSummary().getChargeOffReasonId());
             assertNull(loanDetails.getSummary().getChargeOffReason());
@@ -6307,128 +5926,122 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertTrue(undoChargeOffTransaction.getManuallyReversed());
 
             exception = assertThrows(CallFailedRuntimeException.class, () -> {
-                errorLoanTransactionHelper.undoChargeOffLoan((long) loanID, new PostLoansLoanIdTransactionsRequest());
+                undoChargeOffLoan(loanID);
             });
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("error.msg.loan.is.not.charged.off"));
 
-            BUSINESS_DATE_HELPER.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("08 September 2022").dateFormat(DATETIME_PATTERN).locale("en"));
+            updateBusinessDate("08 September 2022");
 
-            PostLoansLoanIdTransactionsResponse loanRepaymentResponse = LOAN_TRANSACTION_HELPER.makeLoanRepayment((long) loanID,
+            PostLoansLoanIdTransactionsResponse loanRepaymentResponse = makeLoanRepayment((long) loanID,
                     new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate("05 September 2022").locale("en")
                             .transactionAmount(5.0));
 
             exception = assertThrows(CallFailedRuntimeException.class, () -> {
-                errorLoanTransactionHelper.chargeOffLoan((long) loanID,
-                        new PostLoansLoanIdTransactionsRequest().transactionDate("04 September 2022").locale("en")
-                                .dateFormat(DATETIME_PATTERN).externalId(UUID.randomUUID().toString())
-                                .chargeOffReasonId((long) chargeOffReasonId));
+                chargeOffLoan(loanID, new PostLoansLoanIdTransactionsRequest().transactionDate("04 September 2022").locale("en")
+                        .dateFormat(DATETIME_PATTERN).externalId(UUID.randomUUID().toString()).chargeOffReasonId(chargeOffReasonId));
             });
 
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("error.msg.loan.charge.off.is.before.than.the.last.user.transaction"));
 
-            LOAN_TRANSACTION_HELPER.chargeOffLoan((long) loanID,
-                    new PostLoansLoanIdTransactionsRequest().transactionDate("06 September 2022").locale("en").dateFormat(DATETIME_PATTERN)
-                            .externalId(UUID.randomUUID().toString()).chargeOffReasonId((long) chargeOffReasonId));
+            chargeOffLoan((long) loanID, new PostLoansLoanIdTransactionsRequest().transactionDate("06 September 2022").locale("en")
+                    .dateFormat(DATETIME_PATTERN).externalId(UUID.randomUUID().toString()).chargeOffReasonId((long) chargeOffReasonId));
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
             chargeOffTransaction = loanDetails.getTransactions().get(loanDetails.getTransactions().size() - 1);
 
             assertEquals(1998.0, Utils.getDoubleValue(chargeOffTransaction.getAmount()));
             assertEquals(1998.0, Utils.getDoubleValue(chargeOffTransaction.getPrincipalPortion()));
 
-            LOAN_TRANSACTION_HELPER.makeLoanRepayment((long) loanID, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+            makeLoanRepayment((long) loanID, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
                     .transactionDate("07 September 2022").locale("en").transactionAmount(5.0));
 
             exception = assertThrows(CallFailedRuntimeException.class, () -> {
-                errorLoanTransactionHelper.undoChargeOffLoan((long) loanID, new PostLoansLoanIdTransactionsRequest());
+                undoChargeOffLoan(loanID);
             });
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("error.msg.loan.charge.off.is.not.the.last.user.transaction"));
 
             exception = assertThrows(CallFailedRuntimeException.class, () -> {
-                errorLoanTransactionHelper.makeWriteoff((long) loanID, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                writeOffLoan(loanID, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
                         .transactionDate("05 September 2022").locale("en"));
             });
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("error.msg.transaction.date.cannot.be.earlier.than.charge.off.date"));
 
             exception = assertThrows(CallFailedRuntimeException.class, () -> {
-                errorLoanTransactionHelper.closeLoan((long) loanID, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                closeLoan(loanID, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate("05 September 2022")
+                        .locale("en"));
+            });
+            assertEquals(403, exception.getStatus());
+            assertTrue(exception.getMessage().contains("error.msg.transaction.date.cannot.be.earlier.than.charge.off.date"));
+
+            exception = assertThrows(CallFailedRuntimeException.class, () -> {
+                forecloseLoan(loanID, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
                         .transactionDate("05 September 2022").locale("en"));
             });
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("error.msg.transaction.date.cannot.be.earlier.than.charge.off.date"));
 
             exception = assertThrows(CallFailedRuntimeException.class, () -> {
-                errorLoanTransactionHelper.forecloseLoan((long) loanID, new PostLoansLoanIdTransactionsRequest()
-                        .dateFormat(DATETIME_PATTERN).transactionDate("05 September 2022").locale("en"));
+                closeRescheduledLoan(loanID, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                        .transactionDate("05 September 2022").locale("en"));
             });
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
+            assertTrue(exception.getMessage().contains("error.msg.loan.is.charged.off"));
+
+            CallFailedRuntimeException disbursementDetailError = assertThrows(CallFailedRuntimeException.class,
+                    () -> addAndDeleteDisbursementDetail(loanID, List
+                            .of(new DisbursementDetail().expectedDisbursementDate("05 September 2022").principal(new BigDecimal("200")))));
+            assertEquals(403, disbursementDetailError.getStatus());
+            assertTrue(disbursementDetailError.getMessage().contains("error.msg.loan.is.charged.off"));
+
+            exception = assertThrows(CallFailedRuntimeException.class, () -> {
+                undoLastDisbursement(loanID, new PostLoansLoanIdRequest());
+            });
+            assertEquals(403, exception.getStatus());
+            assertTrue(exception.getMessage().contains("error.msg.loan.is.charged.off"));
+
+            exception = assertThrows(CallFailedRuntimeException.class, () -> {
+                undoDisbursement(loanID, new PostLoansLoanIdRequest());
+            });
+            assertEquals(403, exception.getStatus());
+            assertTrue(exception.getMessage().contains("error.msg.loan.is.charged.off"));
+
+            exception = assertThrows(CallFailedRuntimeException.class, () -> {
+                makeCreditBalanceRefund(loanID, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                        .transactionDate("05 September 2022").locale("en").transactionAmount(5.0));
+            });
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("error.msg.transaction.date.cannot.be.earlier.than.charge.off.date"));
 
             exception = assertThrows(CallFailedRuntimeException.class, () -> {
-                errorLoanTransactionHelper.closeRescheduledLoan((long) loanID, new PostLoansLoanIdTransactionsRequest()
-                        .dateFormat(DATETIME_PATTERN).transactionDate("05 September 2022").locale("en"));
+                disburseLoan(loanID, new PostLoansLoanIdRequest().actualDisbursementDate("4 September 2022")
+                        .transactionAmount(new BigDecimal("10")).locale("en").dateFormat(DATETIME_PATTERN));
             });
-            assertEquals(403, exception.getResponse().code());
-            assertTrue(exception.getMessage().contains("error.msg.loan.is.charged.off"));
-
-            HashMap disbursementDetailREsponse = (HashMap) errorLoanTransactionHelper.addAndDeleteDisbursementDetail(loanID, "1000",
-                    "03 September 2022", List.of(LOAN_TRANSACTION_HELPER.createTrancheDetail(null, "05 September 2022", "200")), "");
-
-            assertEquals("error.msg.loan.is.charged.off",
-                    ((Map) ((List) disbursementDetailREsponse.get("errors")).get(0)).get("userMessageGlobalisationCode"));
-
-            exception = assertThrows(CallFailedRuntimeException.class, () -> {
-                errorLoanTransactionHelper.undoLastDisbursalLoan((long) loanID, new PostLoansLoanIdRequest());
-            });
-            assertEquals(403, exception.getResponse().code());
-            assertTrue(exception.getMessage().contains("error.msg.loan.is.charged.off"));
-
-            exception = assertThrows(CallFailedRuntimeException.class, () -> {
-                errorLoanTransactionHelper.undoDisbursalLoan((long) loanID, new PostLoansLoanIdRequest());
-            });
-            assertEquals(403, exception.getResponse().code());
-            assertTrue(exception.getMessage().contains("error.msg.loan.is.charged.off"));
-
-            exception = assertThrows(CallFailedRuntimeException.class, () -> {
-                errorLoanTransactionHelper.makeCreditBalanceRefund((long) loanID, new PostLoansLoanIdTransactionsRequest()
-                        .dateFormat(DATETIME_PATTERN).transactionDate("05 September 2022").locale("en").transactionAmount(5.0));
-            });
-            assertEquals(403, exception.getResponse().code());
-            assertTrue(exception.getMessage().contains("error.msg.transaction.date.cannot.be.earlier.than.charge.off.date"));
-
-            exception = assertThrows(CallFailedRuntimeException.class, () -> {
-                errorLoanTransactionHelper.disburseLoan((long) loanID,
-                        new PostLoansLoanIdRequest().actualDisbursementDate("4 September 2022").transactionAmount(new BigDecimal("10"))
-                                .locale("en").dateFormat(DATETIME_PATTERN));
-            });
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("amount.can't.be.greater.than.maximum.applied.loan.amount.calculation"));
 
             exception = assertThrows(CallFailedRuntimeException.class, () -> {
-                errorLoanTransactionHelper.disburseLoan((long) loanID,
-                        new PostLoansLoanIdRequest().actualDisbursementDate("7 September 2022").transactionAmount(new BigDecimal("10"))
-                                .locale("en").dateFormat(DATETIME_PATTERN));
+                disburseLoan(loanID, new PostLoansLoanIdRequest().actualDisbursementDate("7 September 2022")
+                        .transactionAmount(new BigDecimal("10")).locale("en").dateFormat(DATETIME_PATTERN));
             });
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("amount.can't.be.greater.than.maximum.applied.loan.amount.calculation"));
 
-            LOAN_TRANSACTION_HELPER.makeLoanRepayment((long) loanID, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+            makeLoanRepayment((long) loanID, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
                     .transactionDate("07 September 2022").locale("en").transactionAmount(5000.0));
 
             exception = assertThrows(CallFailedRuntimeException.class, () -> {
-                errorLoanTransactionHelper.makeRefundByCash((long) loanID, new PostLoansLoanIdTransactionsRequest()
-                        .dateFormat(DATETIME_PATTERN).transactionDate("05 September 2022").locale("en").transactionAmount(5.0));
+                transactionHelper.makeRefundByCash(loanID, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                        .transactionDate("05 September 2022").locale("en").transactionAmount(5.0));
             });
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("error.msg.transaction.date.cannot.be.earlier.than.charge.off.date"));
 
-            LOAN_TRANSACTION_HELPER.makeCreditBalanceRefund((long) loanID, new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("08 September 2022").locale("en").transactionAmount(3007.0));
+            makeCreditBalanceRefund((long) loanID, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("08 September 2022").locale("en").transactionAmount(3007.0));
         } finally {
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(false));
@@ -6442,38 +6055,35 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         try {
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID,
                     new PutGlobalConfigurationsRequest().enabled(true));
-            final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-            final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-            final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-            final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+            final Account assetAccount = accountHelper.createAssetAccount();
+            final Account incomeAccount = accountHelper.createIncomeAccount();
+            final Account expenseAccount = accountHelper.createExpenseAccount();
+            final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-            final Integer loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount,
-                    expenseAccount, overpaymentAccount);
+            final Long loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount, expenseAccount,
+                    overpaymentAccount);
 
-            final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC, "01 January 2011");
+            final Long clientID = createClient("01 January 2011");
 
-            final Integer loanID = applyForLoanApplication(clientID, loanProductID);
+            final Long loanID = applyForLoanApplication(clientID, loanProductID);
 
-            HashMap<String, Object> loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+            verifyLoanIsPending(loanID);
 
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("02 September 2022", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-            LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+            verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("02 September 2022", loanID));
 
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+            GetLoansLoanIdResponse loanStatusHashMap = disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
+            verifyLoanIsActive(loanStatusHashMap);
 
-            GetLoansLoanIdResponse loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanID);
             LocalDate expectedMaturityDate = loanDetails.getTimeline().getExpectedMaturityDate();
             LocalDate actualMaturityDate = loanDetails.getTimeline().getActualMaturityDate();
 
             assertTrue(DateUtils.isEqual(expectedMaturityDate, actualMaturityDate));
 
-            LOAN_TRANSACTION_HELPER.makeRepayment("04 September 2022", Float.parseFloat("500"), loanID);
-            LOAN_TRANSACTION_HELPER.makeRepayment("05 September 2022", Float.parseFloat("700"), loanID);
+            makeRepayment("04 September 2022", Float.parseFloat("500"), loanID);
+            makeRepayment("05 September 2022", Float.parseFloat("700"), loanID);
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
 
             expectedMaturityDate = loanDetails.getTimeline().getExpectedMaturityDate();
             actualMaturityDate = loanDetails.getTimeline().getActualMaturityDate();
@@ -6481,11 +6091,11 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertNotNull(expectedMaturityDate);
             assertNull(actualMaturityDate);
 
-            LOAN_TRANSACTION_HELPER.reverseLoanTransaction((long) loanID, loanDetails.getTransactions().get(1).getId(),
+            reverseLoanTransaction((long) loanID, loanDetails.getTransactions().get(1).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("04 September 2022")
                             .transactionAmount(0.0).locale("en"));
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
 
             expectedMaturityDate = loanDetails.getTimeline().getExpectedMaturityDate();
             actualMaturityDate = loanDetails.getTimeline().getActualMaturityDate();
@@ -6505,34 +6115,31 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         try {
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID,
                     new PutGlobalConfigurationsRequest().enabled(true));
-            final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-            final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-            final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-            final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+            final Account assetAccount = accountHelper.createAssetAccount();
+            final Account incomeAccount = accountHelper.createIncomeAccount();
+            final Account expenseAccount = accountHelper.createExpenseAccount();
+            final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-            final Integer loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount,
-                    expenseAccount, overpaymentAccount);
+            final Long loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount, expenseAccount,
+                    overpaymentAccount);
 
-            final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC, "01 January 2011");
+            final Long clientID = createClient("01 January 2011");
 
-            final Integer loanID = applyForLoanApplication(clientID, loanProductID);
+            final Long loanID = applyForLoanApplication(clientID, loanProductID);
 
-            HashMap<String, Object> loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+            verifyLoanIsPending(loanID);
 
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("02 September 2022", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-            LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+            verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("02 September 2022", loanID));
 
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+            GetLoansLoanIdResponse loanStatusHashMap = disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
+            verifyLoanIsActive(loanStatusHashMap);
 
-            LOAN_TRANSACTION_HELPER.makeRepayment("04 September 2022", Float.parseFloat("500"), loanID);
-            LOAN_TRANSACTION_HELPER.makeRepayment("05 September 2022", Float.parseFloat("10"), loanID);
-            LOAN_TRANSACTION_HELPER.makeRepayment("06 September 2022", Float.parseFloat("400"), loanID);
-            LOAN_TRANSACTION_HELPER.makeRepayment("07 September 2022", Float.parseFloat("390"), loanID);
+            makeRepayment("04 September 2022", Float.parseFloat("500"), loanID);
+            makeRepayment("05 September 2022", Float.parseFloat("10"), loanID);
+            makeRepayment("06 September 2022", Float.parseFloat("400"), loanID);
+            makeRepayment("07 September 2022", Float.parseFloat("390"), loanID);
 
-            GetLoansLoanIdResponse loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanID);
 
             assertEquals(300.0, Utils.getDoubleValue(loanDetails.getTotalOverpaid()));
 
@@ -6553,11 +6160,11 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(300.0, Utils.getDoubleValue(loanDetails.getTransactions().get(4).getOverpaymentPortion()));
             assertEquals(LocalDate.of(2022, 9, 7), loanDetails.getTransactions().get(4).getDate());
 
-            LOAN_TRANSACTION_HELPER.reverseLoanTransaction((long) loanID, loanDetails.getTransactions().get(2).getId(),
+            reverseLoanTransaction((long) loanID, loanDetails.getTransactions().get(2).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("05 September 2022")
                             .transactionAmount(0.0).locale("en"));
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
 
             assertEquals(290.0, Utils.getDoubleValue(loanDetails.getTotalOverpaid()));
 
@@ -6579,11 +6186,11 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(290.0, Utils.getDoubleValue(loanDetails.getTransactions().get(4).getOverpaymentPortion()));
             assertEquals(LocalDate.of(2022, 9, 7), loanDetails.getTransactions().get(4).getDate());
 
-            LOAN_TRANSACTION_HELPER.reverseLoanTransaction((long) loanID, loanDetails.getTransactions().get(1).getId(),
+            reverseLoanTransaction((long) loanID, loanDetails.getTransactions().get(1).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("05 September 2022")
                             .transactionAmount(0.0).locale("en"));
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
 
             assertEquals(210.0, Utils.getDoubleValue(loanDetails.getSummary().getTotalOutstanding()));
 
@@ -6605,9 +6212,9 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(390.0, Utils.getDoubleValue(loanDetails.getTransactions().get(4).getPrincipalPortion()));
             assertEquals(LocalDate.of(2022, 9, 7), loanDetails.getTransactions().get(4).getDate());
 
-            LOAN_TRANSACTION_HELPER.makeRepayment("04 September 2022", Float.parseFloat("500"), loanID);
+            makeRepayment("04 September 2022", Float.parseFloat("500"), loanID);
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
 
             assertEquals(290.0, Utils.getDoubleValue(loanDetails.getTotalOverpaid()));
 
@@ -6646,42 +6253,38 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
                     new PutGlobalConfigurationsRequest().enabled(true));
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
-            BUSINESS_DATE_HELPER.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("10 October 2022").dateFormat(DATETIME_PATTERN).locale("en"));
+            updateBusinessDate("10 October 2022");
 
-            final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-            final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-            final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-            final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+            final Account assetAccount = accountHelper.createAssetAccount();
+            final Account incomeAccount = accountHelper.createIncomeAccount();
+            final Account expenseAccount = accountHelper.createExpenseAccount();
+            final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-            final Integer loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount,
-                    expenseAccount, overpaymentAccount);
+            final Long loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount, expenseAccount,
+                    overpaymentAccount);
 
-            final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC, "01 January 2011");
+            final Long clientID = createClient("01 January 2011");
 
-            final Integer loanID = applyForLoanApplication(clientID, loanProductID);
+            final Long loanID = applyForLoanApplication(clientID, loanProductID);
 
-            HashMap<String, Object> loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+            verifyLoanIsPending(loanID);
 
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("02 September 2022", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-            LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+            verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("02 September 2022", loanID));
 
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+            GetLoansLoanIdResponse loanStatusHashMap = disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
+            verifyLoanIsActive(loanStatusHashMap);
 
-            LOAN_TRANSACTION_HELPER.makeRepayment("04 September 2022", Float.parseFloat("100"), loanID);
-            LOAN_TRANSACTION_HELPER.makeRepayment("05 September 2022", Float.parseFloat("1100"), loanID);
+            makeRepayment("04 September 2022", Float.parseFloat("100"), loanID);
+            makeRepayment("05 September 2022", Float.parseFloat("1100"), loanID);
 
-            GetLoansLoanIdResponse loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanID);
             assertEquals(200.0, Utils.getDoubleValue(loanDetails.getTotalOverpaid()));
             assertTrue(loanDetails.getStatus().getOverpaid());
 
-            LOAN_TRANSACTION_HELPER.makeCreditBalanceRefund((long) loanID, new PostLoansLoanIdTransactionsRequest().transactionAmount(200.0)
+            makeCreditBalanceRefund((long) loanID, new PostLoansLoanIdTransactionsRequest().transactionAmount(200.0)
                     .transactionDate("10 October 2022").dateFormat(DATETIME_PATTERN).locale("en").paymentTypeId(1L));
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
             assertTrue(loanDetails.getStatus().getClosedObligationsMet());
 
             assertEquals(2, loanDetails.getRepaymentSchedule().getPeriods().size());
@@ -6701,7 +6304,7 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(LocalDate.of(2022, 10, 10), loanDetails.getTransactions().get(3).getDate());
             assertEquals(0.0, Utils.getDoubleValue(loanDetails.getTransactions().get(3).getOutstandingLoanBalance()));
             assertEquals(1L, loanDetails.getTransactions().get(3).getPaymentDetailData().getPaymentType().getId());
-            GetJournalEntriesTransactionIdResponse journalEntriesForTransaction = JOURNAL_ENTRY_HELPER
+            GetJournalEntriesTransactionIdResponse journalEntriesForTransaction = journalHelper
                     .getJournalEntries("L" + loanDetails.getTransactions().get(3).getId());
             List<JournalEntryTransactionItem> journalItems = journalEntriesForTransaction.getPageItems();
             assertEquals(2, journalItems.size());
@@ -6713,11 +6316,11 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(200.0, journalItems.stream().filter(j -> "CREDIT".equalsIgnoreCase(j.getEntryType().getValue())
                     && j.getGlAccountId().equals(assetAccount.getAccountID().longValue())).findFirst().get().getAmount());
 
-            LOAN_TRANSACTION_HELPER.reverseLoanTransaction(loanDetails.getId(), loanDetails.getTransactions().get(1).getId(),
+            reverseLoanTransaction(loanDetails.getId(), loanDetails.getTransactions().get(1).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionAmount(0.0)
                             .transactionDate("10 October 2022").locale("en"));
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
 
             assertEquals(100.0, Utils.getDoubleValue(loanDetails.getTransactions().get(1).getAmount()));
             assertEquals(100.0, Utils.getDoubleValue(loanDetails.getTransactions().get(1).getPrincipalPortion()));
@@ -6748,7 +6351,7 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(100.0, Utils.getDoubleValue(loanDetails.getRepaymentSchedule().getPeriods().get(2).getPrincipalPaid()));
             assertEquals(100.0, Utils.getDoubleValue(loanDetails.getRepaymentSchedule().getPeriods().get(2).getPrincipalOutstanding()));
 
-            journalEntriesForTransaction = JOURNAL_ENTRY_HELPER.getJournalEntries("L" + loanDetails.getTransactions().get(3).getId());
+            journalEntriesForTransaction = journalHelper.getJournalEntries("L" + loanDetails.getTransactions().get(3).getId());
             journalItems = journalEntriesForTransaction.getPageItems();
             assertEquals(3, journalItems.size());
             assertEquals(1,
@@ -6782,48 +6385,44 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
                     new PutGlobalConfigurationsRequest().enabled(true));
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
-            BUSINESS_DATE_HELPER.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("10 October 2022").dateFormat(DATETIME_PATTERN).locale("en"));
+            updateBusinessDate("10 October 2022");
 
-            final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-            final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-            final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-            final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+            final Account assetAccount = accountHelper.createAssetAccount();
+            final Account incomeAccount = accountHelper.createIncomeAccount();
+            final Account expenseAccount = accountHelper.createExpenseAccount();
+            final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-            final Integer loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount,
-                    expenseAccount, overpaymentAccount);
+            final Long loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount, expenseAccount,
+                    overpaymentAccount);
 
-            final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC, "01 January 2011");
+            final Long clientID = createClient("01 January 2011");
 
-            final Integer loanID = applyForLoanApplication(clientID, loanProductID);
+            final Long loanID = applyForLoanApplication(clientID, loanProductID);
 
-            HashMap<String, Object> loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+            verifyLoanIsPending(loanID);
 
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("02 September 2022", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-            LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+            verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("02 September 2022", loanID));
 
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+            GetLoansLoanIdResponse loanStatusHashMap = disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
+            verifyLoanIsActive(loanStatusHashMap);
 
-            LOAN_TRANSACTION_HELPER.makeRepayment("04 September 2022", Float.parseFloat("500"), loanID);
-            LOAN_TRANSACTION_HELPER.makeRepayment("05 September 2022", Float.parseFloat("700"), loanID);
+            makeRepayment("04 September 2022", Float.parseFloat("500"), loanID);
+            makeRepayment("05 September 2022", Float.parseFloat("700"), loanID);
 
-            GetLoansLoanIdResponse loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanID);
             assertEquals(200.0, Utils.getDoubleValue(loanDetails.getTotalOverpaid()));
             assertTrue(loanDetails.getStatus().getOverpaid());
 
-            LOAN_TRANSACTION_HELPER.makeCreditBalanceRefund((long) loanID, new PostLoansLoanIdTransactionsRequest().transactionAmount(200.0)
+            makeCreditBalanceRefund((long) loanID, new PostLoansLoanIdTransactionsRequest().transactionAmount(200.0)
                     .transactionDate("06 September 2022").dateFormat(DATETIME_PATTERN).locale("en"));
 
-            LOAN_TRANSACTION_HELPER.makeMerchantIssuedRefund((long) loanID, new PostLoansLoanIdTransactionsRequest().locale("en")
-                    .dateFormat(DATETIME_PATTERN).transactionDate("07 September 2022").transactionAmount(500.0));
+            makeMerchantIssuedRefund((long) loanID, new PostLoansLoanIdTransactionsRequest().locale("en").dateFormat(DATETIME_PATTERN)
+                    .transactionDate("07 September 2022").transactionAmount(500.0));
 
-            LOAN_TRANSACTION_HELPER.makeCreditBalanceRefund((long) loanID, new PostLoansLoanIdTransactionsRequest().transactionAmount(500.0)
+            makeCreditBalanceRefund((long) loanID, new PostLoansLoanIdTransactionsRequest().transactionAmount(500.0)
                     .transactionDate("08 September 2022").dateFormat(DATETIME_PATTERN).locale("en"));
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
             assertTrue(loanDetails.getStatus().getClosedObligationsMet());
 
             assertEquals(2, loanDetails.getRepaymentSchedule().getPeriods().size());
@@ -6855,11 +6454,11 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(LocalDate.of(2022, 9, 8), loanDetails.getTransactions().get(5).getDate());
             assertEquals(0.0, Utils.getDoubleValue(loanDetails.getTransactions().get(5).getOutstandingLoanBalance()));
 
-            LOAN_TRANSACTION_HELPER.reverseLoanTransaction(loanDetails.getId(), loanDetails.getTransactions().get(2).getId(),
+            reverseLoanTransaction(loanDetails.getId(), loanDetails.getTransactions().get(2).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionAmount(0.0)
                             .transactionDate("07 September 2022").locale("en"));
 
-            loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            loanDetails = getLoanDetails(loanID);
 
             assertEquals(500.0, Utils.getDoubleValue(loanDetails.getTransactions().get(1).getAmount()));
             assertEquals(500.0, Utils.getDoubleValue(loanDetails.getTransactions().get(1).getPrincipalPortion()));
@@ -6914,53 +6513,45 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
                     new PutGlobalConfigurationsRequest().enabled(true));
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
-            BUSINESS_DATE_HELPER.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("10 October 2022").dateFormat(DATETIME_PATTERN).locale("en"));
+            updateBusinessDate("10 October 2022");
 
-            final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-            final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-            final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-            final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
+            final Account assetAccount = accountHelper.createAssetAccount();
+            final Account incomeAccount = accountHelper.createIncomeAccount();
+            final Account expenseAccount = accountHelper.createExpenseAccount();
+            final Account overpaymentAccount = accountHelper.createLiabilityAccount();
 
-            final Integer loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount,
-                    expenseAccount, overpaymentAccount);
+            final Long loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount, expenseAccount,
+                    overpaymentAccount);
 
-            final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC, "01 January 2011");
-            List<HashMap> charges = new ArrayList<>();
-            Integer installmentFee = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                    ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", false));
-            addCharges(charges, installmentFee, "10", null);
+            final Long clientID = createClient("01 January 2011");
+            List<PostLoansRequestChargeData> charges = new ArrayList<>();
+            Long installmentFee = chargesHelper.createLoanInstallmentCharge(ChargeCalculationType.FLAT, 10.0, false).getResourceId();
+            addCharges(charges, installmentFee, 10.0, null);
 
-            final Integer loanID = applyForLoanApplication(clientID, loanProductID, charges);
+            final Long loanID = applyForLoanApplication(clientID, loanProductID, charges);
 
-            HashMap<String, Object> loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+            verifyLoanIsPending(loanID);
 
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("02 September 2022", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-            LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+            verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan("02 September 2022", loanID));
 
-            loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+            GetLoansLoanIdResponse loanStatusHashMap = disburseLoanWithNetDisbursalAmount("03 September 2022", loanID, "1000");
+            verifyLoanIsActive(loanStatusHashMap);
 
-            LOAN_TRANSACTION_HELPER.makeRepayment("04 September 2022", Float.parseFloat("5"), loanID);
+            makeRepayment("04 September 2022", Float.parseFloat("5"), loanID);
 
-            PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting("04 September 2022");
+            runPeriodicAccrualAccounting("04 September 2022");
 
-            Integer penalty = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "11", true));
+            Long penalty = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.FLAT, 11.0, true).getResourceId();
             LocalDate targetDate = LocalDate.of(2022, 9, 6);
-            final String penaltyCharge1AddedDate = DATE_TIME_FORMATTER.format(targetDate);
+            final String penaltyCharge1AddedDate = dateTimeFormatter.format(targetDate);
 
-            Integer penalty1LoanChargeId = LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), penaltyCharge1AddedDate, "11"));
+            Long penalty1LoanChargeId = addLoanCharge(loanID, penalty, penaltyCharge1AddedDate, 11.0).getResourceId();
 
-            LOAN_TRANSACTION_HELPER.waiveLoanCharge((long) loanID, (long) penalty1LoanChargeId,
-                    new PostLoansLoanIdChargesChargeIdRequest());
+            waiveWholeLoanCharge(loanID, penalty1LoanChargeId);
 
-            LOAN_TRANSACTION_HELPER.makeRepayment("08 September 2022", Float.parseFloat("1010"), loanID);
+            makeRepayment("08 September 2022", Float.parseFloat("1010"), loanID);
 
-            GetLoansLoanIdResponse loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails((long) loanID);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanID);
 
             GetLoansLoanIdTransactions lastAccrualTransaction = loanDetails.getTransactions().stream()
                     .filter(t -> Boolean.TRUE.equals(t.getType().getAccrual())).findFirst().get();
@@ -6968,8 +6559,8 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(5.0, Utils.getDoubleValue(lastAccrualTransaction.getPenaltyChargesPortion()));
             assertEquals(10.0, Utils.getDoubleValue(lastAccrualTransaction.getFeeChargesPortion()));
 
-            GetLoansLoanIdTransactionsTransactionIdResponse accrualTransactionDetails = LOAN_TRANSACTION_HELPER
-                    .getLoanTransactionDetails((long) loanID, lastAccrualTransaction.getId());
+            GetLoansLoanIdTransactionsTransactionIdResponse accrualTransactionDetails = getLoanTransactionDetails(loanID,
+                    lastAccrualTransaction.getId());
 
             assertEquals(2, accrualTransactionDetails.getLoanChargePaidByList().size());
             accrualTransactionDetails.getLoanChargePaidByList().forEach(loanCharge -> {
@@ -6996,65 +6587,61 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
                     new PutGlobalConfigurationsRequest().enabled(true));
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
-            BUSINESS_DATE_HELPER.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("01 January 2023").dateFormat(DATETIME_PATTERN).locale("en"));
+            updateBusinessDate("01 January 2023");
             LOG.info("-----------------------------------NEW CLIENT-----------------------------------------");
-            final PostClientsRequest newClient = createRandomClientWithDate("01 January 2023");
-            final PostClientsResponse clientResponse = CLIENT_HELPER.createClient(newClient);
+            final Long newClientId = createClient("01 January 2023");
             LOG.info("-----------------------------------NEW LOAN PRODUCT-----------------------------------------");
             PostLoanProductsRequest loanProductsRequest = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct();
-            final PostLoanProductsResponse loanProductResponse = LOAN_PRODUCT_HELPER.createLoanProduct(loanProductsRequest);
+            final Long loanProductId = createLoanProduct(loanProductsRequest);
             LOG.info("-----------------------------------CREATE CHARGES-----------------------------------------");
-            PostChargesResponse penaltyCharge = CHARGES_HELPER.createCharges(new ChargeRequest().penalty(true).amount(10.0)
+            PostChargesResponse penaltyCharge = chargesHelper.createCharge(new ChargeRequest().penalty(true).amount(10.0)
                     .chargeCalculationType(ChargeCalculationType.FLAT.getValue())
                     .chargeTimeType(ChargeTimeType.SPECIFIED_DUE_DATE.getValue()).chargePaymentMode(ChargePaymentMode.REGULAR.getValue())
                     .currencyCode("USD").name(Utils.randomStringGenerator("PENALTY_" + Calendar.getInstance().getTimeInMillis(), 5))
                     .chargeAppliesTo(1).locale("en").active(true));
             LOG.info("-----------------------------------SUBMIT LOAN-----------------------------------------");
             final PostLoansResponse loanApplicationResult = applyForLoanApplicationForOnePeriod30DaysLongNoInterestPeriodicAccrual(
-                    clientResponse.getResourceId(), loanProductResponse.getResourceId(), "01 January 2023",
-                    LoanApplicationTestBuilder.DUE_PENALTY_INTEREST_PRINCIPAL_FEE_IN_ADVANCE_PENALTY_INTEREST_PRINCIPAL_FEE_STRATEGY);
+                    newClientId, loanProductId, "01 January 2023",
+                    DUE_PENALTY_INTEREST_PRINCIPAL_FEE_IN_ADVANCE_PENALTY_INTEREST_PRINCIPAL_FEE_STRATEGY);
             LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-            PostLoansLoanIdResponse approvedLoanResult = LOAN_TRANSACTION_HELPER.approveLoan(loanApplicationResult.getResourceId(),
+            PostLoansLoanIdResponse approvedLoanResult = approveLoan(loanApplicationResult.getResourceId(),
                     new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000.0)).dateFormat(DATETIME_PATTERN)
                             .approvedOnDate("01 January 2023").locale("en"));
             LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
             String loanDisbursementUUID = UUID.randomUUID().toString();
-            PostLoansLoanIdResponse disbursedLoanResult = LOAN_TRANSACTION_HELPER.disburseLoan(loanApplicationResult.getResourceId(),
+            PostLoansLoanIdResponse disbursedLoanResult = disburseLoan(loanApplicationResult.getResourceId(),
                     new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
                             .transactionAmount(BigDecimal.valueOf(1000.00)).locale("en").externalId(loanDisbursementUUID));
             Long loanId = disbursedLoanResult.getResourceId();
             LOG.info("-------------------------------ADD CHARGES-------------------------------------------");
-            PostLoansLoanIdChargesResponse penaltyLoanChargeResult = LOAN_TRANSACTION_HELPER.addChargesForLoan(loanId,
+            PostLoansLoanIdChargesResponse penaltyLoanChargeResult = addLoanCharge(loanId,
                     new PostLoansLoanIdChargesRequest().chargeId(penaltyCharge.getResourceId()).dateFormat(DATETIME_PATTERN).locale("en")
                             .amount(10.0).dueDate("10 January 2023"));
             LOG.info("-------------------------------DO SOME PARTIAL REPAYMENTS-------------------------------------------");
-            BUSINESS_DATE_HELPER.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("07 January 2023").dateFormat(DATETIME_PATTERN).locale("en"));
+            updateBusinessDate("07 January 2023");
             String firstRepaymentUUID = UUID.randomUUID().toString();
-            PostLoansLoanIdTransactionsResponse firstRepaymentResult = LOAN_TRANSACTION_HELPER.makeLoanRepayment(loanId,
+            PostLoansLoanIdTransactionsResponse firstRepaymentResult = makeLoanRepayment(loanId,
                     new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate("07 January 2023").locale("en")
                             .transactionAmount(9.0).externalId(firstRepaymentUUID));
             String secondRepaymentUUID = UUID.randomUUID().toString();
-            PostLoansLoanIdTransactionsResponse secondRepaymentResult = LOAN_TRANSACTION_HELPER.makeLoanRepayment(loanId,
+            PostLoansLoanIdTransactionsResponse secondRepaymentResult = makeLoanRepayment(loanId,
                     new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate("07 January 2023").locale("en")
                             .transactionAmount(8.0).externalId(secondRepaymentUUID));
             String thirdRepaymentUUID = UUID.randomUUID().toString();
-            PostLoansLoanIdTransactionsResponse thirdRepaymentResult = LOAN_TRANSACTION_HELPER.makeLoanRepayment(loanId,
+            PostLoansLoanIdTransactionsResponse thirdRepaymentResult = makeLoanRepayment(loanId,
                     new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate("07 January 2023").locale("en")
                             .transactionAmount(7.0).externalId(thirdRepaymentUUID));
             LOG.info("-------------------------------CHECK LOAN TRANSACTION ORDER-------------------------------------------");
             checkLoanTransactionOrder(loanId, loanDisbursementUUID, firstRepaymentUUID, secondRepaymentUUID, thirdRepaymentUUID);
             LOG.info(
                     "-------------------------------REVERT FIRST REPAYMENT AND CHECK LOAN TRANSACTION ORDER-------------------------------------------");
-            LOAN_TRANSACTION_HELPER.reverseLoanTransaction(loanId, firstRepaymentUUID, new PostLoansLoanIdTransactionsTransactionIdRequest()
+            reverseLoanTransaction(loanId, firstRepaymentUUID, new PostLoansLoanIdTransactionsTransactionIdRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("07 January 2023").transactionAmount(0.0).locale("en"));
             checkLoanTransactionOrder(loanId, loanDisbursementUUID, firstRepaymentUUID, secondRepaymentUUID, thirdRepaymentUUID);
             LOG.info(
                     "-------------------------------REVERT SECOND REPAYMENT AND CHECK LOAN TRANSACTION ORDER-------------------------------------------");
-            LOAN_TRANSACTION_HELPER.reverseLoanTransaction(loanId, secondRepaymentUUID,
-                    new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("07 January 2023")
-                            .transactionAmount(0.0).locale("en"));
+            reverseLoanTransaction(loanId, secondRepaymentUUID, new PostLoansLoanIdTransactionsTransactionIdRequest()
+                    .dateFormat(DATETIME_PATTERN).transactionDate("07 January 2023").transactionAmount(0.0).locale("en"));
             checkLoanTransactionOrder(loanId, loanDisbursementUUID, firstRepaymentUUID, secondRepaymentUUID, thirdRepaymentUUID);
         } finally {
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
@@ -7075,172 +6662,894 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         }
 
         String fourMonthsfromNow = Utils.convertDateToURLFormat(fourMonthsfromNowCalendar);
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProduct(false, NONE);
+        final Long clientID = createClient();
+        verifyClientCreatedOnServer(clientID);
+        final Long loanProductID = createLoanProduct(false, NONE);
 
-        List<HashMap> charges = new ArrayList<>();
-        Integer disbursementFee = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanDisbursementJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT_AND_INTEREST, "2"));
-        addCharges(charges, disbursementFee, "2", null);
+        List<PostLoansRequestChargeData> charges = new ArrayList<>();
+        Long disbursementFee = chargesHelper.createLoanDisbursementCharge(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST, 2.0)
+                .getResourceId();
+        addCharges(charges, disbursementFee, 2.0, null);
 
-        List<HashMap> collaterals = new ArrayList<>();
-        final Integer loanID = applyForLoanApplicationWithPaymentStrategyAndPastMonth(clientID, loanProductID, charges, null, "1000",
-                LoanApplicationTestBuilder.DEFAULT_STRATEGY, fourMonthsfromNow, collaterals);
+        List<PostLoansRequestCollateralData> collaterals = new ArrayList<>();
+        final Long loanID = applyForLoanApplicationWithPaymentStrategyAndPastMonth(clientID, loanProductID, charges, null, "1000",
+                DEFAULT_STRATEGY, fourMonthsfromNow, collaterals);
         Assertions.assertNotNull(loanID);
 
-        LOAN_TRANSACTION_HELPER.approveLoan(fourMonthsfromNow, loanID);
+        approveLoan(fourMonthsfromNow, loanID);
 
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(fourMonthsfromNow, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanID);
+        disburseLoanWithNetDisbursalAmount(fourMonthsfromNow, loanID);
 
         // check for disbursement fee: Principal 1,000 with 24% Annual Rate for 6 Months we have Total Interest of:
         // 120.00
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        HashMap disbursementDetail = loanSchedule.get(0);
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanID);
+        GetLoansLoanIdRepaymentPeriod disbursementDetail = loanSchedule.get(0);
         // Disbursement Fee: 2% of 1,120.00 = 22.40
-        validateNumberForEqual("22.40", String.valueOf(disbursementDetail.get("feeChargesDue")));
+        validateNumberForEqual("22.40", String.valueOf(disbursementDetail.getFeeChargesDue()));
     }
 
     private void checkLoanTransactionOrder(Long loanId, String... transactionUUIDs) {
         LOG.info("-------------------------------CHECK LOAN TRANSACTION ORDER-------------------------------------------");
-        GetLoansLoanIdResponse loanDetailsResult = LOAN_TRANSACTION_HELPER.getLoanDetails(loanId);
+        GetLoansLoanIdResponse loanDetailsResult = getLoanDetails(loanId);
         for (int i = 0; i < transactionUUIDs.length; i++) {
             assertEquals(transactionUUIDs[i], loanDetailsResult.getTransactions().get(i).getExternalId());
         }
     }
 
-    private PostClientsRequest createRandomClientWithDate(String date) {
-        return new PostClientsRequest().officeId(1L).legalFormId(1L).firstname(Utils.randomFirstNameGenerator())
-                .lastname(Utils.randomLastNameGenerator()).active(true).locale("en").activationDate(date).dateFormat(DATETIME_PATTERN);
+    // ----------------------------------------------------------------------------------------------------
+    // Loan product builders
+    // ----------------------------------------------------------------------------------------------------
+
+    /** The defaults previously supplied by {@code LoanProductTestBuilder}. */
+    private PostLoanProductsRequest baseLoanProduct() {
+        return new PostLoanProductsRequest()//
+                .name(Utils.uniqueRandomStringGenerator("LOAN_PRODUCT_", 6))//
+                .shortName(Utils.uniqueRandomStringGenerator("", 4))//
+                .currencyCode("USD")//
+                .locale(LOCALE)//
+                .dateFormat(DATETIME_PATTERN)//
+                .digitsAfterDecimal(2)//
+                .inMultiplesOf(0)//
+                .principal(10000.00)//
+                .minPrincipal(1000.00)//
+                .maxPrincipal(10000000.00)//
+                .numberOfRepayments(5)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS_L)//
+                .interestRatePerPeriod(2.0)//
+                .interestRateFrequencyType(LoanTestData.InterestRateFrequencyType.MONTHS)//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_INSTALLMENTS)//
+                .interestType(LoanTestData.InterestType.FLAT)//
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)//
+                .inArrearsTolerance(0)//
+                .transactionProcessingStrategyCode(DEFAULT_STRATEGY)//
+                .accountingRule(NONE)//
+                .isEqualAmortization(false)//
+                .overdueDaysForNPA(5)//
+                .loanScheduleType(LoanScheduleType.CUMULATIVE.name())//
+                .loanScheduleProcessingType(LoanScheduleProcessingType.HORIZONTAL.name())//
+                .daysInYearType(1)//
+                .daysInMonthType(1)//
+                .isInterestRecalculationEnabled(false)//
+                .allowPartialPeriodInterestCalculation(false)//
+                .allowVariableInstallments(false);
     }
 
-    private Integer applyForLoanApplication(final Integer clientID, final Integer loanProductID, final List<HashMap> charges) {
-        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
-        final String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal("1000").withLoanTermFrequency("1")
-                .withLoanTermFrequencyAsMonths().withNumberOfRepayments("1").withRepaymentEveryAfter("1")
-                .withRepaymentFrequencyTypeAsMonths().withInterestRatePerPeriod("0").withInterestTypeAsFlatBalance()
-                .withAmortizationTypeAsEqualPrincipalPayments().withInterestCalculationPeriodTypeSameAsRepaymentPeriod()
-                .withCharges(charges).withExpectedDisbursementDate("03 September 2022").withSubmittedOnDate("01 September 2022")
-                .withLoanType("individual").build(clientID.toString(), loanProductID.toString(), null);
-        return LOAN_TRANSACTION_HELPER.getLoanId(loanApplicationJSON);
-    }
-
-    private Integer applyForLoanApplication(final Integer clientID, final Integer loanProductID) {
-        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
-        final String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal("1000").withLoanTermFrequency("1")
-                .withLoanTermFrequencyAsMonths().withNumberOfRepayments("1").withRepaymentEveryAfter("1")
-                .withRepaymentFrequencyTypeAsMonths().withInterestRatePerPeriod("0").withInterestTypeAsDecliningBalance()
-                .withAmortizationTypeAsEqualPrincipalPayments().withInterestCalculationPeriodTypeSameAsRepaymentPeriod()
-                .withExpectedDisbursementDate("03 September 2022").withSubmittedOnDate("01 September 2022").withLoanType("individual")
-                .build(clientID.toString(), loanProductID.toString(), null);
-        return LOAN_TRANSACTION_HELPER.getLoanId(loanApplicationJSON);
-    }
-
-    private Integer createLoanProductWithPeriodicAccrualAccountingNoInterest(final Account... accounts) {
-        LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-        final String loanProductJSON = new LoanProductTestBuilder().withPrincipal("1000").withRepaymentTypeAsMonth()
-                .withRepaymentAfterEvery("1").withNumberOfRepayments("1").withRepaymentTypeAsMonth().withinterestRatePerPeriod("0")
-                .withInterestRateFrequencyTypeAsMonths().withAmortizationTypeAsEqualPrincipalPayment().withInterestTypeAsFlat()
-                .withAccountingRulePeriodicAccrual(accounts).withDaysInMonth("30").withDaysInYear("365").withMoratorium("0", "0")
-                .build(null);
-        return LOAN_TRANSACTION_HELPER.getLoanProductId(loanProductJSON);
-    }
-
-    private Integer createLoanProductWithPeriodicAccrualAccountingNoInterestMultiDisbursement(final Account... accounts) {
-        LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-        final String loanProductJSON = new LoanProductTestBuilder().withPrincipal("1000").withRepaymentTypeAsMonth()
-                .withRepaymentAfterEvery("1").withNumberOfRepayments("1").withRepaymentTypeAsMonth().withinterestRatePerPeriod("0")
-                .withInterestRateFrequencyTypeAsMonths().withAmortizationTypeAsEqualPrincipalPayment().withInterestTypeAsDecliningBalance()
-                .withAccountingRulePeriodicAccrual(accounts).withInterestCalculationPeriodTypeAsRepaymentPeriod(true).withDaysInMonth("30")
-                .withDaysInYear("365").withMoratorium("0", "0").withMultiDisburse().withDisallowExpectedDisbursements(true).build(null);
-        return LOAN_TRANSACTION_HELPER.getLoanProductId(loanProductJSON);
-    }
-
-    private void validateIfValuesAreNotOverridden(Integer loanID, Integer loanProductID) {
-        String loanProductDetails = LOAN_TRANSACTION_HELPER.getLoanProductDetails(REQUEST_SPEC, RESPONSE_SPEC, loanProductID);
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        List<String> comparisonAttributes = Arrays.asList("amortizationType", "interestType", "transactionProcessingStrategyCode",
-                "interestCalculationPeriodType", "repaymentFrequencyType", "graceOnPrincipalPayment", "graceOnInterestPayment",
-                "inArrearsTolerance", "graceOnArrearsAgeing");
-
-        for (String comparisonAttribute : comparisonAttributes) {
-            Object val1 = JsonPath.from(loanProductDetails).get(comparisonAttribute);
-            Object val2 = JsonPath.from(loanDetails).get(comparisonAttribute);
-            assertEquals(val1, val2);
+    /**
+     * Mirrors {@code LoanProductTestBuilder}'s account mapping: every account of a given type overwrites the mapping
+     * contributed by the previous account of that type, so the last one in {@code accounts} wins.
+     */
+    private PostLoanProductsRequest withAccounting(PostLoanProductsRequest product, Integer accountingRule, Account... accounts) {
+        product.accountingRule(accountingRule);
+        if (NONE.equals(accountingRule) || accounts == null) {
+            return product;
         }
+        boolean accrualBased = ACCRUAL_PERIODIC.equals(accountingRule) || ACCRUAL_UPFRONT.equals(accountingRule);
+        for (Account account : accounts) {
+            Long accountId = account.getAccountID().longValue();
+            switch (account.getAccountType()) {
+                case ASSET -> {
+                    product.fundSourceAccountId(accountId)//
+                            .loanPortfolioAccountId(accountId)//
+                            .transfersInSuspenseAccountId(accountId);
+                    if (accrualBased) {
+                        product.receivableInterestAccountId(accountId)//
+                                .receivableFeeAccountId(accountId)//
+                                .receivablePenaltyAccountId(accountId);
+                    }
+                }
+                case INCOME -> product.interestOnLoanAccountId(accountId)//
+                        .incomeFromFeeAccountId(accountId)//
+                        .incomeFromPenaltyAccountId(accountId)//
+                        .incomeFromRecoveryAccountId(accountId)//
+                        .incomeFromChargeOffInterestAccountId(accountId)//
+                        .incomeFromChargeOffFeesAccountId(accountId)//
+                        .incomeFromChargeOffPenaltyAccountId(accountId)//
+                        .incomeFromGoodwillCreditInterestAccountId(accountId)//
+                        .incomeFromGoodwillCreditFeesAccountId(accountId)//
+                        .incomeFromGoodwillCreditPenaltyAccountId(accountId);
+                case EXPENSE -> product.writeOffAccountId(accountId)//
+                        .goodwillCreditAccountId(accountId)//
+                        .chargeOffExpenseAccountId(accountId)//
+                        .chargeOffFraudExpenseAccountId(accountId);
+                case LIABILITY -> product.overpaymentLiabilityAccountId(accountId);
+                default -> throw new IllegalArgumentException("Unsupported GL account type: " + account.getAccountType());
+            }
+        }
+        return product;
     }
 
-    private JsonObject createLoanProductConfigurationDetail(JsonObject loanProductConfiguration, Boolean bool) {
-        loanProductConfiguration.addProperty("amortizationType", bool);
-        loanProductConfiguration.addProperty("interestType", bool);
-        loanProductConfiguration.addProperty("transactionProcessingStrategyCode", bool);
-        loanProductConfiguration.addProperty("interestCalculationPeriodType", bool);
-        loanProductConfiguration.addProperty("inArrearsTolerance", bool);
-        loanProductConfiguration.addProperty("repaymentEvery", bool);
-        loanProductConfiguration.addProperty("graceOnPrincipalAndInterestPayment", bool);
-        loanProductConfiguration.addProperty("graceOnArrearsAgeing", bool);
-        return loanProductConfiguration;
+    private PostLoanProductsRequest withTranches(PostLoanProductsRequest product) {
+        return product.multiDisburseLoan(true)//
+                .allowFullTermForTranche(false)//
+                .maxTrancheCount(3)//
+                .outstandingLoanBalance(35000.0)//
+                .disallowExpectedDisbursements(false);
     }
 
-    private Integer applyForLoanApplicationWithProductConfigurationAsTrue(final Integer clientID, final Integer loanProductID,
-            String principal) {
+    private Long createLoanProduct(final boolean multiDisburseLoan, final Integer accountingRule, final Account... accounts) {
+        LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
+        PostLoanProductsRequest product = baseLoanProduct()//
+                .principal(12000.00)//
+                .numberOfRepayments(4)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS_L)//
+                .interestRatePerPeriod(1.0)//
+                .interestRateFrequencyType(LoanTestData.InterestRateFrequencyType.MONTHS)//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_INSTALLMENTS)//
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE);
+        if (multiDisburseLoan) {
+            withTranches(product);
+            product.interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)
+                    .allowPartialPeriodInterestCalculation(true);
+        }
+        withAccounting(product, accountingRule, accounts);
+        return createLoanProduct(product);
+    }
+
+    private Long createLoanProduct(final Integer inMultiplesOf, final Integer digitsAfterDecimal, final String repaymentStrategy) {
+        return createLoanProduct(inMultiplesOf, digitsAfterDecimal, repaymentStrategy, NONE);
+    }
+
+    private Long createLoanProduct(final Integer inMultiplesOf, final Integer digitsAfterDecimal, final String repaymentStrategy,
+            final Integer accountingRule, final Account... accounts) {
+        LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
+        PostLoanProductsRequest product = baseLoanProduct()//
+                .principal(10000000.00)//
+                .numberOfRepayments(24)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS_L)//
+                .interestRatePerPeriod(2.0)//
+                .interestRateFrequencyType(LoanTestData.InterestRateFrequencyType.MONTHS)//
+                .transactionProcessingStrategyCode(repaymentStrategy)//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_PRINCIPAL)//
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE)//
+                .digitsAfterDecimal(digitsAfterDecimal)//
+                .inMultiplesOf(inMultiplesOf);
+        withAccounting(product, accountingRule, accounts);
+        return createLoanProduct(product);
+    }
+
+    private Long createLoanProductWithPeriodicAccrualAccountingNoInterest(final Account... accounts) {
+        LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
+        PostLoanProductsRequest product = baseLoanProduct()//
+                .principal(1000.00)//
+                .numberOfRepayments(1)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS_L)//
+                .interestRatePerPeriod(0.0)//
+                .interestRateFrequencyType(LoanTestData.InterestRateFrequencyType.MONTHS)//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_PRINCIPAL)//
+                .interestType(LoanTestData.InterestType.FLAT)//
+                .daysInMonthType(30)//
+                .daysInYearType(365)//
+                .graceOnPrincipalPayment(0)//
+                .graceOnInterestPayment(0);
+        withAccounting(product, ACCRUAL_PERIODIC, accounts);
+        return createLoanProduct(product);
+    }
+
+    private Long createLoanProductWithPeriodicAccrualAccountingNoInterestMultiDisbursement(final Account... accounts) {
+        LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
+        PostLoanProductsRequest product = baseLoanProduct()//
+                .principal(1000.00)//
+                .numberOfRepayments(1)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS_L)//
+                .interestRatePerPeriod(0.0)//
+                .interestRateFrequencyType(LoanTestData.InterestRateFrequencyType.MONTHS)//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_PRINCIPAL)//
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE)//
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)//
+                .allowPartialPeriodInterestCalculation(true)//
+                .daysInMonthType(30)//
+                .daysInYearType(365)//
+                .graceOnPrincipalPayment(0)//
+                .graceOnInterestPayment(0);
+        withTranches(product);
+        // The pre-migration LoanProductTestBuilder.withDisallowExpectedDisbursements(true) implicitly enabled a 100%
+        // over-applied allowance. chargeOff() relies on it to disburse two 1000 tranches against a 1000 approval.
+        product.disallowExpectedDisbursements(true)//
+                .allowApprovedDisbursedAmountsOverApplied(true)//
+                .overAppliedCalculationType("percentage")//
+                .overAppliedNumber(100);
+        withAccounting(product, ACCRUAL_PERIODIC, accounts);
+        return createLoanProduct(product);
+    }
+
+    private PostLoanProductsRequest withInterestRecalculation(PostLoanProductsRequest product,
+            final Integer interestRecalculationCompoundingMethod, final Integer rescheduleStrategyMethod,
+            final Integer preCloseInterestCalculationStrategy, final Integer recalculationRestFrequencyType,
+            final Integer recalculationRestFrequencyInterval, final Integer recalculationCompoundingFrequencyType,
+            final Integer recalculationCompoundingFrequencyInterval, final Integer recalculationCompoundingFrequencyOnDayType,
+            final Integer recalculationCompoundingFrequencyDayOfWeekType, final Integer recalculationRestFrequencyOnDayType,
+            final Integer recalculationRestFrequencyDayOfWeekType) {
+        product.isInterestRecalculationEnabled(true)//
+                .interestRecalculationCompoundingMethod(interestRecalculationCompoundingMethod)//
+                .rescheduleStrategyMethod(rescheduleStrategyMethod)//
+                .recalculationRestFrequencyType(recalculationRestFrequencyType)//
+                .recalculationRestFrequencyInterval(recalculationRestFrequencyInterval)//
+                .preClosureInterestCalculationStrategy(preCloseInterestCalculationStrategy)//
+                .recalculationCompoundingFrequencyOnDayType(recalculationCompoundingFrequencyOnDayType)//
+                .recalculationCompoundingFrequencyDayOfWeekType(recalculationCompoundingFrequencyDayOfWeekType)//
+                .recalculationRestFrequencyOnDayType(recalculationRestFrequencyOnDayType)//
+                .recalculationRestFrequencyDayOfWeekType(recalculationRestFrequencyDayOfWeekType);
+        if (!LoanTestData.InterestRecalculationCompoundingMethod.NONE.equals(interestRecalculationCompoundingMethod)) {
+            product.recalculationCompoundingFrequencyType(recalculationCompoundingFrequencyType)//
+                    .recalculationCompoundingFrequencyInterval(recalculationCompoundingFrequencyInterval);
+        }
+        return product;
+    }
+
+    private Long createLoanProductWithInterestRecalculation(final String repaymentStrategy,
+            final Integer interestRecalculationCompoundingMethod, final Integer rescheduleStrategyMethod,
+            final Integer recalculationRestFrequencyType, final Integer recalculationRestFrequencyInterval,
+            final Integer preCloseInterestCalculationStrategy, final Account[] accounts, final Integer recalculationRestFrequencyOnDayType,
+            final Integer recalculationRestFrequencyDayOfWeekType) {
+        return createLoanProductWithInterestRecalculationAndCompoundingDetails(repaymentStrategy, interestRecalculationCompoundingMethod,
+                rescheduleStrategyMethod, recalculationRestFrequencyType, recalculationRestFrequencyInterval, null, null,
+                preCloseInterestCalculationStrategy, accounts, null, null, recalculationRestFrequencyOnDayType,
+                recalculationRestFrequencyDayOfWeekType);
+    }
+
+    /** The 24-repayment weekly product used by the interest-recalculation tests. */
+    private Long createLoanProductWithInterestRecalculationAndCompoundingDetails(final String repaymentStrategy,
+            final Integer interestRecalculationCompoundingMethod, final Integer rescheduleStrategyMethod,
+            final Integer recalculationRestFrequencyType, final Integer recalculationRestFrequencyInterval,
+            final Integer recalculationCompoundingFrequencyType, final Integer recalculationCompoundingFrequencyInterval,
+            final Integer preCloseInterestCalculationStrategy, final Account[] accounts,
+            final Integer recalculationCompoundingFrequencyOnDayType, final Integer recalculationCompoundingFrequencyDayOfWeekType,
+            final Integer recalculationRestFrequencyOnDayType, final Integer recalculationRestFrequencyDayOfWeekType) {
+        return createLoanProductWithInterestRecalculation(repaymentStrategy, interestRecalculationCompoundingMethod,
+                rescheduleStrategyMethod, recalculationRestFrequencyType, recalculationRestFrequencyInterval,
+                recalculationCompoundingFrequencyType, recalculationCompoundingFrequencyInterval, preCloseInterestCalculationStrategy,
+                accounts, null, false, recalculationCompoundingFrequencyOnDayType, recalculationCompoundingFrequencyDayOfWeekType,
+                recalculationRestFrequencyOnDayType, recalculationRestFrequencyDayOfWeekType);
+    }
+
+    /**
+     * The 24-repayment weekly product used by the interest-recalculation tests, optionally with a charge and arrears
+     * config.
+     */
+    private Long createLoanProductWithInterestRecalculation(final String repaymentStrategy,
+            final Integer interestRecalculationCompoundingMethod, final Integer rescheduleStrategyMethod,
+            final Integer recalculationRestFrequencyType, final Integer recalculationRestFrequencyInterval,
+            final Integer recalculationCompoundingFrequencyType, final Integer recalculationCompoundingFrequencyInterval,
+            final Integer preCloseInterestCalculationStrategy, final Account[] accounts, final Long chargeId,
+            boolean isArrearsBasedOnOriginalSchedule, final Integer recalculationCompoundingFrequencyOnDayType,
+            final Integer recalculationCompoundingFrequencyDayOfWeekType, final Integer recalculationRestFrequencyOnDayType,
+            final Integer recalculationRestFrequencyDayOfWeekType) {
+        LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
+        PostLoanProductsRequest product = baseLoanProduct()//
+                .principal(10000000.00)//
+                .numberOfRepayments(24)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.WEEKS_L)//
+                .interestRatePerPeriod(2.0)//
+                .interestRateFrequencyType(LoanTestData.InterestRateFrequencyType.MONTHS)//
+                .transactionProcessingStrategyCode(repaymentStrategy)//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_PRINCIPAL)//
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)//
+                .allowPartialPeriodInterestCalculation(true)//
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE);
+        withInterestRecalculation(product, interestRecalculationCompoundingMethod, rescheduleStrategyMethod,
+                preCloseInterestCalculationStrategy, recalculationRestFrequencyType, recalculationRestFrequencyInterval,
+                recalculationCompoundingFrequencyType, recalculationCompoundingFrequencyInterval,
+                recalculationCompoundingFrequencyOnDayType, recalculationCompoundingFrequencyDayOfWeekType,
+                recalculationRestFrequencyOnDayType, recalculationRestFrequencyDayOfWeekType);
+        if (accounts != null) {
+            withAccounting(product, ACCRUAL_PERIODIC, accounts);
+        }
+        if (isArrearsBasedOnOriginalSchedule) {
+            product.isArrearsBasedOnOriginalSchedule(true);
+        }
+        if (chargeId != null) {
+            product.charges(List.of(new LoanProductChargeData().id(chargeId)));
+        }
+        return createLoanProduct(product);
+    }
+
+    /** The 12-repayment monthly 19.9% product used by the daily-interest-calculation recalculation tests. */
+    private Long createLoanProductWithInterestRecalculationAndInstallmentAmount(final String repaymentStrategy,
+            final Integer interestRecalculationCompoundingMethod, final Integer rescheduleStrategyMethod,
+            final Integer preCloseInterestCalculationStrategy, final Account[] accounts, final Integer installmentAmountInMultiplesOf) {
+        LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
+        PostLoanProductsRequest product = baseLoanProduct()//
+                .principal(10000.00)//
+                .numberOfRepayments(12)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS_L)//
+                .interestRatePerPeriod(19.9)//
+                .interestRateFrequencyType(LoanTestData.InterestRateFrequencyType.MONTHS)//
+                .transactionProcessingStrategyCode(repaymentStrategy)//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_INSTALLMENTS)//
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE)//
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.DAILY)//
+                .canDefineInstallmentAmount(true)//
+                .installmentAmountInMultiplesOf(installmentAmountInMultiplesOf);
+        // The RestAssured builder left the rest frequency at its defaults (daily, every 1) for this product shape.
+        withInterestRecalculation(product, interestRecalculationCompoundingMethod, rescheduleStrategyMethod,
+                preCloseInterestCalculationStrategy, LoanTestData.RecalculationRestFrequencyType.DAILY, 1, null, null, null, null, null,
+                null);
+        if (accounts != null) {
+            withAccounting(product, ACCRUAL_PERIODIC, accounts);
+        }
+        return createLoanProduct(product);
+    }
+
+    // ----------------------------------------------------------------------------------------------------
+    // Loan application builders
+    // ----------------------------------------------------------------------------------------------------
+
+    /** The defaults previously supplied by {@code LoanApplicationTestBuilder}. */
+    private PostLoansRequest baseLoanApplication(final Long clientId, final Long loanProductId) {
+        return new PostLoansRequest()//
+                .clientId(clientId)//
+                .productId(loanProductId)//
+                .dateFormat(DATETIME_PATTERN)//
+                .locale(LOCALE)//
+                .loanType("individual")//
+                .transactionProcessingStrategyCode(DEFAULT_STRATEGY)//
+                .interestRatePerPeriod(BigDecimal.valueOf(2))//
+                .interestType(LoanTestData.InterestType.FLAT)//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_PRINCIPAL)//
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)//
+                .maxOutstandingLoanBalance(BigDecimal.valueOf(36000))//
+                .collateral(Collections.emptyList());
+    }
+
+    private Long applyForLoanApplication(final Long clientId, final Long loanProductId, final List<PostLoansRequestChargeData> charges) {
         LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
-        Assertions.assertNotNull(collateralId);
-        List<HashMap> collaterals = new ArrayList<>();
-
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
-        Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
-        final String loanApplicationJSON = new LoanApplicationTestBuilder() //
-                .withPrincipal(principal) //
-                .withRepaymentEveryAfter("1") //
-                .withLoanTermFrequency("4") //
-                .withLoanTermFrequencyAsMonths() //
-                .withNumberOfRepayments("4") //
-                .withRepaymentFrequencyTypeAsMonths() //
-                .withInterestRatePerPeriod("2") //
-                .withInterestCalculationPeriodTypeSameAsRepaymentPeriod() //
-                .withExpectedDisbursementDate("01 March 2014") //
-                .withSubmittedOnDate("01 March 2014") //
-                .withCollaterals(collaterals).build(clientID.toString(), loanProductID.toString(), null);
-        return LOAN_TRANSACTION_HELPER.getLoanId(loanApplicationJSON);
+        return applyForLoan(baseLoanApplication(clientId, loanProductId)//
+                .principal(BigDecimal.valueOf(1000))//
+                .loanTermFrequency(1)//
+                .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .numberOfRepayments(1)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .interestRatePerPeriod(BigDecimal.ZERO)//
+                .interestType(LoanTestData.InterestType.FLAT)//
+                .expectedDisbursementDate("03 September 2022")//
+                .submittedOnDate("01 September 2022")//
+                .charges(charges));
     }
 
-    private Integer applyForLoanApplicationWithProductConfigurationAsFalse(final Integer clientID, final Integer loanProductID,
-            String principal) {
+    private Long applyForLoanApplication(final Long clientId, final Long loanProductId) {
         LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        return applyForLoan(baseLoanApplication(clientId, loanProductId)//
+                .principal(BigDecimal.valueOf(1000))//
+                .loanTermFrequency(1)//
+                .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .numberOfRepayments(1)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .interestRatePerPeriod(BigDecimal.ZERO)//
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE)//
+                .expectedDisbursementDate("03 September 2022")//
+                .submittedOnDate("01 September 2022"));
+    }
+
+    /** The 4-month, 2%, equal-installment application shared by the charge tests. */
+    private PostLoansRequest fourMonthLoanApplication(final Long clientId, final Long loanProductId, final BigDecimal principal,
+            final List<PostLoansRequestChargeData> charges, final Long savingsId, final List<PostLoansRequestCollateralData> collaterals) {
+        return baseLoanApplication(clientId, loanProductId)//
+                .principal(principal)//
+                .loanTermFrequency(4)//
+                .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .numberOfRepayments(4)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .interestRatePerPeriod(BigDecimal.valueOf(2))//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_INSTALLMENTS)//
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE)//
+                .expectedDisbursementDate("20 September 2011")//
+                .submittedOnDate("20 September 2011")//
+                .collateral(collaterals)//
+                .charges(charges)//
+                .linkAccountId(savingsId);
+    }
+
+    private Long applyForLoanApplication(final Long clientId, final Long loanProductId, final List<PostLoansRequestChargeData> charges,
+            final Long savingsId, final String principal, final List<PostLoansRequestCollateralData> collaterals) {
+        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
+        return applyForLoan(fourMonthLoanApplication(clientId, loanProductId, toAmount(principal), charges, savingsId, collaterals));
+    }
+
+    private Long applyForLoanApplication(final Long clientId, final Long loanProductId, final String disbursementDate,
+            final String submissionDate, final String interestRate, final List<PostLoansRequestChargeData> charges, final Long savingsId,
+            final String principal, final List<PostLoansRequestCollateralData> collaterals) {
+        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
+        return applyForLoan(baseLoanApplication(clientId, loanProductId)//
+                .principal(toAmount(principal))//
+                .loanTermFrequency(2)//
+                .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .numberOfRepayments(2)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .interestRatePerPeriod(new BigDecimal(interestRate))//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_INSTALLMENTS)//
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE)//
+                .expectedDisbursementDate(disbursementDate)//
+                .submittedOnDate(submissionDate)//
+                .collateral(collaterals)//
+                .charges(charges)//
+                .linkAccountId(savingsId));
+    }
+
+    /** The 24-repayment, equal-principal application used by the currency-detail tests. */
+    private Long applyForLoanApplication(final Long clientId, final Long loanProductId, final Integer graceOnPrincipalPayment,
+            final List<PostLoansRequestCollateralData> collaterals) {
+        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
+        return applyForLoan(baseLoanApplication(clientId, loanProductId)//
+                .principal(new BigDecimal("10000000.00"))//
+                .loanTermFrequency(24)//
+                .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .numberOfRepayments(24)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .interestRatePerPeriod(BigDecimal.valueOf(2))//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_PRINCIPAL)//
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE)//
+                .graceOnPrincipalPayment(graceOnPrincipalPayment)//
+                .expectedDisbursementDate("02 June 2014")//
+                .submittedOnDate("02 June 2014")//
+                .collateral(collaterals));
+    }
+
+    private Long applyForLoanApplicationWithExternalId(final Long clientId, final Long loanProductId, final String principal,
+            final String externalId) {
+        LOG.info("------------------------APPLYING FOR LOAN APPLICATION WITH EXTERNALID------------------------");
+        return applyForLoan(fourMonthLoanApplication(clientId, loanProductId, toAmount(principal), null, null, Collections.emptyList())
+                .externalId(externalId));
+    }
+
+    private Long applyForLoanApplicationWithTranches(final Long clientId, final Long loanProductId,
+            final List<PostLoansRequestChargeData> charges, final Long savingsId, final String principal,
+            final List<PostLoansDisbursementData> tranches, final List<PostLoansRequestCollateralData> collaterals) {
+        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
+        return applyForLoan(fourMonthLoanApplication(clientId, loanProductId, toAmount(principal), charges, savingsId, collaterals)//
+                .expectedDisbursementDate("01 March 2014")//
+                .submittedOnDate("01 March 2014")//
+                .disbursementData(tranches)//
+                .fixedEmiAmount(BigDecimal.valueOf(10000)));
+    }
+
+    /** Re-expresses an application's charge list as the update endpoint's charge model. */
+    private List<PutLoansLoanIdChargeData> toUpdateCharges(final List<PostLoansRequestChargeData> charges) {
+        return charges.stream().map(charge -> new PutLoansLoanIdChargeData().chargeId(charge.getChargeId()).amount(charge.getAmount())
+                .dueDate(charge.getDueDate())).toList();
+    }
+
+    /** Re-expresses an application's collateral list as the update endpoint's collateral model. */
+    private List<PutLoansLoanIdCollateral> toUpdateCollaterals(final List<PostLoansRequestCollateralData> collaterals) {
+        return collaterals.stream()
+                .map(item -> new PutLoansLoanIdCollateral().clientCollateralId(item.getClientCollateralId()).quantity(item.getQuantity()))
+                .toList();
+    }
+
+    private PutLoansLoanIdRequest updateLoanRequest(final Long clientId, final Long loanProductId,
+            final List<PutLoansLoanIdChargeData> charges, final Long savingsId, final List<PostLoansRequestCollateralData> collaterals) {
+        LOG.info("--------------------------------UPDATING LOAN APPLICATION--------------------------------");
+        return new PutLoansLoanIdRequest()//
+                .clientId(clientId)//
+                .productId(loanProductId)//
+                .dateFormat(DATETIME_PATTERN)//
+                .locale(LOCALE)//
+                .loanType("individual")//
+                .transactionProcessingStrategyCode(DEFAULT_STRATEGY)//
+                .principal(10000L)//
+                .loanTermFrequency(4)//
+                .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .numberOfRepayments(4)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .interestRatePerPeriod(BigDecimal.valueOf(2))//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_INSTALLMENTS)//
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE)//
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)//
+                .maxOutstandingLoanBalance(36000L)//
+                .expectedDisbursementDate("20 September 2011")//
+                .submittedOnDate("20 September 2011")//
+                .collateral(toUpdateCollaterals(collaterals))//
+                .charges(charges)//
+                .linkAccountId(savingsId);
+    }
+
+    private Long applyForLoanApplicationWithPaymentStrategy(final Long clientId, final Long loanProductId,
+            final List<PostLoansRequestChargeData> charges, final Long savingsId, final String principal, final String repaymentStrategy,
+            final List<PostLoansRequestCollateralData> collaterals) {
+        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
+        return applyForLoan(fourMonthLoanApplication(clientId, loanProductId, toAmount(principal), charges, savingsId, collaterals)//
+                .transactionProcessingStrategyCode(repaymentStrategy));
+    }
+
+    private Long applyForLoanApplicationWithPaymentStrategyAndPastMonth(final Long clientId, final Long loanProductId,
+            final List<PostLoansRequestChargeData> charges, final Long savingsId, final String principal, final String repaymentStrategy,
+            final String fourMonthsfromNow, final List<PostLoansRequestCollateralData> collaterals) {
+        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
+        return applyForLoan(baseLoanApplication(clientId, loanProductId)//
+                .principal(toAmount(principal))//
+                .loanTermFrequency(6)//
+                .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .numberOfRepayments(6)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .interestRatePerPeriod(BigDecimal.valueOf(2))//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_INSTALLMENTS)//
+                .interestType(LoanTestData.InterestType.FLAT)//
+                .expectedDisbursementDate(fourMonthsfromNow)//
+                .submittedOnDate(fourMonthsfromNow)//
+                .transactionProcessingStrategyCode(repaymentStrategy)//
+                .collateral(collaterals)//
+                .charges(charges)//
+                .linkAccountId(savingsId));
+    }
+
+    private Long applyForLoanApplicationWithProductConfigurationAsTrue(final Long clientId, final Long loanProductId,
+            final String principal) {
+        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
+        return applyForLoan(baseLoanApplication(clientId, loanProductId)//
+                .principal(toAmount(principal))//
+                .repaymentEvery(1)//
+                .loanTermFrequency(4)//
+                .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .numberOfRepayments(4)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .interestRatePerPeriod(BigDecimal.valueOf(2))//
+                .expectedDisbursementDate("01 March 2014")//
+                .submittedOnDate("01 March 2014")//
+                .collateral(createClientCollateral(clientId)));
+    }
+
+    private Long applyForLoanApplicationWithProductConfigurationAsFalse(final Long clientId, final Long loanProductId,
+            final String principal) {
+        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
+        return applyForLoan(baseLoanApplication(clientId, loanProductId)//
+                .principal(toAmount(principal))//
+                .repaymentEvery(2)//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_PRINCIPAL)//
+                .transactionProcessingStrategyCode(RBI_INDIA_STRATEGY)//
+                .interestType(LoanTestData.InterestType.FLAT)//
+                .graceOnPrincipalPayment(1)//
+                .graceOnInterestPayment(1)//
+                .loanTermFrequency(4)//
+                .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .numberOfRepayments(4)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .interestRatePerPeriod(BigDecimal.valueOf(2))//
+                .expectedDisbursementDate("01 March 2014")//
+                .submittedOnDate("01 March 2014")//
+                .collateral(createClientCollateral(clientId)));
+    }
+
+    /** The 4-week, 2%, equal-installment application used by the interest-recalculation tests. */
+    private Long applyForLoanApplicationForInterestRecalculation(final Long clientId, final Long loanProductId,
+            final String disbursementDate, final String repaymentStrategy, final List<PostLoansRequestChargeData> charges) {
+        return applyForLoanApplicationForInterestRecalculation(clientId, loanProductId, disbursementDate, repaymentStrategy, charges, null,
+                null);
+    }
+
+    private Long applyForLoanApplicationForInterestRecalculationWithMoratorium(final Long clientId, final Long loanProductId,
+            final String disbursementDate, final String repaymentStrategy, final List<PostLoansRequestChargeData> charges,
+            final Integer graceOnInterestPayment, final Integer graceOnPrincipalPayment) {
+        return applyForLoanApplicationForInterestRecalculation(clientId, loanProductId, disbursementDate, repaymentStrategy, charges,
+                graceOnInterestPayment, graceOnPrincipalPayment);
+    }
+
+    private Long applyForLoanApplicationForInterestRecalculation(final Long clientId, final Long loanProductId,
+            final String disbursementDate, final String repaymentStrategy, final List<PostLoansRequestChargeData> charges,
+            final Integer graceOnInterestPayment, final Integer graceOnPrincipalPayment) {
+        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
+        return applyForLoan(baseLoanApplication(clientId, loanProductId)//
+                .principal(new BigDecimal("10000.00"))//
+                .loanTermFrequency(4)//
+                .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.WEEKS)//
+                .numberOfRepayments(4)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.WEEKS)//
+                .interestRatePerPeriod(BigDecimal.valueOf(2))//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_INSTALLMENTS)//
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE)//
+                .expectedDisbursementDate(disbursementDate)//
+                .submittedOnDate(disbursementDate)//
+                .transactionProcessingStrategyCode(repaymentStrategy)//
+                .graceOnPrincipalPayment(graceOnPrincipalPayment)//
+                .graceOnInterestPayment(graceOnInterestPayment)//
+                .charges(charges)//
+                .collateral(createClientCollateral(clientId)));
+    }
+
+    /** The 12-month, 19.9%, daily-interest application whose first repayment date is pinned. */
+    private Long applyForLoanApplicationForInterestRecalculationWithFirstRepaymentDate(final Long clientId, final Long loanProductId,
+            final String disbursementDate, final String repaymentStrategy, final String firstRepaymentDate) {
+        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
+        PostLoansRequest request = baseLoanApplication(clientId, loanProductId)//
+                .principal(new BigDecimal("10000.00"))//
+                .loanTermFrequency(12)//
+                .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .numberOfRepayments(12)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .interestRatePerPeriod(BigDecimal.valueOf(19.9))//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_INSTALLMENTS)//
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE)//
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.DAILY)//
+                .expectedDisbursementDate(disbursementDate)//
+                .submittedOnDate(disbursementDate)//
+                .transactionProcessingStrategyCode(repaymentStrategy)//
+                .collateral(createClientCollateral(clientId));
+        return applyForLoan(LoanRequestBuilders.applyLoanWithLegacyDates(request, null, firstRepaymentDate));
+    }
+
+    private PostLoansResponse applyForLoanApplicationForOnePeriod30DaysLongNoInterestPeriodicAccrual(Long clientId, Long loanProductId,
+            String loanDisbursementDate, String repaymentStrategyCode) {
+        return loanHelper.applyForLoan(new PostLoansRequest().clientId(clientId).productId(loanProductId)
+                .expectedDisbursementDate(loanDisbursementDate).dateFormat(DATETIME_PATTERN)
+                .transactionProcessingStrategyCode(repaymentStrategyCode).locale("en").submittedOnDate(loanDisbursementDate)
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_INSTALLMENTS).interestRatePerPeriod(BigDecimal.ZERO)
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE).repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.DAYS)
+                .repaymentEvery(30).numberOfRepayments(1).loanTermFrequency(30)
+                .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.DAYS).principal(BigDecimal.valueOf(1000.0))
+                .loanType("individual"));
+    }
+
+    // ----------------------------------------------------------------------------------------------------
+    // Collateral / charge / savings helpers
+    // ----------------------------------------------------------------------------------------------------
+
+    /**
+     * Creates a collateral product plus a client collateral, returning the single-entry collateral list a loan needs.
+     */
+    private List<PostLoansRequestCollateralData> createClientCollateral(final Long clientId) {
+        Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
         Assertions.assertNotNull(collateralId);
-        List<HashMap> collaterals = new ArrayList<>();
-
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
+        Long clientCollateralId = collateralHelper.createClientCollateral(clientId, collateralId).getResourceId();
         Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
-        final String loanApplicationJSON = new LoanApplicationTestBuilder()
-                //
-                .withPrincipal(principal)
-                //
-                .withRepaymentEveryAfter("2")
-                //
-                .withAmortizationTypeAsEqualPrincipalPayments().withRepaymentFrequencyTypeAsWeeks()
-                .withRepaymentStrategy(LoanProductTestBuilder.RBI_INDIA_STRATEGY).withInterestTypeAsFlatBalance()
-                .withInterestCalculationPeriodTypeSameAsRepaymentPeriod().withPrincipalGrace("1").withInterestGrace("1")
-                .withLoanTermFrequency("4") //
-                .withLoanTermFrequencyAsMonths() //
-                .withNumberOfRepayments("4") //
-                .withRepaymentFrequencyTypeAsMonths() //
-                .withInterestRatePerPeriod("2") //
-                .withInterestCalculationPeriodTypeSameAsRepaymentPeriod() //
-                .withExpectedDisbursementDate("01 March 2014") //
-                .withSubmittedOnDate("01 March 2014") //
-                .withCollaterals(collaterals).build(clientID.toString(), loanProductID.toString(), null);
+        return List.of(collateral(clientCollateralId, BigDecimal.ONE));
+    }
 
-        return LOAN_TRANSACTION_HELPER.getLoanId(loanApplicationJSON);
+    private PostLoansRequestCollateralData collateral(final Long clientCollateralId, final BigDecimal quantity) {
+        return new PostLoansRequestCollateralData().clientCollateralId(clientCollateralId).quantity(quantity);
+    }
+
+    /**
+     * Parses an amount that may carry {@code en_GB} grouping separators, e.g. {@code "12,000.00"}. The RestAssured
+     * builders sent these strings verbatim and let the server parse them under the request's locale; the typed models
+     * carry a JSON number, so the grouping has to be removed here.
+     */
+    private BigDecimal toAmount(final String value) {
+        return new BigDecimal(value.replace(",", ""));
+    }
+
+    private PostLoansRequestChargeData charge(final Long chargeId, final Double amount, final String dueDate) {
+        PostLoansRequestChargeData charge = new PostLoansRequestChargeData().chargeId(chargeId).amount(BigDecimal.valueOf(amount));
+        if (dueDate != null) {
+            charge.dueDate(dueDate);
+        }
+        return charge;
+    }
+
+    private void addCharges(List<PostLoansRequestChargeData> charges, Long chargeId, Double amount, String dueDate) {
+        charges.add(charge(chargeId, amount, dueDate));
+    }
+
+    /**
+     * Compares an installment's period against an installment number. The schedule exposes the period as an
+     * {@link Integer} while installment numbers are sent as {@link Long}, so {@code equals} between the two is always
+     * false - compare the numeric values instead.
+     */
+    private boolean isPeriod(GetLoansLoanIdRepaymentPeriod installment, Long installmentNumber) {
+        return installment.getPeriod() != null && installmentNumber != null && installment.getPeriod().longValue() == installmentNumber;
+    }
+
+    private GetLoansLoanIdChargesChargeIdResponse getloanCharge(Long chargeId, List<GetLoansLoanIdChargesChargeIdResponse> charges) {
+        return charges.stream().filter(charge -> Objects.equals(charge.getChargeId(), chargeId)).reduce((first, second) -> second)
+                .orElse(null);
+    }
+
+    /**
+     * Rebuilds the loan's charge array for a loan-application update, optionally dropping one charge and overriding the
+     * amount.
+     */
+    private List<PutLoansLoanIdChargeData> copyChargesForUpdate(List<GetLoansLoanIdChargesChargeIdResponse> charges,
+            Long deleteWithChargeId, Double amount) {
+        List<PutLoansLoanIdChargeData> loanCharges = new ArrayList<>();
+        for (GetLoansLoanIdChargesChargeIdResponse charge : charges) {
+            if (!Objects.equals(charge.getChargeId(), deleteWithChargeId)) {
+                loanCharges.add(copyForUpdate(charge, amount));
+            }
+        }
+        return loanCharges;
+    }
+
+    private PutLoansLoanIdChargeData copyForUpdate(GetLoansLoanIdChargesChargeIdResponse charge, Double amount) {
+        PutLoansLoanIdChargeData data = new PutLoansLoanIdChargeData()//
+                .id(charge.getId())//
+                .chargeId(charge.getChargeId())//
+                .amount(BigDecimal.valueOf(amount == null ? charge.getAmountOrPercentage() : amount));
+        if (charge.getDueDate() != null) {
+            data.dueDate(dateTimeFormatter.format(charge.getDueDate()));
+        }
+        return data;
+    }
+
+    private PostLoansDisbursementData createTrancheDetail(final String date, final String amount) {
+        return new PostLoansDisbursementData().expectedDisbursementDate(date).principal(toAmount(amount));
+    }
+
+    /** Adds an installment-fee loan charge whose amount is sent as a JSON number under the given locale. */
+    private void addInstallmentChargeWithLocale(final Long loanId, final Long chargeId, final Double amount, final Locale locale) {
+        addLoanCharge(loanId, new PostLoansLoanIdChargesRequest()//
+                .chargeId(chargeId)//
+                .amount(amount)//
+                .locale(locale.getLanguage())//
+                .dateFormat(DATETIME_PATTERN));
+    }
+
+    /**
+     * Adds an installment-fee loan charge whose {@code amount} is a locale-formatted <em>string</em> (the German
+     * {@code "50,05"}), which is what this test exists to prove the server parses.
+     *
+     * <p>
+     * {@code PostLoansLoanIdChargesRequest.amount} is a JSON number, so the generated model cannot carry a decimal
+     * comma - see {@link LoanChargeCommandsApi#createLoanChargeWithLocaleFormattedAmount} for why this gets its own
+     * request model instead of a Swagger change.
+     *
+     * @param amountText
+     *            the {@code amount} formatted for {@code locale}, e.g. the German {@code "50,05"}
+     */
+    private void addInstallmentChargeWithLocaleFormattedAmount(final Long loanId, final Long chargeId, final String amountText,
+            final Locale locale) {
+        ok(() -> loanChargeCommands().createLoanChargeWithLocaleFormattedAmount(loanId,
+                new LoanChargeCommandsApi.LocaleFormattedAmountLoanChargeRequest()//
+                        .chargeId(String.valueOf(chargeId))//
+                        .amount(amountText)//
+                        .locale(locale.getLanguage())//
+                        .dateFormat(DATETIME_PATTERN)));
+    }
+
+    /**
+     * Waives a loan charge in full. Goes through {@link LoanChargeCommandsApi#waiveLoanChargeInFull} because the
+     * endpoint needs an empty body, which no request model can express.
+     *
+     * @return the waived loan charge's id
+     */
+    private Long waiveWholeLoanCharge(final Long loanId, final Long loanChargeId) {
+        return ok(() -> loanChargeCommands().waiveLoanChargeInFull(loanId, loanChargeId)).getResourceId();
+    }
+
+    private static LoanChargeCommandsApi loanChargeCommands() {
+        return FineractFeignClientHelper.getFineractFeignClient().create(LoanChargeCommandsApi.class);
+    }
+
+    /**
+     * Re-submits a savings application with a new {@code submittedOnDate} and reports whether the server echoed that
+     * field back as changed.
+     *
+     * @return whether {@code submittedOnDate} comes back in the response's {@code changes}
+     */
+    private boolean updateSavingsSubmittedOnDate(final Long savingsId, final Long clientId, final Long productId,
+            final String submittedOnDate) {
+        PutSavingsAccountsAccountIdRequest request = new PutSavingsAccountsAccountIdRequest()//
+                .clientId(clientId)//
+                .productId(productId)//
+                .submittedOnDate(submittedOnDate)//
+                .locale(LOCALE)//
+                .dateFormat(DATETIME_PATTERN);
+        PutSavingsAccountsAccountIdResponse response = ok(() -> FineractFeignClientHelper.getFineractFeignClient().savingsAccount()
+                .updateSavingsAccount(savingsId, request, (String) null));
+        return response.getChanges() != null && response.getChanges().getSubmittedOnDate() != null;
+    }
+
+    private Long createSavingsProduct(final String minOpenningBalance) {
+        LOG.info("------------------------------CREATING NEW SAVINGS PRODUCT ---------------------------------------");
+        return savingsProductHelper.createSavingsProduct(SavingsRequestBuilders.defaultSavingsProduct()//
+                .minRequiredOpeningBalance(new BigDecimal(minOpenningBalance))).getResourceId();
+    }
+
+    /**
+     * Opens a savings account submitted on {@code 08 January 2013} and activated on {@code 01 March 2013}, funded by
+     * the product's minimum opening balance. The inherited {@code openSavingsAccount} activates on today's date, which
+     * is after the 2011-2013 transaction dates these tests use.
+     */
+    private Long openSavingsAccountActivatedOnTransactionDate(final Long clientId, final String minimumOpeningBalance) {
+        final Long savingsProductId = createSavingsProduct(minimumOpeningBalance);
+        Assertions.assertNotNull(savingsProductId);
+        final Long savingsId = savingsHelper.submitApplication(clientId, savingsProductId, SAVINGS_CREATED_DATE).getSavingsId();
+        Assertions.assertNotNull(savingsId);
+        savingsHelper.approveSavings(savingsId, SAVINGS_TRANSACTION_DATE);
+        savingsHelper.activateSavings(savingsId, SAVINGS_TRANSACTION_DATE);
+        return savingsId;
+    }
+
+    // ----------------------------------------------------------------------------------------------------
+    // Assertion helpers
+    // ----------------------------------------------------------------------------------------------------
+
+    /**
+     * Asserts the loan did not override any of the product's defaults — the same attribute set the RestAssured version
+     * compared. The enum-valued attributes reach the two responses as different generated wrapper types, so they are
+     * compared on their {@code id} and {@code code} rather than by {@code equals}.
+     */
+    private void validateIfValuesAreNotOverridden(Long loanId, Long loanProductId) {
+        GetLoanProductsProductIdResponse loanProduct = retrieveLoanProduct(loanProductId);
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
+
+        assertEnumEquals(loanProduct.getAmortizationType().getId(), loanProduct.getAmortizationType().getCode(),
+                loanDetails.getAmortizationType().getId(), loanDetails.getAmortizationType().getCode(), "amortizationType");
+        assertEnumEquals(loanProduct.getInterestType().getId(), loanProduct.getInterestType().getCode(),
+                loanDetails.getInterestType().getId(), loanDetails.getInterestType().getCode(), "interestType");
+        assertEnumEquals(loanProduct.getInterestCalculationPeriodType().getId(), loanProduct.getInterestCalculationPeriodType().getCode(),
+                loanDetails.getInterestCalculationPeriodType().getId(), loanDetails.getInterestCalculationPeriodType().getCode(),
+                "interestCalculationPeriodType");
+        assertEnumEquals(loanProduct.getRepaymentFrequencyType().getId(), loanProduct.getRepaymentFrequencyType().getCode(),
+                loanDetails.getRepaymentFrequencyType().getId(), loanDetails.getRepaymentFrequencyType().getCode(),
+                "repaymentFrequencyType");
+
+        assertEquals(loanProduct.getTransactionProcessingStrategyCode(), loanDetails.getTransactionProcessingStrategyCode(),
+                OVERRIDE_MESSAGE.formatted("transactionProcessingStrategyCode"));
+        assertEquals(loanProduct.getGraceOnPrincipalPayment(), loanDetails.getGraceOnPrincipalPayment(),
+                OVERRIDE_MESSAGE.formatted("graceOnPrincipalPayment"));
+        assertEquals(loanProduct.getGraceOnInterestPayment(), loanDetails.getGraceOnInterestPayment(),
+                OVERRIDE_MESSAGE.formatted("graceOnInterestPayment"));
+        assertEquals(loanProduct.getInArrearsTolerance(), loanDetails.getInArrearsTolerance(),
+                OVERRIDE_MESSAGE.formatted("inArrearsTolerance"));
+        assertEquals(loanProduct.getGraceOnArrearsAgeing(), loanDetails.getGraceOnArrearsAgeing(),
+                OVERRIDE_MESSAGE.formatted("graceOnArrearsAgeing"));
+    }
+
+    private static void assertEnumEquals(Long productId, String productCode, Long loanId, String loanCode, String attribute) {
+        assertEquals(productId, loanId, OVERRIDE_MESSAGE.formatted(attribute));
+        assertEquals(productCode, loanCode, OVERRIDE_MESSAGE.formatted(attribute));
+    }
+
+    /**
+     * A product whose {@code allowAttributeOverrides} are all set to {@code allowOverride}, so a loan application
+     * either may or may not deviate from the product's defaults.
+     */
+    private Long createLoanProductWithAttributeOverrides(boolean allowOverride) {
+        PostLoanProductsRequest product = baseLoanProduct()//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_INSTALLMENTS)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS_L)//
+                .repaymentEvery(1)//
+                .transactionProcessingStrategyCode(DEFAULT_STRATEGY)//
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE)//
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.DAILY)//
+                .inArrearsTolerance(10)//
+                .graceOnPrincipalPayment(2)//
+                .graceOnInterestPayment(3)//
+                .allowAttributeOverrides(new AllowAttributeOverrides()//
+                        .amortizationType(allowOverride)//
+                        .interestType(allowOverride)//
+                        .transactionProcessingStrategyCode(allowOverride)//
+                        .interestCalculationPeriodType(allowOverride)//
+                        .inArrearsTolerance(allowOverride)//
+                        .repaymentEvery(allowOverride)//
+                        .graceOnPrincipalAndInterestPayment(allowOverride)//
+                        .graceOnArrearsAgeing(allowOverride));
+        return createLoanProduct(product);
     }
 
     private Integer getDayOfWeek(Calendar date) {
@@ -7262,494 +7571,344 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
                 dayOfMonth = 28;
             }
         }
-
         return dayOfMonth;
     }
 
-    private void validateCharge(Integer amountPercentage, final List<HashMap> loanCharges, final String amount, final String outstanding,
-            String amountPaid, String amountWaived) {
-        HashMap chargeDetail = getloanCharge(amountPercentage, loanCharges);
-        assertTrue(Float.valueOf(amount).compareTo(Float.valueOf(String.valueOf(chargeDetail.get("amountOrPercentage")))) == 0);
-        assertTrue(Float.valueOf(outstanding).compareTo(Float.valueOf(String.valueOf(chargeDetail.get("amountOutstanding")))) == 0);
-        assertTrue(Float.valueOf(amountPaid).compareTo(Float.valueOf(String.valueOf(chargeDetail.get("amountPaid")))) == 0);
-        assertTrue(Float.valueOf(amountWaived).compareTo(Float.valueOf(String.valueOf(chargeDetail.get("amountWaived")))) == 0);
+    private void validateCharge(Long chargeId, final List<GetLoansLoanIdChargesChargeIdResponse> loanCharges, final String amount,
+            final String outstanding, String amountPaid, String amountWaived) {
+        GetLoansLoanIdChargesChargeIdResponse chargeDetail = getloanCharge(chargeId, loanCharges);
+        assertNotNull(chargeDetail, "Loan charge not found for charge " + chargeId);
+        validateNumberForEqual(amount, String.valueOf(chargeDetail.getAmountOrPercentage()));
+        validateNumberForEqual(outstanding, String.valueOf(chargeDetail.getAmountOutstanding()));
+        validateNumberForEqual(amountPaid, String.valueOf(chargeDetail.getAmountPaid()));
+        validateNumberForEqual(amountWaived, String.valueOf(chargeDetail.getAmountWaived()));
     }
 
-    private void validateChargeExcludePrecission(Integer amountPercentage, final List<HashMap> loanCharges, final String amount,
-            final String outstanding, String amountPaid, String amountWaived) {
-        DecimalFormat twoDForm = new DecimalFormat("#");
-        HashMap chargeDetail = getloanCharge(amountPercentage, loanCharges);
-        assertTrue(Float.valueOf(twoDForm.format(Float.valueOf(amount)))
-                .compareTo(Float.parseFloat(twoDForm.format(Float.valueOf(String.valueOf(chargeDetail.get("amountOrPercentage")))))) == 0);
-        assertTrue(Float.valueOf(twoDForm.format(Float.valueOf(outstanding)))
-                .compareTo(Float.valueOf(twoDForm.format(Float.parseFloat(String.valueOf(chargeDetail.get("amountOutstanding")))))) == 0);
-        assertTrue(Float.valueOf(twoDForm.format(Float.parseFloat(amountPaid)))
-                .compareTo(Float.valueOf(twoDForm.format(Float.parseFloat(String.valueOf(chargeDetail.get("amountPaid")))))) == 0);
-        assertTrue(Float.valueOf(twoDForm.format(Float.parseFloat(amountWaived)))
-                .compareTo(Float.valueOf(twoDForm.format(Float.parseFloat(String.valueOf(chargeDetail.get("amountWaived")))))) == 0);
+    private void validateChargeExcludePrecission(Long chargeId, final List<GetLoansLoanIdChargesChargeIdResponse> loanCharges,
+            final String amount, final String outstanding, String amountPaid, String amountWaived) {
+        GetLoansLoanIdChargesChargeIdResponse chargeDetail = getloanCharge(chargeId, loanCharges);
+        assertNotNull(chargeDetail, "Loan charge not found for charge " + chargeId);
+        validateNumberForEqualExcludePrecission(amount, String.valueOf(chargeDetail.getAmountOrPercentage()));
+        validateNumberForEqualExcludePrecission(outstanding, String.valueOf(chargeDetail.getAmountOutstanding()));
+        validateNumberForEqualExcludePrecission(amountPaid, String.valueOf(chargeDetail.getAmountPaid()));
+        validateNumberForEqualExcludePrecission(amountWaived, String.valueOf(chargeDetail.getAmountWaived()));
     }
 
     private void validateNumberForEqual(String val, String val2) {
-        assertTrue(Float.valueOf(val).compareTo(Float.valueOf(val2)) == 0);
+        assertEquals(0, Float.valueOf(val).compareTo(Float.valueOf(val2)), String.format("%s is not equal to %s", val, val2));
     }
 
     private void validateNumberForEqualWithMsg(String msg, String val, String val2) {
-        assertTrue(Float.valueOf(val).compareTo(Float.valueOf(val2)) == 0, msg + "expected " + val + " but was " + val2);
+        assertEquals(0, Float.valueOf(val).compareTo(Float.valueOf(val2)), msg + "expected " + val + " but was " + val2);
     }
 
     private void validateNumberForEqualExcludePrecission(String val, String val2) {
         DecimalFormat twoDForm = new DecimalFormat("#");
-        assertTrue(Float.valueOf(twoDForm.format(Float.valueOf(val))).compareTo(Float.valueOf(twoDForm.format(Float.valueOf(val2)))) == 0,
+        assertEquals(0, Float.valueOf(twoDForm.format(Float.valueOf(val))).compareTo(Float.valueOf(twoDForm.format(Float.valueOf(val2)))),
                 String.format("%s is not equal to %s", val, val2));
     }
 
-    private Integer createLoanProduct(final boolean multiDisburseLoan, final String accountingRule, final Account... accounts) {
-        LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-        LoanProductTestBuilder builder = new LoanProductTestBuilder() //
-                .withPrincipal("12,000.00") //
-                .withNumberOfRepayments("4") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("1") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualInstallments() //
-                .withInterestTypeAsDecliningBalance() //
-                .withTranches(multiDisburseLoan) //
-                .withAccounting(accountingRule, accounts);
-        if (multiDisburseLoan) {
-            builder = builder.withInterestCalculationPeriodTypeAsRepaymentPeriod(true);
+    private List<GetLoansLoanIdRepaymentPeriod> getLoanRepaymentSchedule(Long loanId) {
+        return getLoanDetails(loanId).getRepaymentSchedule().getPeriods();
+    }
+
+    /**
+     * The future (not-yet-due) repayment periods. {@code getLoanDetails} excludes the {@code futureSchedule}
+     * association, so this asks for it explicitly.
+     */
+    private List<GetLoansLoanIdRepaymentPeriod> getLoanFutureRepaymentSchedule(Long loanId) {
+        return loanHelper.getLoanDetails(loanId, "repaymentSchedule,futureSchedule").getRepaymentSchedule().getFuturePeriods();
+    }
+
+    /**
+     * The prepayment template with no explicit transaction date, letting the server default it, exactly as the
+     * RestAssured helper did. Passing a date here would require a business date to be set.
+     */
+    private GetLoansLoanIdTransactionsTemplateResponse getPrepayAmount(Long loanId) {
+        return transactionHelper.getPrepaymentAmount(loanId, null, null);
+    }
+
+    private void verifyLoanRepaymentSchedule(final List<GetLoansLoanIdRepaymentPeriod> loanSchedule) {
+        LOG.info("--------------------VERIFYING THE PRINCIPAL DUES,INTEREST DUE AND DUE DATE--------------------------");
+
+        assertEquals(LocalDate.of(2011, 10, 20), loanSchedule.get(1).getDueDate(), "Checking for Due Date for 1st Month");
+        validateNumberForEqualWithMsg("Checking for Principal Due for 1st Month", "2911.49",
+                String.valueOf(loanSchedule.get(1).getPrincipalOriginalDue()));
+        validateNumberForEqualWithMsg("Checking for Interest Due for 1st Month", "240.00",
+                String.valueOf(loanSchedule.get(1).getInterestOriginalDue()));
+
+        assertEquals(LocalDate.of(2011, 11, 20), loanSchedule.get(2).getDueDate(), "Checking for Due Date for 2nd Month");
+        validateNumberForEqualWithMsg("Checking for Principal Due for 2nd Month", "2969.72",
+                String.valueOf(loanSchedule.get(2).getPrincipalDue()));
+        validateNumberForEqualWithMsg("Checking for Interest Due for 2nd Month", "181.77",
+                String.valueOf(loanSchedule.get(2).getInterestOriginalDue()));
+
+        assertEquals(LocalDate.of(2011, 12, 20), loanSchedule.get(3).getDueDate(), "Checking for Due Date for 3rd Month");
+        validateNumberForEqualWithMsg("Checking for Principal Due for 3rd Month", "3029.11",
+                String.valueOf(loanSchedule.get(3).getPrincipalDue()));
+        validateNumberForEqualWithMsg("Checking for Interest Due for 3rd Month", "122.38",
+                String.valueOf(loanSchedule.get(3).getInterestOriginalDue()));
+
+        assertEquals(LocalDate.of(2012, 1, 20), loanSchedule.get(4).getDueDate(), "Checking for Due Date for 4th Month");
+        validateNumberForEqualWithMsg("Checking for Principal Due for 4th Month", "3089.68",
+                String.valueOf(loanSchedule.get(4).getPrincipalDue()));
+        validateNumberForEqualWithMsg("Checking for Interest Due for 4th Month", "61.79",
+                String.valueOf(loanSchedule.get(4).getInterestOriginalDue()));
+    }
+
+    private void verifyLoanRepaymentScheduleForEqualPrincipal(final List<GetLoansLoanIdRepaymentPeriod> loanSchedule) {
+        LOG.info("--------------------VERIFYING THE PRINCIPAL DUES,INTEREST DUE AND DUE DATE--------------------------");
+
+        verifyEqualPrincipalInstallment(loanSchedule, 1, LocalDate.of(2014, 7, 2), "416700", "200000", true);
+        verifyEqualPrincipalInstallment(loanSchedule, 2, LocalDate.of(2014, 8, 2), "416700", "191700", false);
+        verifyEqualPrincipalInstallment(loanSchedule, 3, LocalDate.of(2014, 9, 2), "416700", "183300", false);
+        verifyEqualPrincipalInstallment(loanSchedule, 4, LocalDate.of(2014, 10, 2), "416700", "175000", false);
+        verifyEqualPrincipalInstallment(loanSchedule, 5, LocalDate.of(2014, 11, 2), "416700", "166700", false);
+        verifyEqualPrincipalInstallment(loanSchedule, 6, LocalDate.of(2014, 12, 2), "416700", "158300", false);
+        verifyEqualPrincipalInstallment(loanSchedule, 10, LocalDate.of(2015, 4, 2), "416700", "125000", false);
+        verifyEqualPrincipalInstallment(loanSchedule, 20, LocalDate.of(2016, 2, 2), "416700", "41700", false);
+        verifyEqualPrincipalInstallment(loanSchedule, 24, LocalDate.of(2016, 6, 2), "415900", "8300", false);
+    }
+
+    private void verifyLoanRepaymentScheduleForEqualPrincipalWithGrace(final List<GetLoansLoanIdRepaymentPeriod> loanSchedule) {
+        LOG.info("--------------------VERIFYING THE PRINCIPAL DUES,INTEREST DUE AND DUE DATE--------------------------");
+
+        verifyEqualPrincipalInstallment(loanSchedule, 1, LocalDate.of(2014, 7, 2), "0.0", "200000", true);
+        verifyEqualPrincipalInstallment(loanSchedule, 2, LocalDate.of(2014, 8, 2), "0.0", "200000", true);
+        verifyEqualPrincipalInstallment(loanSchedule, 3, LocalDate.of(2014, 9, 2), "0.0", "200000", false);
+        verifyEqualPrincipalInstallment(loanSchedule, 4, LocalDate.of(2014, 10, 2), "0", "200000", false);
+        verifyEqualPrincipalInstallment(loanSchedule, 5, LocalDate.of(2014, 11, 2), "0", "200000", false);
+        verifyEqualPrincipalInstallment(loanSchedule, 6, LocalDate.of(2014, 12, 2), "526300", "200000", false);
+        verifyEqualPrincipalInstallment(loanSchedule, 7, LocalDate.of(2015, 1, 2), "526300", "189500", false);
+        verifyEqualPrincipalInstallment(loanSchedule, 10, LocalDate.of(2015, 4, 2), "526300", "157900", false);
+        verifyEqualPrincipalInstallment(loanSchedule, 20, LocalDate.of(2016, 2, 2), "526300", "52600", false);
+        verifyEqualPrincipalInstallment(loanSchedule, 24, LocalDate.of(2016, 6, 2), "526600", "10500", false);
+    }
+
+    /**
+     * @param useOriginalPrincipalDue
+     *            reads {@code principalOriginalDue} instead of {@code principalDue}, mirroring the assertions the
+     *            RestAssured version of this test made per installment.
+     */
+    private void verifyEqualPrincipalInstallment(final List<GetLoansLoanIdRepaymentPeriod> loanSchedule, int installment,
+            LocalDate expectedDueDate, String expectedPrincipalDue, String expectedInterestDue, boolean useOriginalPrincipalDue) {
+        GetLoansLoanIdRepaymentPeriod period = loanSchedule.get(installment);
+        assertEquals(expectedDueDate, period.getDueDate(), "Checking for Due Date for installment " + installment);
+        BigDecimal principalDue = useOriginalPrincipalDue ? period.getPrincipalOriginalDue() : period.getPrincipalDue();
+        validateNumberForEqualWithMsg("Checking for Principal Due for installment " + installment, expectedPrincipalDue,
+                String.valueOf(principalDue));
+        validateNumberForEqualWithMsg("Checking for Interest Due for installment " + installment, expectedInterestDue,
+                String.valueOf(period.getInterestOriginalDue()));
+    }
+
+    private void addRepaymentValues(List<ExpectedInstallment> expectedvalues, Calendar todaysDate, int addPeriod, boolean isAddDays,
+            String principalDue, String interestDue, String feeChargesDue, String penaltyChargesDue) {
+        LocalDate dueDate = isAddDays ? addDays(todaysDate, addPeriod) : addDays(todaysDate, addPeriod * 7);
+        LOG.info("Updated date {}", dueDate);
+        expectedvalues.add(new ExpectedInstallment(dueDate, principalDue, interestDue, feeChargesDue, penaltyChargesDue));
+    }
+
+    private LocalDate addDays(Calendar todaysDate, int addValue) {
+        todaysDate.add(Calendar.DAY_OF_MONTH, addValue);
+        return toLocalDate(todaysDate);
+    }
+
+    private LocalDate toLocalDate(Calendar date) {
+        return LocalDate.of(date.get(Calendar.YEAR), date.get(Calendar.MONTH) + 1, date.get(Calendar.DAY_OF_MONTH));
+    }
+
+    /**
+     * One expected repayment-schedule row, replacing the untyped {@code Map<String, Object>} the RestAssured test used.
+     */
+    private record ExpectedInstallment(LocalDate dueDate, String principalDue, String interestDue, String feeChargesDue,
+            String penaltyChargesDue) {
+    }
+
+    private void verifyLoanRepaymentSchedule(final List<GetLoansLoanIdRepaymentPeriod> loanSchedule,
+            List<ExpectedInstallment> expectedvalues) {
+        verifyLoanRepaymentSchedule(loanSchedule, expectedvalues, 1);
+    }
+
+    private void verifyLoanRepaymentSchedule(final List<GetLoansLoanIdRepaymentPeriod> loanSchedule,
+            List<ExpectedInstallment> expectedvalues, int index) {
+        LOG.info("--------------------VERIFYING THE PRINCIPAL DUES,INTEREST DUE AND DUE DATE--------------------------");
+        for (ExpectedInstallment values : expectedvalues) {
+            GetLoansLoanIdRepaymentPeriod period = loanSchedule.get(index);
+            assertEquals(values.dueDate(), period.getDueDate(), "Checking for Due Date for  installment " + index);
+            validateNumberForEqualWithMsg("Checking for Principal Due for installment " + index, values.principalDue(),
+                    String.valueOf(period.getPrincipalDue()));
+            validateNumberForEqualWithMsg("Checking for Interest Due for installment " + index, values.interestDue(),
+                    String.valueOf(period.getInterestDue()));
+            validateNumberForEqualWithMsg("Checking for Fee charge Due for installment " + index, values.feeChargesDue(),
+                    String.valueOf(period.getFeeChargesDue()));
+            validateNumberForEqualWithMsg("Checking for Penalty charge Due for installment " + index, values.penaltyChargesDue(),
+                    String.valueOf(period.getPenaltyChargesDue()));
+            index++;
         }
-        final String loanProductJSON = builder.build(null);
-        return LOAN_TRANSACTION_HELPER.getLoanProductId(loanProductJSON);
     }
 
-    private Integer createLoanProduct(final String inMultiplesOf, final String digitsAfterDecimal, final String repaymentStrategy) {
-        LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withRepaymentStrategy(repaymentStrategy) //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails(digitsAfterDecimal, inMultiplesOf).build(null);
-        return LOAN_TRANSACTION_HELPER.getLoanProductId(loanProductJSON);
-    }
+    private void checkAccrualTransactions(final List<GetLoansLoanIdRepaymentPeriod> loanSchedule, final Long loanId) {
+        for (int i = 1; i < loanSchedule.size(); i++) {
+            final GetLoansLoanIdRepaymentPeriod repayment = loanSchedule.get(i);
+            final LocalDate transactionDate = repayment.getDueDate();
 
-    private Integer createLoanProduct(final String inMultiplesOf, final String digitsAfterDecimal, final String repaymentStrategy,
-            final String accountingRule, final Account... accounts) {
-        LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-        final String loanProductJSON = new LoanProductTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withNumberOfRepayments("24") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("2") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withRepaymentStrategy(repaymentStrategy) //
-                .withAmortizationTypeAsEqualPrincipalPayment() //
-                .withInterestTypeAsDecliningBalance() //
-                .currencyDetails(digitsAfterDecimal, inMultiplesOf).withAccounting(accountingRule, accounts).build(null);
-        return LOAN_TRANSACTION_HELPER.getLoanProductId(loanProductJSON);
-    }
+            final Float interestPortion = repayment.getInterestDue().subtract(repayment.getInterestWaived())
+                    .subtract(repayment.getInterestWrittenOff()).floatValue();
+            final Float feePortion = repayment.getFeeChargesDue().subtract(repayment.getFeeChargesWaived())
+                    .subtract(repayment.getFeeChargesWrittenOff()).floatValue();
+            final Float penaltyPortion = repayment.getPenaltyChargesDue().subtract(repayment.getPenaltyChargesWaived())
+                    .subtract(repayment.getPenaltyChargesWrittenOff()).floatValue();
 
-    private Integer applyForLoanApplication(final Integer clientID, final Integer loanProductID, String graceOnPrincipalPayment,
-            List<HashMap> collaterals) {
-        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
-        final String loanApplicationJSON = new LoanApplicationTestBuilder() //
-                .withPrincipal("10000000.00") //
-                .withLoanTermFrequency("24") //
-                .withLoanTermFrequencyAsMonths() //
-                .withNumberOfRepayments("24") //
-                .withRepaymentEveryAfter("1") //
-                .withRepaymentFrequencyTypeAsMonths() //
-                .withInterestRatePerPeriod("2") //
-                .withAmortizationTypeAsEqualPrincipalPayments() //
-                .withInterestTypeAsDecliningBalance() //
-                .withInterestCalculationPeriodTypeSameAsRepaymentPeriod() //
-                .withPrincipalGrace(graceOnPrincipalPayment).withExpectedDisbursementDate("02 June 2014") //
-                .withSubmittedOnDate("02 June 2014") //
-                .withCollaterals(collaterals).build(clientID.toString(), loanProductID.toString(), null);
-        return LOAN_TRANSACTION_HELPER.getLoanId(loanApplicationJSON);
-    }
-
-    private Integer applyForLoanApplication(final Integer clientID, final Integer loanProductID, List<HashMap> charges,
-            final String savingsId, String principal, List<HashMap> collaterals) {
-        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
-        final String loanApplicationJSON = new LoanApplicationTestBuilder() //
-                .withPrincipal(principal) //
-                .withLoanTermFrequency("4") //
-                .withLoanTermFrequencyAsMonths() //
-                .withNumberOfRepayments("4") //
-                .withRepaymentEveryAfter("1") //
-                .withRepaymentFrequencyTypeAsMonths() //
-                .withInterestRatePerPeriod("2") //
-                .withAmortizationTypeAsEqualInstallments() //
-                .withInterestTypeAsDecliningBalance() //
-                .withInterestCalculationPeriodTypeSameAsRepaymentPeriod() //
-                .withExpectedDisbursementDate("20 September 2011") //
-                .withSubmittedOnDate("20 September 2011") //
-                .withCollaterals(collaterals).withCharges(charges).build(clientID.toString(), loanProductID.toString(), savingsId);
-        return LOAN_TRANSACTION_HELPER.getLoanId(loanApplicationJSON);
-    }
-
-    private Integer applyForLoanApplication(final Integer clientID, final Integer loanProductID, String disbursementDate,
-            String submissionDate, String interestRate, List<HashMap> charges, final String savingsId, String principal,
-            List<HashMap> collaterals) {
-        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
-        final String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal(principal).withLoanTermFrequency("2")
-                .withLoanTermFrequencyAsMonths().withNumberOfRepayments("2").withRepaymentEveryAfter("1")
-                .withRepaymentFrequencyTypeAsMonths().withInterestRatePerPeriod(interestRate).withAmortizationTypeAsEqualInstallments()
-                .withInterestTypeAsDecliningBalance().withInterestCalculationPeriodTypeSameAsRepaymentPeriod()
-                .withExpectedDisbursementDate(disbursementDate).withSubmittedOnDate(submissionDate).withCollaterals(collaterals)
-                .withCharges(charges).build(clientID.toString(), loanProductID.toString(), savingsId);
-        return LOAN_TRANSACTION_HELPER.getLoanId(loanApplicationJSON);
-    }
-
-    private Integer applyForLoanApplicationWithExternalId(RequestSpecification requestSpecification,
-            ResponseSpecification responseSpecification, final Integer clientID, final Integer loanProductID, String principal,
-            final String externalId) {
-        LOG.info("------------------------APPLYING FOR LOAN APPLICATION WITH EXTERNALID------------------------");
-        final String loanApplicationJSON = new LoanApplicationTestBuilder() //
-                .withPrincipal(principal) //
-                .withExternalId(externalId) //
-                .withLoanTermFrequency("4") //
-                .withLoanTermFrequencyAsMonths() //
-                .withNumberOfRepayments("4") //
-                .withRepaymentEveryAfter("1") //
-                .withRepaymentFrequencyTypeAsMonths() //
-                .withInterestRatePerPeriod("2") //
-                .withAmortizationTypeAsEqualInstallments() //
-                .withInterestTypeAsDecliningBalance() //
-                .withInterestCalculationPeriodTypeSameAsRepaymentPeriod() //
-                .withExpectedDisbursementDate("20 September 2011") //
-                .withSubmittedOnDate("20 September 2011") //
-                .build(clientID.toString(), loanProductID.toString(), null);
-        return LOAN_TRANSACTION_HELPER.getLoanId(loanApplicationJSON, requestSpecification, responseSpecification);
-    }
-
-    private Integer applyForLoanApplicationWithTranches(final Integer clientID, final Integer loanProductID, List<HashMap> charges,
-            final String savingsId, String principal, List<HashMap> tranches, List<HashMap> collaterals) {
-        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
-        final String loanApplicationJSON = new LoanApplicationTestBuilder() //
-                .withPrincipal(principal) //
-                .withLoanTermFrequency("4") //
-                .withLoanTermFrequencyAsMonths() //
-                .withNumberOfRepayments("4") //
-                .withRepaymentEveryAfter("1") //
-                .withRepaymentFrequencyTypeAsMonths() //
-                .withInterestRatePerPeriod("2") //
-                .withAmortizationTypeAsEqualInstallments() //
-                .withInterestTypeAsDecliningBalance() //
-                .withInterestCalculationPeriodTypeSameAsRepaymentPeriod() //
-                .withExpectedDisbursementDate("01 March 2014") //
-                .withCollaterals(collaterals).withTranches(tranches) //
-                .withSubmittedOnDate("01 March 2014") //
-                .withCharges(charges).build(clientID.toString(), loanProductID.toString(), savingsId);
-        return LOAN_TRANSACTION_HELPER.getLoanId(loanApplicationJSON);
-    }
-
-    private String updateLoanJson(final Integer clientID, final Integer loanProductID, List<HashMap> charges, String savingsId,
-            List<HashMap> collaterals) {
-        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
-        final String loanApplicationJSON = new LoanApplicationTestBuilder() //
-                .withPrincipal("10,000.00") //
-                .withLoanTermFrequency("4") //
-                .withLoanTermFrequencyAsMonths() //
-                .withNumberOfRepayments("4") //
-                .withRepaymentEveryAfter("1") //
-                .withRepaymentFrequencyTypeAsMonths() //
-                .withInterestRatePerPeriod("2") //
-                .withAmortizationTypeAsEqualInstallments() //
-                .withInterestTypeAsDecliningBalance() //
-                .withInterestCalculationPeriodTypeSameAsRepaymentPeriod() //
-                .withExpectedDisbursementDate("20 September 2011") //
-                .withSubmittedOnDate("20 September 2011") //
-                .withCollaterals(collaterals).withCharges(charges).build(clientID.toString(), loanProductID.toString(), savingsId);
-        return loanApplicationJSON;
-    }
-
-    private Integer applyForLoanApplicationWithPaymentStrategy(final Integer clientID, final Integer loanProductID, List<HashMap> charges,
-            final String savingsId, String principal, final String repaymentStrategy, final List<HashMap> collaterals) {
-        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
-        final String loanApplicationJSON = new LoanApplicationTestBuilder() //
-                .withPrincipal(principal) //
-                .withLoanTermFrequency("4") //
-                .withLoanTermFrequencyAsMonths() //
-                .withNumberOfRepayments("4") //
-                .withRepaymentEveryAfter("1") //
-                .withRepaymentFrequencyTypeAsMonths() //
-                .withInterestRatePerPeriod("2") //
-                .withAmortizationTypeAsEqualInstallments() //
-                .withInterestTypeAsDecliningBalance() //
-                .withInterestCalculationPeriodTypeSameAsRepaymentPeriod() //
-                .withExpectedDisbursementDate("20 September 2011") //
-                .withSubmittedOnDate("20 September 2011") //
-                .withRepaymentStrategy(repaymentStrategy) //
-                .withCollaterals(collaterals).withCharges(charges).build(clientID.toString(), loanProductID.toString(), savingsId);
-        return LOAN_TRANSACTION_HELPER.getLoanId(loanApplicationJSON);
-    }
-
-    private Integer applyForLoanApplicationWithPaymentStrategyAndPastMonth(final Integer clientID, final Integer loanProductID,
-            List<HashMap> charges, final String savingsId, String principal, final String repaymentStrategy, final String fourMonthsfromNow,
-            List<HashMap> collaterals) {
-        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
-
-        DateFormat dateFormat = new SimpleDateFormat(DATETIME_PATTERN);
-        dateFormat.setTimeZone(Utils.getTimeZoneOfTenant());
-        final String loanApplicationJSON = new LoanApplicationTestBuilder() //
-                .withPrincipal(principal) //
-                .withLoanTermFrequency("6") //
-                .withLoanTermFrequencyAsMonths() //
-                .withNumberOfRepayments("6") //
-                .withRepaymentEveryAfter("1") //
-                .withRepaymentFrequencyTypeAsMonths() //
-                .withInterestRatePerPeriod("2") //
-                .withAmortizationTypeAsEqualInstallments() //
-                .withInterestTypeAsFlatBalance() //
-                .withInterestCalculationPeriodTypeSameAsRepaymentPeriod() //
-                .withExpectedDisbursementDate(fourMonthsfromNow) //
-                .withSubmittedOnDate(fourMonthsfromNow) //
-                .withRepaymentStrategy(repaymentStrategy) //
-                .withCollaterals(collaterals).withCharges(charges).build(clientID.toString(), loanProductID.toString(), savingsId);
-        return LOAN_TRANSACTION_HELPER.getLoanId(loanApplicationJSON);
-    }
-
-    private void verifyLoanRepaymentSchedule(final ArrayList<HashMap> loanSchedule) {
-        LOG.info("--------------------VERIFYING THE PRINCIPAL DUES,INTEREST DUE AND DUE DATE--------------------------");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2011, 10, 20)), loanSchedule.get(1).get("dueDate"),
-                "Checking for Due Date for 1st Month");
-        assertEquals(Float.parseFloat("2911.49"), loanSchedule.get(1).get("principalOriginalDue"),
-                "Checking for Principal Due for 1st Month");
-        assertEquals(Float.parseFloat("240.00"), loanSchedule.get(1).get("interestOriginalDue"), "Checking for Interest Due for 1st Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2011, 11, 20)), loanSchedule.get(2).get("dueDate"),
-                "Checking for Due Date for 2nd Month");
-        assertEquals(Float.parseFloat("2969.72"), loanSchedule.get(2).get("principalDue"), "Checking for Principal Due for 2nd Month");
-        assertEquals(Float.parseFloat("181.77"), loanSchedule.get(2).get("interestOriginalDue"), "Checking for Interest Due for 2nd Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2011, 12, 20)), loanSchedule.get(3).get("dueDate"),
-                "Checking for Due Date for 3rd Month");
-        assertEquals(Float.parseFloat("3029.11"), loanSchedule.get(3).get("principalDue"), "Checking for Principal Due for 3rd Month");
-        assertEquals(Float.parseFloat("122.38"), loanSchedule.get(3).get("interestOriginalDue"), "Checking for Interest Due for 3rd Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2012, 1, 20)), loanSchedule.get(4).get("dueDate"),
-                "Checking for Due Date for 4th Month");
-        assertEquals(Float.parseFloat("3089.68"), loanSchedule.get(4).get("principalDue"), "Checking for Principal Due for 4th Month");
-        assertEquals(Float.parseFloat("61.79"), loanSchedule.get(4).get("interestOriginalDue"), "Checking for Interest Due for 4th Month");
-    }
-
-    private void verifyLoanRepaymentScheduleForEqualPrincipal(final ArrayList<HashMap> loanSchedule) {
-        LOG.info("--------------------VERIFYING THE PRINCIPAL DUES,INTEREST DUE AND DUE DATE--------------------------");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2014, 7, 2)), loanSchedule.get(1).get("dueDate"), "Checking for Due Date for 1st Month");
-        assertEquals(Float.parseFloat("416700"), loanSchedule.get(1).get("principalOriginalDue"),
-                "Checking for Principal Due for 1st Month");
-        assertEquals(Float.parseFloat("200000"), loanSchedule.get(1).get("interestOriginalDue"), "Checking for Interest Due for 1st Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2014, 8, 2)), loanSchedule.get(2).get("dueDate"), "Checking for Due Date for 2nd Month");
-        assertEquals(Float.parseFloat("416700"), loanSchedule.get(2).get("principalDue"), "Checking for Principal Due for 2nd Month");
-        assertEquals(Float.parseFloat("191700"), loanSchedule.get(2).get("interestOriginalDue"), "Checking for Interest Due for 2nd Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2014, 9, 2)), loanSchedule.get(3).get("dueDate"), "Checking for Due Date for 3rd Month");
-        assertEquals(Float.parseFloat("416700"), loanSchedule.get(3).get("principalDue"), "Checking for Principal Due for 3rd Month");
-        assertEquals(Float.parseFloat("183300"), loanSchedule.get(3).get("interestOriginalDue"), "Checking for Interest Due for 3rd Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2014, 10, 2)), loanSchedule.get(4).get("dueDate"),
-                "Checking for Due Date for 4th Month");
-        assertEquals(Float.parseFloat("416700"), loanSchedule.get(4).get("principalDue"), "Checking for Principal Due for 4th Month");
-        assertEquals(Float.parseFloat("175000"), loanSchedule.get(4).get("interestOriginalDue"), "Checking for Interest Due for 4th Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2014, 11, 2)), loanSchedule.get(5).get("dueDate"),
-                "Checking for Due Date for 5th Month");
-        assertEquals(Float.parseFloat("416700"), loanSchedule.get(5).get("principalDue"), "Checking for Principal Due for 5th Month");
-        assertEquals(Float.parseFloat("166700"), loanSchedule.get(5).get("interestOriginalDue"), "Checking for Interest Due for 5th Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2014, 12, 2)), loanSchedule.get(6).get("dueDate"),
-                "Checking for Due Date for 6th Month");
-        assertEquals(Float.parseFloat("416700"), loanSchedule.get(6).get("principalDue"), "Checking for Principal Due for 6th Month");
-        assertEquals(Float.parseFloat("158300"), loanSchedule.get(6).get("interestOriginalDue"), "Checking for Interest Due for 6th Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2015, 4, 2)), loanSchedule.get(10).get("dueDate"),
-                "Checking for Due Date for 10th Month");
-        assertEquals(Float.parseFloat("416700"), loanSchedule.get(10).get("principalDue"), "Checking for Principal Due for 10th Month");
-        assertEquals(Float.parseFloat("125000"), loanSchedule.get(10).get("interestOriginalDue"),
-                "Checking for Interest Due for 10th Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2016, 2, 2)), loanSchedule.get(20).get("dueDate"),
-                "Checking for Due Date for 20th Month");
-        assertEquals(Float.parseFloat("416700"), loanSchedule.get(20).get("principalDue"), "Checking for Principal Due for 20th Month");
-        assertEquals(Float.parseFloat("41700"), loanSchedule.get(20).get("interestOriginalDue"),
-                "Checking for Interest Due for 20th Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2016, 6, 2)), loanSchedule.get(24).get("dueDate"),
-                "Checking for Due Date for 24th Month");
-        assertEquals(Float.parseFloat("415900"), loanSchedule.get(24).get("principalDue"), "Checking for Principal Due for 24th Month");
-        assertEquals(Float.parseFloat("8300"), loanSchedule.get(24).get("interestOriginalDue"), "Checking for Interest Due for 24th Month");
-
-    }
-
-    private void verifyLoanRepaymentScheduleForEqualPrincipalWithGrace(final ArrayList<HashMap> loanSchedule) {
-        LOG.info("--------------------VERIFYING THE PRINCIPAL DUES,INTEREST DUE AND DUE DATE--------------------------");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2014, 7, 2)), loanSchedule.get(1).get("dueDate"), "Checking for Due Date for 1st Month");
-        validateNumberForEqualWithMsg("Checking for Principal Due for 1st Month",
-                String.valueOf(loanSchedule.get(1).get("principalOriginalDue")), "0.0");
-        assertEquals(Float.parseFloat("200000"), loanSchedule.get(1).get("interestOriginalDue"), "Checking for Interest Due for 1st Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2014, 8, 2)), loanSchedule.get(2).get("dueDate"), "Checking for Due Date for 2nd Month");
-        validateNumberForEqualWithMsg("Checking for Principal Due for 2nd Month", "0.0",
-                String.valueOf(loanSchedule.get(2).get("principalOriginalDue")));
-        assertEquals(Float.parseFloat("200000"), loanSchedule.get(2).get("interestOriginalDue"), "Checking for Interest Due for 2nd Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2014, 9, 2)), loanSchedule.get(3).get("dueDate"), "Checking for Due Date for 3rd Month");
-        validateNumberForEqualWithMsg("Checking for Principal Due for 3rd Month", "0.0",
-                String.valueOf(loanSchedule.get(3).get("principalDue")));
-        assertEquals(Float.parseFloat("200000"), loanSchedule.get(3).get("interestOriginalDue"), "Checking for Interest Due for 3rd Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2014, 10, 2)), loanSchedule.get(4).get("dueDate"),
-                "Checking for Due Date for 4th Month");
-        validateNumberForEqualWithMsg("Checking for Principal Due for 4th Month", "0",
-                String.valueOf(loanSchedule.get(4).get("principalDue")));
-        assertEquals(Float.parseFloat("200000"), loanSchedule.get(4).get("interestOriginalDue"), "Checking for Interest Due for 4th Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2014, 11, 2)), loanSchedule.get(5).get("dueDate"),
-                "Checking for Due Date for 5th Month");
-        validateNumberForEqualWithMsg("Checking for Principal Due for 5th Month", "0",
-                String.valueOf(loanSchedule.get(5).get("principalDue")));
-        assertEquals(Float.parseFloat("200000"), loanSchedule.get(5).get("interestOriginalDue"), "Checking for Interest Due for 5th Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2014, 12, 2)), loanSchedule.get(6).get("dueDate"),
-                "Checking for Due Date for 6th Month");
-        assertEquals(Float.parseFloat("526300"), loanSchedule.get(6).get("principalDue"), "Checking for Principal Due for 6th Month");
-        assertEquals(Float.parseFloat("200000"), loanSchedule.get(6).get("interestOriginalDue"), "Checking for Interest Due for 6th Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2015, 1, 2)), loanSchedule.get(7).get("dueDate"), "Checking for Due Date for 7th Month");
-        assertEquals(Float.parseFloat("526300"), loanSchedule.get(7).get("principalDue"), "Checking for Principal Due for 7th Month");
-        assertEquals(Float.parseFloat("189500"), loanSchedule.get(7).get("interestOriginalDue"), "Checking for Interest Due for 7th Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2015, 4, 2)), loanSchedule.get(10).get("dueDate"),
-                "Checking for Due Date for 10th Month");
-        assertEquals(Float.parseFloat("526300"), loanSchedule.get(10).get("principalDue"), "Checking for Principal Due for 10th Month");
-        assertEquals(Float.parseFloat("157900"), loanSchedule.get(10).get("interestOriginalDue"),
-                "Checking for Interest Due for 10th Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2016, 2, 2)), loanSchedule.get(20).get("dueDate"),
-                "Checking for Due Date for 20th Month");
-        assertEquals(Float.parseFloat("526300"), loanSchedule.get(20).get("principalDue"), "Checking for Principal Due for 20th Month");
-        assertEquals(Float.parseFloat("52600"), loanSchedule.get(20).get("interestOriginalDue"),
-                "Checking for Interest Due for 20th Month");
-
-        assertEquals(new ArrayList<>(Arrays.asList(2016, 6, 2)), loanSchedule.get(24).get("dueDate"),
-                "Checking for Due Date for 24th Month");
-        assertEquals(Float.parseFloat("526600"), loanSchedule.get(24).get("principalDue"), "Checking for Principal Due for 24th Month");
-        assertEquals(Float.parseFloat("10500"), loanSchedule.get(24).get("interestOriginalDue"),
-                "Checking for Interest Due for 24th Month");
-    }
-
-    private void addCharges(List<HashMap> charges, Integer chargeId, String amount, String duedate) {
-        charges.add(charges(chargeId, amount, duedate));
-    }
-
-    private void addCollaterals(List<HashMap> collaterals, Integer collateralId, BigDecimal quantity) {
-        collaterals.add(collaterals(collateralId, quantity));
-    }
-
-    private HashMap charges(Integer chargeId, String amount, String duedate) {
-        HashMap charge = new HashMap(2);
-        charge.put("chargeId", chargeId.toString());
-        charge.put("amount", amount);
-        if (duedate != null) {
-            charge.put("dueDate", duedate);
+            checkAccrualTransactionForRepayment(transactionDate, interestPortion, feePortion, penaltyPortion, loanId);
         }
-        return charge;
     }
 
-    private HashMap<String, String> collaterals(Integer collateralId, BigDecimal quantity) {
-        HashMap<String, String> collateral = new HashMap<String, String>(2);
-        collateral.put("clientCollateralId", collateralId.toString());
-        collateral.put("quantity", quantity.toString());
-        return collateral;
-    }
-
-    private HashMap getloanCharge(Integer chargeId, List<HashMap> charges) {
-        HashMap charge = null;
-        for (HashMap loancharge : charges) {
-            if (loancharge.get("chargeId").equals(chargeId)) {
-                charge = loancharge;
+    /** Asserts that an accrual transaction on {@code transactionDate} carries the expected portions. */
+    private void checkAccrualTransactionForRepayment(final LocalDate transactionDate, final Float interestPortion, final Float feePortion,
+            final Float penaltyPortion, final Long loanId) {
+        boolean isAccrualTransactionFound = false;
+        for (GetLoansLoanIdTransactions transaction : getLoanDetails(loanId).getTransactions()) {
+            if (Boolean.TRUE.equals(transaction.getType().getAccrual()) && transactionDate.equals(transaction.getDate())) {
+                assertEquals(interestPortion, transaction.getInterestPortion().floatValue(), "Mismatch in transaction amounts");
+                assertEquals(feePortion, transaction.getFeeChargesPortion().floatValue(), "Mismatch in transaction amounts");
+                assertEquals(penaltyPortion, transaction.getPenaltyChargesPortion().floatValue(), "Mismatch in transaction amounts");
+                isAccrualTransactionFound = true;
+                break;
             }
         }
-        return charge;
+        assertTrue(isAccrualTransactionFound, "No accrual transaction found on " + transactionDate);
     }
 
-    private List<HashMap> copyChargesForUpdate(List<HashMap> charges, Integer deleteWithChargeId, String amount) {
-        List<HashMap> loanCharges = new ArrayList<>();
-        for (HashMap charge : charges) {
-            if (!charge.get("chargeId").equals(deleteWithChargeId)) {
-                loanCharges.add(copyForUpdate(charge, amount));
-            }
+    // ----------------------------------------------------------------------------------------------------
+    // Loan lifecycle helpers
+    // ----------------------------------------------------------------------------------------------------
+
+    /** Approves the loan for its full principal on {@code approvalDate}, as the RestAssured helper did. */
+    private GetLoansLoanIdResponse approveLoan(String approvalDate, Long loanId) {
+        approveLoan(loanId, new PostLoansLoanIdRequest().approvedOnDate(approvalDate).dateFormat(DATETIME_PATTERN).locale(LOCALE));
+        return getLoanDetails(loanId);
+    }
+
+    /** Disburses echoing the loan's own {@code netDisbursalAmount}, mirroring the RestAssured helper. */
+    private GetLoansLoanIdResponse disburseLoanWithNetDisbursalAmount(String date, Long loanId, String transactionAmount) {
+        BigDecimal netDisbursalAmount = getLoanDetails(loanId).getNetDisbursalAmount();
+        PostLoansLoanIdRequest request = new PostLoansLoanIdRequest()//
+                .actualDisbursementDate(date)//
+                .dateFormat(DATETIME_PATTERN)//
+                .locale(LOCALE)//
+                .netDisbursalAmount(netDisbursalAmount);
+        if (transactionAmount != null) {
+            request.transactionAmount(toAmount(transactionAmount));
         }
-        return loanCharges;
+        disburseLoan(loanId, request);
+        return getLoanDetails(loanId);
     }
 
-    private HashMap copyForUpdate(HashMap charge, String amount) {
-        HashMap map = new HashMap();
-        map.put("id", charge.get("id"));
-        if (amount == null) {
-            map.put("amount", charge.get("amountOrPercentage"));
-        } else {
-            map.put("amount", amount);
+    private GetLoansLoanIdResponse disburseLoanWithNetDisbursalAmount(String date, Long loanId) {
+        return disburseLoanWithNetDisbursalAmount(date, loanId, null);
+    }
+
+    /** Disburses a tranche of {@code transactionAmount} without echoing a net disbursal amount. */
+    private GetLoansLoanIdResponse disburseLoanWithTransactionAmount(Long loanId, String date, String transactionAmount) {
+        disburseLoan(loanId, new PostLoansLoanIdRequest()//
+                .actualDisbursementDate(date)//
+                .dateFormat(DATETIME_PATTERN)//
+                .locale(LOCALE)//
+                .transactionAmount(toAmount(transactionAmount)));
+        return getLoanDetails(loanId);
+    }
+
+    /** Disburses into the loan's linked savings account, echoing the loan's own {@code netDisbursalAmount}. */
+    private GetLoansLoanIdResponse disburseToSavingsWithNetDisbursalAmount(String date, Long loanId) {
+        BigDecimal netDisbursalAmount = getLoanDetails(loanId).getNetDisbursalAmount();
+        disburseToSavings(loanId, new PostLoansLoanIdRequest()//
+                .actualDisbursementDate(date)//
+                .dateFormat(DATETIME_PATTERN)//
+                .locale(LOCALE)//
+                .netDisbursalAmount(netDisbursalAmount));
+        return getLoanDetails(loanId);
+    }
+
+    private void waiveInterestOnLoan(Long loanId, String date, double amountToBeWaived) {
+        addInterestWaiver(loanId, LoanRequestBuilders.waiveInterest(amountToBeWaived, date));
+    }
+
+    /**
+     * Repays a loan through the interoperation API, which addresses the loan by account number. That endpoint forwards
+     * its body straight to the standard loan repayment command, so it takes {@code PostLoansLoanIdTransactionsRequest}.
+     */
+    private String makeRepaymentByAccountNo(String accountNo, String transactionDate, Float transactionAmount) {
+        PostLoansLoanIdTransactionsRequest request = new PostLoansLoanIdTransactionsRequest()//
+                .transactionDate(transactionDate)//
+                .transactionAmount(transactionAmount.doubleValue())//
+                .note("Repayment Made!!!")//
+                .locale(INTEROP_LOCALE)//
+                .dateFormat(DATETIME_PATTERN);
+        return ok(() -> FineractFeignClientHelper.getFineractFeignClient().interOperation().loanRepayment(accountNo, request));
+    }
+
+    /** Asserts that no accrual transaction has been posted on the loan. */
+    private void assertNoAccrualTransactions(Long loanId) {
+        for (GetLoansLoanIdTransactions transaction : getLoanDetails(loanId).getTransactions()) {
+            assertFalse(Boolean.TRUE.equals(transaction.getType().getAccrual()), "Accrual entries are posted!");
         }
-        if (charge.get("dueDate") != null) {
-            map.put("dueDate", DATE_TIME_FORMATTER.format(fromArrayToLocalDate((List) charge.get("dueDate"))));
-        }
-        map.put("chargeId", charge.get("chargeId"));
-        return map;
     }
 
-    private LocalDate fromArrayToLocalDate(List<Integer> dueDate) {
-        return LocalDate.of(dueDate.get(0), dueDate.get(1), dueDate.get(2));
+    private void verifyClientCreatedOnServer(Long clientId) {
+        assertNotNull(clientHelper.getClient(clientId), "Client not found on server: " + clientId);
     }
 
-    private HashMap createTrancheDetail(final String date, final String amount) {
-        HashMap detail = new HashMap();
-        detail.put("expectedDisbursementDate", date);
-        detail.put("principal", amount);
-
-        return detail;
+    private void verifyLoanIsPending(Long loanId) {
+        verifyLoanStatus(getLoanDetails(loanId), LoanStatus.SUBMITTED_AND_PENDING_APPROVAL);
     }
 
-    private void testLoanScheduleWithInterestRecalculation_FOR_PRE_CLOSE_WITH_MORATORIUM(final String preCloseStrategy,
+    private void verifyLoanIsApprovedAndWaitingForDisbursal(GetLoansLoanIdResponse loanDetails) {
+        verifyLoanStatus(loanDetails, LoanStatus.APPROVED);
+        verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getWaitingForDisbursal);
+    }
+
+    private void verifyLoanIsActive(GetLoansLoanIdResponse loanDetails) {
+        verifyLoanStatus(loanDetails, LoanStatus.ACTIVE);
+    }
+
+    private void verifyLoanAccountIsClosed(Long loanId) {
+        verifyLoanStatus(getLoanDetails(loanId), GetLoansLoanIdStatus::getClosed);
+    }
+
+    private String todayAsString(DateFormat dateFormat) {
+        return dateFormat.format(Calendar.getInstance(Utils.getTimeZoneOfTenant()).getTime());
+    }
+
+    private String prepayAmount(Long loanId, String date) {
+        return String.valueOf(getPrepayAmount(loanId, date).getAmount());
+    }
+
+    // ----------------------------------------------------------------------------------------------------
+    // Shared interest-recalculation test bodies
+    // ----------------------------------------------------------------------------------------------------
+
+    private void testLoanScheduleWithInterestRecalculation_FOR_PRE_CLOSE_WITH_MORATORIUM(final Integer preCloseStrategy,
             final String preCloseAmount) {
-
         DateFormat dateFormat = new SimpleDateFormat(DATETIME_PATTERN, Locale.US);
         dateFormat.setTimeZone(Utils.getTimeZoneOfTenant());
 
         Calendar todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -1);
-        final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todaysDate.getTime());
+        final String loanDisbursementDate = dateFormat.format(todaysDate.getTime());
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProductWithInterestRecalculation(LoanProductTestBuilder.DEFAULT_STRATEGY,
-                LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_NONE,
-                LoanProductTestBuilder.RECALCULATION_STRATEGY_REDUCE_EMI_AMOUN,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_SAME_AS_REPAYMENT_PERIOD, "0", null, preCloseStrategy, null, null,
-                null);
+        final Long clientId = createClient();
+        final Long loanProductId = createLoanProductWithInterestRecalculation(DEFAULT_STRATEGY,
+                LoanTestData.InterestRecalculationCompoundingMethod.NONE, LoanTestData.RescheduleStrategyMethod.REDUCE_EMI_AMOUNT,
+                LoanTestData.RecalculationRestFrequencyType.SAME_AS_REPAYMENT_PERIOD, 0, preCloseStrategy, null, null, null);
 
-        final Integer loanID = applyForLoanApplicationForInterestRecalculationWithMoratorium(clientID, loanProductID,
-                LOAN_DISBURSEMENT_DATE, LoanApplicationTestBuilder.DEFAULT_STRATEGY, new ArrayList<HashMap>(0), "1", null);
+        final Long loanId = applyForLoanApplicationForInterestRecalculationWithMoratorium(clientId, loanProductId, loanDisbursementDate,
+                DEFAULT_STRATEGY, Collections.emptyList(), 1, null);
 
-        Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        Assertions.assertNotNull(loanId);
+        verifyLoanIsPending(loanId);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        List<Map<String, Object>> expectedvalues = new ArrayList<>();
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanId);
+        List<ExpectedInstallment> expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -1);
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2482.76", "0.0", "0.0", "0.0");
@@ -7759,17 +7918,12 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(loanDisbursementDate, loanId));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(loanDisbursementDate, loanId));
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanId);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -1);
@@ -7777,317 +7931,37 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2494.22", "80.84", "0.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2505.73", "23.18", "0.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2517.29", "11.62", "0.0", "0.0");
-
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
-        HashMap prepayDetail = LOAN_TRANSACTION_HELPER.getPrepayAmount(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        String prepayAmount = String.valueOf(prepayDetail.get("amount"));
+        final String loanRepaymentDate = todayAsString(dateFormat);
+        String prepayAmount = prepayAmount(loanId, loanRepaymentDate);
         validateNumberForEqualWithMsg("verify pre-close amount", preCloseAmount, prepayAmount);
-        todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
-        final String loanRepaymentDate = dateFormat.format(todaysDate.getTime());
-        LOAN_TRANSACTION_HELPER.makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanID);
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
-    }
-
-    private void addRepaymentValues(List<Map<String, Object>> expectedvalues, Calendar todaysDate, int addPeriod, boolean isAddDays,
-            String principalDue, String interestDue, String feeChargesDue, String penaltyChargesDue) {
-        Map<String, Object> values = new HashMap<>(3);
-        if (isAddDays) {
-            values.put("dueDate", getDateAsArray(todaysDate, addPeriod));
-        } else {
-            values.put("dueDate", getDateAsArray(todaysDate, addPeriod * 7));
-        }
-        LOG.info("Updated date {}", values.get("dueDate"));
-        values.put("principalDue", principalDue);
-        values.put("interestDue", interestDue);
-        values.put("feeChargesDue", feeChargesDue);
-        values.put("penaltyChargesDue", penaltyChargesDue);
-        expectedvalues.add(values);
-    }
-
-    private List getDateAsArray(Calendar todaysDate, int addPeriod) {
-        return getDateAsArray(todaysDate, addPeriod, Calendar.DAY_OF_MONTH);
-    }
-
-    private List getDateAsArray(Calendar todaysDate, int addvalue, int type) {
-        todaysDate.add(type, addvalue);
-        return new ArrayList<>(
-                Arrays.asList(todaysDate.get(Calendar.YEAR), todaysDate.get(Calendar.MONTH) + 1, todaysDate.get(Calendar.DAY_OF_MONTH)));
-    }
-
-    private Integer createLoanProductWithInterestRecalculation(final String repaymentStrategy,
-            final String interestRecalculationCompoundingMethod, final String rescheduleStrategyMethod,
-            final String recalculationRestFrequencyType, final String recalculationRestFrequencyInterval,
-            final String recalculationRestFrequencyDate, final String preCloseInterestCalculationStrategy, final Account[] accounts,
-            final Integer recalculationRestFrequencyOnDayType, final Integer recalculationRestFrequencyDayOfWeekType) {
-        final String recalculationCompoundingFrequencyType = null;
-        final String recalculationCompoundingFrequencyInterval = null;
-        final String recalculationCompoundingFrequencyDate = null;
-        final Integer recalculationCompoundingFrequencyOnDayType = null;
-        final Integer recalculationCompoundingFrequencyDayOfWeekType = null;
-        return createLoanProductWithInterestRecalculation(repaymentStrategy, interestRecalculationCompoundingMethod,
-                rescheduleStrategyMethod, recalculationRestFrequencyType, recalculationRestFrequencyInterval,
-                recalculationRestFrequencyDate, recalculationCompoundingFrequencyType, recalculationCompoundingFrequencyInterval,
-                recalculationCompoundingFrequencyDate, preCloseInterestCalculationStrategy, accounts, null, false,
-                recalculationCompoundingFrequencyOnDayType, recalculationCompoundingFrequencyDayOfWeekType,
-                recalculationRestFrequencyOnDayType, recalculationRestFrequencyDayOfWeekType);
-    }
-
-    private Integer createLoanProductWithInterestRecalculationAndCompoundingDetails(final String repaymentStrategy,
-            final String interestRecalculationCompoundingMethod, final String rescheduleStrategyMethod,
-            final String recalculationRestFrequencyType, final String recalculationRestFrequencyInterval,
-            final String recalculationRestFrequencyDate, final String recalculationCompoundingFrequencyType,
-            final String recalculationCompoundingFrequencyInterval, final String recalculationCompoundingFrequencyDate,
-            final String preCloseInterestCalculationStrategy, final Account[] accounts,
-            final Integer recalculationCompoundingFrequencyOnDayType, final Integer recalculationCompoundingFrequencyDayOfWeekType,
-            final Integer recalculationRestFrequencyOnDayType, final Integer recalculationRestFrequencyDayOfWeekType) {
-        return createLoanProductWithInterestRecalculation(repaymentStrategy, interestRecalculationCompoundingMethod,
-                rescheduleStrategyMethod, recalculationRestFrequencyType, recalculationRestFrequencyInterval,
-                recalculationRestFrequencyDate, recalculationCompoundingFrequencyType, recalculationCompoundingFrequencyInterval,
-                recalculationCompoundingFrequencyDate, preCloseInterestCalculationStrategy, accounts, null, false,
-                recalculationCompoundingFrequencyOnDayType, recalculationCompoundingFrequencyDayOfWeekType,
-                recalculationRestFrequencyOnDayType, recalculationRestFrequencyDayOfWeekType);
-    }
-
-    private Integer createLoanProductWithInterestRecalculation(final String repaymentStrategy,
-            final String interestRecalculationCompoundingMethod, final String rescheduleStrategyMethod,
-            final String recalculationRestFrequencyType, final String recalculationRestFrequencyInterval,
-            final String recalculationRestFrequencyDate, final String recalculationCompoundingFrequencyType,
-            final String recalculationCompoundingFrequencyInterval, final String recalculationCompoundingFrequencyDate,
-            final String preCloseInterestCalculationStrategy, final Account[] accounts, final String chargeId,
-            boolean isArrearsBasedOnOriginalSchedule, final Integer recalculationCompoundingFrequencyOnDayType,
-            final Integer recalculationCompoundingFrequencyDayOfWeekType, final Integer recalculationRestFrequencyOnDayType,
-            final Integer recalculationRestFrequencyDayOfWeekType) {
-        LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-        LoanProductTestBuilder builder = new LoanProductTestBuilder().withPrincipal("10000000.00").withNumberOfRepayments("24")
-                .withRepaymentAfterEvery("1").withRepaymentTypeAsWeek().withinterestRatePerPeriod("2")
-                .withInterestRateFrequencyTypeAsMonths().withRepaymentStrategy(repaymentStrategy)
-                .withAmortizationTypeAsEqualPrincipalPayment().withInterestCalculationPeriodTypeAsRepaymentPeriod(true)
-                .withInterestTypeAsDecliningBalance()
-                .withInterestRecalculationDetails(interestRecalculationCompoundingMethod, rescheduleStrategyMethod,
-                        preCloseInterestCalculationStrategy)
-                .withInterestRecalculationRestFrequencyDetails(recalculationRestFrequencyType, recalculationRestFrequencyInterval,
-                        recalculationRestFrequencyOnDayType, recalculationRestFrequencyDayOfWeekType)
-                .withInterestRecalculationCompoundingFrequencyDetails(recalculationCompoundingFrequencyType,
-                        recalculationCompoundingFrequencyInterval, recalculationCompoundingFrequencyOnDayType,
-                        recalculationCompoundingFrequencyDayOfWeekType);
-        if (accounts != null) {
-            builder = builder.withAccountingRulePeriodicAccrual(accounts);
-        }
-
-        if (isArrearsBasedOnOriginalSchedule) {
-            builder = builder.withArrearsConfiguration();
-        }
-
-        final String loanProductJSON = builder.build(chargeId);
-        return LOAN_TRANSACTION_HELPER.getLoanProductId(loanProductJSON);
-    }
-
-    private Integer createLoanProductWithInterestRecalculationAndCompoundingDetails(final String repaymentStrategy,
-            final String interestRecalculationCompoundingMethod, final String rescheduleStrategyMethod,
-            final String recalculationRestFrequencyType, final String preCloseInterestCalculationStrategy, final Account[] accounts,
-            final String installmentMultipleOf) {
-        final String recalculationCompoundingFrequencyType = null;
-        final String recalculationCompoundingFrequencyInterval = null;
-        final Integer recalculationCompoundingFrequencyOnDayType = null;
-        final Integer recalculationCompoundingFrequencyDayOfWeekType = null;
-        return createLoanProductWithInterestRecalculation(repaymentStrategy, interestRecalculationCompoundingMethod,
-                rescheduleStrategyMethod, recalculationCompoundingFrequencyType, recalculationCompoundingFrequencyInterval,
-                preCloseInterestCalculationStrategy, accounts, null, false, recalculationCompoundingFrequencyOnDayType,
-                recalculationCompoundingFrequencyDayOfWeekType, installmentMultipleOf);
-    }
-
-    private Integer createLoanProductWithInterestRecalculation(final String repaymentStrategy,
-            final String interestRecalculationCompoundingMethod, final String rescheduleStrategyMethod,
-            final String recalculationCompoundingFrequencyType, final String recalculationCompoundingFrequencyInterval,
-            final String preCloseInterestCalculationStrategy, final Account[] accounts, final String chargeId,
-            boolean isArrearsBasedOnOriginalSchedule, final Integer recalculationCompoundingFrequencyOnDayType,
-            final Integer recalculationCompoundingFrequencyDayOfWeekType, final String installmentsMultiplesOf) {
-        LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-        LoanProductTestBuilder builder = new LoanProductTestBuilder().withPrincipal("10000.00").withNumberOfRepayments("12")
-                .withRepaymentAfterEvery("1").withRepaymentTypeAsMonth().withinterestRatePerPeriod("19.9")
-                .withInterestRateFrequencyTypeAsMonths().withRepaymentStrategy(repaymentStrategy).withAmortizationTypeAsEqualInstallments()
-                .withInterestTypeAsDecliningBalance().withInterestCalculationPeriodTypeAsDays()
-                .withInterestRecalculationDetails(interestRecalculationCompoundingMethod, rescheduleStrategyMethod,
-                        preCloseInterestCalculationStrategy)
-                .withInterestRecalculationDetails(interestRecalculationCompoundingMethod, rescheduleStrategyMethod,
-                        preCloseInterestCalculationStrategy)
-                .withInterestRecalculationCompoundingFrequencyDetails(recalculationCompoundingFrequencyType,
-                        recalculationCompoundingFrequencyInterval, recalculationCompoundingFrequencyOnDayType,
-                        recalculationCompoundingFrequencyDayOfWeekType)
-                .withDefineInstallmentAmount(true).withInstallmentAmountInMultiplesOf(installmentsMultiplesOf);
-        if (accounts != null) {
-            builder = builder.withAccountingRulePeriodicAccrual(accounts);
-        }
-
-        if (isArrearsBasedOnOriginalSchedule) {
-            builder = builder.withArrearsConfiguration();
-        }
-
-        final String loanProductJSON = builder.build(chargeId);
-        return LOAN_TRANSACTION_HELPER.getLoanProductId(loanProductJSON);
-    }
-
-    private Integer applyForLoanApplicationForInterestRecalculation(final Integer clientID, final Integer loanProductID,
-            final String disbursementDate, final String repaymentStrategy, final String firstRepaymentDate) {
-        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
-        Assertions.assertNotNull(collateralId);
-        List<HashMap> collaterals = new ArrayList<>();
-
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
-        Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
-
-        final String loanApplicationJSON = new LoanApplicationTestBuilder() //
-                .withPrincipal("10000.00") //
-                .withLoanTermFrequency("12") //
-                .withLoanTermFrequencyAsMonths() //
-                .withNumberOfRepayments("12") //
-                .withRepaymentEveryAfter("1") //
-                .withLoanTermFrequencyAsMonths() //
-                .withInterestRatePerPeriod("19.9") //
-                .withAmortizationTypeAsEqualInstallments() //
-                .withInterestTypeAsDecliningBalance() //
-                .withInterestCalculationPeriodTypeAsDays() //
-                .withExpectedDisbursementDate(disbursementDate) //
-                .withSubmittedOnDate(disbursementDate) //
-                .withRepaymentStrategy(repaymentStrategy).withRepaymentFrequencyTypeAsMonths()//
-                .withFirstRepaymentDate(firstRepaymentDate).withCollaterals(collaterals)
-                .build(clientID.toString(), loanProductID.toString(), null);
-        return LOAN_TRANSACTION_HELPER.getLoanId(loanApplicationJSON);
-    }
-
-    private Integer applyForLoanApplicationForInterestRecalculation(final Integer clientID, final Integer loanProductID,
-            final String disbursementDate, final String repaymentStrategy, final List<HashMap> charges) {
-        return applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, disbursementDate, repaymentStrategy, charges, null,
-                null);
-    }
-
-    private Integer applyForLoanApplicationForInterestRecalculationWithMoratorium(final Integer clientID, final Integer loanProductID,
-            final String disbursementDate, final String repaymentStrategy, final List<HashMap> charges, final String graceOnInterestPayment,
-            final String graceOnPrincipalPayment) {
-        return applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, disbursementDate, repaymentStrategy, charges,
-                graceOnInterestPayment, graceOnPrincipalPayment);
-    }
-
-    private Integer applyForLoanApplicationForInterestRecalculation(final Integer clientID, final Integer loanProductID,
-            final String disbursementDate, final String compoundingStartDate, final String repaymentStrategy, final List<HashMap> charges) {
-        return applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, disbursementDate, repaymentStrategy, charges, null,
-                null);
-    }
-
-    private Integer applyForLoanApplicationForInterestRecalculation(final Integer clientID, final Integer loanProductID,
-            final String disbursementDate, final String repaymentStrategy, final List<HashMap> charges, final String graceOnInterestPayment,
-            final String graceOnPrincipalPayment) {
-        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
-        Assertions.assertNotNull(collateralId);
-        List<HashMap> collaterals = new ArrayList<>();
-
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
-                String.valueOf(clientID), collateralId);
-        Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
-
-        final String loanApplicationJSON = new LoanApplicationTestBuilder() //
-                .withPrincipal("10000.00") //
-                .withLoanTermFrequency("4") //
-                .withLoanTermFrequencyAsWeeks() //
-                .withNumberOfRepayments("4") //
-                .withRepaymentEveryAfter("1") //
-                .withRepaymentFrequencyTypeAsWeeks() //
-                .withInterestRatePerPeriod("2") //
-                .withAmortizationTypeAsEqualInstallments() //
-                .withInterestTypeAsDecliningBalance() //
-                .withInterestCalculationPeriodTypeSameAsRepaymentPeriod() //
-                .withExpectedDisbursementDate(disbursementDate) //
-                .withSubmittedOnDate(disbursementDate) //
-                .withRepaymentStrategy(repaymentStrategy) //
-                .withPrincipalGrace(graceOnPrincipalPayment) //
-                .withInterestGrace(graceOnInterestPayment)//
-                .withCharges(charges)//
-                .withCollaterals(collaterals).build(clientID.toString(), loanProductID.toString(), null);
-        return LOAN_TRANSACTION_HELPER.getLoanId(loanApplicationJSON);
-    }
-
-    private void verifyLoanRepaymentSchedule(final ArrayList<HashMap> loanSchedule, List<Map<String, Object>> expectedvalues) {
-        int index = 1;
-        verifyLoanRepaymentSchedule(loanSchedule, expectedvalues, index);
-
-    }
-
-    private void verifyLoanRepaymentSchedule(final ArrayList<HashMap> loanSchedule, List<Map<String, Object>> expectedvalues, int index) {
-        LOG.info("--------------------VERIFYING THE PRINCIPAL DUES,INTEREST DUE AND DUE DATE--------------------------");
-        for (Map<String, Object> values : expectedvalues) {
-            assertEquals(values.get("dueDate"), loanSchedule.get(index).get("dueDate"), "Checking for Due Date for  installment " + index);
-            validateNumberForEqualWithMsg("Checking for Principal Due for installment " + index, String.valueOf(values.get("principalDue")),
-                    String.valueOf(loanSchedule.get(index).get("principalDue")));
-            validateNumberForEqualWithMsg("Checking for Interest Due for installment " + index, String.valueOf(values.get("interestDue")),
-                    String.valueOf(loanSchedule.get(index).get("interestDue")));
-            validateNumberForEqualWithMsg("Checking for Fee charge Due for installment " + index,
-                    String.valueOf(values.get("feeChargesDue")), String.valueOf(loanSchedule.get(index).get("feeChargesDue")));
-            validateNumberForEqualWithMsg("Checking for Penalty charge Due for installment " + index,
-                    String.valueOf(values.get("penaltyChargesDue")), String.valueOf(loanSchedule.get(index).get("penaltyChargesDue")));
-            index++;
-        }
-    }
-
-    private void checkAccrualTransactions(final ArrayList<HashMap> loanSchedule, final Integer loanID) {
-
-        for (int i = 1; i < loanSchedule.size(); i++) {
-
-            final HashMap repayment = loanSchedule.get(i);
-
-            final ArrayList<Integer> dueDateAsArray = (ArrayList<Integer>) repayment.get("dueDate");
-            final LocalDate transactionDate = LocalDate.of(dueDateAsArray.get(0), dueDateAsArray.get(1), dueDateAsArray.get(2));
-
-            final Float interestPortion = BigDecimal.valueOf(Double.parseDouble(repayment.get("interestDue").toString()))
-                    .subtract(BigDecimal.valueOf(Double.parseDouble(repayment.get("interestWaived").toString())))
-                    .subtract(BigDecimal.valueOf(Double.parseDouble(repayment.get("interestWrittenOff").toString()))).floatValue();
-
-            final Float feePortion = BigDecimal.valueOf(Double.parseDouble(repayment.get("feeChargesDue").toString()))
-                    .subtract(BigDecimal.valueOf(Double.parseDouble(repayment.get("feeChargesWaived").toString())))
-                    .subtract(BigDecimal.valueOf(Double.parseDouble(repayment.get("feeChargesWrittenOff").toString()))).floatValue();
-
-            final Float penaltyPortion = BigDecimal.valueOf(Double.parseDouble(repayment.get("penaltyChargesDue").toString()))
-                    .subtract(BigDecimal.valueOf(Double.parseDouble(repayment.get("penaltyChargesWaived").toString())))
-                    .subtract(BigDecimal.valueOf(Double.parseDouble(repayment.get("penaltyChargesWrittenOff").toString()))).floatValue();
-
-            LOAN_TRANSACTION_HELPER.checkAccrualTransactionForRepayment(transactionDate, interestPortion, feePortion, penaltyPortion,
-                    loanID);
-        }
+        makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanId);
+        verifyLoanAccountIsClosed(loanId);
     }
 
     private void testLoanScheduleWithInterestRecalculation_WITH_REST_SAME_AS_REPAYMENT_INTEREST_COMPOUND_NONE_STRATEGY_REDUCE_EMI_PRE_CLOSE_INTEREST(
-            String preCloseInterestStrategy, String preCloseAmount) {
-
+            Integer preCloseInterestStrategy, String preCloseAmount) {
         DateFormat dateFormat = new SimpleDateFormat(DATETIME_PATTERN, Locale.US);
         dateFormat.setTimeZone(Utils.getTimeZoneOfTenant());
 
         Calendar todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -16);
-        final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todaysDate.getTime());
+        final String loanDisbursementDate = dateFormat.format(todaysDate.getTime());
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProductWithInterestRecalculation(LoanProductTestBuilder.DEFAULT_STRATEGY,
-                LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_NONE,
-                LoanProductTestBuilder.RECALCULATION_STRATEGY_REDUCE_EMI_AMOUN,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_SAME_AS_REPAYMENT_PERIOD, "0", null, preCloseInterestStrategy, null,
-                null, null);
+        final Long clientId = createClient();
+        final Long loanProductId = createLoanProductWithInterestRecalculation(DEFAULT_STRATEGY,
+                LoanTestData.InterestRecalculationCompoundingMethod.NONE, LoanTestData.RescheduleStrategyMethod.REDUCE_EMI_AMOUNT,
+                LoanTestData.RecalculationRestFrequencyType.SAME_AS_REPAYMENT_PERIOD, 0, preCloseInterestStrategy, null, null, null);
 
-        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE, null,
-                LoanApplicationTestBuilder.DEFAULT_STRATEGY, new ArrayList<HashMap>(0));
+        final Long loanId = applyForLoanApplicationForInterestRecalculation(clientId, loanProductId, loanDisbursementDate, DEFAULT_STRATEGY,
+                Collections.emptyList());
 
-        Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        Assertions.assertNotNull(loanId);
+        verifyLoanIsPending(loanId);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        List<Map<String, Object>> expectedvalues = new ArrayList<>();
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanId);
+        List<ExpectedInstallment> expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -9, true, "2482.76", "46.15", "0.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2494.22", "34.69", "0.0", "0.0");
@@ -8096,33 +7970,27 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(loanDisbursementDate, loanId));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(loanDisbursementDate, loanId));
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanId);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -9, true, "2482.76", "46.15", "0.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2482.76", "46.15", "0.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2482.76", "46.15", "0.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2551.72", "11.78", "0.0", "0.0");
-
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -9);
-        final String LOAN_FIRST_REPAYMENT_DATE = dateFormat.format(todaysDate.getTime());
-        Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        final String loanFirstRepaymentDate = dateFormat.format(todaysDate.getTime());
+        float totalDueForCurrentPeriod = loanSchedule.get(1).getTotalDueForPeriod().floatValue();
+        makeRepayment(loanFirstRepaymentDate, totalDueForCurrentPeriod, loanId);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanId);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -9, true, "2482.76", "46.15", "0.0", "0.0");
@@ -8131,63 +7999,54 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2528.8", "11.67", "0.0", "0.0");
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
-        HashMap prepayDetail = LOAN_TRANSACTION_HELPER.getPrepayAmount(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        String prepayAmount = String.valueOf(prepayDetail.get("amount"));
+        final String loanRepaymentDate = todayAsString(dateFormat);
+        String prepayAmount = prepayAmount(loanId, loanRepaymentDate);
         validateNumberForEqualWithMsg("verify pre-close amount", preCloseAmount, prepayAmount);
-        todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
-        final String loanRepaymentDate = dateFormat.format(todaysDate.getTime());
-        LOAN_TRANSACTION_HELPER.makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanID);
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
+        makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanId);
+        verifyLoanAccountIsClosed(loanId);
     }
 
     private void testLoanScheduleWithInterestRecalculation_WITH_REST_WEEKLY_INTEREST_COMPOUND_INTEREST_FEE_STRATEGY_REDUCE_NEXT_INSTALLMENTS_PRE_CLOSE_INTEREST(
-            String preCloseInterestStrategy, String preCloseAmount) {
-
+            Integer preCloseInterestStrategy, String preCloseAmount) {
         DateFormat dateFormat = new SimpleDateFormat(DATETIME_PATTERN, Locale.US);
         dateFormat.setTimeZone(Utils.getTimeZoneOfTenant());
 
         Calendar todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -16);
-        final String LOAN_DISBURSEMENT_DATE = dateFormat.format(todaysDate.getTime());
+        final String loanDisbursementDate = dateFormat.format(todaysDate.getTime());
         todaysDate.add(Calendar.DAY_OF_MONTH, -4);
         Integer restDateOfMonth = getDayOfMonth(todaysDate);
         Integer restDateOfWeek = getDayOfWeek(todaysDate);
-        final String REST_START_DATE = null;
 
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         todaysDate.add(Calendar.DAY_OF_MONTH, -16);
         todaysDate.add(Calendar.DAY_OF_MONTH, 2);
-        final String LOAN_FLAT_CHARGE_DATE = dateFormat.format(todaysDate.getTime());
+        final String loanFlatChargeDate = dateFormat.format(todaysDate.getTime());
         todaysDate.add(Calendar.DAY_OF_MONTH, 14);
-        final String LOAN_INTEREST_CHARGE_DATE = dateFormat.format(todaysDate.getTime());
-        List<HashMap> charges = new ArrayList<>(2);
-        Integer flat = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "100", false));
-        Integer principalPercentage = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT, "2", false));
+        final String loanInterestChargeDate = dateFormat.format(todaysDate.getTime());
 
-        addCharges(charges, flat, "100", LOAN_FLAT_CHARGE_DATE);
-        addCharges(charges, principalPercentage, "2", LOAN_INTEREST_CHARGE_DATE);
+        List<PostLoansRequestChargeData> charges = new ArrayList<>(2);
+        Long flat = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.FLAT, 100.0, false).getResourceId();
+        Long principalPercentage = chargesHelper.createLoanSpecifiedDueDateCharge(ChargeCalculationType.PERCENT_OF_AMOUNT, 2.0, false)
+                .getResourceId();
+        addCharges(charges, flat, 100.0, loanFlatChargeDate);
+        addCharges(charges, principalPercentage, 2.0, loanInterestChargeDate);
 
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
-        final Integer loanProductID = createLoanProductWithInterestRecalculationAndCompoundingDetails(
-                LoanProductTestBuilder.DEFAULT_STRATEGY, LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_INTEREST_AND_FEE,
-                LoanProductTestBuilder.RECALCULATION_STRATEGY_RESCHEDULE_NEXT_REPAYMENTS,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_WEEKLY, "1", REST_START_DATE,
-                LoanProductTestBuilder.RECALCULATION_FREQUENCY_TYPE_SAME_AS_REPAYMENT_PERIOD, null, null, preCloseInterestStrategy, null,
-                null, null, restDateOfMonth, restDateOfWeek);
+        final Long clientId = createClient();
+        final Long loanProductId = createLoanProductWithInterestRecalculationAndCompoundingDetails(DEFAULT_STRATEGY,
+                LoanTestData.InterestRecalculationCompoundingMethod.INTEREST_AND_FEE,
+                LoanTestData.RescheduleStrategyMethod.RESCHEDULE_NEXT_REPAYMENTS, LoanTestData.RecalculationRestFrequencyType.WEEKLY, 1,
+                LoanTestData.RecalculationCompoundingFrequencyType.SAME_AS_REPAYMENT_PERIOD, null, preCloseInterestStrategy, null, null,
+                null, restDateOfMonth, restDateOfWeek);
 
-        final Integer loanID = applyForLoanApplicationForInterestRecalculation(clientID, loanProductID, LOAN_DISBURSEMENT_DATE,
-                REST_START_DATE, LoanApplicationTestBuilder.DEFAULT_STRATEGY, charges);
+        final Long loanId = applyForLoanApplicationForInterestRecalculation(clientId, loanProductId, loanDisbursementDate, DEFAULT_STRATEGY,
+                charges);
 
-        Assertions.assertNotNull(loanID);
-        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        Assertions.assertNotNull(loanId);
+        verifyLoanIsPending(loanId);
 
-        ArrayList<HashMap> loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        List<Map<String, Object>> expectedvalues = new ArrayList<>();
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getLoanRepaymentSchedule(loanId);
+        List<ExpectedInstallment> expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -9, true, "2482.76", "46.15", "100.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2494.22", "34.69", "0.0", "0.0");
@@ -8196,33 +8055,27 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         LOG.info("-----------------------------------APPROVE LOAN-----------------------------------------");
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(LOAN_DISBURSEMENT_DATE, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
+        verifyLoanIsApprovedAndWaitingForDisbursal(approveLoan(loanDisbursementDate, loanId));
 
         LOG.info("-------------------------------DISBURSE LOAN-------------------------------------------");
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(LOAN_DISBURSEMENT_DATE, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        verifyLoanIsActive(disburseLoanWithNetDisbursalAmount(loanDisbursementDate, loanId));
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanId);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -9, true, "2482.76", "46.15", "100.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2482.08", "46.83", "0.0", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2481.87", "47.04", "200", "0.0");
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2553.29", "11.78", "0.0", "0.0");
-
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
         Calendar repaymentDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         repaymentDate.add(Calendar.DAY_OF_MONTH, -9);
-        final String LOAN_FIRST_REPAYMENT_DATE = dateFormat.format(repaymentDate.getTime());
-        Float totalDueForCurrentPeriod = (Float) loanSchedule.get(1).get("totalDueForPeriod");
-        LOAN_TRANSACTION_HELPER.makeRepayment(LOAN_FIRST_REPAYMENT_DATE, totalDueForCurrentPeriod, loanID);
+        final String loanFirstRepaymentDate = dateFormat.format(repaymentDate.getTime());
+        float totalDueForCurrentPeriod = loanSchedule.get(1).getTotalDueForPeriod().floatValue();
+        makeRepayment(loanFirstRepaymentDate, totalDueForCurrentPeriod, loanId);
 
-        loanSchedule = LOAN_TRANSACTION_HELPER.getLoanRepaymentSchedule(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        loanSchedule = getLoanRepaymentSchedule(loanId);
         expectedvalues = new ArrayList<>();
         todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
         addRepaymentValues(expectedvalues, todaysDate, -9, true, "2482.76", "46.15", "100.0", "0.0");
@@ -8231,40 +8084,11 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         addRepaymentValues(expectedvalues, todaysDate, 1, false, "2528.97", "11.67", "0.0", "0.0");
         verifyLoanRepaymentSchedule(loanSchedule, expectedvalues);
 
-        HashMap prepayDetail = LOAN_TRANSACTION_HELPER.getPrepayAmount(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        String prepayAmount = String.valueOf(prepayDetail.get("amount"));
+        final String loanRepaymentDate = todayAsString(dateFormat);
+        String prepayAmount = prepayAmount(loanId, loanRepaymentDate);
         validateNumberForEqualWithMsg("verify pre-close amount", preCloseAmount, prepayAmount);
-        todaysDate = Calendar.getInstance(Utils.getTimeZoneOfTenant());
-        final String loanRepaymentDate = dateFormat.format(todaysDate.getTime());
-        LOAN_TRANSACTION_HELPER.makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanID);
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
-    }
-
-    private Integer createSavingsProduct(final String minOpenningBalance) {
-        LOG.info("------------------------------CREATING NEW SAVINGS PRODUCT ---------------------------------------");
-        SavingsProductHelper savingsProductHelper = new SavingsProductHelper();
-
-        final String savingsProductJSON = savingsProductHelper
-                //
-                .withInterestCompoundingPeriodTypeAsDaily()
-                //
-                .withInterestPostingPeriodTypeAsMonthly()
-                //
-                .withInterestCalculationPeriodTypeAsDailyBalance()
-
-                .withMinimumOpenningBalance(minOpenningBalance).build();
-        return SavingsProductHelper.createSavingsProduct(savingsProductJSON, REQUEST_SPEC, RESPONSE_SPEC);
-    }
-
-    private PostLoansResponse applyForLoanApplicationForOnePeriod30DaysLongNoInterestPeriodicAccrual(Long clientId, Long loanProductId,
-            String loanDisbursementDate, String repaymentStrategyCode) {
-        return LOAN_TRANSACTION_HELPER.applyLoan(new PostLoansRequest().clientId(clientId.longValue()).productId(loanProductId)
-                .expectedDisbursementDate(loanDisbursementDate).dateFormat(DATETIME_PATTERN)
-                .transactionProcessingStrategyCode(repaymentStrategyCode).locale("en").submittedOnDate(loanDisbursementDate)
-                .amortizationType(1).interestRatePerPeriod(BigDecimal.ZERO).interestCalculationPeriodType(1).interestType(0)
-                .repaymentFrequencyType(0).repaymentEvery(30).repaymentFrequencyType(0).numberOfRepayments(1).loanTermFrequency(30)
-                .loanTermFrequencyType(0).principal(BigDecimal.valueOf(1000.0)).loanType("individual"));
+        makeRepayment(loanRepaymentDate, Float.parseFloat(prepayAmount), loanId);
+        verifyLoanAccountIsClosed(loanId);
     }
 
     @Override
@@ -8288,15 +8112,14 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
                 .minInterestRatePerPeriod((double) 0)//
                 .interestRatePerPeriod((double) 0)//
                 .maxInterestRatePerPeriod((double) 0)//
-                .interestRateFrequencyType(2)//
+                .interestRateFrequencyType(LoanTestData.InterestRateFrequencyType.MONTHS)//
                 .repaymentEvery(30)//
-                .repaymentFrequencyType(0L)//
-                .amortizationType(1)//
-                .interestType(0)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.DAYS_L)//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_INSTALLMENTS)//
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE)//
                 .isEqualAmortization(false)//
-                .interestCalculationPeriodType(1)//
-                .transactionProcessingStrategyCode(
-                        LoanProductTestBuilder.DUE_PENALTY_FEE_INTEREST_PRINCIPAL_IN_ADVANCE_PRINCIPAL_PENALTY_FEE_INTEREST_STRATEGY)//
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)//
+                .transactionProcessingStrategyCode(DUE_PENALTY_FEE_INTEREST_PRINCIPAL_IN_ADVANCE_PRINCIPAL_PENALTY_FEE_INTEREST_STRATEGY)//
                 .daysInYearType(1)//
                 .daysInMonthType(1)//
                 .canDefineInstallmentAmount(true)//
@@ -8322,33 +8145,33 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
                 .maxTrancheCount(10)//
                 .outstandingLoanBalance(10000.0)//
                 .charges(Collections.emptyList())//
-                .accountingRule(3)//
-                .fundSourceAccountId(SUSPENSE_CLEARING_ACCOUNT.getAccountID().longValue())//
-                .loanPortfolioAccountId(LOANS_RECEIVABLE_ACCOUNT.getAccountID().longValue())//
-                .transfersInSuspenseAccountId(SUSPENSE_ACCOUNT.getAccountID().longValue())//
-                .interestOnLoanAccountId(INTEREST_INCOME_ACCOUNT.getAccountID().longValue())//
-                .incomeFromFeeAccountId(FEE_INCOME_ACCOUNT.getAccountID().longValue())//
-                .incomeFromPenaltyAccountId(FEE_INCOME_ACCOUNT.getAccountID().longValue())//
-                .incomeFromRecoveryAccountId(RECOVERIES_ACCOUNT.getAccountID().longValue())//
-                .writeOffAccountId(WRITTEN_OFF_ACCOUNT.getAccountID().longValue())//
-                .overpaymentLiabilityAccountId(OVERPAYMENT_ACCOUNT.getAccountID().longValue())//
-                .receivableInterestAccountId(INTEREST_FEE_RECEIVABLE_ACCOUNT.getAccountID().longValue())//
-                .receivableFeeAccountId(INTEREST_FEE_RECEIVABLE_ACCOUNT.getAccountID().longValue())//
-                .receivablePenaltyAccountId(INTEREST_FEE_RECEIVABLE_ACCOUNT.getAccountID().longValue())//
+                .accountingRule(ACCRUAL_PERIODIC)//
+                .fundSourceAccountId(suspenseClearingAccount.getAccountID().longValue())//
+                .loanPortfolioAccountId(loansReceivableAccount.getAccountID().longValue())//
+                .transfersInSuspenseAccountId(suspenseAccount.getAccountID().longValue())//
+                .interestOnLoanAccountId(interestIncomeAccount.getAccountID().longValue())//
+                .incomeFromFeeAccountId(feeIncomeAccount.getAccountID().longValue())//
+                .incomeFromPenaltyAccountId(feeIncomeAccount.getAccountID().longValue())//
+                .incomeFromRecoveryAccountId(recoveriesAccount.getAccountID().longValue())//
+                .writeOffAccountId(writtenOffAccount.getAccountID().longValue())//
+                .overpaymentLiabilityAccountId(overpaymentAccount.getAccountID().longValue())//
+                .receivableInterestAccountId(interestFeeReceivableAccount.getAccountID().longValue())//
+                .receivableFeeAccountId(interestFeeReceivableAccount.getAccountID().longValue())//
+                .receivablePenaltyAccountId(interestFeeReceivableAccount.getAccountID().longValue())//
                 .dateFormat(DATETIME_PATTERN)//
-                .locale("en_GB")//
+                .locale(LOCALE)//
                 .disallowExpectedDisbursements(true)//
                 .allowApprovedDisbursedAmountsOverApplied(true)//
                 .overAppliedCalculationType("percentage")//
                 .overAppliedNumber(50)//
-                .goodwillCreditAccountId(GOODWILL_EXPENSE_ACCOUNT.getAccountID().longValue())//
-                .incomeFromGoodwillCreditInterestAccountId(INTEREST_INCOME_CHARGE_OFF_ACCOUNT.getAccountID().longValue())//
-                .incomeFromGoodwillCreditFeesAccountId(FEE_CHARGE_OFF_ACCOUNT.getAccountID().longValue())//
-                .incomeFromGoodwillCreditPenaltyAccountId(FEE_CHARGE_OFF_ACCOUNT.getAccountID().longValue())//
-                .incomeFromChargeOffInterestAccountId(INTEREST_INCOME_CHARGE_OFF_ACCOUNT.getAccountID().longValue())//
-                .incomeFromChargeOffFeesAccountId(FEE_CHARGE_OFF_ACCOUNT.getAccountID().longValue())//
-                .chargeOffExpenseAccountId(CREDIT_LOSS_BAD_DEBT_ACCOUNT.getAccountID().longValue())//
-                .chargeOffFraudExpenseAccountId(CREDIT_LOSS_BAD_DEBT_FRAUD_ACCOUNT.getAccountID().longValue())//
-                .incomeFromChargeOffPenaltyAccountId(FEE_CHARGE_OFF_ACCOUNT.getAccountID().longValue());
+                .goodwillCreditAccountId(goodwillExpenseAccount.getAccountID().longValue())//
+                .incomeFromGoodwillCreditInterestAccountId(interestIncomeChargeOffAccount.getAccountID().longValue())//
+                .incomeFromGoodwillCreditFeesAccountId(feeChargeOffAccount.getAccountID().longValue())//
+                .incomeFromGoodwillCreditPenaltyAccountId(feeChargeOffAccount.getAccountID().longValue())//
+                .incomeFromChargeOffInterestAccountId(interestIncomeChargeOffAccount.getAccountID().longValue())//
+                .incomeFromChargeOffFeesAccountId(feeChargeOffAccount.getAccountID().longValue())//
+                .chargeOffExpenseAccountId(creditLossBadDebtAccount.getAccountID().longValue())//
+                .chargeOffFraudExpenseAccountId(creditLossBadDebtFraudAccount.getAccountID().longValue())//
+                .incomeFromChargeOffPenaltyAccountId(feeChargeOffAccount.getAccountID().longValue());
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/CustomSnapshotEventIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/CustomSnapshotEventIntegrationTest.java
@@ -22,16 +22,12 @@ import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.fineract.client.models.BusinessDateUpdateRequest;
-import org.apache.fineract.client.models.ExternalEventConfigurationUpdateRequest;
 import org.apache.fineract.client.models.PostLoanProductsRequest;
-import org.apache.fineract.client.models.PostLoanProductsResponse;
 import org.apache.fineract.infrastructure.event.external.data.ExternalEventResponse;
-import org.apache.fineract.integrationtests.common.BusinessStepHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.ExternalEventConfigurationHelper;
-import org.apache.fineract.integrationtests.common.SchedulerJobHelper;
-import org.apache.fineract.integrationtests.common.externalevents.ExternalEventHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignBusinessStepHelper;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.externalevents.ExternalEventsExtension;
 import org.apache.fineract.integrationtests.common.loans.LoanTestLifecycleExtension;
 import org.junit.jupiter.api.Assertions;
@@ -42,7 +38,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Slf4j
 @ExtendWith({ LoanTestLifecycleExtension.class, ExternalEventsExtension.class })
 @Order(1)
-public class CustomSnapshotEventIntegrationTest extends BaseLoanIntegrationTest {
+public class CustomSnapshotEventIntegrationTest extends FeignLoanTestBase {
+
+    private static final String LOAN_COB_JOB = "LOAN_CLOSE_OF_BUSINESS";
+    private static final String LOAN_ACCOUNT_CUSTOM_SNAPSHOT_EVENT = "LoanAccountCustomSnapshotBusinessEvent";
+
+    private final FeignBusinessStepHelper businessStepHelper = new FeignBusinessStepHelper(
+            FineractFeignClientHelper.getFineractFeignClient());
 
     @Test
     public void testSnapshotEventGenerationWhenLoanInstallmentIsNotPayed() {
@@ -55,15 +57,15 @@ public class CustomSnapshotEventIntegrationTest extends BaseLoanIntegrationTest 
             enableLoanAccountCustomSnapshotBusinessEvent();
 
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create Loan Product
             PostLoanProductsRequest loanProductsRequest = create1InstallmentAmountInMultiplesOf4Period1MonthLongWithInterestAndAmortizationProduct(
-                    InterestType.FLAT, AmortizationType.EQUAL_INSTALLMENTS);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+                    LoanTestData.InterestType.FLAT, LoanTestData.AmortizationType.EQUAL_INSTALLMENTS);
+            Long loanProductId = createLoanProduct(loanProductsRequest);
 
             // Apply and Approve Loan
-            Long loanId = applyAndApproveLoan(clientId, loanProductResponse.getResourceId(), "01 January 2023", 1250.0, 4);
+            Long loanId = applyAndApproveLoan(clientId, loanProductId, "01 January 2023", 1250.0, 4);
 
             // Disburse Loan
             disburseLoan(loanId, BigDecimal.valueOf(1250), "01 January 2023");
@@ -84,9 +86,9 @@ public class CustomSnapshotEventIntegrationTest extends BaseLoanIntegrationTest 
             updateBusinessDateAndExecuteCOBJob("01 February 2023");
 
             // verify external events
-            List<ExternalEventResponse> allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            List<ExternalEventResponse> allExternalEvents = externalEventHelper.getAllExternalEvents();
             Assertions.assertEquals(1, allExternalEvents.size());
-            Assertions.assertEquals("LoanAccountCustomSnapshotBusinessEvent", allExternalEvents.get(0).getType());
+            Assertions.assertEquals(LOAN_ACCOUNT_CUSTOM_SNAPSHOT_EVENT, allExternalEvents.get(0).getType());
             Assertions.assertEquals(loanId, allExternalEvents.get(0).getAggregateRootId());
 
             // Loan Delinquency data validation
@@ -122,15 +124,15 @@ public class CustomSnapshotEventIntegrationTest extends BaseLoanIntegrationTest 
             enableLoanAccountCustomSnapshotBusinessEvent();
 
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create Loan Product
             PostLoanProductsRequest loanProductsRequest = create1InstallmentAmountInMultiplesOf4Period1MonthLongWithInterestAndAmortizationProduct(
-                    InterestType.FLAT, AmortizationType.EQUAL_INSTALLMENTS);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+                    LoanTestData.InterestType.FLAT, LoanTestData.AmortizationType.EQUAL_INSTALLMENTS);
+            Long loanProductId = createLoanProduct(loanProductsRequest);
 
             // Apply and Approve Loan
-            Long loanId = applyAndApproveLoan(clientId, loanProductResponse.getResourceId(), "01 January 2023", 1250.0, 4);
+            Long loanId = applyAndApproveLoan(clientId, loanProductId, "01 January 2023", 1250.0, 4);
 
             // Disburse Loan
             disburseLoan(loanId, BigDecimal.valueOf(1250), "01 January 2023");
@@ -162,7 +164,7 @@ public class CustomSnapshotEventIntegrationTest extends BaseLoanIntegrationTest 
             updateBusinessDateAndExecuteCOBJob("01 February 2023");
 
             // verify external events
-            List<ExternalEventResponse> allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            List<ExternalEventResponse> allExternalEvents = externalEventHelper.getAllExternalEvents();
             Assertions.assertEquals(0, allExternalEvents.size());
         });
     }
@@ -178,15 +180,15 @@ public class CustomSnapshotEventIntegrationTest extends BaseLoanIntegrationTest 
             enableLoanAccountCustomSnapshotBusinessEvent();
 
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create Loan Product
             PostLoanProductsRequest loanProductsRequest = create1InstallmentAmountInMultiplesOf4Period1MonthLongWithInterestAndAmortizationProduct(
-                    InterestType.FLAT, AmortizationType.EQUAL_INSTALLMENTS);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+                    LoanTestData.InterestType.FLAT, LoanTestData.AmortizationType.EQUAL_INSTALLMENTS);
+            Long loanProductId = createLoanProduct(loanProductsRequest);
 
             // Apply and Approve Loan
-            Long loanId = applyAndApproveLoan(clientId, loanProductResponse.getResourceId(), "01 January 2023", 1250.0, 4);
+            Long loanId = applyAndApproveLoan(clientId, loanProductId, "01 January 2023", 1250.0, 4);
 
             // Disburse Loan
             disburseLoan(loanId, BigDecimal.valueOf(1250), "01 January 2023");
@@ -207,7 +209,7 @@ public class CustomSnapshotEventIntegrationTest extends BaseLoanIntegrationTest 
             updateBusinessDateAndExecuteCOBJob("01 February 2023");
 
             // verify external events
-            List<ExternalEventResponse> allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            List<ExternalEventResponse> allExternalEvents = externalEventHelper.getAllExternalEvents();
             Assertions.assertEquals(0, allExternalEvents.size());
         });
     }
@@ -222,15 +224,15 @@ public class CustomSnapshotEventIntegrationTest extends BaseLoanIntegrationTest 
             enableLoanAccountCustomSnapshotBusinessEvent();
 
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create Loan Product
             PostLoanProductsRequest loanProductsRequest = create1InstallmentAmountInMultiplesOf4Period1MonthLongWithInterestAndAmortizationProduct(
-                    InterestType.FLAT, AmortizationType.EQUAL_INSTALLMENTS);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+                    LoanTestData.InterestType.FLAT, LoanTestData.AmortizationType.EQUAL_INSTALLMENTS);
+            Long loanProductId = createLoanProduct(loanProductsRequest);
 
             // Apply and Approve Loan
-            Long loanId = applyAndApproveLoan(clientId, loanProductResponse.getResourceId(), "01 January 2023", 1250.0, 4);
+            Long loanId = applyAndApproveLoan(clientId, loanProductId, "01 January 2023", 1250.0, 4);
 
             // Disburse Loan
             disburseLoan(loanId, BigDecimal.valueOf(1250), "01 January 2023");
@@ -251,7 +253,7 @@ public class CustomSnapshotEventIntegrationTest extends BaseLoanIntegrationTest 
             updateBusinessDateAndExecuteCOBJob("31 January 2023");
 
             // verify external events
-            List<ExternalEventResponse> allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            List<ExternalEventResponse> allExternalEvents = externalEventHelper.getAllExternalEvents();
             Assertions.assertEquals(0, allExternalEvents.size());
         });
     }
@@ -267,15 +269,15 @@ public class CustomSnapshotEventIntegrationTest extends BaseLoanIntegrationTest 
                     "EXTERNAL_ASSET_OWNER_TRANSFER", "CHECK_DUE_INSTALLMENTS");
 
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create Loan Product
             PostLoanProductsRequest loanProductsRequest = create1InstallmentAmountInMultiplesOf4Period1MonthLongWithInterestAndAmortizationProduct(
-                    InterestType.FLAT, AmortizationType.EQUAL_INSTALLMENTS);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+                    LoanTestData.InterestType.FLAT, LoanTestData.AmortizationType.EQUAL_INSTALLMENTS);
+            Long loanProductId = createLoanProduct(loanProductsRequest);
 
             // Apply and Approve Loan
-            Long loanId = applyAndApproveLoan(clientId, loanProductResponse.getResourceId(), "01 January 2023", 1250.0, 4);
+            Long loanId = applyAndApproveLoan(clientId, loanProductId, "01 January 2023", 1250.0, 4);
 
             // Disburse Loan
             disburseLoan(loanId, BigDecimal.valueOf(1250), "01 January 2023");
@@ -296,38 +298,26 @@ public class CustomSnapshotEventIntegrationTest extends BaseLoanIntegrationTest 
             updateBusinessDateAndExecuteCOBJob("01 February 2023");
 
             // verify external events
-            List<ExternalEventResponse> allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            List<ExternalEventResponse> allExternalEvents = externalEventHelper.getAllExternalEvents();
             Assertions.assertEquals(0, allExternalEvents.size());
         });
     }
 
     private void enableCOBBusinessStep(String... steps) {
-        new BusinessStepHelper().updateSteps("LOAN_CLOSE_OF_BUSINESS", steps);
-
+        businessStepHelper.updateSteps(LOAN_COB_JOB, steps);
     }
 
     private void enableLoanAccountCustomSnapshotBusinessEvent() {
-        final Map<String, Boolean> updatedConfigurations = ExternalEventConfigurationHelper.updateExternalEventConfigurations(requestSpec,
-                responseSpec, new ExternalEventConfigurationUpdateRequest()
-                        .externalEventConfigurations(Map.of("LoanAccountCustomSnapshotBusinessEvent", true)));
-        Assertions.assertEquals(updatedConfigurations.size(), 1);
-        Assertions.assertTrue(updatedConfigurations.containsKey("LoanAccountCustomSnapshotBusinessEvent"));
-        Assertions.assertTrue(updatedConfigurations.get("LoanAccountCustomSnapshotBusinessEvent"));
+        externalEventHelper.enableBusinessEvent(LOAN_ACCOUNT_CUSTOM_SNAPSHOT_EVENT);
     }
 
     private void disableLoanAccountCustomSnapshotBusinessEvent() {
-        final Map<String, Boolean> updatedConfigurations = ExternalEventConfigurationHelper.updateExternalEventConfigurations(requestSpec,
-                responseSpec, new ExternalEventConfigurationUpdateRequest()
-                        .externalEventConfigurations(Map.of("LoanAccountCustomSnapshotBusinessEvent", false)));
-        Assertions.assertEquals(updatedConfigurations.size(), 1);
-        Assertions.assertTrue(updatedConfigurations.containsKey("LoanAccountCustomSnapshotBusinessEvent"));
-        Assertions.assertFalse(updatedConfigurations.get("LoanAccountCustomSnapshotBusinessEvent"));
+        externalEventHelper.disableBusinessEvent(LOAN_ACCOUNT_CUSTOM_SNAPSHOT_EVENT);
     }
 
     private void updateBusinessDateAndExecuteCOBJob(String date) {
-        businessDateHelper.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                .date(date).dateFormat(DATETIME_PATTERN).locale("en"));
-        SchedulerJobHelper.executeAndAwaitJob("Loan COB");
+        updateBusinessDate(date);
+        schedulerHelper.executeAndAwaitJob("Loan COB");
     }
 
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/CustomSnapshotEventIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/CustomSnapshotEventIntegrationTest.java
@@ -18,21 +18,16 @@
  */
 package org.apache.fineract.integrationtests;
 
-import com.google.gson.Gson;
 import java.math.BigDecimal;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.fineract.client.models.BusinessDateUpdateRequest;
 import org.apache.fineract.client.models.PostLoanProductsRequest;
-import org.apache.fineract.client.models.PostLoanProductsResponse;
 import org.apache.fineract.infrastructure.event.external.data.ExternalEventResponse;
-import org.apache.fineract.integrationtests.common.BusinessStepHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.ExternalEventConfigurationHelper;
-import org.apache.fineract.integrationtests.common.SchedulerJobHelper;
-import org.apache.fineract.integrationtests.common.externalevents.ExternalEventHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignBusinessStepHelper;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.externalevents.ExternalEventsExtension;
 import org.apache.fineract.integrationtests.common.loans.LoanTestLifecycleExtension;
 import org.junit.jupiter.api.Assertions;
@@ -41,9 +36,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 @Slf4j
 @ExtendWith({ LoanTestLifecycleExtension.class, ExternalEventsExtension.class })
-public class CustomSnapshotEventIntegrationTest extends BaseLoanIntegrationTest {
+public class CustomSnapshotEventIntegrationTest extends FeignLoanTestBase {
 
-    private final SchedulerJobHelper schedulerJobHelper = new SchedulerJobHelper(this.requestSpec);
+    private static final String LOAN_COB_JOB = "LOAN_CLOSE_OF_BUSINESS";
+    private static final String LOAN_ACCOUNT_CUSTOM_SNAPSHOT_EVENT = "LoanAccountCustomSnapshotBusinessEvent";
+
+    private final FeignBusinessStepHelper businessStepHelper = new FeignBusinessStepHelper(
+            FineractFeignClientHelper.getFineractFeignClient());
 
     @Test
     public void testSnapshotEventGenerationWhenLoanInstallmentIsNotPayed() {
@@ -56,15 +55,15 @@ public class CustomSnapshotEventIntegrationTest extends BaseLoanIntegrationTest 
             enableLoanAccountCustomSnapshotBusinessEvent();
 
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create Loan Product
             PostLoanProductsRequest loanProductsRequest = create1InstallmentAmountInMultiplesOf4Period1MonthLongWithInterestAndAmortizationProduct(
-                    InterestType.FLAT, AmortizationType.EQUAL_INSTALLMENTS);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+                    LoanTestData.InterestType.FLAT, LoanTestData.AmortizationType.EQUAL_INSTALLMENTS);
+            Long loanProductId = createLoanProduct(loanProductsRequest);
 
             // Apply and Approve Loan
-            Long loanId = applyAndApproveLoan(clientId, loanProductResponse.getResourceId(), "01 January 2023", 1250.0, 4);
+            Long loanId = applyAndApproveLoan(clientId, loanProductId, "01 January 2023", 1250.0, 4);
 
             // Disburse Loan
             disburseLoan(loanId, BigDecimal.valueOf(1250), "01 January 2023");
@@ -85,9 +84,9 @@ public class CustomSnapshotEventIntegrationTest extends BaseLoanIntegrationTest 
             updateBusinessDateAndExecuteCOBJob("01 February 2023");
 
             // verify external events
-            List<ExternalEventResponse> allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            List<ExternalEventResponse> allExternalEvents = externalEventHelper.getAllExternalEvents();
             Assertions.assertEquals(1, allExternalEvents.size());
-            Assertions.assertEquals("LoanAccountCustomSnapshotBusinessEvent", allExternalEvents.get(0).getType());
+            Assertions.assertEquals(LOAN_ACCOUNT_CUSTOM_SNAPSHOT_EVENT, allExternalEvents.get(0).getType());
             Assertions.assertEquals(loanId, allExternalEvents.get(0).getAggregateRootId());
 
             // Loan Delinquency data validation
@@ -123,15 +122,15 @@ public class CustomSnapshotEventIntegrationTest extends BaseLoanIntegrationTest 
             enableLoanAccountCustomSnapshotBusinessEvent();
 
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create Loan Product
             PostLoanProductsRequest loanProductsRequest = create1InstallmentAmountInMultiplesOf4Period1MonthLongWithInterestAndAmortizationProduct(
-                    InterestType.FLAT, AmortizationType.EQUAL_INSTALLMENTS);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+                    LoanTestData.InterestType.FLAT, LoanTestData.AmortizationType.EQUAL_INSTALLMENTS);
+            Long loanProductId = createLoanProduct(loanProductsRequest);
 
             // Apply and Approve Loan
-            Long loanId = applyAndApproveLoan(clientId, loanProductResponse.getResourceId(), "01 January 2023", 1250.0, 4);
+            Long loanId = applyAndApproveLoan(clientId, loanProductId, "01 January 2023", 1250.0, 4);
 
             // Disburse Loan
             disburseLoan(loanId, BigDecimal.valueOf(1250), "01 January 2023");
@@ -163,7 +162,7 @@ public class CustomSnapshotEventIntegrationTest extends BaseLoanIntegrationTest 
             updateBusinessDateAndExecuteCOBJob("01 February 2023");
 
             // verify external events
-            List<ExternalEventResponse> allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            List<ExternalEventResponse> allExternalEvents = externalEventHelper.getAllExternalEvents();
             Assertions.assertEquals(0, allExternalEvents.size());
         });
     }
@@ -179,15 +178,15 @@ public class CustomSnapshotEventIntegrationTest extends BaseLoanIntegrationTest 
             enableLoanAccountCustomSnapshotBusinessEvent();
 
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create Loan Product
             PostLoanProductsRequest loanProductsRequest = create1InstallmentAmountInMultiplesOf4Period1MonthLongWithInterestAndAmortizationProduct(
-                    InterestType.FLAT, AmortizationType.EQUAL_INSTALLMENTS);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+                    LoanTestData.InterestType.FLAT, LoanTestData.AmortizationType.EQUAL_INSTALLMENTS);
+            Long loanProductId = createLoanProduct(loanProductsRequest);
 
             // Apply and Approve Loan
-            Long loanId = applyAndApproveLoan(clientId, loanProductResponse.getResourceId(), "01 January 2023", 1250.0, 4);
+            Long loanId = applyAndApproveLoan(clientId, loanProductId, "01 January 2023", 1250.0, 4);
 
             // Disburse Loan
             disburseLoan(loanId, BigDecimal.valueOf(1250), "01 January 2023");
@@ -208,7 +207,7 @@ public class CustomSnapshotEventIntegrationTest extends BaseLoanIntegrationTest 
             updateBusinessDateAndExecuteCOBJob("01 February 2023");
 
             // verify external events
-            List<ExternalEventResponse> allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            List<ExternalEventResponse> allExternalEvents = externalEventHelper.getAllExternalEvents();
             Assertions.assertEquals(0, allExternalEvents.size());
         });
     }
@@ -223,15 +222,15 @@ public class CustomSnapshotEventIntegrationTest extends BaseLoanIntegrationTest 
             enableLoanAccountCustomSnapshotBusinessEvent();
 
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create Loan Product
             PostLoanProductsRequest loanProductsRequest = create1InstallmentAmountInMultiplesOf4Period1MonthLongWithInterestAndAmortizationProduct(
-                    InterestType.FLAT, AmortizationType.EQUAL_INSTALLMENTS);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+                    LoanTestData.InterestType.FLAT, LoanTestData.AmortizationType.EQUAL_INSTALLMENTS);
+            Long loanProductId = createLoanProduct(loanProductsRequest);
 
             // Apply and Approve Loan
-            Long loanId = applyAndApproveLoan(clientId, loanProductResponse.getResourceId(), "01 January 2023", 1250.0, 4);
+            Long loanId = applyAndApproveLoan(clientId, loanProductId, "01 January 2023", 1250.0, 4);
 
             // Disburse Loan
             disburseLoan(loanId, BigDecimal.valueOf(1250), "01 January 2023");
@@ -252,7 +251,7 @@ public class CustomSnapshotEventIntegrationTest extends BaseLoanIntegrationTest 
             updateBusinessDateAndExecuteCOBJob("31 January 2023");
 
             // verify external events
-            List<ExternalEventResponse> allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            List<ExternalEventResponse> allExternalEvents = externalEventHelper.getAllExternalEvents();
             Assertions.assertEquals(0, allExternalEvents.size());
         });
     }
@@ -268,15 +267,15 @@ public class CustomSnapshotEventIntegrationTest extends BaseLoanIntegrationTest 
                     "EXTERNAL_ASSET_OWNER_TRANSFER", "CHECK_DUE_INSTALLMENTS");
 
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create Loan Product
             PostLoanProductsRequest loanProductsRequest = create1InstallmentAmountInMultiplesOf4Period1MonthLongWithInterestAndAmortizationProduct(
-                    InterestType.FLAT, AmortizationType.EQUAL_INSTALLMENTS);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+                    LoanTestData.InterestType.FLAT, LoanTestData.AmortizationType.EQUAL_INSTALLMENTS);
+            Long loanProductId = createLoanProduct(loanProductsRequest);
 
             // Apply and Approve Loan
-            Long loanId = applyAndApproveLoan(clientId, loanProductResponse.getResourceId(), "01 January 2023", 1250.0, 4);
+            Long loanId = applyAndApproveLoan(clientId, loanProductId, "01 January 2023", 1250.0, 4);
 
             // Disburse Loan
             disburseLoan(loanId, BigDecimal.valueOf(1250), "01 January 2023");
@@ -297,45 +296,26 @@ public class CustomSnapshotEventIntegrationTest extends BaseLoanIntegrationTest 
             updateBusinessDateAndExecuteCOBJob("01 February 2023");
 
             // verify external events
-            List<ExternalEventResponse> allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            List<ExternalEventResponse> allExternalEvents = externalEventHelper.getAllExternalEvents();
             Assertions.assertEquals(0, allExternalEvents.size());
         });
     }
 
     private void enableCOBBusinessStep(String... steps) {
-        new BusinessStepHelper().updateSteps("LOAN_CLOSE_OF_BUSINESS", steps);
-
-    }
-
-    public static String getExternalEventConfigurationsForUpdateJSON() {
-        Map<String, Map<String, Boolean>> configurationsForUpdate = new HashMap<>();
-        Map<String, Boolean> configurations = new HashMap<>();
-        configurations.put("CentersCreateBusinessEvent", true);
-        configurations.put("ClientActivateBusinessEvent", true);
-        configurationsForUpdate.put("externalEventConfigurations", configurations);
-        return new Gson().toJson(configurationsForUpdate);
+        businessStepHelper.updateSteps(LOAN_COB_JOB, steps);
     }
 
     private void enableLoanAccountCustomSnapshotBusinessEvent() {
-        final Map<String, Boolean> updatedConfigurations = ExternalEventConfigurationHelper.updateExternalEventConfigurations(requestSpec,
-                responseSpec, "{\"externalEventConfigurations\":{\"LoanAccountCustomSnapshotBusinessEvent\":true}}\n");
-        Assertions.assertEquals(updatedConfigurations.size(), 1);
-        Assertions.assertTrue(updatedConfigurations.containsKey("LoanAccountCustomSnapshotBusinessEvent"));
-        Assertions.assertTrue(updatedConfigurations.get("LoanAccountCustomSnapshotBusinessEvent"));
+        externalEventHelper.enableBusinessEvent(LOAN_ACCOUNT_CUSTOM_SNAPSHOT_EVENT);
     }
 
     private void disableLoanAccountCustomSnapshotBusinessEvent() {
-        final Map<String, Boolean> updatedConfigurations = ExternalEventConfigurationHelper.updateExternalEventConfigurations(requestSpec,
-                responseSpec, "{\"externalEventConfigurations\":{\"LoanAccountCustomSnapshotBusinessEvent\":false}}\n");
-        Assertions.assertEquals(updatedConfigurations.size(), 1);
-        Assertions.assertTrue(updatedConfigurations.containsKey("LoanAccountCustomSnapshotBusinessEvent"));
-        Assertions.assertFalse(updatedConfigurations.get("LoanAccountCustomSnapshotBusinessEvent"));
+        externalEventHelper.disableBusinessEvent(LOAN_ACCOUNT_CUSTOM_SNAPSHOT_EVENT);
     }
 
     private void updateBusinessDateAndExecuteCOBJob(String date) {
-        businessDateHelper.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                .date(date).dateFormat(DATETIME_PATTERN).locale("en"));
-        schedulerJobHelper.executeAndAwaitJob("Loan COB");
+        updateBusinessDate(date);
+        schedulerHelper.executeAndAwaitJob("Loan COB");
     }
 
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/DelinquencyActionIntegrationTests.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/DelinquencyActionIntegrationTests.java
@@ -39,7 +39,7 @@ import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.fineract.client.models.BusinessDateUpdateRequest;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
 import org.apache.fineract.client.models.GetDelinquencyActionsResponse;
 import org.apache.fineract.client.models.GetLoanProductsProductIdResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdDelinquencyPausePeriod;
@@ -47,13 +47,12 @@ import org.apache.fineract.client.models.GetLoansLoanIdLoanInstallmentLevelDelin
 import org.apache.fineract.client.models.GetLoansLoanIdRepaymentPeriod;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
 import org.apache.fineract.client.models.PostLoanProductsRequest;
-import org.apache.fineract.client.models.PostLoanProductsResponse;
 import org.apache.fineract.client.models.PostLoansDelinquencyActionResponse;
-import org.apache.fineract.client.util.CallFailedRuntimeException;
-import org.apache.fineract.integrationtests.common.ClientHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignDelinquencyHelper;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.loans.LoanTestLifecycleExtension;
-import org.apache.fineract.integrationtests.common.products.DelinquencyBucketsHelper;
-import org.apache.fineract.integrationtests.inlinecob.InlineLoanCOBHelper;
+import org.apache.fineract.portfolio.delinquency.domain.DelinquencyAction;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -61,15 +60,39 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 @Slf4j
 @ExtendWith(LoanTestLifecycleExtension.class)
-public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
+public class DelinquencyActionIntegrationTests extends FeignLoanTestBase {
 
     public static final BigDecimal DOWN_PAYMENT_PERCENTAGE = new BigDecimal(25);
+
+    private final FeignDelinquencyHelper delinquencyHelper = new FeignDelinquencyHelper(FineractFeignClientHelper.getFineractFeignClient());
+
+    private PostLoansDelinquencyActionResponse createLoanDelinquencyAction(Long loanId, DelinquencyAction action, String startDate,
+            String endDate) {
+        return loanHelper.createLoanDelinquencyAction(loanId, action.name(), startDate, endDate);
+    }
+
+    private PostLoansDelinquencyActionResponse createLoanDelinquencyAction(Long loanId, DelinquencyAction action, String startDate) {
+        return loanHelper.createLoanDelinquencyAction(loanId, action.name(), startDate, null);
+    }
+
+    private PostLoansDelinquencyActionResponse createLoanDelinquencyAction(String loanExternalId, DelinquencyAction action,
+            String startDate, String endDate) {
+        return loanHelper.createLoanDelinquencyAction(loanExternalId, action.name(), startDate, endDate);
+    }
+
+    private List<GetDelinquencyActionsResponse> getLoanDelinquencyActions(Long loanId) {
+        return loanHelper.getLoanDelinquencyActions(loanId);
+    }
+
+    private List<GetDelinquencyActionsResponse> getLoanDelinquencyActions(String loanExternalId) {
+        return loanHelper.getLoanDelinquencyActions(loanExternalId);
+    }
 
     @Test
     public void testCreateAndReadPauseDelinquencyAction() {
         runAt("01 January 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create Loan Product
             Long loanProductId = createLoanProductWith25PctDownPayment(true, true);
@@ -81,10 +104,9 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
             disburseLoan(loanId, BigDecimal.valueOf(1000.00), "01 January 2023");
 
             // Create Delinquency Pause for the Loan
-            PostLoansDelinquencyActionResponse response = loanTransactionHelper.createLoanDelinquencyAction(loanId, PAUSE,
-                    "10 January 2023", "15 January 2023");
+            createLoanDelinquencyAction(loanId, PAUSE, "10 January 2023", "15 January 2023");
 
-            List<GetDelinquencyActionsResponse> loanDelinquencyActions = loanTransactionHelper.getLoanDelinquencyActions(loanId);
+            List<GetDelinquencyActionsResponse> loanDelinquencyActions = getLoanDelinquencyActions(loanId);
             Assertions.assertNotNull(loanDelinquencyActions);
             Assertions.assertEquals(1, loanDelinquencyActions.size());
             Assertions.assertEquals("PAUSE", loanDelinquencyActions.get(0).getAction());
@@ -97,7 +119,7 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
     public void testCreateAndReadPauseDelinquencyActionUsingExternalId() {
         runAt("01 January 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create Loan Product
             Long loanProductId = createLoanProductWith25PctDownPayment(true, true);
@@ -112,10 +134,9 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
             disburseLoan(loanId, BigDecimal.valueOf(1000.00), "01 January 2023");
 
             // Create Delinquency Pause for the Loan
-            PostLoansDelinquencyActionResponse response = loanTransactionHelper.createLoanDelinquencyAction(externalId, PAUSE,
-                    "10 January 2023", "15 January 2023");
+            createLoanDelinquencyAction(externalId, PAUSE, "10 January 2023", "15 January 2023");
 
-            List<GetDelinquencyActionsResponse> loanDelinquencyActions = loanTransactionHelper.getLoanDelinquencyActions(externalId);
+            List<GetDelinquencyActionsResponse> loanDelinquencyActions = getLoanDelinquencyActions(externalId);
             Assertions.assertNotNull(loanDelinquencyActions);
             Assertions.assertEquals(1, loanDelinquencyActions.size());
             Assertions.assertEquals("PAUSE", loanDelinquencyActions.get(0).getAction());
@@ -128,7 +149,7 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
     public void testCreatePauseAndResumeDelinquencyAction() {
         runAt("01 January 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create Loan Product
             Long loanProductId = createLoanProductWith25PctDownPayment(true, true);
@@ -140,16 +161,15 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
             disburseLoan(loanId, BigDecimal.valueOf(1000.00), "01 January 2023");
 
             // Create Delinquency Pause for the Loan
-            loanTransactionHelper.createLoanDelinquencyAction(loanId, PAUSE, "10 January 2023", "15 January 2023");
+            createLoanDelinquencyAction(loanId, PAUSE, "10 January 2023", "15 January 2023");
 
             // Update business date
-            businessDateHelper.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("14 January 2023").dateFormat(DATETIME_PATTERN).locale("en"));
+            updateBusinessDate("14 January 2023");
 
             // Create 2nd Delinquency Resume for the Loan
-            loanTransactionHelper.createLoanDelinquencyAction(loanId, RESUME, "14 January 2023");
+            createLoanDelinquencyAction(loanId, RESUME, "14 January 2023");
 
-            List<GetDelinquencyActionsResponse> loanDelinquencyActions = loanTransactionHelper.getLoanDelinquencyActions(loanId);
+            List<GetDelinquencyActionsResponse> loanDelinquencyActions = getLoanDelinquencyActions(loanId);
             Assertions.assertNotNull(loanDelinquencyActions);
             Assertions.assertEquals(2, loanDelinquencyActions.size());
 
@@ -166,7 +186,7 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
     public void testCreatePauseAndResumeDelinquencyActionWithStatusFlag() {
         runAt("01 January 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create Loan Product
             Long loanProductId = createLoanProductWith25PctDownPayment(true, true);
@@ -178,30 +198,28 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
             disburseLoan(loanId, BigDecimal.valueOf(1000.00), "01 January 2023");
 
             // Create Delinquency Pause for the Loan
-            loanTransactionHelper.createLoanDelinquencyAction(loanId, PAUSE, "10 January 2023", "15 January 2023");
+            createLoanDelinquencyAction(loanId, PAUSE, "10 January 2023", "15 January 2023");
 
             // Update business date
-            businessDateHelper.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("14 January 2023").dateFormat(DATETIME_PATTERN).locale("en"));
+            updateBusinessDate("14 January 2023");
 
             // Validate Loan Delinquency Pause Period on Loan
             validateLoanDelinquencyPausePeriods(loanId, pausePeriods("10 January 2023", "15 January 2023", true));
 
             // Create a Resume for the Loan for the current business date, it is still expected to be in pause
-            loanTransactionHelper.createLoanDelinquencyAction(loanId, RESUME, "14 January 2023");
+            createLoanDelinquencyAction(loanId, RESUME, "14 January 2023");
 
             // Validate Loan Delinquency Pause Period on Loan
             validateLoanDelinquencyPausePeriods(loanId, pausePeriods("10 January 2023", "14 January 2023", true));
 
             // Update business date to 15 January 2023
-            businessDateHelper.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("15 January 2023").dateFormat(DATETIME_PATTERN).locale("en"));
+            updateBusinessDate("15 January 2023");
 
             // Validate Loan Delinquency Pause Period on Loan
             validateLoanDelinquencyPausePeriods(loanId, pausePeriods("10 January 2023", "14 January 2023", false));
 
             // Create a new pause action for the future
-            loanTransactionHelper.createLoanDelinquencyAction(loanId, PAUSE, "20 January 2023", "25 January 2023");
+            createLoanDelinquencyAction(loanId, PAUSE, "20 January 2023", "25 January 2023");
 
             // Validate Loan Delinquency Pause Period on Loan
             validateLoanDelinquencyPausePeriods(loanId, //
@@ -215,7 +233,7 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
     public void testValidationErrorIsThrownWhenCreatingPauseActionWithBackdatedStartDateBeforeDisbursement() {
         runAt("01 January 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create Loan Product
             Long loanProductId = createLoanProductWith25PctDownPayment(true, true);
@@ -228,7 +246,7 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
 
             // Create Delinquency Pause for the Loan before disbursement date
             CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.createLoanDelinquencyAction(loanId, PAUSE, "05 December 2022", "15 January 2023"));
+                    () -> createLoanDelinquencyAction(loanId, PAUSE, "05 December 2022", "15 January 2023"));
             assertTrue(exception.getMessage().contains("Start date of pause period must be after first disbursal date"));
         });
     }
@@ -237,7 +255,7 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
     public void testCreateAndVerifyBackdatedPauseDelinquencyAction() {
         runAt("30 January 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create Loan Product
             Long loanProductId = createLoanProductWith25PctDownPayment(true, true);
@@ -250,10 +268,9 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
             disburseLoan(loanId, BigDecimal.valueOf(1000.00), "25 December 2022");
 
             // Create Delinquency Pause for the Loan in the past
-            PostLoansDelinquencyActionResponse response = loanTransactionHelper.createLoanDelinquencyAction(loanId, PAUSE,
-                    "28 January 2023", "15 February 2023");
+            createLoanDelinquencyAction(loanId, PAUSE, "28 January 2023", "15 February 2023");
 
-            List<GetDelinquencyActionsResponse> loanDelinquencyActions = loanTransactionHelper.getLoanDelinquencyActions(loanId);
+            List<GetDelinquencyActionsResponse> loanDelinquencyActions = getLoanDelinquencyActions(loanId);
             Assertions.assertNotNull(loanDelinquencyActions);
             Assertions.assertEquals(1, loanDelinquencyActions.size());
             Assertions.assertEquals("PAUSE", loanDelinquencyActions.get(0).getAction());
@@ -269,7 +286,7 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
     public void testVerifyLoanDelinquencyRecalculationForBackdatedPauseDelinquencyAction() {
         runAt("30 January 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create Loan Product
             Long loanProductId = createLoanProductWith25PctDownPaymentAndDelinquencyBucket(true, true, true, 3);
@@ -285,9 +302,9 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
             verifyLoanDelinquencyData(loanId, 6, new InstallmentDelinquencyData(4, 10, BigDecimal.valueOf(250.0)));
 
             // Create Delinquency Pause for the Loan in the past
-            loanTransactionHelper.createLoanDelinquencyAction(loanId, PAUSE, "27 January 2023", "15 February 2023");
+            createLoanDelinquencyAction(loanId, PAUSE, "27 January 2023", "15 February 2023");
 
-            List<GetDelinquencyActionsResponse> loanDelinquencyActions = loanTransactionHelper.getLoanDelinquencyActions(loanId);
+            List<GetDelinquencyActionsResponse> loanDelinquencyActions = getLoanDelinquencyActions(loanId);
             Assertions.assertNotNull(loanDelinquencyActions);
             Assertions.assertEquals(1, loanDelinquencyActions.size());
             Assertions.assertEquals("PAUSE", loanDelinquencyActions.getFirst().getAction());
@@ -307,7 +324,7 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
     public void testValidationErrorIsThrownWhenCreatingActionThatOverlaps() {
         runAt("01 January 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create Loan Product
             Long loanProductId = createLoanProductWith25PctDownPayment(true, true);
@@ -319,11 +336,11 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
             disburseLoan(loanId, BigDecimal.valueOf(1000.00), "01 January 2023");
 
             // Create Delinquency Pause for the Loan
-            loanTransactionHelper.createLoanDelinquencyAction(loanId, PAUSE, "01 January 2023", "15 January 2023");
+            createLoanDelinquencyAction(loanId, PAUSE, "01 January 2023", "15 January 2023");
 
             // Create overlapping Delinquency Pause for the Loan
             CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.createLoanDelinquencyAction(loanId, PAUSE, "01 January 2023", "15 January 2023"));
+                    () -> createLoanDelinquencyAction(loanId, PAUSE, "01 January 2023", "15 January 2023"));
             assertTrue(exception.getMessage().contains("Delinquency pause period cannot overlap with another pause period"));
         });
     }
@@ -332,7 +349,7 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
     public void testLoanAndInstallmentDelinquencyCalculationForCOBAfterPausePeriodEndTest() {
         runAt("01 November 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create Loan Product
             Long loanProductId = createLoanProductWith25PctDownPaymentAndDelinquencyBucket(true, true, true, 0);
@@ -349,18 +366,14 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
             disburseLoan(loanId, BigDecimal.valueOf(100.00), "01 November 2023");
 
             // Update business date
-            businessDateHelper.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("05 November 2023").dateFormat(DATETIME_PATTERN).locale("en"));
+            updateBusinessDate("05 November 2023");
 
             // Create Delinquency Pause for the Loan
-            PostLoansDelinquencyActionResponse response = loanTransactionHelper.createLoanDelinquencyAction(loanId, PAUSE,
-                    "16 November 2023", "25 November 2023");
+            createLoanDelinquencyAction(loanId, PAUSE, "16 November 2023", "25 November 2023");
 
             // run cob for business date 26 November
-            final InlineLoanCOBHelper inlineLoanCOBHelper = new InlineLoanCOBHelper(requestSpec, responseSpec);
-            businessDateHelper.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("26 November 2023").dateFormat(DATETIME_PATTERN).locale("en"));
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.longValue()));
+            updateBusinessDate("26 November 2023");
+            executeInlineCOB(loanId);
 
             // Loan delinquency data
             verifyLoanDelinquencyData(loanId, 1, new InstallmentDelinquencyData(1, 3, BigDecimal.valueOf(25.0)));
@@ -371,7 +384,7 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
     }
 
     private void validateLoanDelinquencyPausePeriods(Long loanId, GetLoansLoanIdDelinquencyPausePeriod... pausePeriods) {
-        GetLoansLoanIdResponse loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId.intValue());
+        GetLoansLoanIdResponse loan = getLoanDetails(loanId);
         Assertions.assertNotNull(loan.getDelinquent());
         if (pausePeriods.length > 0) {
             Assertions.assertEquals(Arrays.asList(pausePeriods), loan.getDelinquent().getDelinquencyPausePeriods());
@@ -390,7 +403,7 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
 
     private void verifyLoanDelinquencyData(Long loanId, Integer loanLevelDelinquentDays,
             InstallmentDelinquencyData... expectedInstallmentLevelInstallmentDelinquencyData) {
-        GetLoansLoanIdResponse loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId.intValue());
+        GetLoansLoanIdResponse loan = getLoanDetails(loanId);
         Assertions.assertNotNull(loan.getDelinquent());
         List<GetLoansLoanIdLoanInstallmentLevelDelinquency> installmentLevelDelinquency = loan.getDelinquent()
                 .getInstallmentLevelDelinquency();
@@ -421,11 +434,8 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
         product.setDisbursedAmountPercentageForDownPayment(DOWN_PAYMENT_PERCENTAGE);
         product.setEnableAutoRepaymentForDownPayment(autoDownPaymentEnabled);
 
-        PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-        GetLoanProductsProductIdResponse getLoanProductsProductIdResponse = loanProductHelper
-                .retrieveLoanProductById(loanProductResponse.getResourceId());
-
-        Long loanProductId = loanProductResponse.getResourceId();
+        Long loanProductId = createLoanProduct(product);
+        GetLoanProductsProductIdResponse getLoanProductsProductIdResponse = retrieveLoanProduct(loanProductId);
 
         assertEquals(TRUE, getLoanProductsProductIdResponse.getEnableDownPayment());
         assertNotNull(getLoanProductsProductIdResponse.getDisbursedAmountPercentageForDownPayment());
@@ -438,7 +448,7 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
     private Long createLoanProductWith25PctDownPaymentAndDelinquencyBucket(boolean autoDownPaymentEnabled, boolean multiDisburseEnabled,
             boolean installmentLevelDelinquencyEnabled, Integer graceOnArrearsAging) {
         // Create DelinquencyBuckets
-        Long delinquencyBucketId = DelinquencyBucketsHelper.createBucket(List.of(//
+        Long delinquencyBucketId = delinquencyHelper.createBucket(List.of(//
                 Pair.of(1, 3), //
                 Pair.of(4, 10), //
                 Pair.of(11, 60), //
@@ -454,11 +464,8 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
         product.setEnableAutoRepaymentForDownPayment(autoDownPaymentEnabled);
         product.setEnableInstallmentLevelDelinquency(installmentLevelDelinquencyEnabled);
 
-        PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-        GetLoanProductsProductIdResponse getLoanProductsProductIdResponse = loanProductHelper
-                .retrieveLoanProductById(loanProductResponse.getResourceId());
-
-        Long loanProductId = loanProductResponse.getResourceId();
+        Long loanProductId = createLoanProduct(product);
+        GetLoanProductsProductIdResponse getLoanProductsProductIdResponse = retrieveLoanProduct(loanProductId);
 
         assertEquals(TRUE, getLoanProductsProductIdResponse.getEnableDownPayment());
         assertNotNull(getLoanProductsProductIdResponse.getDisbursedAmountPercentageForDownPayment());
@@ -471,7 +478,7 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
 
     private Long createLoanProductWithDelinquencyBucketNoDownPayment(boolean multiDisburseEnabled,
             boolean installmentLevelDelinquencyEnabled, Integer graceOnArrearsAging) {
-        Long delinquencyBucketId = DelinquencyBucketsHelper.createBucket(List.of(//
+        Long delinquencyBucketId = delinquencyHelper.createBucket(List.of(//
                 Pair.of(1, 3), //
                 Pair.of(4, 10), //
                 Pair.of(11, 60), //
@@ -484,8 +491,7 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
         product.setGraceOnArrearsAgeing(graceOnArrearsAging);
         product.setEnableInstallmentLevelDelinquency(installmentLevelDelinquencyEnabled);
 
-        PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-        return loanProductResponse.getResourceId();
+        return createLoanProduct(product);
     }
 
     @Test
@@ -493,7 +499,7 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
         final Long[] loanIdHolder = new Long[1];
 
         runAt("01 January 2022", () -> {
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
             Long loanProductId = createLoanProductWith25PctDownPaymentAndDelinquencyBucket(true, true, false, 0);
             Long loanId = applyAndApproveLoan(clientId, loanProductId, "01 January 2022", 1000.0, 2, req -> {
                 req.setLoanTermFrequency(30);
@@ -503,16 +509,15 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
             disburseLoan(loanId, BigDecimal.valueOf(1000.00), "01 January 2022");
             loanIdHolder[0] = loanId;
 
-            loanTransactionHelper.createLoanDelinquencyAction(loanId, PAUSE, "20 January 2022", "30 January 2022");
+            createLoanDelinquencyAction(loanId, PAUSE, "20 January 2022", "30 January 2022");
         });
 
         runAt("02 February 2022", () -> {
-            final InlineLoanCOBHelper inlineLoanCOBHelper = new InlineLoanCOBHelper(requestSpec, responseSpec);
             Long loanId = loanIdHolder[0];
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
 
             assertNotNull(loanDetails.getDelinquent(), "Delinquent data should not be null");
 
@@ -543,7 +548,7 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
         final Long[] loanIdHolder = new Long[1];
 
         runAt("01 January 2022", () -> {
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
             Long loanProductId = createLoanProductWith25PctDownPaymentAndDelinquencyBucket(true, true, true, 0);
             Long loanId = applyAndApproveLoan(clientId, loanProductId, "01 January 2022", 1000.0, 3, req -> {
                 req.setLoanTermFrequency(45);
@@ -553,18 +558,16 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
             disburseLoan(loanId, BigDecimal.valueOf(100.00), "01 January 2022");
             loanIdHolder[0] = loanId;
 
-            businessDateHelper.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("05 January 2022").dateFormat(DATETIME_PATTERN).locale("en"));
+            updateBusinessDate("05 January 2022");
 
-            loanTransactionHelper.createLoanDelinquencyAction(loanId, PAUSE, "20 January 2022", "30 January 2022");
+            createLoanDelinquencyAction(loanId, PAUSE, "20 January 2022", "30 January 2022");
         });
 
         runAt("02 March 2022", () -> {
-            final InlineLoanCOBHelper inlineLoanCOBHelper = new InlineLoanCOBHelper(requestSpec, responseSpec);
             Long loanId = loanIdHolder[0];
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
 
             assertNotNull(loanDetails.getDelinquent(), "Loan delinquent data should not be null");
 
@@ -590,7 +593,7 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
         final Long[] loanIdHolder = new Long[1];
 
         runAt("10 January 2022", () -> {
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
             Long loanProductId = createLoanProductWith25PctDownPaymentAndDelinquencyBucket(true, true, true, 0);
             Long loanId = applyAndApproveLoan(clientId, loanProductId, "10 January 2022", 1000.0, 3, req -> {
                 req.setLoanTermFrequency(30);
@@ -600,18 +603,16 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
             disburseLoan(loanId, BigDecimal.valueOf(100.00), "10 January 2022");
             loanIdHolder[0] = loanId;
 
-            businessDateHelper.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("14 January 2022").dateFormat(DATETIME_PATTERN).locale("en"));
+            updateBusinessDate("14 January 2022");
 
-            loanTransactionHelper.createLoanDelinquencyAction(loanId, PAUSE, "15 January 2022", "25 January 2022");
+            createLoanDelinquencyAction(loanId, PAUSE, "15 January 2022", "25 January 2022");
         });
 
         runAt("05 February 2022", () -> {
-            final InlineLoanCOBHelper inlineLoanCOBHelper = new InlineLoanCOBHelper(requestSpec, responseSpec);
             Long loanId = loanIdHolder[0];
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             assertNotNull(loanDetails.getDelinquent(), "Loan delinquent data should not be null");
 
             List<GetLoansLoanIdLoanInstallmentLevelDelinquency> delinquencies = loanDetails.getDelinquent()
@@ -637,7 +638,7 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
         final Long[] loanIdHolder = new Long[1];
 
         runAt("01 January 2022", () -> {
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
             Long loanProductId = createLoanProductWith25PctDownPaymentAndDelinquencyBucket(true, true, true, 0);
             Long loanId = applyAndApproveLoan(clientId, loanProductId, "01 January 2022", 1000.0, 1, req -> {
                 req.setLoanTermFrequency(30);
@@ -650,20 +651,19 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
 
         runAt("04 February 2022", () -> {
             Long loanId = loanIdHolder[0];
-            loanTransactionHelper.createLoanDelinquencyAction(loanId, PAUSE, "04 February 2022", "09 February 2022");
+            createLoanDelinquencyAction(loanId, PAUSE, "04 February 2022", "09 February 2022");
         });
 
         runAt("15 February 2022", () -> {
             Long loanId = loanIdHolder[0];
-            loanTransactionHelper.createLoanDelinquencyAction(loanId, PAUSE, "15 February 2022", "20 February 2022");
+            createLoanDelinquencyAction(loanId, PAUSE, "15 February 2022", "20 February 2022");
         });
 
         runAt("01 March 2022", () -> {
-            final InlineLoanCOBHelper inlineLoanCOBHelper = new InlineLoanCOBHelper(requestSpec, responseSpec);
             Long loanId = loanIdHolder[0];
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             assertNotNull(loanDetails.getDelinquent(), "Loan delinquent data should not be null");
 
             LocalDate businessDate = LocalDate.parse("01 March 2022", dateTimeFormatter);
@@ -703,7 +703,7 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
         final Long[] loanIdHolder = new Long[1];
 
         runAt("01 January 2022", () -> {
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
             Long loanProductId = createLoanProductWith25PctDownPaymentAndDelinquencyBucket(true, true, true, 0);
             Long loanId = applyAndApproveLoan(clientId, loanProductId, "01 January 2022", 1000.0, 2, req -> {
                 req.setLoanTermFrequency(20);
@@ -713,18 +713,16 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
             disburseLoan(loanId, BigDecimal.valueOf(100.00), "01 January 2022");
             loanIdHolder[0] = loanId;
 
-            businessDateHelper.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("02 January 2022").dateFormat(DATETIME_PATTERN).locale("en"));
+            updateBusinessDate("02 January 2022");
 
-            loanTransactionHelper.createLoanDelinquencyAction(loanId, PAUSE, "03 January 2022", "10 January 2022");
+            createLoanDelinquencyAction(loanId, PAUSE, "03 January 2022", "10 January 2022");
         });
 
         runAt("12 January 2022", () -> {
-            final InlineLoanCOBHelper inlineLoanCOBHelper = new InlineLoanCOBHelper(requestSpec, responseSpec);
             Long loanId = loanIdHolder[0];
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             assertNotNull(loanDetails.getDelinquent(), "Loan delinquent data should not be null");
 
             Map<String, BigDecimal> expectedTotals = calculateExpectedBucketTotals(loanDetails,
@@ -738,7 +736,7 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
         final Long[] loanIdHolder = new Long[1];
 
         runAt("01 January 2022", () -> {
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
             Long loanProductId = createLoanProductWith25PctDownPaymentAndDelinquencyBucket(true, true, true, 0);
             Long loanId = applyAndApproveLoan(clientId, loanProductId, "01 January 2022", 1000.0, 4, req -> {
                 req.setLoanTermFrequency(60);
@@ -748,18 +746,16 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
             disburseLoan(loanId, BigDecimal.valueOf(1000.00), "01 January 2022");
             loanIdHolder[0] = loanId;
 
-            businessDateHelper.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("01 January 2022").dateFormat(DATETIME_PATTERN).locale("en"));
+            updateBusinessDate("01 January 2022");
 
-            loanTransactionHelper.createLoanDelinquencyAction(loanId, PAUSE, "02 January 2022", "20 January 2022");
+            createLoanDelinquencyAction(loanId, PAUSE, "02 January 2022", "20 January 2022");
         });
 
         runAt("01 March 2022", () -> {
-            final InlineLoanCOBHelper inlineLoanCOBHelper = new InlineLoanCOBHelper(requestSpec, responseSpec);
             Long loanId = loanIdHolder[0];
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             assertNotNull(loanDetails.getDelinquent(), "Loan delinquent data should not be null");
 
             Map<String, BigDecimal> expectedTotals = calculateExpectedBucketTotals(loanDetails,
@@ -773,7 +769,7 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
         final Long[] loanIdHolder = new Long[1];
 
         runAt("01 January 2025", () -> {
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
             Long loanProductId = createLoanProductWithDelinquencyBucketNoDownPayment(true, true, 3);
             Long loanId = applyAndApproveLoan(clientId, loanProductId, "01 January 2025", 1000.0, 4, req -> {
                 req.setLoanTermFrequency(40);
@@ -785,31 +781,27 @@ public class DelinquencyActionIntegrationTests extends BaseLoanIntegrationTest {
         });
 
         runAt("07 January 2025", () -> {
-            final InlineLoanCOBHelper inlineLoanCOBHelper = new InlineLoanCOBHelper(requestSpec, responseSpec);
             Long loanId = loanIdHolder[0];
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            loanTransactionHelper.createLoanDelinquencyAction(loanId, PAUSE, "09 January 2025", "20 January 2025");
+            createLoanDelinquencyAction(loanId, PAUSE, "09 January 2025", "20 January 2025");
         });
 
         runAt("15 January 2025", () -> {
-            final InlineLoanCOBHelper inlineLoanCOBHelper = new InlineLoanCOBHelper(requestSpec, responseSpec);
             Long loanId = loanIdHolder[0];
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
         });
 
         runAt("25 January 2025", () -> {
-            final InlineLoanCOBHelper inlineLoanCOBHelper = new InlineLoanCOBHelper(requestSpec, responseSpec);
             Long loanId = loanIdHolder[0];
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
         });
 
         runAt("10 February 2025", () -> {
-            final InlineLoanCOBHelper inlineLoanCOBHelper = new InlineLoanCOBHelper(requestSpec, responseSpec);
             Long loanId = loanIdHolder[0];
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             assertNotNull(loanDetails.getDelinquent(), "Loan delinquent data should not be null");
 
             Integer loanLevelPastDueDays = loanDetails.getDelinquent().getPastDueDays();

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/DelinquencyBucketsIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/DelinquencyBucketsIntegrationTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.fineract.integrationtests;
 
-import static org.apache.fineract.integrationtests.BaseLoanIntegrationTest.RepaymentFrequencyType.DAYS;
+import static org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder.DEFAULT_STRATEGY;
 import static org.apache.fineract.portfolio.delinquency.domain.DelinquencyAction.PAUSE;
 import static org.apache.fineract.portfolio.delinquency.domain.DelinquencyAction.RESUME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -29,18 +29,12 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.gson.Gson;
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
 import org.apache.fineract.client.models.BusinessDateResponse;
 import org.apache.fineract.client.models.DeleteDelinquencyBucketResponse;
 import org.apache.fineract.client.models.DeleteDelinquencyRangeResponse;
@@ -53,69 +47,64 @@ import org.apache.fineract.client.models.GetDelinquencyTagHistoryResponse;
 import org.apache.fineract.client.models.GetLoanProductsProductIdResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdDelinquencySummary;
 import org.apache.fineract.client.models.GetLoansLoanIdLoanInstallmentLevelDelinquency;
-import org.apache.fineract.client.models.GetLoansLoanIdRepaymentPeriod;
-import org.apache.fineract.client.models.GetLoansLoanIdRepaymentSchedule;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
+import org.apache.fineract.client.models.JobBusinessStepConfigData;
 import org.apache.fineract.client.models.PostDelinquencyBucketResponse;
 import org.apache.fineract.client.models.PostDelinquencyRangeResponse;
+import org.apache.fineract.client.models.PostLoanProductsRequest;
 import org.apache.fineract.client.models.PostLoansDelinquencyActionResponse;
+import org.apache.fineract.client.models.PostLoansLoanIdChargesRequest;
+import org.apache.fineract.client.models.PostLoansLoanIdChargesResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsTransactionIdRequest;
 import org.apache.fineract.client.models.PostLoansRequest;
-import org.apache.fineract.client.models.PostLoansResponse;
 import org.apache.fineract.client.models.PutDelinquencyBucketResponse;
 import org.apache.fineract.client.models.PutDelinquencyRangeResponse;
 import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
 import org.apache.fineract.client.models.PutLoanProductsProductIdRequest;
 import org.apache.fineract.client.models.PutLoanProductsProductIdResponse;
-import org.apache.fineract.client.util.CallFailedRuntimeException;
-import org.apache.fineract.cob.data.JobBusinessStepConfigData;
 import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
-import org.apache.fineract.integrationtests.common.BusinessDateHelper;
-import org.apache.fineract.integrationtests.common.BusinessStepConfigurationHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.CommonConstants;
-import org.apache.fineract.integrationtests.common.SchedulerJobHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignBusinessStepHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignDelinquencyHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.LoanProductCommandsApi;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.AmortizationType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.DaysInMonthType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.DaysInYearType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestCalculationPeriodType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestRateFrequencyType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.RepaymentFrequencyType;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
-import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
 import org.apache.fineract.integrationtests.common.loans.LoanTestLifecycleExtension;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.apache.fineract.integrationtests.common.products.DelinquencyBucketsHelper;
-import org.apache.fineract.integrationtests.common.products.DelinquencyRangesHelper;
+import org.apache.fineract.portfolio.delinquency.domain.DelinquencyAction;
+import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleType;
 import org.assertj.core.api.SoftAssertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Slf4j
 @ExtendWith(LoanTestLifecycleExtension.class)
-public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
+public class DelinquencyBucketsIntegrationTest extends FeignLoanTestBase {
 
-    private ResponseSpecification responseSpec;
-    private RequestSpecification requestSpec;
-    private BusinessDateHelper businessDateHelper;
-    private static final String principalAmount = "10000";
+    private static final String CLIENT_ACTIVATION_DATE = "01 January 2012";
+    private static final Double PRINCIPAL_AMOUNT = 10000.0;
+    private static final Integer ACCOUNTING_RULE_NONE = 1;
 
-    @BeforeEach
-    public void setup() {
-        Utils.initializeRESTAssured();
-
-        requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        this.businessDateHelper = new BusinessDateHelper();
-    }
+    private final FeignDelinquencyHelper delinquencyHelper = new FeignDelinquencyHelper(FineractFeignClientHelper.getFineractFeignClient());
+    private final FeignBusinessStepHelper businessStepHelper = new FeignBusinessStepHelper(
+            FineractFeignClientHelper.getFineractFeignClient());
 
     @Test
     public void testCreateDelinquencyRanges() {
         // given
-        final PostDelinquencyRangeResponse delinquencyRangeResponse01 = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                .minimumAgeDays(1).maximumAgeDays(3).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
-        final List<DelinquencyRangeResponse> ranges = DelinquencyRangesHelper.getRanges();
+        final PostDelinquencyRangeResponse delinquencyRangeResponse01 = delinquencyHelper.createRange(new DelinquencyRangeRequest()
+                .minimumAgeDays(1).maximumAgeDays(3).locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+        final List<DelinquencyRangeResponse> ranges = delinquencyHelper.getRanges();
 
         // then
         assertNotNull(delinquencyRangeResponse01);
@@ -131,14 +120,14 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void testUpdateDelinquencyRanges() {
         // given
-        final PostDelinquencyRangeResponse delinquencyRangeResponse01 = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                .minimumAgeDays(1).maximumAgeDays(3).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+        final PostDelinquencyRangeResponse delinquencyRangeResponse01 = delinquencyHelper.createRange(new DelinquencyRangeRequest()
+                .minimumAgeDays(1).maximumAgeDays(3).locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
         // when
-        final PutDelinquencyRangeResponse delinquencyRangeResponse02 = DelinquencyRangesHelper
+        final PutDelinquencyRangeResponse delinquencyRangeResponse02 = delinquencyHelper
                 .updateRange(delinquencyRangeResponse01.getResourceId(), new DelinquencyRangeRequest().minimumAgeDays(1).maximumAgeDays(7)
-                        .locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
-        final DelinquencyRangeResponse range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse01.getResourceId());
-        final DeleteDelinquencyRangeResponse deleteDelinquencyRangeResponse = DelinquencyRangesHelper
+                        .locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+        final DelinquencyRangeResponse range = delinquencyHelper.getRange(delinquencyRangeResponse01.getResourceId());
+        final DeleteDelinquencyRangeResponse deleteDelinquencyRangeResponse = delinquencyHelper
                 .deleteRange(delinquencyRangeResponse01.getResourceId());
 
         // then
@@ -154,29 +143,29 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     public void testDelinquencyBuckets() {
         // given
         ArrayList<Long> rangeIds = new ArrayList<>();
-        PostDelinquencyRangeResponse delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                .minimumAgeDays(1).maximumAgeDays(3).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+        PostDelinquencyRangeResponse delinquencyRangeResponse = delinquencyHelper.createRange(new DelinquencyRangeRequest()
+                .minimumAgeDays(1).maximumAgeDays(3).locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
         rangeIds.add(delinquencyRangeResponse.getResourceId());
-        delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(4).maximumAgeDays(30)
-                .locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+        delinquencyRangeResponse = delinquencyHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(4).maximumAgeDays(30)
+                .locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
         rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-        PostDelinquencyBucketResponse delinquencyBucketResponse = DelinquencyBucketsHelper
+        PostDelinquencyBucketResponse delinquencyBucketResponse = delinquencyHelper
                 .createBucket(new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds));
         // Update
         rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-        PutDelinquencyBucketResponse updateDelinquencyBucketResponse = DelinquencyBucketsHelper.updateBucket(
+        PutDelinquencyBucketResponse updateDelinquencyBucketResponse = delinquencyHelper.updateBucket(
                 delinquencyBucketResponse.getResourceId(),
                 new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds));
-        delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(31).maximumAgeDays(60)
-                .locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+        delinquencyRangeResponse = delinquencyHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(31).maximumAgeDays(60)
+                .locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
         rangeIds.add(delinquencyRangeResponse.getResourceId());
         // Read
-        final DelinquencyBucketResponse delinquencyBucket = DelinquencyBucketsHelper.getBucket(delinquencyBucketResponse.getResourceId());
+        final DelinquencyBucketResponse delinquencyBucket = delinquencyHelper.getBucket(delinquencyBucketResponse.getResourceId());
 
         // when
-        final List<DelinquencyBucketResponse> bucketList = DelinquencyBucketsHelper.getBuckets();
+        final List<DelinquencyBucketResponse> bucketList = delinquencyHelper.getBuckets();
 
         // then
         assertNotNull(bucketList);
@@ -190,18 +179,18 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     public void testDelinquencyBucketDelete() {
         // given
         ArrayList<Long> rangeIds = new ArrayList<>();
-        final PostDelinquencyRangeResponse delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                .minimumAgeDays(1).maximumAgeDays(3).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+        final PostDelinquencyRangeResponse delinquencyRangeResponse = delinquencyHelper.createRange(new DelinquencyRangeRequest()
+                .minimumAgeDays(1).maximumAgeDays(3).locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
         rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-        PostDelinquencyBucketResponse delinquencyBucketResponse = DelinquencyBucketsHelper
+        PostDelinquencyBucketResponse delinquencyBucketResponse = delinquencyHelper
                 .createBucket(new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds));
         // Delete
-        DeleteDelinquencyBucketResponse deleteDelinquencyBucketResponse = DelinquencyBucketsHelper
+        DeleteDelinquencyBucketResponse deleteDelinquencyBucketResponse = delinquencyHelper
                 .deleteBucket(delinquencyBucketResponse.getResourceId());
 
         // when
-        final List<DelinquencyBucketResponse> bucketList = DelinquencyBucketsHelper.getBuckets();
+        final List<DelinquencyBucketResponse> bucketList = delinquencyHelper.getBuckets();
 
         // then
         assertNotNull(bucketList);
@@ -213,19 +202,18 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     public void testDelinquencyBucketsRangeAgeOverlaped() {
         // Given
         ArrayList<Long> rangeIds = new ArrayList<>();
-        PostDelinquencyRangeResponse delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                .minimumAgeDays(1).maximumAgeDays(3).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+        PostDelinquencyRangeResponse delinquencyRangeResponse = delinquencyHelper.createRange(new DelinquencyRangeRequest()
+                .minimumAgeDays(1).maximumAgeDays(3).locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
         rangeIds.add(delinquencyRangeResponse.getResourceId());
-        delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(3).maximumAgeDays(30)
-                .locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+        delinquencyRangeResponse = delinquencyHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(3).maximumAgeDays(30)
+                .locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
         rangeIds.add(delinquencyRangeResponse.getResourceId());
 
         // When
         CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class, () -> {
-            DelinquencyBucketsHelper
-                    .createBucket(new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds));
+            delinquencyHelper.createBucket(new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds));
         });
-        assertEquals(403, exception.getResponse().code());
+        assertEquals(403, exception.getStatus());
 
     }
 
@@ -233,62 +221,60 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     public void testDelinquencyBucketsNameDuplication() {
         // Given
         ArrayList<Long> rangeIds = new ArrayList<>();
-        PostDelinquencyRangeResponse delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                .minimumAgeDays(1).maximumAgeDays(3).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+        PostDelinquencyRangeResponse delinquencyRangeResponse = delinquencyHelper.createRange(new DelinquencyRangeRequest()
+                .minimumAgeDays(1).maximumAgeDays(3).locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
         // When
         String bucketName = Utils.randomStringGenerator("DLQ_B_", 10);
         rangeIds.add(delinquencyRangeResponse.getResourceId());
-        DelinquencyBucketsHelper.createBucket(new DelinquencyBucketRequest().name(bucketName).ranges(rangeIds));
+        delinquencyHelper.createBucket(new DelinquencyBucketRequest().name(bucketName).ranges(rangeIds));
 
         // When
         CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class, () -> {
-            DelinquencyBucketsHelper.createBucket(new DelinquencyBucketRequest().name(bucketName).ranges(rangeIds));
+            delinquencyHelper.createBucket(new DelinquencyBucketRequest().name(bucketName).ranges(rangeIds));
         });
-        assertEquals(403, exception.getResponse().code());
+        assertEquals(403, exception.getStatus());
     }
 
     @Test
     public void testLoanProductCreationWithAndWithoutDelinquencyBucket() {
         // Given
-        final LoanTransactionHelper loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-
         ArrayList<Long> rangeIds = new ArrayList<>();
         // First Range
-        PostDelinquencyRangeResponse delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                .minimumAgeDays(1).maximumAgeDays(3).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+        PostDelinquencyRangeResponse delinquencyRangeResponse = delinquencyHelper.createRange(new DelinquencyRangeRequest()
+                .minimumAgeDays(1).maximumAgeDays(3).locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
         rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-        DelinquencyRangeResponse range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
+        DelinquencyRangeResponse range = delinquencyHelper.getRange(delinquencyRangeResponse.getResourceId());
 
         // Second Range
-        delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(4).maximumAgeDays(60)
-                .locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+        delinquencyRangeResponse = delinquencyHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(4).maximumAgeDays(60)
+                .locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
         rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-        range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
+        range = delinquencyHelper.getRange(delinquencyRangeResponse.getResourceId());
         final String classificationExpected = range.getClassification();
         log.info("Expected Delinquency Range classification after Disbursement {}", classificationExpected);
 
-        PostDelinquencyBucketResponse delinquencyBucketResponse = DelinquencyBucketsHelper
+        PostDelinquencyBucketResponse delinquencyBucketResponse = delinquencyHelper
                 .createBucket(new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds));
         assertNotNull(delinquencyBucketResponse);
-        final DelinquencyBucketResponse delinquencyBucket = DelinquencyBucketsHelper.getBucket(delinquencyBucketResponse.getResourceId());
+        final DelinquencyBucketResponse delinquencyBucket = delinquencyHelper.getBucket(delinquencyBucketResponse.getResourceId());
 
         // Loan product creation without Delinquency bucket
-        GetLoanProductsProductIdResponse getLoanProductResponse = createLoanProduct(loanTransactionHelper, null, null);
+        GetLoanProductsProductIdResponse getLoanProductResponse = createLoanProduct(null, null);
         assertNotNull(getLoanProductResponse);
         assertNull(getLoanProductResponse.getDelinquencyBucket().getId());
 
         // Loan product creation with Delinquency bucket
-        getLoanProductResponse = createLoanProduct(loanTransactionHelper, delinquencyBucket.getId(), null);
+        getLoanProductResponse = createLoanProduct(delinquencyBucket.getId(), null);
         assertNotNull(getLoanProductResponse);
         log.info("Loan Product Bucket Name: {}", getLoanProductResponse.getDelinquencyBucket().getName());
         assertEquals(getLoanProductResponse.getDelinquencyBucket().getName(), delinquencyBucket.getName());
 
         // Update Loan product to remove the Delinquency bucket
         final Long loanProductId = getLoanProductResponse.getId();
-        loanTransactionHelper.updateLoanProduct(loanProductId, "{delinquencyBucketId: null}");
-        getLoanProductResponse = loanTransactionHelper.getLoanProduct(loanProductId.intValue());
+        clearDelinquencyBucket(loanProductId);
+        getLoanProductResponse = retrieveLoanProduct(loanProductId);
         assertNotNull(getLoanProductResponse);
         assertNull(getLoanProductResponse.getDelinquencyBucket().getId());
     }
@@ -297,43 +283,40 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     public void testLoanClassificationRealtime() {
         try {
             // Given
-            final LoanTransactionHelper loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+            updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
 
             final LocalDate bussinesLocalDate = Utils.getDateAsLocalDate("01 March 2012");
             log.info("Current date {}", bussinesLocalDate);
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, bussinesLocalDate);
-            final BusinessDateResponse businessDateResponse = this.businessDateHelper
-                    .getBusinessDate(BusinessDateType.BUSINESS_DATE.name());
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), dateTimeFormatter.format(bussinesLocalDate));
+            final BusinessDateResponse businessDateResponse = businessDateHelper.getBusinessDate(BusinessDateType.BUSINESS_DATE.name());
 
             ArrayList<Long> rangeIds = new ArrayList<>();
             // First Range
-            PostDelinquencyRangeResponse delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                    .minimumAgeDays(1).maximumAgeDays(3).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+            PostDelinquencyRangeResponse delinquencyRangeResponse = delinquencyHelper
+                    .createRange(new DelinquencyRangeRequest().minimumAgeDays(1).maximumAgeDays(3).locale(LoanTestData.LOCALE)
+                            .classification(Utils.randomStringGenerator("DLQ_R_", 10)));
             rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-            DelinquencyRangeResponse range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
+            DelinquencyRangeResponse range = delinquencyHelper.getRange(delinquencyRangeResponse.getResourceId());
 
             // Second Range
-            delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(4)
-                    .maximumAgeDays(60).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+            delinquencyRangeResponse = delinquencyHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(4).maximumAgeDays(60)
+                    .locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
             rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-            range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
+            range = delinquencyHelper.getRange(delinquencyRangeResponse.getResourceId());
             final String classificationExpected = range.getClassification();
             log.info("Expected Delinquency Range classification after Disbursement {}", classificationExpected);
 
-            PostDelinquencyBucketResponse delinquencyBucketResponse = DelinquencyBucketsHelper
+            PostDelinquencyBucketResponse delinquencyBucketResponse = delinquencyHelper
                     .createBucket(new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds));
             assertNotNull(delinquencyBucketResponse);
-            final DelinquencyBucketResponse delinquencyBucket = DelinquencyBucketsHelper
-                    .getBucket(delinquencyBucketResponse.getResourceId());
+            final DelinquencyBucketResponse delinquencyBucket = delinquencyHelper.getBucket(delinquencyBucketResponse.getResourceId());
 
             // Client and Loan account creation
-            final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper,
-                    delinquencyBucket.getId(), null);
+            final Long clientId = createClient(CLIENT_ACTIVATION_DATE);
+            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(delinquencyBucket.getId(), null);
             assertNotNull(getLoanProductsProductResponse);
             log.info("Loan Product Bucket Name: {}", getLoanProductsProductResponse.getDelinquencyBucket().getName());
             assertEquals(getLoanProductsProductResponse.getDelinquencyBucket().getName(), delinquencyBucket.getName());
@@ -343,38 +326,34 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
             String operationDate = Utils.dateFormatter.format(transactionDate);
 
             // Create Loan Account
-            final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                    getLoanProductsProductResponse.getId().toString(), operationDate, null);
+            final Long loanId = createLoanAccount(clientId, getLoanProductsProductResponse.getId(), operationDate, null);
 
-            GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+            GetLoansLoanIdResponse getLoansLoanIdResponse = getLoanDetails(loanId);
             assertNotNull(getLoansLoanIdResponse);
             assertNotNull(getLoansLoanIdResponse.getDelinquencyRange());
             log.info("Loan Delinquency Range after Disbursement {}", getLoansLoanIdResponse.getDelinquencyRange().getClassification());
             // First Loan Delinquency Classification after Disbursement command
             assertEquals(getLoansLoanIdResponse.getDelinquencyRange().getClassification(), classificationExpected);
 
-            loanTransactionHelper.printRepaymentSchedule(getLoansLoanIdResponse);
-
             // Apply a partial repayment
             operationDate = Utils.dateFormatter.format(bussinesLocalDate);
-            loanTransactionHelper.makeLoanRepayment(operationDate, 100.0f, loanId);
+            makeLoanRepayment(loanId, "repayment", operationDate, 100.0);
 
-            getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+            getLoansLoanIdResponse = getLoanDetails(loanId);
             log.info("Loan Delinquency Range after Repayment {}", getLoansLoanIdResponse.getDelinquencyRange());
             assertNotNull(getLoansLoanIdResponse.getDelinquencyRange());
             // First Loan Delinquency Classification remains after Repayment because the installment is not fully paid
             assertEquals(getLoansLoanIdResponse.getDelinquencyRange().getClassification(), classificationExpected);
 
             // Apply a repayment to get a full paid installment
-            loanTransactionHelper.makeLoanRepayment(operationDate, 1000.0f, loanId);
-            getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+            makeLoanRepayment(loanId, "repayment", operationDate, 1000.0);
+            getLoansLoanIdResponse = getLoanDetails(loanId);
             log.info("Loan Delinquency Range after Repayment {}", getLoansLoanIdResponse.getDelinquencyRange());
             assertNotNull(getLoansLoanIdResponse);
             // The Loan Delinquency Classification after Repayment command must be null
             assertNull(getLoansLoanIdResponse.getDelinquencyRange());
             // Get the Delinquency Tags
-            ArrayList<GetDelinquencyTagHistoryResponse> getDelinquencyTagsHistory = loanTransactionHelper
-                    .getLoanDelinquencyTags(requestSpec, responseSpec, loanId);
+            List<GetDelinquencyTagHistoryResponse> getDelinquencyTagsHistory = getLoanDelinquencyTags(loanId);
             assertNotNull(getDelinquencyTagsHistory);
             log.info("Delinquency Tag History items {}", getDelinquencyTagsHistory.size());
             assertEquals(1, getDelinquencyTagsHistory.size());
@@ -384,7 +363,7 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(getDelinquencyTagsHistory.get(0).getDelinquencyRange().getClassification(), classificationExpected);
             log.info("Delinquency Tag Item with Lifted On {}", getDelinquencyTagsHistory.get(0).getLiftedOnDate());
         } finally {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+            updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(false));
         }
     }
@@ -392,43 +371,40 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void testLoanClassificationRealtimeWithCharges() {
         try {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+            updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
 
             final LocalDate bussinesLocalDate = Utils.getDateAsLocalDate("01 April 2012");
             log.info("Current date {}", bussinesLocalDate);
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, bussinesLocalDate);
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), dateTimeFormatter.format(bussinesLocalDate));
 
             // Given
-            final LoanTransactionHelper loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-
             ArrayList<Long> rangeIds = new ArrayList<>();
             // First Range
-            PostDelinquencyRangeResponse delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                    .minimumAgeDays(1).maximumAgeDays(3).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+            PostDelinquencyRangeResponse delinquencyRangeResponse = delinquencyHelper
+                    .createRange(new DelinquencyRangeRequest().minimumAgeDays(1).maximumAgeDays(3).locale(LoanTestData.LOCALE)
+                            .classification(Utils.randomStringGenerator("DLQ_R_", 10)));
             rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-            DelinquencyRangeResponse range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
+            DelinquencyRangeResponse range = delinquencyHelper.getRange(delinquencyRangeResponse.getResourceId());
 
             // Second Range
-            delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(4)
-                    .maximumAgeDays(60).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+            delinquencyRangeResponse = delinquencyHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(4).maximumAgeDays(60)
+                    .locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
             rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-            range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
+            range = delinquencyHelper.getRange(delinquencyRangeResponse.getResourceId());
             final String classificationExpected = range.getClassification();
             log.info("Expected Delinquency Range classification after Disbursement {}", classificationExpected);
 
-            PostDelinquencyBucketResponse delinquencyBucketResponse = DelinquencyBucketsHelper
+            PostDelinquencyBucketResponse delinquencyBucketResponse = delinquencyHelper
                     .createBucket(new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds));
             assertNotNull(delinquencyBucketResponse);
-            final DelinquencyBucketResponse delinquencyBucket = DelinquencyBucketsHelper
-                    .getBucket(delinquencyBucketResponse.getResourceId());
+            final DelinquencyBucketResponse delinquencyBucket = delinquencyHelper.getBucket(delinquencyBucketResponse.getResourceId());
 
             // Client and Loan account creation
-            final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper,
-                    delinquencyBucket.getId(), null);
+            final Long clientId = createClient(CLIENT_ACTIVATION_DATE);
+            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(delinquencyBucket.getId(), null);
             assertNotNull(getLoanProductsProductResponse);
             log.info("Loan Product Bucket Name: {}", getLoanProductsProductResponse.getDelinquencyBucket().getName());
             assertEquals(getLoanProductsProductResponse.getDelinquencyBucket().getName(), delinquencyBucket.getName());
@@ -438,47 +414,42 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
             String operationDate = Utils.dateFormatter.format(transactionDate);
 
             // Create Loan Account
-            final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                    getLoanProductsProductResponse.getId().toString(), operationDate, null);
+            final Long loanId = createLoanAccount(clientId, getLoanProductsProductResponse.getId(), operationDate, null);
 
-            GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+            GetLoansLoanIdResponse getLoansLoanIdResponse = getLoanDetails(loanId);
             log.info("Loan Delinquency Range after Disbursement {}", getLoansLoanIdResponse.getDelinquencyRange().getClassification());
             assertNotNull(getLoansLoanIdResponse);
             // First Loan Delinquency Classification after Disbursement command
             assertEquals(getLoansLoanIdResponse.getDelinquencyRange().getClassification(), classificationExpected);
-            loanTransactionHelper.printRepaymentSchedule(getLoansLoanIdResponse);
 
             // Apply a repayment to get a full paid installment
             operationDate = Utils.dateFormatter.format(bussinesLocalDate);
-            loanTransactionHelper.makeLoanRepayment(operationDate, 2049.99f, loanId);
+            makeLoanRepayment(loanId, "repayment", operationDate, 2049.99);
 
-            getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+            getLoansLoanIdResponse = getLoanDetails(loanId);
             assertNotNull(getLoansLoanIdResponse);
             // The Loan Delinquency Classification after Repayment command must be null
             log.info("Loan Delinquency Range after Repayment {}", getLoansLoanIdResponse.getDelinquencyRange());
             assertNull(getLoansLoanIdResponse.getDelinquencyRange());
-            loanTransactionHelper.printRepaymentSchedule(getLoansLoanIdResponse);
 
             transactionDate = bussinesLocalDate.minusDays(18);
             operationDate = Utils.dateFormatter.format(transactionDate);
 
             // Create and apply Charge for Specific Due Date
-            final Integer chargeId = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(1, "30", false));
+            final Long chargeId = createLoanSpecifiedDueDateCharge(30.0);
             assertNotNull(chargeId);
-            final Integer loanChargeId = loanTransactionHelper.addChargesForLoan(loanId, getChargeApplyJSON(chargeId, operationDate),
-                    responseSpec);
-            assertNotNull(loanChargeId);
+            final PostLoansLoanIdChargesResponse loanChargeResponse = addChargesForLoan(loanId, new PostLoansLoanIdChargesRequest()
+                    .chargeId(chargeId).amount(12.0).dueDate(operationDate).dateFormat(DATETIME_PATTERN).locale(LoanTestData.LOCALE));
+            assertNotNull(loanChargeResponse.getResourceId());
 
-            getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-            loanTransactionHelper.printRepaymentSchedule(getLoansLoanIdResponse);
+            getLoansLoanIdResponse = getLoanDetails(loanId);
 
             log.info("Loan Delinquency Range after add Loan Charge {}", getLoansLoanIdResponse.getDelinquencyRange());
             assertNotNull(getLoansLoanIdResponse.getDelinquencyRange());
             // Evaluate a Delinquency Tag set after add charge to the Loan
             assertEquals(getLoansLoanIdResponse.getDelinquencyRange().getClassification(), classificationExpected);
         } finally {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+            updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(false));
         }
     }
@@ -487,42 +458,40 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     public void testLoanClassificationRealtimeOlderLoan() {
 
         // Given
-        final LoanTransactionHelper loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-
         ArrayList<Long> rangeIds = new ArrayList<>();
         // First Range
-        PostDelinquencyRangeResponse delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                .minimumAgeDays(4).maximumAgeDays(30).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+        PostDelinquencyRangeResponse delinquencyRangeResponse = delinquencyHelper
+                .createRange(new DelinquencyRangeRequest().minimumAgeDays(4).maximumAgeDays(30).locale(LoanTestData.LOCALE)
+                        .classification(Utils.randomStringGenerator("DLQ_R_", 10)));
         rangeIds.add(delinquencyRangeResponse.getResourceId());
-        DelinquencyRangeResponse range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
+        DelinquencyRangeResponse range = delinquencyHelper.getRange(delinquencyRangeResponse.getResourceId());
         final String classificationExpected02 = range.getClassification();
         log.info("Expected Delinquency Range classification after first repayment {}", classificationExpected02);
 
         // Second Range
-        delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(31).maximumAgeDays(60)
-                .locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+        delinquencyRangeResponse = delinquencyHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(31).maximumAgeDays(60)
+                .locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
         rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-        range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
+        range = delinquencyHelper.getRange(delinquencyRangeResponse.getResourceId());
         final String classificationExpected01 = range.getClassification();
         log.info("Expected Delinquency Range classification after Disbursement {}", classificationExpected01);
 
         // Third Range
-        delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(61).maximumAgeDays(90)
-                .locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+        delinquencyRangeResponse = delinquencyHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(61).maximumAgeDays(90)
+                .locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
         rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-        range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
+        range = delinquencyHelper.getRange(delinquencyRangeResponse.getResourceId());
 
-        PostDelinquencyBucketResponse delinquencyBucketResponse = DelinquencyBucketsHelper
+        PostDelinquencyBucketResponse delinquencyBucketResponse = delinquencyHelper
                 .createBucket(new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds));
         assertNotNull(delinquencyBucketResponse);
-        final DelinquencyBucketResponse delinquencyBucket = DelinquencyBucketsHelper.getBucket(delinquencyBucketResponse.getResourceId());
+        final DelinquencyBucketResponse delinquencyBucket = delinquencyHelper.getBucket(delinquencyBucketResponse.getResourceId());
 
         // Client and Loan account creation
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-        final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper,
-                delinquencyBucket.getId(), null);
+        final Long clientId = createClient(CLIENT_ACTIVATION_DATE);
+        final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(delinquencyBucket.getId(), null);
         assertNotNull(getLoanProductsProductResponse);
         log.info("Loan Product Bucket Name: {}", getLoanProductsProductResponse.getDelinquencyBucket().getName());
         assertEquals(getLoanProductsProductResponse.getDelinquencyBucket().getName(), delinquencyBucket.getName());
@@ -533,10 +502,9 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
         String operationDate = Utils.dateFormatter.format(transactionDate);
 
         // Create Loan Account
-        final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                getLoanProductsProductResponse.getId().toString(), operationDate, null);
+        final Long loanId = createLoanAccount(clientId, getLoanProductsProductResponse.getId(), operationDate, null);
 
-        GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+        GetLoansLoanIdResponse getLoansLoanIdResponse = getLoanDetails(loanId);
         assertNotNull(getLoansLoanIdResponse);
         log.info("Loan Delinquency Range after Disbursement in null? {}", (getLoansLoanIdResponse.getDelinquencyRange() == null));
         assertNotNull(getLoansLoanIdResponse.getDelinquencyRange());
@@ -544,23 +512,19 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
         // First Loan Delinquency Classification after Disbursement command
         assertEquals(getLoansLoanIdResponse.getDelinquencyRange().getClassification(), classificationExpected01);
 
-        loanTransactionHelper.printRepaymentSchedule(getLoansLoanIdResponse);
-
         // Apply a repayment to get a first full paid installment
         transactionDate = todaysDate.minusDays(1);
         operationDate = Utils.dateFormatter.format(transactionDate);
-        PostLoansLoanIdTransactionsResponse loansLoanIdTransactions = loanTransactionHelper.makeLoanRepayment(operationDate, 1050.0f,
-                loanId);
+        PostLoansLoanIdTransactionsResponse loansLoanIdTransactions = makeLoanRepayment(loanId, "repayment", operationDate, 1050.0);
         assertNotNull(loansLoanIdTransactions);
         log.info("Loan repayment transaction id {}", loansLoanIdTransactions.getResourceId());
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+        getLoansLoanIdResponse = getLoanDetails(loanId);
         log.info("Loan Delinquency Range after first Repayment {}", getLoansLoanIdResponse.getDelinquencyRange());
         assertNotNull(getLoansLoanIdResponse.getDelinquencyRange());
         // First Loan Delinquency Classification remains after Repayment because the installment is not fully paid
         assertEquals(getLoansLoanIdResponse.getDelinquencyRange().getClassification(), classificationExpected02);
 
-        ArrayList<GetDelinquencyTagHistoryResponse> getDelinquencyTagsHistory = loanTransactionHelper.getLoanDelinquencyTags(requestSpec,
-                responseSpec, loanId);
+        List<GetDelinquencyTagHistoryResponse> getDelinquencyTagsHistory = getLoanDelinquencyTags(loanId);
         assertNotNull(getDelinquencyTagsHistory);
         log.info("Delinquency Tag History items {}", getDelinquencyTagsHistory.size());
         log.info("Delinquency Tag Item with Lifted On {}", getDelinquencyTagsHistory.get(0).getLiftedOnDate());
@@ -570,16 +534,16 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
         log.info("Loan Id {} with Loan status {}", getLoansLoanIdResponse.getId(), getLoansLoanIdResponse.getStatus().getCode());
 
         // Apply a repayment to get a second full paid installment
-        loansLoanIdTransactions = loanTransactionHelper.makeLoanRepayment(operationDate, 1020.0f, loanId);
+        loansLoanIdTransactions = makeLoanRepayment(loanId, "repayment", operationDate, 1020.0);
         assertNotNull(loansLoanIdTransactions);
         log.info("Loan repayment transaction id {}", loansLoanIdTransactions.getResourceId());
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+        getLoansLoanIdResponse = getLoanDetails(loanId);
         log.info("Loan Delinquency Range after second Repayment {}", getLoansLoanIdResponse.getDelinquencyRange());
         assertNotNull(getLoansLoanIdResponse);
         // The Loan Delinquency Classification after Repayment command must be null
         assertNull(getLoansLoanIdResponse.getDelinquencyRange());
 
-        getDelinquencyTagsHistory = loanTransactionHelper.getLoanDelinquencyTags(requestSpec, responseSpec, loanId);
+        getDelinquencyTagsHistory = getLoanDelinquencyTags(loanId);
         assertNotNull(getDelinquencyTagsHistory);
         log.info("Delinquency Tag History items {}", getDelinquencyTagsHistory.size());
         log.info("Delinquency Tag Item with Lifted On {}", getDelinquencyTagsHistory.get(1).getLiftedOnDate());
@@ -592,26 +556,24 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void testLoanClassificationRealtimeWithReversedRepayment() {
         // Given
-        final LoanTransactionHelper loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-
         ArrayList<Long> rangeIds = new ArrayList<>();
         // First Range
-        PostDelinquencyRangeResponse delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                .minimumAgeDays(4).maximumAgeDays(30).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+        PostDelinquencyRangeResponse delinquencyRangeResponse = delinquencyHelper
+                .createRange(new DelinquencyRangeRequest().minimumAgeDays(4).maximumAgeDays(30).locale(LoanTestData.LOCALE)
+                        .classification(Utils.randomStringGenerator("DLQ_R_", 10)));
         rangeIds.add(delinquencyRangeResponse.getResourceId());
-        DelinquencyRangeResponse range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
+        DelinquencyRangeResponse range = delinquencyHelper.getRange(delinquencyRangeResponse.getResourceId());
         final String classificationExpected = range.getClassification();
         log.info("Expected Delinquency Range classification after first repayment {}", classificationExpected);
 
-        PostDelinquencyBucketResponse delinquencyBucketResponse = DelinquencyBucketsHelper
+        PostDelinquencyBucketResponse delinquencyBucketResponse = delinquencyHelper
                 .createBucket(new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds));
         assertNotNull(delinquencyBucketResponse);
-        final DelinquencyBucketResponse delinquencyBucket = DelinquencyBucketsHelper.getBucket(delinquencyBucketResponse.getResourceId());
+        final DelinquencyBucketResponse delinquencyBucket = delinquencyHelper.getBucket(delinquencyBucketResponse.getResourceId());
 
         // Client and Loan account creation
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-        final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper,
-                delinquencyBucket.getId(), null);
+        final Long clientId = createClient(CLIENT_ACTIVATION_DATE);
+        final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(delinquencyBucket.getId(), null);
         assertNotNull(getLoanProductsProductResponse);
         log.info("Loan Product Bucket Name: {}", getLoanProductsProductResponse.getDelinquencyBucket().getName());
         assertEquals(getLoanProductsProductResponse.getDelinquencyBucket().getName(), delinquencyBucket.getName());
@@ -624,12 +586,9 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
         String operationDate = Utils.dateFormatter.format(transactionDate);
 
         // Create Loan Account
-        final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                getLoanProductsProductResponse.getId().toString(), operationDate, null);
+        final Long loanId = createLoanAccount(clientId, getLoanProductsProductResponse.getId(), operationDate, null);
 
-        GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        loanTransactionHelper.printRepaymentSchedule(getLoansLoanIdResponse);
-        loanTransactionHelper.printDelinquencyData(getLoansLoanIdResponse);
+        GetLoansLoanIdResponse getLoansLoanIdResponse = getLoanDetails(loanId);
 
         log.info("Loan Delinquency Range after Disbursement in null? {}", (getLoansLoanIdResponse.getDelinquencyRange() == null));
         assertNotNull(getLoansLoanIdResponse);
@@ -638,21 +597,17 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
         // First Loan Delinquency Classification after Disbursement command
         assertEquals(getLoansLoanIdResponse.getDelinquencyRange().getClassification(), classificationExpected);
 
-        loanTransactionHelper.printRepaymentSchedule(getLoansLoanIdResponse);
-
         // Apply a repayment to get a full paid installment
         operationDate = Utils.dateFormatter.format(todaysDate);
-        PostLoansLoanIdTransactionsResponse loansLoanIdTransactions = loanTransactionHelper.makeLoanRepayment(operationDate, 1050.0f,
-                loanId);
+        PostLoansLoanIdTransactionsResponse loansLoanIdTransactions = makeLoanRepayment(loanId, "repayment", operationDate, 1050.0);
         assertNotNull(loansLoanIdTransactions);
         log.info("Loan repayment transaction id {}", loansLoanIdTransactions.getResourceId());
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+        getLoansLoanIdResponse = getLoanDetails(loanId);
         log.info("Loan Delinquency Range after Repayment {}", getLoansLoanIdResponse.getDelinquencyRange());
         // Loan Delinquency Classification removed after Repayment because the installment is fully paid
         assertNull(getLoansLoanIdResponse.getDelinquencyRange());
 
-        ArrayList<GetDelinquencyTagHistoryResponse> getDelinquencyTagsHistory = loanTransactionHelper.getLoanDelinquencyTags(requestSpec,
-                responseSpec, loanId);
+        List<GetDelinquencyTagHistoryResponse> getDelinquencyTagsHistory = getLoanDelinquencyTags(loanId);
         assertNotNull(getDelinquencyTagsHistory);
         log.info("Delinquency Tag History items {}", getDelinquencyTagsHistory.size());
         log.info("Delinquency Tag Item with Lifted On {}", getDelinquencyTagsHistory.get(0).getLiftedOnDate());
@@ -662,16 +617,16 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
         log.info("Loan Id {} with Loan status {}", getLoansLoanIdResponse.getId(), getLoansLoanIdResponse.getStatus().getCode());
 
         // Reverse the Previous Loan Repayment
-        PostLoansLoanIdTransactionsResponse loansLoanIdReverseTransactions = loanTransactionHelper.reverseLoanTransaction(loanId,
-                loansLoanIdTransactions.getResourceId(), operationDate, responseSpec);
+        PostLoansLoanIdTransactionsResponse loansLoanIdReverseTransactions = reverseLoanTransaction(loanId,
+                loansLoanIdTransactions.getResourceId(), operationDate);
         assertNotNull(loansLoanIdReverseTransactions);
         log.info("Loan repayment reverse transaction id {}", loansLoanIdReverseTransactions.getResourceId());
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+        getLoansLoanIdResponse = getLoanDetails(loanId);
         log.info("Loan Delinquency Range after Reverse Repayment {}", getLoansLoanIdResponse.getDelinquencyRange());
         // Loan Delinquency Classification goes back after Repayment because the installment is not paid
         assertEquals(getLoansLoanIdResponse.getDelinquencyRange().getClassification(), classificationExpected);
 
-        getDelinquencyTagsHistory = loanTransactionHelper.getLoanDelinquencyTags(requestSpec, responseSpec, loanId);
+        getDelinquencyTagsHistory = getLoanDelinquencyTags(loanId);
         assertNotNull(getDelinquencyTagsHistory);
         log.info("Delinquency Tag History items {}", getDelinquencyTagsHistory.size());
         log.info("Delinquency Tag Item with Lifted On {}", getDelinquencyTagsHistory.get(1).getLiftedOnDate());
@@ -685,42 +640,39 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void testLoanClassificationJob() {
         try {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+            updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
 
             LocalDate businessDate = Utils.getLocalDateOfTenant();
             businessDate = businessDate.minusDays(37);
             log.info("Current date {}", businessDate);
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, businessDate);
-
-            final LoanTransactionHelper loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), dateTimeFormatter.format(businessDate));
 
             ArrayList<Long> rangeIds = new ArrayList<>();
             // First Range
-            PostDelinquencyRangeResponse delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                    .minimumAgeDays(1).maximumAgeDays(3).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+            PostDelinquencyRangeResponse delinquencyRangeResponse = delinquencyHelper
+                    .createRange(new DelinquencyRangeRequest().minimumAgeDays(1).maximumAgeDays(3).locale(LoanTestData.LOCALE)
+                            .classification(Utils.randomStringGenerator("DLQ_R_", 10)));
             rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-            DelinquencyRangeResponse range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
+            DelinquencyRangeResponse range = delinquencyHelper.getRange(delinquencyRangeResponse.getResourceId());
 
             // Second Range
-            delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(4)
-                    .maximumAgeDays(60).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+            delinquencyRangeResponse = delinquencyHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(4).maximumAgeDays(60)
+                    .locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
             rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-            range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
+            range = delinquencyHelper.getRange(delinquencyRangeResponse.getResourceId());
             final String classificationExpected = range.getClassification();
             log.info("Expected Delinquency Range classification {}", classificationExpected);
 
-            PostDelinquencyBucketResponse delinquencyBucketResponse = DelinquencyBucketsHelper
+            PostDelinquencyBucketResponse delinquencyBucketResponse = delinquencyHelper
                     .createBucket(new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds));
-            final DelinquencyBucketResponse delinquencyBucket = DelinquencyBucketsHelper
-                    .getBucket(delinquencyBucketResponse.getResourceId());
+            final DelinquencyBucketResponse delinquencyBucket = delinquencyHelper.getBucket(delinquencyBucketResponse.getResourceId());
 
             // Client and Loan account creation
-            final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper,
-                    delinquencyBucket.getId(), null);
+            final Long clientId = createClient(CLIENT_ACTIVATION_DATE);
+            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(delinquencyBucket.getId(), null);
             assertNotNull(getLoanProductsProductResponse);
             log.info("Loan Product Bucket Name: {}", getLoanProductsProductResponse.getDelinquencyBucket().getName());
             assertEquals(getLoanProductsProductResponse.getDelinquencyBucket().getName(), delinquencyBucket.getName());
@@ -731,31 +683,26 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
             String operationDate = Utils.dateFormatter.format(transactionDate);
 
             // Create Loan Account
-            final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                    getLoanProductsProductResponse.getId().toString(), operationDate, null);
+            final Long loanId = createLoanAccount(clientId, getLoanProductsProductResponse.getId(), operationDate, null);
 
             // Run first time the Job
             final String jobName = "Loan Delinquency Classification";
-            SchedulerJobHelper.executeAndAwaitJob(jobName);
+            schedulerHelper.executeAndAwaitJob(jobName);
 
             // Get loan details expecting to have not a delinquency classification
-            GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-            loanTransactionHelper.printDelinquencyData(getLoansLoanIdResponse);
+            GetLoansLoanIdResponse getLoansLoanIdResponse = getLoanDetails(loanId);
             final DelinquencyRangeData firstTestCase = getLoansLoanIdResponse.getDelinquencyRange();
             log.info("Loan Delinquency Range is null {}", (firstTestCase == null));
-            loanTransactionHelper.printRepaymentSchedule(getLoansLoanIdResponse);
 
             // Move the Business date to get older the loan and to have an overdue loan
             businessDate = businessDate.plusMonths(1);
             log.info("Current date {}", businessDate);
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, businessDate);
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), dateTimeFormatter.format(businessDate));
             // Run Second time the Job
-            SchedulerJobHelper.executeAndAwaitJob(jobName);
+            schedulerHelper.executeAndAwaitJob(jobName);
 
             // Get loan details expecting to have a delinquency classification
-            getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-            loanTransactionHelper.printRepaymentSchedule(getLoansLoanIdResponse);
-            loanTransactionHelper.printDelinquencyData(getLoansLoanIdResponse);
+            getLoansLoanIdResponse = getLoanDetails(loanId);
 
             final DelinquencyRangeData secondTestCase = getLoansLoanIdResponse.getDelinquencyRange();
             assertNotNull(secondTestCase);
@@ -769,7 +716,7 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(secondTestCase.getClassification(), classificationExpected);
 
         } finally {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+            updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(false));
         }
     }
@@ -777,40 +724,37 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void testLoanClassificationStepAsPartOfCOB() {
         try {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+            updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
 
             LocalDate bussinesLocalDate = Utils.getDateAsLocalDate("01 April 2012");
             log.info("Current date {}", bussinesLocalDate);
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, bussinesLocalDate);
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), dateTimeFormatter.format(bussinesLocalDate));
 
             // Given
-            final LoanTransactionHelper loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-
             ArrayList<Long> rangeIds = new ArrayList<>();
             // First Range
-            PostDelinquencyRangeResponse delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                    .minimumAgeDays(1).maximumAgeDays(3).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+            PostDelinquencyRangeResponse delinquencyRangeResponse = delinquencyHelper
+                    .createRange(new DelinquencyRangeRequest().minimumAgeDays(1).maximumAgeDays(3).locale(LoanTestData.LOCALE)
+                            .classification(Utils.randomStringGenerator("DLQ_R_", 10)));
             rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-            DelinquencyRangeResponse range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
+            DelinquencyRangeResponse range = delinquencyHelper.getRange(delinquencyRangeResponse.getResourceId());
             final String classificationExpected = range.getClassification();
             // Second Range
-            delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(4)
-                    .maximumAgeDays(60).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+            delinquencyRangeResponse = delinquencyHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(4).maximumAgeDays(60)
+                    .locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
             rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-            range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
+            range = delinquencyHelper.getRange(delinquencyRangeResponse.getResourceId());
 
-            PostDelinquencyBucketResponse delinquencyBucketResponse = DelinquencyBucketsHelper
+            PostDelinquencyBucketResponse delinquencyBucketResponse = delinquencyHelper
                     .createBucket(new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds));
-            final DelinquencyBucketResponse delinquencyBucket = DelinquencyBucketsHelper
-                    .getBucket(delinquencyBucketResponse.getResourceId());
+            final DelinquencyBucketResponse delinquencyBucket = delinquencyHelper.getBucket(delinquencyBucketResponse.getResourceId());
 
             // Client and Loan account creation
-            final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper,
-                    delinquencyBucket.getId(), null);
+            final Long clientId = createClient(CLIENT_ACTIVATION_DATE);
+            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(delinquencyBucket.getId(), null);
             assertNotNull(getLoanProductsProductResponse);
             log.info("Loan Product Bucket Name: {}", getLoanProductsProductResponse.getDelinquencyBucket().getName());
             assertEquals(getLoanProductsProductResponse.getDelinquencyBucket().getName(), delinquencyBucket.getName());
@@ -820,12 +764,11 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
             String operationDate = Utils.dateFormatter.format(transactionDate);
 
             // Create Loan Account
-            final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                    getLoanProductsProductResponse.getId().toString(), operationDate, null);
+            final Long loanId = createLoanAccount(clientId, getLoanProductsProductResponse.getId(), operationDate, null);
 
             // COB Step Validation
-            final JobBusinessStepConfigData jobBusinessStepConfigData = BusinessStepConfigurationHelper
-                    .getConfiguredBusinessStepsByJobName(requestSpec, responseSpec, BusinessConfigurationApiTest.LOAN_JOB_NAME);
+            final JobBusinessStepConfigData jobBusinessStepConfigData = businessStepHelper
+                    .getConfiguredBusinessStepsByJobName(BusinessConfigurationApiTest.LOAN_JOB_NAME);
             assertNotNull(jobBusinessStepConfigData);
             assertEquals(BusinessConfigurationApiTest.LOAN_JOB_NAME, jobBusinessStepConfigData.getJobName());
             assertTrue(jobBusinessStepConfigData.getBusinessSteps().size() > 0);
@@ -833,31 +776,22 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
                     businessStep -> BusinessConfigurationApiTest.LOAN_DELINQUENCY_CLASSIFICATION.equals(businessStep.getStepName())));
 
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
 
             // Get loan details expecting to have not a delinquency classification
-            GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+            GetLoansLoanIdResponse getLoansLoanIdResponse = getLoanDetails(loanId);
             final DelinquencyRangeData firstTestCase = getLoansLoanIdResponse.getDelinquencyRange();
             log.info("Loan Delinquency Range is null {}", (firstTestCase == null));
-            GetLoansLoanIdRepaymentSchedule getLoanRepaymentSchedule = getLoansLoanIdResponse.getRepaymentSchedule();
-            if (getLoanRepaymentSchedule != null) {
-                log.info("Loan with {} periods", getLoanRepaymentSchedule.getPeriods().size());
-                for (GetLoansLoanIdRepaymentPeriod period : getLoanRepaymentSchedule.getPeriods()) {
-                    log.info("Period number {} for due date {} and outstanding {}", period.getPeriod(), period.getDueDate(),
-                            period.getTotalOutstandingForPeriod());
-                }
-            }
 
             // Move the Business date to get older the loan and to have an overdue loan
             bussinesLocalDate = bussinesLocalDate.plusDays(3);
 
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, bussinesLocalDate);
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), dateTimeFormatter.format(bussinesLocalDate));
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
 
             // Get loan details expecting to have a delinquency classification
-            getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-            loanTransactionHelper.printRepaymentSchedule(getLoansLoanIdResponse);
+            getLoansLoanIdResponse = getLoanDetails(loanId);
             final DelinquencyRangeData secondTestCase = getLoansLoanIdResponse.getDelinquencyRange();
             assertNotNull(secondTestCase);
             log.info("Loan Delinquency Range is {}", secondTestCase.getClassification());
@@ -869,7 +803,7 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(getLoanProductsProductResponse.getDelinquencyBucket().getName(), delinquencyBucket.getName());
             assertEquals(secondTestCase.getClassification(), classificationExpected);
         } finally {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+            updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(false));
         }
     }
@@ -877,40 +811,37 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void testLoanClassificationToValidateNegatives() {
         try {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+            updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
 
             LocalDate bussinesLocalDate = Utils.getDateAsLocalDate("01 January 2012");
             log.info("Current date {}", bussinesLocalDate);
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, bussinesLocalDate);
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), dateTimeFormatter.format(bussinesLocalDate));
 
             // Given
-            final LoanTransactionHelper loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-
             ArrayList<Long> rangeIds = new ArrayList<>();
             // First Range
-            PostDelinquencyRangeResponse delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                    .minimumAgeDays(1).maximumAgeDays(3).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+            PostDelinquencyRangeResponse delinquencyRangeResponse = delinquencyHelper
+                    .createRange(new DelinquencyRangeRequest().minimumAgeDays(1).maximumAgeDays(3).locale(LoanTestData.LOCALE)
+                            .classification(Utils.randomStringGenerator("DLQ_R_", 10)));
             rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-            DelinquencyRangeResponse range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
+            DelinquencyRangeResponse range = delinquencyHelper.getRange(delinquencyRangeResponse.getResourceId());
 
             // Second Range
-            delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(4)
-                    .maximumAgeDays(60).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+            delinquencyRangeResponse = delinquencyHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(4).maximumAgeDays(60)
+                    .locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
             rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-            range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
+            range = delinquencyHelper.getRange(delinquencyRangeResponse.getResourceId());
 
-            PostDelinquencyBucketResponse delinquencyBucketResponse = DelinquencyBucketsHelper
+            PostDelinquencyBucketResponse delinquencyBucketResponse = delinquencyHelper
                     .createBucket(new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds));
-            final DelinquencyBucketResponse delinquencyBucket = DelinquencyBucketsHelper
-                    .getBucket(delinquencyBucketResponse.getResourceId());
+            final DelinquencyBucketResponse delinquencyBucket = delinquencyHelper.getBucket(delinquencyBucketResponse.getResourceId());
 
             // Client and Loan account creation
-            final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper,
-                    delinquencyBucket.getId(), "3");
+            final Long clientId = createClient(CLIENT_ACTIVATION_DATE);
+            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(delinquencyBucket.getId(), 3);
             assertNotNull(getLoanProductsProductResponse);
             log.info("Loan Product Bucket Name: {}", getLoanProductsProductResponse.getDelinquencyBucket().getName());
             assertEquals(getLoanProductsProductResponse.getDelinquencyBucket().getName(), delinquencyBucket.getName());
@@ -920,24 +851,21 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
             String operationDate = Utils.dateFormatter.format(transactionDate);
 
             // Create Loan Account
-            final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                    getLoanProductsProductResponse.getId().toString(), operationDate, null);
+            final Long loanId = createLoanAccount(clientId, getLoanProductsProductResponse.getId(), operationDate, null);
 
             // Get loan details expecting to have a delinquency classification
-            GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+            GetLoansLoanIdResponse getLoansLoanIdResponse = getLoanDetails(loanId);
             final DelinquencyRangeData firstTestCase = getLoansLoanIdResponse.getDelinquencyRange();
             log.info("Loan Delinquency Range is null {}", (firstTestCase == null));
-            loanTransactionHelper.printRepaymentSchedule(getLoansLoanIdResponse);
 
             bussinesLocalDate = Utils.getDateAsLocalDate("31 January 2012");
 
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, bussinesLocalDate);
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), dateTimeFormatter.format(bussinesLocalDate));
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
 
             // Get loan details expecting to have a delinquency classification
-            getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-            loanTransactionHelper.printDelinquencyData(getLoansLoanIdResponse);
+            getLoansLoanIdResponse = getLoanDetails(loanId);
 
             GetLoansLoanIdDelinquencySummary getLoansLoanIdCollectionData = getLoansLoanIdResponse.getDelinquent();
             assertNotNull(getLoansLoanIdCollectionData);
@@ -945,7 +873,7 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(0, getLoansLoanIdCollectionData.getPastDueDays());
 
         } finally {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+            updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(false));
         }
     }
@@ -953,40 +881,37 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void testLoanClassificationUsingAgeingArrears() {
         try {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+            updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
 
             LocalDate bussinesLocalDate = Utils.getDateAsLocalDate("01 January 2012");
             log.info("Current date {}", bussinesLocalDate);
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, bussinesLocalDate);
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), dateTimeFormatter.format(bussinesLocalDate));
 
             // Given
-            final LoanTransactionHelper loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-
             ArrayList<Long> rangeIds = new ArrayList<>();
             // First Range
-            PostDelinquencyRangeResponse delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                    .minimumAgeDays(1).maximumAgeDays(3).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+            PostDelinquencyRangeResponse delinquencyRangeResponse = delinquencyHelper
+                    .createRange(new DelinquencyRangeRequest().minimumAgeDays(1).maximumAgeDays(3).locale(LoanTestData.LOCALE)
+                            .classification(Utils.randomStringGenerator("DLQ_R_", 10)));
             rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-            DelinquencyRangeResponse range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
+            DelinquencyRangeResponse range = delinquencyHelper.getRange(delinquencyRangeResponse.getResourceId());
 
             // Second Range
-            delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(4)
-                    .maximumAgeDays(60).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+            delinquencyRangeResponse = delinquencyHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(4).maximumAgeDays(60)
+                    .locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
             rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-            range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
+            range = delinquencyHelper.getRange(delinquencyRangeResponse.getResourceId());
 
-            PostDelinquencyBucketResponse delinquencyBucketResponse = DelinquencyBucketsHelper
+            PostDelinquencyBucketResponse delinquencyBucketResponse = delinquencyHelper
                     .createBucket(new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds));
-            final DelinquencyBucketResponse delinquencyBucket = DelinquencyBucketsHelper
-                    .getBucket(delinquencyBucketResponse.getResourceId());
+            final DelinquencyBucketResponse delinquencyBucket = delinquencyHelper.getBucket(delinquencyBucketResponse.getResourceId());
 
             // Client and Loan account creation
-            final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper,
-                    delinquencyBucket.getId(), "3");
+            final Long clientId = createClient(CLIENT_ACTIVATION_DATE);
+            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(delinquencyBucket.getId(), 3);
             assertNotNull(getLoanProductsProductResponse);
             log.info("Loan Product Arrears: {}", getLoanProductsProductResponse.getInArrearsTolerance());
             assertEquals(3, getLoanProductsProductResponse.getInArrearsTolerance());
@@ -996,34 +921,30 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
             String operationDate = Utils.dateFormatter.format(transactionDate);
 
             // Create Loan Account
-            final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                    getLoanProductsProductResponse.getId().toString(), operationDate, "3");
+            final Long loanId = createLoanAccount(clientId, getLoanProductsProductResponse.getId(), operationDate, 3);
 
             // Get loan details expecting to have a delinquency classification
-            GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+            GetLoansLoanIdResponse getLoansLoanIdResponse = getLoanDetails(loanId);
             final DelinquencyRangeData firstTestCase = getLoansLoanIdResponse.getDelinquencyRange();
             log.info("Loan Delinquency Range is null {}", (firstTestCase == null));
-            loanTransactionHelper.printRepaymentSchedule(getLoansLoanIdResponse);
             log.info("Loan Account Arrears {}", getLoansLoanIdResponse.getInArrearsTolerance());
             assertEquals(3, getLoansLoanIdResponse.getInArrearsTolerance());
 
             // Update the Loan Product
-            updateLoanProduct(loanTransactionHelper, getLoanProductsProductResponse.getId(), 0);
-            GetLoanProductsProductIdResponse loanProductsProductIdResponseUpd = loanTransactionHelper
-                    .getLoanProduct(getLoanProductsProductResponse.getId().intValue());
+            updateLoanProductInArrearsTolerance(getLoanProductsProductResponse.getId(), 0);
+            GetLoanProductsProductIdResponse loanProductsProductIdResponseUpd = retrieveLoanProduct(getLoanProductsProductResponse.getId());
             assertNotNull(loanProductsProductIdResponseUpd);
             log.info("Loan Product Arrears: {}", loanProductsProductIdResponseUpd.getInArrearsTolerance());
             assertEquals(0, loanProductsProductIdResponseUpd.getInArrearsTolerance());
 
             bussinesLocalDate = Utils.getDateAsLocalDate("31 January 2012");
 
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, bussinesLocalDate);
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), dateTimeFormatter.format(bussinesLocalDate));
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
 
             // Get loan details expecting to have a delinquency classification
-            getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-            loanTransactionHelper.printDelinquencyData(getLoansLoanIdResponse);
+            getLoansLoanIdResponse = getLoanDetails(loanId);
 
             GetLoansLoanIdDelinquencySummary getLoansLoanIdCollectionData = getLoansLoanIdResponse.getDelinquent();
             assertNotNull(getLoansLoanIdCollectionData);
@@ -1031,7 +952,7 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(0, getLoansLoanIdCollectionData.getPastDueDays());
 
         } finally {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+            updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(false));
         }
     }
@@ -1039,46 +960,39 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void testDelinquencyWithPauseLettingPauseExpire() {
         runAt("01 January 2012", () -> {
-            Long delinquencyBucketId = DelinquencyBucketsHelper.createDefaultBucket();
+            Long delinquencyBucketId = delinquencyHelper.createDefaultBucket();
 
-            LocalDate bussinesLocalDate = Utils.getDateAsLocalDate("01 January 2012");
-
-            final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper,
-                    delinquencyBucketId, "3");
+            final Long clientId = createClient(CLIENT_ACTIVATION_DATE);
+            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(delinquencyBucketId, 3);
             assertNotNull(getLoanProductsProductResponse);
             log.info("Loan Product Arrears: {}", getLoanProductsProductResponse.getInArrearsTolerance());
             assertEquals(3, getLoanProductsProductResponse.getInArrearsTolerance());
 
-            final LocalDate transactionDate = bussinesLocalDate;
-            String operationDate = Utils.dateFormatter.format(transactionDate);
+            final String operationDate = "01 January 2012";
 
-            final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                    getLoanProductsProductResponse.getId().toString(), operationDate, "3");
+            final Long loanId = createLoanAccount(clientId, getLoanProductsProductResponse.getId(), operationDate, 3);
 
-            GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+            GetLoansLoanIdResponse getLoansLoanIdResponse = getLoanDetails(loanId);
             final DelinquencyRangeData firstTestCase = getLoansLoanIdResponse.getDelinquencyRange();
             log.info("Loan Delinquency Range is null {}", (firstTestCase == null));
-            loanTransactionHelper.printRepaymentSchedule(getLoansLoanIdResponse);
             log.info("Loan Account Arrears {}", getLoansLoanIdResponse.getInArrearsTolerance());
             assertEquals(3, getLoansLoanIdResponse.getInArrearsTolerance());
 
             updateBusinessDate("06 February 2012");
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
             verifyDelinquency(loanId, "01 February 2012", 1033.33, 5);
 
-            PostLoansDelinquencyActionResponse pauseDelinquencyResponse = loanTransactionHelper
-                    .createLoanDelinquencyAction(loanId.longValue(), PAUSE, "06 February 2012", "10 February 2012");
+            createLoanDelinquencyAction(loanId, PAUSE, "06 February 2012", "10 February 2012");
 
             updateBusinessDate("09 February 2012");
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
             verifyDelinquency(loanId, "01 February 2012", 1033.33, 5);
 
             updateBusinessDate("12 March 2012");
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
             verifyDelinquency(loanId, "01 February 2012", 2049.99, 36);
         });
     }
@@ -1086,49 +1000,42 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void testDelinquencyWithPauseResumeBeforePauseExpires() {
         runAt("01 January 2012", () -> {
-            Long delinquencyBucketId = DelinquencyBucketsHelper.createDefaultBucket();
-            LocalDate bussinesLocalDate = Utils.getDateAsLocalDate("01 January 2012");
+            Long delinquencyBucketId = delinquencyHelper.createDefaultBucket();
 
-            final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper,
-                    delinquencyBucketId, "3");
+            final Long clientId = createClient(CLIENT_ACTIVATION_DATE);
+            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(delinquencyBucketId, 3);
             assertNotNull(getLoanProductsProductResponse);
             log.info("Loan Product Arrears: {}", getLoanProductsProductResponse.getInArrearsTolerance());
             assertEquals(3, getLoanProductsProductResponse.getInArrearsTolerance());
 
-            final LocalDate transactionDate = bussinesLocalDate;
-            String operationDate = Utils.dateFormatter.format(transactionDate);
+            final String operationDate = "01 January 2012";
 
-            final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                    getLoanProductsProductResponse.getId().toString(), operationDate, "3");
+            final Long loanId = createLoanAccount(clientId, getLoanProductsProductResponse.getId(), operationDate, 3);
 
-            GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+            GetLoansLoanIdResponse getLoansLoanIdResponse = getLoanDetails(loanId);
             final DelinquencyRangeData firstTestCase = getLoansLoanIdResponse.getDelinquencyRange();
             log.info("Loan Delinquency Range is null {}", (firstTestCase == null));
-            loanTransactionHelper.printRepaymentSchedule(getLoansLoanIdResponse);
             log.info("Loan Account Arrears {}", getLoansLoanIdResponse.getInArrearsTolerance());
             assertEquals(3, getLoansLoanIdResponse.getInArrearsTolerance());
 
             updateBusinessDate("06 February 2012");
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
             verifyDelinquency(loanId, "01 February 2012", 1033.33, 5);
 
-            PostLoansDelinquencyActionResponse pauseDelinquencyResponse = loanTransactionHelper
-                    .createLoanDelinquencyAction(loanId.longValue(), PAUSE, "06 February 2012", "10 March 2012");
+            createLoanDelinquencyAction(loanId, PAUSE, "06 February 2012", "10 March 2012");
 
             updateBusinessDate("09 February 2012");
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
             verifyDelinquency(loanId, "01 February 2012", 1033.33, 5);
 
-            bussinesLocalDate = Utils.getDateAsLocalDate("10 February 2012");
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, bussinesLocalDate);
-            loanTransactionHelper.createLoanDelinquencyAction(loanId.longValue(), RESUME, "10 February 2012");
+            updateBusinessDate("10 February 2012");
+            createLoanDelinquencyAction(loanId, RESUME, "10 February 2012");
 
             updateBusinessDate("12 March 2012");
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
             verifyDelinquency(loanId, "01 February 2012", 2049.99, 36);
         });
     }
@@ -1137,144 +1044,121 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     public void testDelinquencyWithMultiplePausePeriods() {
         runAt("01 January 2012", () -> {
 
-            Long delinquencyBucketId = DelinquencyBucketsHelper.createDefaultBucket();
+            Long delinquencyBucketId = delinquencyHelper.createDefaultBucket();
 
-            final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper,
-                    delinquencyBucketId, "3");
+            final Long clientId = createClient(CLIENT_ACTIVATION_DATE);
+            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(delinquencyBucketId, 3);
             assertNotNull(getLoanProductsProductResponse);
             log.info("Loan Product Arrears: {}", getLoanProductsProductResponse.getInArrearsTolerance());
             assertEquals(3, getLoanProductsProductResponse.getInArrearsTolerance());
 
-            final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                    getLoanProductsProductResponse.getId().toString(), "01 January 2012", "3");
+            final Long loanId = createLoanAccount(clientId, getLoanProductsProductResponse.getId(), "01 January 2012", 3);
 
-            GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+            GetLoansLoanIdResponse getLoansLoanIdResponse = getLoanDetails(loanId);
             final DelinquencyRangeData firstTestCase = getLoansLoanIdResponse.getDelinquencyRange();
             log.info("Loan Delinquency Range is null {}", (firstTestCase == null));
-            loanTransactionHelper.printRepaymentSchedule(getLoansLoanIdResponse);
             log.info("Loan Account Arrears {}", getLoansLoanIdResponse.getInArrearsTolerance());
             assertEquals(3, getLoansLoanIdResponse.getInArrearsTolerance());
 
             // delinquent days: 5
             updateBusinessDate("06 February 2012");
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
             verifyDelinquency(loanId, "01 February 2012", 1033.33, 5);
 
             // Add delinquency pause on 06 February 2012
-            PostLoansDelinquencyActionResponse pauseDelinquencyResponse = loanTransactionHelper
-                    .createLoanDelinquencyAction(loanId.longValue(), PAUSE, "06 February 2012", "10 March 2012");
+            createLoanDelinquencyAction(loanId, PAUSE, "06 February 2012", "10 March 2012");
             updateBusinessDate("09 February 2012");
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
             verifyDelinquency(loanId, "01 February 2012", 1033.33, 5);
 
             // Add delinquency resume on 10 February 2012
             updateBusinessDate("10 February 2012");
-            loanTransactionHelper.createLoanDelinquencyAction(loanId.longValue(), RESUME, "10 February 2012");
+            createLoanDelinquencyAction(loanId, RESUME, "10 February 2012");
 
             updateBusinessDate("13 February 2012");
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
             verifyDelinquency(loanId, "01 February 2012", 1033.33, 8);
 
             // Add new pause on 13 February 2012
-            pauseDelinquencyResponse = loanTransactionHelper.createLoanDelinquencyAction(loanId.longValue(), PAUSE, "13 February 2012",
-                    "18 February 2012");
+            createLoanDelinquencyAction(loanId, PAUSE, "13 February 2012", "18 February 2012");
 
             updateBusinessDate("23 February 2012");
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
             verifyDelinquency(loanId, "01 February 2012", 1033.33, 13);
 
             // Add new pause on 23 February 2012
-            pauseDelinquencyResponse = loanTransactionHelper.createLoanDelinquencyAction(loanId.longValue(), PAUSE, "23 February 2012",
-                    "28 February 2012");
+            createLoanDelinquencyAction(loanId, PAUSE, "23 February 2012", "28 February 2012");
             updateBusinessDate("25 February 2012");
-            loanTransactionHelper.createLoanDelinquencyAction(loanId.longValue(), RESUME, "25 February 2012");
+            createLoanDelinquencyAction(loanId, RESUME, "25 February 2012");
             updateBusinessDate("12 March 2012");
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
             verifyDelinquency(loanId, "01 February 2012", 2049.99, 29);
         });
-    }
-
-    private void verifyDelinquency(Integer loanId, String date, Double amount, int delinquentDays) {
-        GetLoansLoanIdResponse getLoansLoanIdResponse;
-        GetLoansLoanIdDelinquencySummary delinquent;
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        loanTransactionHelper.printDelinquencyData(getLoansLoanIdResponse);
-        delinquent = getLoansLoanIdResponse.getDelinquent();
-        assertEquals(amount, Utils.getDoubleValue(delinquent.getDelinquentAmount()));
-        assertEquals(LocalDate.parse(date, dateTimeFormatter), delinquent.getDelinquentDate());
-        assertEquals(delinquentDays, delinquent.getDelinquentDays());
     }
 
     @Test
     public void testDelinquencyWithMultiplePausePeriodsWithInstallmentLevelDelinquency() {
         runAt("01 January 2012", () -> {
-            Long delinquencyBucketId = DelinquencyBucketsHelper.createDefaultBucket();
+            Long delinquencyBucketId = delinquencyHelper.createDefaultBucket();
 
-            final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
+            final Long clientId = createClient(CLIENT_ACTIVATION_DATE);
             final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProductWithInstallmentLevelDelinquency(
-                    loanTransactionHelper, delinquencyBucketId, "3");
+                    delinquencyBucketId, 3);
             assertNotNull(getLoanProductsProductResponse);
             log.info("Loan Product Arrears: {}", getLoanProductsProductResponse.getInArrearsTolerance());
             assertEquals(3, getLoanProductsProductResponse.getInArrearsTolerance());
 
-            final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                    getLoanProductsProductResponse.getId().toString(), "01 January 2012", "3");
+            final Long loanId = createLoanAccount(clientId, getLoanProductsProductResponse.getId(), "01 January 2012", 3);
 
-            GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+            GetLoansLoanIdResponse getLoansLoanIdResponse = getLoanDetails(loanId);
             final DelinquencyRangeData firstTestCase = getLoansLoanIdResponse.getDelinquencyRange();
             log.info("Loan Delinquency Range is null {}", (firstTestCase == null));
-            loanTransactionHelper.printRepaymentSchedule(getLoansLoanIdResponse);
             log.info("Loan Account Arrears {}", getLoansLoanIdResponse.getInArrearsTolerance());
             assertEquals(3, getLoansLoanIdResponse.getInArrearsTolerance());
 
             // delinquent days: 5
             updateBusinessDate("06 February 2012");
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
             verifyDelinquency(loanId, "01 February 2012", 1033.33, 5);
 
-            PostLoansDelinquencyActionResponse pauseDelinquencyResponse = loanTransactionHelper
-                    .createLoanDelinquencyAction(loanId.longValue(), PAUSE, "06 February 2012", "10 March 2012");
+            createLoanDelinquencyAction(loanId, PAUSE, "06 February 2012", "10 March 2012");
 
             updateBusinessDate("09 February 2012");
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
             verifyDelinquency(loanId, "01 February 2012", 1033.33, 5);
 
             updateBusinessDate("10 February 2012");
-            loanTransactionHelper.createLoanDelinquencyAction(loanId.longValue(), RESUME, "10 February 2012");
+            createLoanDelinquencyAction(loanId, RESUME, "10 February 2012");
 
             updateBusinessDate("13 February 2012");
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
             verifyDelinquency(loanId, "01 February 2012", 1033.33, 8);
 
-            pauseDelinquencyResponse = loanTransactionHelper.createLoanDelinquencyAction(loanId.longValue(), PAUSE, "13 February 2012",
-                    "18 February 2012");
+            createLoanDelinquencyAction(loanId, PAUSE, "13 February 2012", "18 February 2012");
 
             updateBusinessDate("23 February 2012");
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
             verifyDelinquency(loanId, "01 February 2012", 1033.33, 13);
 
-            pauseDelinquencyResponse = loanTransactionHelper.createLoanDelinquencyAction(loanId.longValue(), PAUSE, "23 February 2012",
-                    "28 February 2012");
+            createLoanDelinquencyAction(loanId, PAUSE, "23 February 2012", "28 February 2012");
 
             updateBusinessDate("25 February 2012");
-            loanTransactionHelper.createLoanDelinquencyAction(loanId.longValue(), RESUME, "25 February 2012");
+            createLoanDelinquencyAction(loanId, RESUME, "25 February 2012");
 
             updateBusinessDate("14 March 2012");
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
 
-            getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-            loanTransactionHelper.printDelinquencyData(getLoansLoanIdResponse);
+            getLoansLoanIdResponse = getLoanDetails(loanId);
             GetLoansLoanIdDelinquencySummary delinquent = getLoansLoanIdResponse.getDelinquent();
 
             SoftAssertions softly = new SoftAssertions();
@@ -1304,23 +1188,21 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     public void testLoanClassificationOnlyForActiveLoan() {
 
         // Given
-        final LoanTransactionHelper loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-
         ArrayList<Long> rangeIds = new ArrayList<>();
         // First Range
-        PostDelinquencyRangeResponse delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                .minimumAgeDays(4).maximumAgeDays(30).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+        PostDelinquencyRangeResponse delinquencyRangeResponse = delinquencyHelper
+                .createRange(new DelinquencyRangeRequest().minimumAgeDays(4).maximumAgeDays(30).locale(LoanTestData.LOCALE)
+                        .classification(Utils.randomStringGenerator("DLQ_R_", 10)));
         rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-        PostDelinquencyBucketResponse delinquencyBucketResponse = DelinquencyBucketsHelper
+        PostDelinquencyBucketResponse delinquencyBucketResponse = delinquencyHelper
                 .createBucket(new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds));
         assertNotNull(delinquencyBucketResponse);
-        final DelinquencyBucketResponse delinquencyBucket = DelinquencyBucketsHelper.getBucket(delinquencyBucketResponse.getResourceId());
+        final DelinquencyBucketResponse delinquencyBucket = delinquencyHelper.getBucket(delinquencyBucketResponse.getResourceId());
 
         // Client and Loan account creation
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-        final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper,
-                delinquencyBucket.getId(), null);
+        final Long clientId = createClient(CLIENT_ACTIVATION_DATE);
+        final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(delinquencyBucket.getId(), null);
         assertNotNull(getLoanProductsProductResponse);
 
         final LocalDate todaysDate = Utils.getLocalDateOfTenant();
@@ -1329,20 +1211,19 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
         String operationDate = Utils.dateFormatter.format(transactionDate);
 
         // Create Loan Application
-        final Integer loanId = createLoanApplication(loanTransactionHelper, clientId.toString(),
-                getLoanProductsProductResponse.getId().toString(), operationDate, null);
+        final Long loanId = createLoanApplication(clientId, getLoanProductsProductResponse.getId(), operationDate, null);
 
         // Evaluate default delinquent values in No Active Loan
-        GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+        GetLoansLoanIdResponse getLoansLoanIdResponse = getLoanDetails(loanId);
         assertNotNull(getLoansLoanIdResponse);
         assertNotNull(getLoansLoanIdResponse.getDelinquent());
         assertEquals(0, getLoansLoanIdResponse.getDelinquent().getDelinquentDays());
         assertEquals(0.0, Utils.getDoubleValue(getLoansLoanIdResponse.getDelinquent().getDelinquentAmount()));
 
         // Loan Disbursement
-        disburseLoanAccount(loanTransactionHelper, loanId, operationDate);
+        disburseLoanWithAmount(loanId, operationDate, PRINCIPAL_AMOUNT);
         // Evaluate default delinquent values in No Active Loan
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+        getLoansLoanIdResponse = getLoanDetails(loanId);
         assertNotNull(getLoansLoanIdResponse);
         assertNotNull(getLoansLoanIdResponse.getDelinquent());
         assertNotEquals(0, getLoansLoanIdResponse.getDelinquent().getDelinquentDays());
@@ -1352,48 +1233,43 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void testLoanClassificationOnlyForActiveLoanWithCOB() {
         try {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+            updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
             final String operationDate = "01 January 2012";
 
             LocalDate bussinesLocalDate = Utils.getDateAsLocalDate(operationDate);
             log.info("Current date {}", bussinesLocalDate);
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, bussinesLocalDate);
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), dateTimeFormatter.format(bussinesLocalDate));
 
             // Given
-            final LoanTransactionHelper loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-
             ArrayList<Long> rangeIds = new ArrayList<>();
             // First Range
-            PostDelinquencyRangeResponse delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                    .minimumAgeDays(4).maximumAgeDays(30).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+            PostDelinquencyRangeResponse delinquencyRangeResponse = delinquencyHelper
+                    .createRange(new DelinquencyRangeRequest().minimumAgeDays(4).maximumAgeDays(30).locale(LoanTestData.LOCALE)
+                            .classification(Utils.randomStringGenerator("DLQ_R_", 10)));
             rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-            PostDelinquencyBucketResponse delinquencyBucketResponse = DelinquencyBucketsHelper
+            PostDelinquencyBucketResponse delinquencyBucketResponse = delinquencyHelper
                     .createBucket(new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds));
             assertNotNull(delinquencyBucketResponse);
-            final DelinquencyBucketResponse delinquencyBucket = DelinquencyBucketsHelper
-                    .getBucket(delinquencyBucketResponse.getResourceId());
+            final DelinquencyBucketResponse delinquencyBucket = delinquencyHelper.getBucket(delinquencyBucketResponse.getResourceId());
 
             // Client creation
-            final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, operationDate);
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper,
-                    delinquencyBucket.getId(), null);
+            final Long clientId = createClient(operationDate);
+            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(delinquencyBucket.getId(), null);
             assertNotNull(getLoanProductsProductResponse);
 
             // Create Loan Application
-            final Integer loanId = createLoanApplication(loanTransactionHelper, clientId.toString(),
-                    getLoanProductsProductResponse.getId().toString(), operationDate, null);
+            final Long loanId = createLoanApplication(clientId, getLoanProductsProductResponse.getId(), operationDate, null);
 
             // run cob for business date 01 January 2012
             bussinesLocalDate = Utils.getDateAsLocalDate(operationDate);
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, bussinesLocalDate);
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), dateTimeFormatter.format(bussinesLocalDate));
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
 
             // Loan delinquency data
-            GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-            loanTransactionHelper.printDelinquencyData(getLoansLoanIdResponse);
+            GetLoansLoanIdResponse getLoansLoanIdResponse = getLoanDetails(loanId);
             GetLoansLoanIdDelinquencySummary delinquent = getLoansLoanIdResponse.getDelinquent();
             assertNotNull(getLoansLoanIdResponse);
             assertNotNull(delinquent);
@@ -1401,7 +1277,7 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(0.0, Utils.getDoubleValue(delinquent.getDelinquentAmount()));
 
         } finally {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+            updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(false));
         }
     }
@@ -1409,25 +1285,22 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void testLoanDelinquencyDataWithAmountPerPortions() {
         // Given
-        final LoanTransactionHelper loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-
         ArrayList<Long> rangeIds = new ArrayList<>();
         // First Range
-        PostDelinquencyRangeResponse delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                .minimumAgeDays(4).maximumAgeDays(30).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+        PostDelinquencyRangeResponse delinquencyRangeResponse = delinquencyHelper
+                .createRange(new DelinquencyRangeRequest().minimumAgeDays(4).maximumAgeDays(30).locale(LoanTestData.LOCALE)
+                        .classification(Utils.randomStringGenerator("DLQ_R_", 10)));
         rangeIds.add(delinquencyRangeResponse.getResourceId());
-        DelinquencyRangeResponse range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
 
-        PostDelinquencyBucketResponse delinquencyBucketResponse = DelinquencyBucketsHelper
+        PostDelinquencyBucketResponse delinquencyBucketResponse = delinquencyHelper
                 .createBucket(new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds));
         assertNotNull(delinquencyBucketResponse);
-        final DelinquencyBucketResponse delinquencyBucket = DelinquencyBucketsHelper.getBucket(delinquencyBucketResponse.getResourceId());
+        final DelinquencyBucketResponse delinquencyBucket = delinquencyHelper.getBucket(delinquencyBucketResponse.getResourceId());
 
         // Client and Loan account creation
-        final Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+        final Long clientId = createClient();
 
-        final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper,
-                delinquencyBucket.getId(), null);
+        final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(delinquencyBucket.getId(), null);
         assertNotNull(getLoanProductsProductResponse);
         log.info("Loan Product Bucket Name: {}", getLoanProductsProductResponse.getDelinquencyBucket().getName());
         assertEquals(getLoanProductsProductResponse.getDelinquencyBucket().getName(), delinquencyBucket.getName());
@@ -1442,20 +1315,20 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
         final Double amount = 2000.0;
         PostLoansRequest applicationRequest = applyLoanRequest(clientId, getLoanProductsProductResponse.getId(), operationDate, amount, 4);
 
-        applicationRequest = applicationRequest.numberOfRepayments(5).loanTermFrequency(5).loanTermFrequencyType(2)
-                .interestRatePerPeriod(BigDecimal.valueOf(12.3)).interestCalculationPeriodType(DAYS).repaymentEvery(1)
-                .repaymentFrequencyType(2);
+        applicationRequest = applicationRequest.numberOfRepayments(5).loanTermFrequency(5)
+                .loanTermFrequencyType(RepaymentFrequencyType.MONTHS).interestRatePerPeriod(BigDecimal.valueOf(12.3))
+                .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY).repaymentEvery(1)
+                .repaymentFrequencyType(RepaymentFrequencyType.MONTHS);
 
-        PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
-        final Long loanId = loanResponse.getResourceId();
+        final Long loanId = applyForLoan(applicationRequest);
 
-        loanTransactionHelper.approveLoan(loanId, new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(amount))
-                .dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
+        approveLoan(loanId, new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(amount)).dateFormat(DATETIME_PATTERN)
+                .approvedOnDate(operationDate).locale(LoanTestData.LOCALE));
 
-        loanTransactionHelper.disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
-                .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(amount)).locale("en"));
+        disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate(operationDate).dateFormat(DATETIME_PATTERN)
+                .transactionAmount(BigDecimal.valueOf(amount)).locale(LoanTestData.LOCALE));
 
-        GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
         log.info("Loan Delinquency Range after Disbursement {}", loanDetails.getDelinquencyRange().getClassification());
         assertNotNull(loanDetails.getDelinquent());
         log.info("Loan Delinquency Data {} {}", loanDetails.getDelinquent().getDelinquentPrincipal(),
@@ -1466,111 +1339,151 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
         assertEquals(new BigDecimal("246"), loanDetails.getDelinquent().getDelinquentInterest().stripTrailingZeros());
 
         // Apply a partial repayment to move only the interest
-        PostLoansLoanIdTransactionsResponse loansLoanIdTransactions = loanTransactionHelper.makeLoanRepayment(operationDate, 120f,
-                loanId.intValue());
+        PostLoansLoanIdTransactionsResponse loansLoanIdTransactions = makeLoanRepayment(loanId, "repayment", operationDate, 120.0);
         assertNotNull(loansLoanIdTransactions);
         log.info("Loan repayment transaction id {}", loansLoanIdTransactions.getResourceId());
 
-        loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+        loanDetails = getLoanDetails(loanId);
         assertNotNull(loanDetails.getDelinquent());
         assertNotNull(loanDetails.getDelinquencyRange().getClassification());
         assertEquals(new BigDecimal("312.95"), loanDetails.getDelinquent().getDelinquentPrincipal().stripTrailingZeros());
         assertEquals(new BigDecimal("126"), loanDetails.getDelinquent().getDelinquentInterest().stripTrailingZeros());
 
         // Apply a repayment to cover interest and part of the principal
-        loansLoanIdTransactions = loanTransactionHelper.makeLoanRepayment(operationDate, 330.72f, loanId.intValue());
+        loansLoanIdTransactions = makeLoanRepayment(loanId, "repayment", operationDate, 330.72);
         assertNotNull(loansLoanIdTransactions);
         log.info("Loan repayment transaction id {}", loansLoanIdTransactions.getResourceId());
 
-        loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+        loanDetails = getLoanDetails(loanId);
         assertNotNull(loanDetails.getDelinquent());
         assertNotNull(loanDetails.getDelinquencyRange().getClassification());
         assertEquals(new BigDecimal("108.23"), loanDetails.getDelinquent().getDelinquentPrincipal().stripTrailingZeros());
         assertEquals(BigDecimal.ZERO, loanDetails.getDelinquent().getDelinquentInterest().stripTrailingZeros());
 
         // Apply a repayment to cover the remain principal
-        loansLoanIdTransactions = loanTransactionHelper.makeLoanRepayment(operationDate, 108.23f, loanId.intValue());
+        loansLoanIdTransactions = makeLoanRepayment(loanId, "repayment", operationDate, 108.23);
         assertNotNull(loansLoanIdTransactions);
         log.info("Loan repayment transaction id {}", loansLoanIdTransactions.getResourceId());
         // Loan without Delinquency Classification
-        loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+        loanDetails = getLoanDetails(loanId);
         assertNotNull(loanDetails.getDelinquent());
         assertNull(loanDetails.getDelinquencyRange());
         assertEquals(BigDecimal.ZERO, loanDetails.getDelinquent().getDelinquentPrincipal().stripTrailingZeros());
         assertEquals(BigDecimal.ZERO, loanDetails.getDelinquent().getDelinquentInterest().stripTrailingZeros());
 
         // Undo the last repayment transaction we must to have pending the principal
-        PostLoansLoanIdTransactionsResponse reverseRepayment = loanTransactionHelper.reverseLoanTransaction(loanId,
-                loansLoanIdTransactions.getResourceId(), new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat("dd MMMM yyyy")
-                        .transactionDate(operationDate).transactionAmount(0.0).locale("en"));
+        PostLoansLoanIdTransactionsResponse reverseRepayment = reverseLoanTransaction(loanId, loansLoanIdTransactions.getResourceId(),
+                new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate(operationDate)
+                        .transactionAmount(0.0).locale(LoanTestData.LOCALE));
         assertNotNull(reverseRepayment);
-        loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+        loanDetails = getLoanDetails(loanId);
         assertNotNull(loanDetails.getDelinquent());
         assertNotNull(loanDetails.getDelinquencyRange().getClassification());
         assertEquals(new BigDecimal("108.23"), loanDetails.getDelinquent().getDelinquentPrincipal().stripTrailingZeros());
         assertEquals(BigDecimal.ZERO, loanDetails.getDelinquent().getDelinquentInterest().stripTrailingZeros());
     }
 
-    private GetLoanProductsProductIdResponse createLoanProduct(final LoanTransactionHelper loanTransactionHelper,
-            final Long delinquencyBucketId, final String inArrearsTolerance) {
-        final HashMap<String, Object> loanProductMap = new LoanProductTestBuilder().withDaysInMonth("30").withDaysInYear("360")
-                .withInArrearsTolerance(inArrearsTolerance).build(null, delinquencyBucketId);
-        final Integer loanProductId = loanTransactionHelper.getLoanProductId(Utils.convertToJson(loanProductMap));
-        return loanTransactionHelper.getLoanProduct(loanProductId);
+    private void verifyDelinquency(Long loanId, String date, Double amount, int delinquentDays) {
+        GetLoansLoanIdResponse getLoansLoanIdResponse = getLoanDetails(loanId);
+        GetLoansLoanIdDelinquencySummary delinquent = getLoansLoanIdResponse.getDelinquent();
+        assertEquals(amount, Utils.getDoubleValue(delinquent.getDelinquentAmount()));
+        assertEquals(LocalDate.parse(date, dateTimeFormatter), delinquent.getDelinquentDate());
+        assertEquals(delinquentDays, delinquent.getDelinquentDays());
     }
 
-    private GetLoanProductsProductIdResponse createLoanProductWithInstallmentLevelDelinquency(
-            final LoanTransactionHelper loanTransactionHelper, final Long delinquencyBucketId, final String inArrearsTolerance) {
-        final HashMap<String, Object> loanProductMap = new LoanProductTestBuilder().withInArrearsTolerance(inArrearsTolerance).build(null,
-                delinquencyBucketId);
-        loanProductMap.put("enableInstallmentLevelDelinquency", true);
-        final Integer loanProductId = loanTransactionHelper.getLoanProductId(Utils.convertToJson(loanProductMap));
-        return loanTransactionHelper.getLoanProduct(loanProductId);
+    private PostLoansDelinquencyActionResponse createLoanDelinquencyAction(Long loanId, DelinquencyAction action, String startDate,
+            String endDate) {
+        return loanHelper.createLoanDelinquencyAction(loanId, action.name(), startDate, endDate);
     }
 
-    private PutLoanProductsProductIdResponse updateLoanProduct(LoanTransactionHelper loanTransactionHelper, Long id,
+    private PostLoansDelinquencyActionResponse createLoanDelinquencyAction(Long loanId, DelinquencyAction action, String startDate) {
+        return loanHelper.createLoanDelinquencyAction(loanId, action.name(), startDate, null);
+    }
+
+    /**
+     * Mirrors the legacy {@code LoanProductTestBuilder} defaults with 30-days months / 360-days years, as used by the
+     * original RestAssured version of this test class.
+     */
+    private GetLoanProductsProductIdResponse createLoanProduct(final Long delinquencyBucketId, final Integer inArrearsTolerance) {
+        final PostLoanProductsRequest request = baseDelinquencyLoanProductRequest(delinquencyBucketId, inArrearsTolerance)
+                .daysInMonthType(DaysInMonthType.DAYS_30).daysInYearType(DaysInYearType.DAYS_360);
+        return retrieveLoanProduct(createLoanProduct(request));
+    }
+
+    private GetLoanProductsProductIdResponse createLoanProductWithInstallmentLevelDelinquency(final Long delinquencyBucketId,
             final Integer inArrearsTolerance) {
-        final PutLoanProductsProductIdRequest requestModifyLoan = new PutLoanProductsProductIdRequest()
-                .inArrearsTolerance(inArrearsTolerance);
-        return loanTransactionHelper.updateLoanProduct(id, requestModifyLoan);
+        final PostLoanProductsRequest request = baseDelinquencyLoanProductRequest(delinquencyBucketId, inArrearsTolerance)
+                .enableInstallmentLevelDelinquency(true);
+        return retrieveLoanProduct(createLoanProduct(request));
     }
 
-    private Integer createLoanApplication(final LoanTransactionHelper loanTransactionHelper, final String clientId,
-            final String loanProductId, final String operationDate, final String inArrearsTolerance) {
-        final String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal(principalAmount).withLoanTermFrequency("12")
-                .withLoanTermFrequencyAsMonths().withNumberOfRepayments("12").withRepaymentEveryAfter("1")
-                .withRepaymentFrequencyTypeAsMonths() //
-                .withInterestRatePerPeriod("2") //
-                .withExpectedDisbursementDate(operationDate) //
-                .withInterestTypeAsDecliningBalance() //
-                .withSubmittedOnDate(operationDate) //
-                .withInArrearsTolerance(inArrearsTolerance) //
-                .build(clientId, loanProductId, null);
-        final Integer loanId = loanTransactionHelper.getLoanId(loanApplicationJSON);
-        loanTransactionHelper.approveLoan(operationDate, principalAmount, loanId, null);
+    private PostLoanProductsRequest baseDelinquencyLoanProductRequest(final Long delinquencyBucketId, final Integer inArrearsTolerance) {
+        return new PostLoanProductsRequest().name(Utils.uniqueRandomStringGenerator("LOAN_PRODUCT_", 6))//
+                .shortName(Utils.uniqueRandomStringGenerator("", 4))//
+                .currencyCode("USD")//
+                .locale(LoanTestData.LOCALE)//
+                .digitsAfterDecimal(2)//
+                .inMultiplesOf(0)//
+                .principal(PRINCIPAL_AMOUNT)//
+                .minPrincipal(1000.0)//
+                .maxPrincipal(10000000.0)//
+                .numberOfRepayments(5)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(RepaymentFrequencyType.MONTHS_L)//
+                .interestRatePerPeriod(2.0)//
+                .interestRateFrequencyType(InterestRateFrequencyType.MONTHS)//
+                .amortizationType(AmortizationType.EQUAL_INSTALLMENTS)//
+                .interestType(InterestType.FLAT)//
+                .interestCalculationPeriodType(InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)//
+                .inArrearsTolerance(inArrearsTolerance)//
+                .transactionProcessingStrategyCode(DEFAULT_STRATEGY)//
+                .accountingRule(ACCOUNTING_RULE_NONE)//
+                .isEqualAmortization(false)//
+                .overdueDaysForNPA(5)//
+                .daysInMonthType(DaysInMonthType.ACTUAL)//
+                .daysInYearType(DaysInYearType.ACTUAL)//
+                .loanScheduleType(LoanScheduleType.CUMULATIVE.name())//
+                .isInterestRecalculationEnabled(false)//
+                .delinquencyBucketId(delinquencyBucketId);
+    }
+
+    private PutLoanProductsProductIdResponse updateLoanProductInArrearsTolerance(final Long productId, final Integer inArrearsTolerance) {
+        return updateLoanProduct(productId, new PutLoanProductsProductIdRequest().inArrearsTolerance(inArrearsTolerance));
+    }
+
+    /**
+     * Mirrors the legacy {@code LoanApplicationTestBuilder} application of the original test class: 10k principal over
+     * 12 monthly repayments at 2% declining-balance interest with equal-principal amortization.
+     */
+    private Long createLoanApplication(final Long clientId, final Long loanProductId, final String operationDate,
+            final Integer inArrearsTolerance) {
+        final PostLoansRequest applicationRequest = new PostLoansRequest().clientId(clientId).productId(loanProductId)
+                .principal(BigDecimal.valueOf(PRINCIPAL_AMOUNT)).loanTermFrequency(12).loanTermFrequencyType(RepaymentFrequencyType.MONTHS)
+                .numberOfRepayments(12).repaymentEvery(1).repaymentFrequencyType(RepaymentFrequencyType.MONTHS)
+                .interestRatePerPeriod(BigDecimal.valueOf(2)).interestType(InterestType.DECLINING_BALANCE)
+                .amortizationType(AmortizationType.EQUAL_PRINCIPAL)
+                .interestCalculationPeriodType(InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)
+                .transactionProcessingStrategyCode(DEFAULT_STRATEGY).expectedDisbursementDate(operationDate).submittedOnDate(operationDate)
+                .loanType("individual").dateFormat(DATETIME_PATTERN).locale(LoanTestData.LOCALE)
+                .inArrearsTolerance(inArrearsTolerance == null ? null : BigDecimal.valueOf(inArrearsTolerance));
+        final Long loanId = applyForLoan(applicationRequest);
+        approveLoan(loanId, approveLoanRequest(PRINCIPAL_AMOUNT, operationDate));
         return loanId;
     }
 
-    private void disburseLoanAccount(final LoanTransactionHelper loanTransactionHelper, final Integer loanId, final String operationDate) {
-        loanTransactionHelper.disburseLoanWithNetDisbursalAmount(operationDate, loanId, principalAmount);
-    }
-
-    private Integer createLoanAccount(final LoanTransactionHelper loanTransactionHelper, final String clientId, final String loanProductId,
-            final String operationDate, final String inArrearsTolerance) {
-        final Integer loanId = createLoanApplication(loanTransactionHelper, clientId, loanProductId, operationDate, inArrearsTolerance);
-        disburseLoanAccount(loanTransactionHelper, loanId, operationDate);
+    private Long createLoanAccount(final Long clientId, final Long loanProductId, final String operationDate,
+            final Integer inArrearsTolerance) {
+        final Long loanId = createLoanApplication(clientId, loanProductId, operationDate, inArrearsTolerance);
+        disburseLoanWithAmount(loanId, operationDate, PRINCIPAL_AMOUNT);
         return loanId;
     }
 
-    private String getChargeApplyJSON(final Integer chargeId, final String dueDate) {
-        final HashMap<String, Object> map = new HashMap<>();
-        map.put("chargeId", chargeId);
-        map.put("amount", 12.0f);
-        map.put("dueDate", dueDate);
-        map.put("dateFormat", Utils.DATE_FORMAT);
-        map.put("locale", CommonConstants.LOCALE);
-        final String chargeApplyJSON = new Gson().toJson(map);
-        log.info("{}", chargeApplyJSON);
-        return chargeApplyJSON;
+    /**
+     * Detaches the delinquency bucket from a loan product. Needs a body carrying an explicit JSON null, which the model
+     * on this module's test classpath cannot produce - see {@link LoanProductCommandsApi}.
+     */
+    private void clearDelinquencyBucket(final Long loanProductId) {
+        ok(() -> FineractFeignClientHelper.getFineractFeignClient().create(LoanProductCommandsApi.class)
+                .clearDelinquencyBucket(loanProductId, new LoanProductCommandsApi.ClearDelinquencyBucketRequest()));
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/DelinquencyBucketsIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/DelinquencyBucketsIntegrationTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.fineract.integrationtests;
 
-import static org.apache.fineract.integrationtests.BaseLoanIntegrationTest.RepaymentFrequencyType.DAYS;
+import static org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder.DEFAULT_STRATEGY;
 import static org.apache.fineract.portfolio.delinquency.domain.DelinquencyAction.PAUSE;
 import static org.apache.fineract.portfolio.delinquency.domain.DelinquencyAction.RESUME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -29,18 +29,12 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.gson.Gson;
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
 import org.apache.fineract.client.models.BusinessDateResponse;
 import org.apache.fineract.client.models.DeleteDelinquencyBucketResponse;
 import org.apache.fineract.client.models.DeleteDelinquencyRangeResponse;
@@ -53,69 +47,64 @@ import org.apache.fineract.client.models.GetDelinquencyTagHistoryResponse;
 import org.apache.fineract.client.models.GetLoanProductsProductIdResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdDelinquencySummary;
 import org.apache.fineract.client.models.GetLoansLoanIdLoanInstallmentLevelDelinquency;
-import org.apache.fineract.client.models.GetLoansLoanIdRepaymentPeriod;
-import org.apache.fineract.client.models.GetLoansLoanIdRepaymentSchedule;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
+import org.apache.fineract.client.models.JobBusinessStepConfigData;
 import org.apache.fineract.client.models.PostDelinquencyBucketResponse;
 import org.apache.fineract.client.models.PostDelinquencyRangeResponse;
+import org.apache.fineract.client.models.PostLoanProductsRequest;
 import org.apache.fineract.client.models.PostLoansDelinquencyActionResponse;
+import org.apache.fineract.client.models.PostLoansLoanIdChargesRequest;
+import org.apache.fineract.client.models.PostLoansLoanIdChargesResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsTransactionIdRequest;
 import org.apache.fineract.client.models.PostLoansRequest;
-import org.apache.fineract.client.models.PostLoansResponse;
 import org.apache.fineract.client.models.PutDelinquencyBucketResponse;
 import org.apache.fineract.client.models.PutDelinquencyRangeResponse;
 import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
 import org.apache.fineract.client.models.PutLoanProductsProductIdRequest;
 import org.apache.fineract.client.models.PutLoanProductsProductIdResponse;
-import org.apache.fineract.client.util.CallFailedRuntimeException;
-import org.apache.fineract.cob.data.JobBusinessStepConfigData;
 import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
-import org.apache.fineract.integrationtests.common.BusinessDateHelper;
-import org.apache.fineract.integrationtests.common.BusinessStepConfigurationHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.CommonConstants;
-import org.apache.fineract.integrationtests.common.SchedulerJobHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignBusinessStepHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignDelinquencyHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.LoanProductCommandsApi;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.AmortizationType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.DaysInMonthType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.DaysInYearType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestCalculationPeriodType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestRateFrequencyType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.RepaymentFrequencyType;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
-import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
 import org.apache.fineract.integrationtests.common.loans.LoanTestLifecycleExtension;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.apache.fineract.integrationtests.common.products.DelinquencyBucketsHelper;
-import org.apache.fineract.integrationtests.common.products.DelinquencyRangesHelper;
+import org.apache.fineract.portfolio.delinquency.domain.DelinquencyAction;
+import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleType;
 import org.assertj.core.api.SoftAssertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Slf4j
 @ExtendWith(LoanTestLifecycleExtension.class)
-public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
+public class DelinquencyBucketsIntegrationTest extends FeignLoanTestBase {
 
-    private ResponseSpecification responseSpec;
-    private RequestSpecification requestSpec;
-    private BusinessDateHelper businessDateHelper;
-    private static final String principalAmount = "10000";
+    private static final String CLIENT_ACTIVATION_DATE = "01 January 2012";
+    private static final Double PRINCIPAL_AMOUNT = 10000.0;
+    private static final Integer ACCOUNTING_RULE_NONE = 1;
 
-    @BeforeEach
-    public void setup() {
-        Utils.initializeRESTAssured();
-
-        requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        this.businessDateHelper = new BusinessDateHelper();
-    }
+    private final FeignDelinquencyHelper delinquencyHelper = new FeignDelinquencyHelper(FineractFeignClientHelper.getFineractFeignClient());
+    private final FeignBusinessStepHelper businessStepHelper = new FeignBusinessStepHelper(
+            FineractFeignClientHelper.getFineractFeignClient());
 
     @Test
     public void testCreateDelinquencyRanges() {
         // given
-        final PostDelinquencyRangeResponse delinquencyRangeResponse01 = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                .minimumAgeDays(1).maximumAgeDays(3).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
-        final List<DelinquencyRangeResponse> ranges = DelinquencyRangesHelper.getRanges();
+        final PostDelinquencyRangeResponse delinquencyRangeResponse01 = delinquencyHelper.createRange(new DelinquencyRangeRequest()
+                .minimumAgeDays(1).maximumAgeDays(3).locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+        final List<DelinquencyRangeResponse> ranges = delinquencyHelper.getRanges();
 
         // then
         assertNotNull(delinquencyRangeResponse01);
@@ -131,14 +120,14 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void testUpdateDelinquencyRanges() {
         // given
-        final PostDelinquencyRangeResponse delinquencyRangeResponse01 = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                .minimumAgeDays(1).maximumAgeDays(3).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+        final PostDelinquencyRangeResponse delinquencyRangeResponse01 = delinquencyHelper.createRange(new DelinquencyRangeRequest()
+                .minimumAgeDays(1).maximumAgeDays(3).locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
         // when
-        final PutDelinquencyRangeResponse delinquencyRangeResponse02 = DelinquencyRangesHelper
+        final PutDelinquencyRangeResponse delinquencyRangeResponse02 = delinquencyHelper
                 .updateRange(delinquencyRangeResponse01.getResourceId(), new DelinquencyRangeRequest().minimumAgeDays(1).maximumAgeDays(7)
-                        .locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
-        final DelinquencyRangeResponse range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse01.getResourceId());
-        final DeleteDelinquencyRangeResponse deleteDelinquencyRangeResponse = DelinquencyRangesHelper
+                        .locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+        final DelinquencyRangeResponse range = delinquencyHelper.getRange(delinquencyRangeResponse01.getResourceId());
+        final DeleteDelinquencyRangeResponse deleteDelinquencyRangeResponse = delinquencyHelper
                 .deleteRange(delinquencyRangeResponse01.getResourceId());
 
         // then
@@ -154,29 +143,29 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     public void testDelinquencyBuckets() {
         // given
         ArrayList<Long> rangeIds = new ArrayList<>();
-        PostDelinquencyRangeResponse delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                .minimumAgeDays(1).maximumAgeDays(3).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+        PostDelinquencyRangeResponse delinquencyRangeResponse = delinquencyHelper.createRange(new DelinquencyRangeRequest()
+                .minimumAgeDays(1).maximumAgeDays(3).locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
         rangeIds.add(delinquencyRangeResponse.getResourceId());
-        delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(4).maximumAgeDays(30)
-                .locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+        delinquencyRangeResponse = delinquencyHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(4).maximumAgeDays(30)
+                .locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
         rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-        PostDelinquencyBucketResponse delinquencyBucketResponse = DelinquencyBucketsHelper
+        PostDelinquencyBucketResponse delinquencyBucketResponse = delinquencyHelper
                 .createBucket(new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds));
         // Update
         rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-        PutDelinquencyBucketResponse updateDelinquencyBucketResponse = DelinquencyBucketsHelper.updateBucket(
+        PutDelinquencyBucketResponse updateDelinquencyBucketResponse = delinquencyHelper.updateBucket(
                 delinquencyBucketResponse.getResourceId(),
                 new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds));
-        delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(31).maximumAgeDays(60)
-                .locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+        delinquencyRangeResponse = delinquencyHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(31).maximumAgeDays(60)
+                .locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
         rangeIds.add(delinquencyRangeResponse.getResourceId());
         // Read
-        final DelinquencyBucketResponse delinquencyBucket = DelinquencyBucketsHelper.getBucket(delinquencyBucketResponse.getResourceId());
+        final DelinquencyBucketResponse delinquencyBucket = delinquencyHelper.getBucket(delinquencyBucketResponse.getResourceId());
 
         // when
-        final List<DelinquencyBucketResponse> bucketList = DelinquencyBucketsHelper.getBuckets();
+        final List<DelinquencyBucketResponse> bucketList = delinquencyHelper.getBuckets();
 
         // then
         assertNotNull(bucketList);
@@ -190,18 +179,18 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     public void testDelinquencyBucketDelete() {
         // given
         ArrayList<Long> rangeIds = new ArrayList<>();
-        final PostDelinquencyRangeResponse delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                .minimumAgeDays(1).maximumAgeDays(3).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+        final PostDelinquencyRangeResponse delinquencyRangeResponse = delinquencyHelper.createRange(new DelinquencyRangeRequest()
+                .minimumAgeDays(1).maximumAgeDays(3).locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
         rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-        PostDelinquencyBucketResponse delinquencyBucketResponse = DelinquencyBucketsHelper
+        PostDelinquencyBucketResponse delinquencyBucketResponse = delinquencyHelper
                 .createBucket(new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds));
         // Delete
-        DeleteDelinquencyBucketResponse deleteDelinquencyBucketResponse = DelinquencyBucketsHelper
+        DeleteDelinquencyBucketResponse deleteDelinquencyBucketResponse = delinquencyHelper
                 .deleteBucket(delinquencyBucketResponse.getResourceId());
 
         // when
-        final List<DelinquencyBucketResponse> bucketList = DelinquencyBucketsHelper.getBuckets();
+        final List<DelinquencyBucketResponse> bucketList = delinquencyHelper.getBuckets();
 
         // then
         assertNotNull(bucketList);
@@ -213,19 +202,18 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     public void testDelinquencyBucketsRangeAgeOverlaped() {
         // Given
         ArrayList<Long> rangeIds = new ArrayList<>();
-        PostDelinquencyRangeResponse delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                .minimumAgeDays(1).maximumAgeDays(3).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+        PostDelinquencyRangeResponse delinquencyRangeResponse = delinquencyHelper.createRange(new DelinquencyRangeRequest()
+                .minimumAgeDays(1).maximumAgeDays(3).locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
         rangeIds.add(delinquencyRangeResponse.getResourceId());
-        delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(3).maximumAgeDays(30)
-                .locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+        delinquencyRangeResponse = delinquencyHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(3).maximumAgeDays(30)
+                .locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
         rangeIds.add(delinquencyRangeResponse.getResourceId());
 
         // When
         CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class, () -> {
-            DelinquencyBucketsHelper
-                    .createBucket(new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds));
+            delinquencyHelper.createBucket(new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds));
         });
-        assertEquals(403, exception.getResponse().code());
+        assertEquals(403, exception.getStatus());
 
     }
 
@@ -233,62 +221,61 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     public void testDelinquencyBucketsNameDuplication() {
         // Given
         ArrayList<Long> rangeIds = new ArrayList<>();
-        PostDelinquencyRangeResponse delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                .minimumAgeDays(1).maximumAgeDays(3).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+        PostDelinquencyRangeResponse delinquencyRangeResponse = delinquencyHelper.createRange(new DelinquencyRangeRequest()
+                .minimumAgeDays(1).maximumAgeDays(3).locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
         // When
         String bucketName = Utils.randomStringGenerator("DLQ_B_", 10);
         rangeIds.add(delinquencyRangeResponse.getResourceId());
-        DelinquencyBucketsHelper.createBucket(new DelinquencyBucketRequest().name(bucketName).ranges(rangeIds));
+        delinquencyHelper.createBucket(new DelinquencyBucketRequest().name(bucketName).ranges(rangeIds));
 
         // When
         CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class, () -> {
-            DelinquencyBucketsHelper.createBucket(new DelinquencyBucketRequest().name(bucketName).ranges(rangeIds));
+            delinquencyHelper.createBucket(new DelinquencyBucketRequest().name(bucketName).ranges(rangeIds));
         });
-        assertEquals(403, exception.getResponse().code());
+        assertEquals(403, exception.getStatus());
     }
 
     @Test
     public void testLoanProductCreationWithAndWithoutDelinquencyBucket() {
         // Given
-        final LoanTransactionHelper loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-
         ArrayList<Long> rangeIds = new ArrayList<>();
         // First Range
-        PostDelinquencyRangeResponse delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                .minimumAgeDays(1).maximumAgeDays(3).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+        PostDelinquencyRangeResponse delinquencyRangeResponse = delinquencyHelper.createRange(new DelinquencyRangeRequest()
+                .minimumAgeDays(1).maximumAgeDays(3).locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
         rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-        DelinquencyRangeResponse range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
+        DelinquencyRangeResponse range = delinquencyHelper.getRange(delinquencyRangeResponse.getResourceId());
 
         // Second Range
-        delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(4).maximumAgeDays(60)
-                .locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+        delinquencyRangeResponse = delinquencyHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(4).maximumAgeDays(60)
+                .locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
         rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-        range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
+        range = delinquencyHelper.getRange(delinquencyRangeResponse.getResourceId());
         final String classificationExpected = range.getClassification();
         log.info("Expected Delinquency Range classification after Disbursement {}", classificationExpected);
 
-        PostDelinquencyBucketResponse delinquencyBucketResponse = DelinquencyBucketsHelper
+        PostDelinquencyBucketResponse delinquencyBucketResponse = delinquencyHelper
                 .createBucket(new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds));
         assertNotNull(delinquencyBucketResponse);
-        final DelinquencyBucketResponse delinquencyBucket = DelinquencyBucketsHelper.getBucket(delinquencyBucketResponse.getResourceId());
+        final DelinquencyBucketResponse delinquencyBucket = delinquencyHelper.getBucket(delinquencyBucketResponse.getResourceId());
 
         // Loan product creation without Delinquency bucket
-        GetLoanProductsProductIdResponse getLoanProductResponse = createLoanProduct(loanTransactionHelper, null, null);
+        GetLoanProductsProductIdResponse getLoanProductResponse = createLoanProduct(null, null);
         assertNotNull(getLoanProductResponse);
         assertNull(getLoanProductResponse.getDelinquencyBucket().getId());
 
         // Loan product creation with Delinquency bucket
-        getLoanProductResponse = createLoanProduct(loanTransactionHelper, delinquencyBucket.getId(), null);
+        getLoanProductResponse = createLoanProduct(delinquencyBucket.getId(), null);
         assertNotNull(getLoanProductResponse);
         log.info("Loan Product Bucket Name: {}", getLoanProductResponse.getDelinquencyBucket().getName());
         assertEquals(getLoanProductResponse.getDelinquencyBucket().getName(), delinquencyBucket.getName());
 
-        // Update Loan product to remove the Delinquency bucket
+        // Update Loan product to remove the Delinquency bucket. The server only clears it when the key is present in
+        // the body, which the generated request model cannot express - see LoanProductCommandsApi.
         final Long loanProductId = getLoanProductResponse.getId();
-        loanTransactionHelper.updateLoanProduct(loanProductId, "{delinquencyBucketId: null}");
-        getLoanProductResponse = loanTransactionHelper.getLoanProduct(loanProductId.intValue());
+        clearDelinquencyBucket(loanProductId);
+        getLoanProductResponse = retrieveLoanProduct(loanProductId);
         assertNotNull(getLoanProductResponse);
         assertNull(getLoanProductResponse.getDelinquencyBucket().getId());
     }
@@ -297,43 +284,40 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     public void testLoanClassificationRealtime() {
         try {
             // Given
-            final LoanTransactionHelper loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+            updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
 
             final LocalDate bussinesLocalDate = Utils.getDateAsLocalDate("01 March 2012");
             log.info("Current date {}", bussinesLocalDate);
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, bussinesLocalDate);
-            final BusinessDateResponse businessDateResponse = this.businessDateHelper
-                    .getBusinessDate(BusinessDateType.BUSINESS_DATE.name());
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), dateTimeFormatter.format(bussinesLocalDate));
+            final BusinessDateResponse businessDateResponse = businessDateHelper.getBusinessDate(BusinessDateType.BUSINESS_DATE.name());
 
             ArrayList<Long> rangeIds = new ArrayList<>();
             // First Range
-            PostDelinquencyRangeResponse delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                    .minimumAgeDays(1).maximumAgeDays(3).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+            PostDelinquencyRangeResponse delinquencyRangeResponse = delinquencyHelper
+                    .createRange(new DelinquencyRangeRequest().minimumAgeDays(1).maximumAgeDays(3).locale(LoanTestData.LOCALE)
+                            .classification(Utils.randomStringGenerator("DLQ_R_", 10)));
             rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-            DelinquencyRangeResponse range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
+            DelinquencyRangeResponse range = delinquencyHelper.getRange(delinquencyRangeResponse.getResourceId());
 
             // Second Range
-            delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(4)
-                    .maximumAgeDays(60).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+            delinquencyRangeResponse = delinquencyHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(4).maximumAgeDays(60)
+                    .locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
             rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-            range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
+            range = delinquencyHelper.getRange(delinquencyRangeResponse.getResourceId());
             final String classificationExpected = range.getClassification();
             log.info("Expected Delinquency Range classification after Disbursement {}", classificationExpected);
 
-            PostDelinquencyBucketResponse delinquencyBucketResponse = DelinquencyBucketsHelper
+            PostDelinquencyBucketResponse delinquencyBucketResponse = delinquencyHelper
                     .createBucket(new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds));
             assertNotNull(delinquencyBucketResponse);
-            final DelinquencyBucketResponse delinquencyBucket = DelinquencyBucketsHelper
-                    .getBucket(delinquencyBucketResponse.getResourceId());
+            final DelinquencyBucketResponse delinquencyBucket = delinquencyHelper.getBucket(delinquencyBucketResponse.getResourceId());
 
             // Client and Loan account creation
-            final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper,
-                    delinquencyBucket.getId(), null);
+            final Long clientId = createClient(CLIENT_ACTIVATION_DATE);
+            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(delinquencyBucket.getId(), null);
             assertNotNull(getLoanProductsProductResponse);
             log.info("Loan Product Bucket Name: {}", getLoanProductsProductResponse.getDelinquencyBucket().getName());
             assertEquals(getLoanProductsProductResponse.getDelinquencyBucket().getName(), delinquencyBucket.getName());
@@ -343,38 +327,34 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
             String operationDate = Utils.dateFormatter.format(transactionDate);
 
             // Create Loan Account
-            final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                    getLoanProductsProductResponse.getId().toString(), operationDate, null);
+            final Long loanId = createLoanAccount(clientId, getLoanProductsProductResponse.getId(), operationDate, null);
 
-            GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+            GetLoansLoanIdResponse getLoansLoanIdResponse = getLoanDetails(loanId);
             assertNotNull(getLoansLoanIdResponse);
             assertNotNull(getLoansLoanIdResponse.getDelinquencyRange());
             log.info("Loan Delinquency Range after Disbursement {}", getLoansLoanIdResponse.getDelinquencyRange().getClassification());
             // First Loan Delinquency Classification after Disbursement command
             assertEquals(getLoansLoanIdResponse.getDelinquencyRange().getClassification(), classificationExpected);
 
-            loanTransactionHelper.printRepaymentSchedule(getLoansLoanIdResponse);
-
             // Apply a partial repayment
             operationDate = Utils.dateFormatter.format(bussinesLocalDate);
-            loanTransactionHelper.makeLoanRepayment(operationDate, 100.0f, loanId);
+            makeLoanRepayment(loanId, "repayment", operationDate, 100.0);
 
-            getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+            getLoansLoanIdResponse = getLoanDetails(loanId);
             log.info("Loan Delinquency Range after Repayment {}", getLoansLoanIdResponse.getDelinquencyRange());
             assertNotNull(getLoansLoanIdResponse.getDelinquencyRange());
             // First Loan Delinquency Classification remains after Repayment because the installment is not fully paid
             assertEquals(getLoansLoanIdResponse.getDelinquencyRange().getClassification(), classificationExpected);
 
             // Apply a repayment to get a full paid installment
-            loanTransactionHelper.makeLoanRepayment(operationDate, 1000.0f, loanId);
-            getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+            makeLoanRepayment(loanId, "repayment", operationDate, 1000.0);
+            getLoansLoanIdResponse = getLoanDetails(loanId);
             log.info("Loan Delinquency Range after Repayment {}", getLoansLoanIdResponse.getDelinquencyRange());
             assertNotNull(getLoansLoanIdResponse);
             // The Loan Delinquency Classification after Repayment command must be null
             assertNull(getLoansLoanIdResponse.getDelinquencyRange());
             // Get the Delinquency Tags
-            ArrayList<GetDelinquencyTagHistoryResponse> getDelinquencyTagsHistory = loanTransactionHelper
-                    .getLoanDelinquencyTags(requestSpec, responseSpec, loanId);
+            List<GetDelinquencyTagHistoryResponse> getDelinquencyTagsHistory = getLoanDelinquencyTags(loanId);
             assertNotNull(getDelinquencyTagsHistory);
             log.info("Delinquency Tag History items {}", getDelinquencyTagsHistory.size());
             assertEquals(1, getDelinquencyTagsHistory.size());
@@ -384,7 +364,7 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(getDelinquencyTagsHistory.get(0).getDelinquencyRange().getClassification(), classificationExpected);
             log.info("Delinquency Tag Item with Lifted On {}", getDelinquencyTagsHistory.get(0).getLiftedOnDate());
         } finally {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+            updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(false));
         }
     }
@@ -392,43 +372,40 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void testLoanClassificationRealtimeWithCharges() {
         try {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+            updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
 
             final LocalDate bussinesLocalDate = Utils.getDateAsLocalDate("01 April 2012");
             log.info("Current date {}", bussinesLocalDate);
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, bussinesLocalDate);
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), dateTimeFormatter.format(bussinesLocalDate));
 
             // Given
-            final LoanTransactionHelper loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-
             ArrayList<Long> rangeIds = new ArrayList<>();
             // First Range
-            PostDelinquencyRangeResponse delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                    .minimumAgeDays(1).maximumAgeDays(3).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+            PostDelinquencyRangeResponse delinquencyRangeResponse = delinquencyHelper
+                    .createRange(new DelinquencyRangeRequest().minimumAgeDays(1).maximumAgeDays(3).locale(LoanTestData.LOCALE)
+                            .classification(Utils.randomStringGenerator("DLQ_R_", 10)));
             rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-            DelinquencyRangeResponse range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
+            DelinquencyRangeResponse range = delinquencyHelper.getRange(delinquencyRangeResponse.getResourceId());
 
             // Second Range
-            delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(4)
-                    .maximumAgeDays(60).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+            delinquencyRangeResponse = delinquencyHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(4).maximumAgeDays(60)
+                    .locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
             rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-            range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
+            range = delinquencyHelper.getRange(delinquencyRangeResponse.getResourceId());
             final String classificationExpected = range.getClassification();
             log.info("Expected Delinquency Range classification after Disbursement {}", classificationExpected);
 
-            PostDelinquencyBucketResponse delinquencyBucketResponse = DelinquencyBucketsHelper
+            PostDelinquencyBucketResponse delinquencyBucketResponse = delinquencyHelper
                     .createBucket(new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds));
             assertNotNull(delinquencyBucketResponse);
-            final DelinquencyBucketResponse delinquencyBucket = DelinquencyBucketsHelper
-                    .getBucket(delinquencyBucketResponse.getResourceId());
+            final DelinquencyBucketResponse delinquencyBucket = delinquencyHelper.getBucket(delinquencyBucketResponse.getResourceId());
 
             // Client and Loan account creation
-            final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper,
-                    delinquencyBucket.getId(), null);
+            final Long clientId = createClient(CLIENT_ACTIVATION_DATE);
+            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(delinquencyBucket.getId(), null);
             assertNotNull(getLoanProductsProductResponse);
             log.info("Loan Product Bucket Name: {}", getLoanProductsProductResponse.getDelinquencyBucket().getName());
             assertEquals(getLoanProductsProductResponse.getDelinquencyBucket().getName(), delinquencyBucket.getName());
@@ -438,47 +415,42 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
             String operationDate = Utils.dateFormatter.format(transactionDate);
 
             // Create Loan Account
-            final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                    getLoanProductsProductResponse.getId().toString(), operationDate, null);
+            final Long loanId = createLoanAccount(clientId, getLoanProductsProductResponse.getId(), operationDate, null);
 
-            GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+            GetLoansLoanIdResponse getLoansLoanIdResponse = getLoanDetails(loanId);
             log.info("Loan Delinquency Range after Disbursement {}", getLoansLoanIdResponse.getDelinquencyRange().getClassification());
             assertNotNull(getLoansLoanIdResponse);
             // First Loan Delinquency Classification after Disbursement command
             assertEquals(getLoansLoanIdResponse.getDelinquencyRange().getClassification(), classificationExpected);
-            loanTransactionHelper.printRepaymentSchedule(getLoansLoanIdResponse);
 
             // Apply a repayment to get a full paid installment
             operationDate = Utils.dateFormatter.format(bussinesLocalDate);
-            loanTransactionHelper.makeLoanRepayment(operationDate, 2049.99f, loanId);
+            makeLoanRepayment(loanId, "repayment", operationDate, 2049.99);
 
-            getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+            getLoansLoanIdResponse = getLoanDetails(loanId);
             assertNotNull(getLoansLoanIdResponse);
             // The Loan Delinquency Classification after Repayment command must be null
             log.info("Loan Delinquency Range after Repayment {}", getLoansLoanIdResponse.getDelinquencyRange());
             assertNull(getLoansLoanIdResponse.getDelinquencyRange());
-            loanTransactionHelper.printRepaymentSchedule(getLoansLoanIdResponse);
 
             transactionDate = bussinesLocalDate.minusDays(18);
             operationDate = Utils.dateFormatter.format(transactionDate);
 
             // Create and apply Charge for Specific Due Date
-            final Integer chargeId = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(1, "30", false));
+            final Long chargeId = createLoanSpecifiedDueDateCharge(30.0);
             assertNotNull(chargeId);
-            final Integer loanChargeId = loanTransactionHelper.addChargesForLoan(loanId, getChargeApplyJSON(chargeId, operationDate),
-                    responseSpec);
-            assertNotNull(loanChargeId);
+            final PostLoansLoanIdChargesResponse loanChargeResponse = addChargesForLoan(loanId, new PostLoansLoanIdChargesRequest()
+                    .chargeId(chargeId).amount(12.0).dueDate(operationDate).dateFormat(DATETIME_PATTERN).locale(LoanTestData.LOCALE));
+            assertNotNull(loanChargeResponse.getResourceId());
 
-            getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-            loanTransactionHelper.printRepaymentSchedule(getLoansLoanIdResponse);
+            getLoansLoanIdResponse = getLoanDetails(loanId);
 
             log.info("Loan Delinquency Range after add Loan Charge {}", getLoansLoanIdResponse.getDelinquencyRange());
             assertNotNull(getLoansLoanIdResponse.getDelinquencyRange());
             // Evaluate a Delinquency Tag set after add charge to the Loan
             assertEquals(getLoansLoanIdResponse.getDelinquencyRange().getClassification(), classificationExpected);
         } finally {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+            updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(false));
         }
     }
@@ -487,42 +459,40 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     public void testLoanClassificationRealtimeOlderLoan() {
 
         // Given
-        final LoanTransactionHelper loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-
         ArrayList<Long> rangeIds = new ArrayList<>();
         // First Range
-        PostDelinquencyRangeResponse delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                .minimumAgeDays(4).maximumAgeDays(30).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+        PostDelinquencyRangeResponse delinquencyRangeResponse = delinquencyHelper
+                .createRange(new DelinquencyRangeRequest().minimumAgeDays(4).maximumAgeDays(30).locale(LoanTestData.LOCALE)
+                        .classification(Utils.randomStringGenerator("DLQ_R_", 10)));
         rangeIds.add(delinquencyRangeResponse.getResourceId());
-        DelinquencyRangeResponse range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
+        DelinquencyRangeResponse range = delinquencyHelper.getRange(delinquencyRangeResponse.getResourceId());
         final String classificationExpected02 = range.getClassification();
         log.info("Expected Delinquency Range classification after first repayment {}", classificationExpected02);
 
         // Second Range
-        delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(31).maximumAgeDays(60)
-                .locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+        delinquencyRangeResponse = delinquencyHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(31).maximumAgeDays(60)
+                .locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
         rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-        range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
+        range = delinquencyHelper.getRange(delinquencyRangeResponse.getResourceId());
         final String classificationExpected01 = range.getClassification();
         log.info("Expected Delinquency Range classification after Disbursement {}", classificationExpected01);
 
         // Third Range
-        delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(61).maximumAgeDays(90)
-                .locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+        delinquencyRangeResponse = delinquencyHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(61).maximumAgeDays(90)
+                .locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
         rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-        range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
+        range = delinquencyHelper.getRange(delinquencyRangeResponse.getResourceId());
 
-        PostDelinquencyBucketResponse delinquencyBucketResponse = DelinquencyBucketsHelper
+        PostDelinquencyBucketResponse delinquencyBucketResponse = delinquencyHelper
                 .createBucket(new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds));
         assertNotNull(delinquencyBucketResponse);
-        final DelinquencyBucketResponse delinquencyBucket = DelinquencyBucketsHelper.getBucket(delinquencyBucketResponse.getResourceId());
+        final DelinquencyBucketResponse delinquencyBucket = delinquencyHelper.getBucket(delinquencyBucketResponse.getResourceId());
 
         // Client and Loan account creation
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-        final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper,
-                delinquencyBucket.getId(), null);
+        final Long clientId = createClient(CLIENT_ACTIVATION_DATE);
+        final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(delinquencyBucket.getId(), null);
         assertNotNull(getLoanProductsProductResponse);
         log.info("Loan Product Bucket Name: {}", getLoanProductsProductResponse.getDelinquencyBucket().getName());
         assertEquals(getLoanProductsProductResponse.getDelinquencyBucket().getName(), delinquencyBucket.getName());
@@ -533,10 +503,9 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
         String operationDate = Utils.dateFormatter.format(transactionDate);
 
         // Create Loan Account
-        final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                getLoanProductsProductResponse.getId().toString(), operationDate, null);
+        final Long loanId = createLoanAccount(clientId, getLoanProductsProductResponse.getId(), operationDate, null);
 
-        GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+        GetLoansLoanIdResponse getLoansLoanIdResponse = getLoanDetails(loanId);
         assertNotNull(getLoansLoanIdResponse);
         log.info("Loan Delinquency Range after Disbursement in null? {}", (getLoansLoanIdResponse.getDelinquencyRange() == null));
         assertNotNull(getLoansLoanIdResponse.getDelinquencyRange());
@@ -544,23 +513,19 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
         // First Loan Delinquency Classification after Disbursement command
         assertEquals(getLoansLoanIdResponse.getDelinquencyRange().getClassification(), classificationExpected01);
 
-        loanTransactionHelper.printRepaymentSchedule(getLoansLoanIdResponse);
-
         // Apply a repayment to get a first full paid installment
         transactionDate = todaysDate.minusDays(1);
         operationDate = Utils.dateFormatter.format(transactionDate);
-        PostLoansLoanIdTransactionsResponse loansLoanIdTransactions = loanTransactionHelper.makeLoanRepayment(operationDate, 1050.0f,
-                loanId);
+        PostLoansLoanIdTransactionsResponse loansLoanIdTransactions = makeLoanRepayment(loanId, "repayment", operationDate, 1050.0);
         assertNotNull(loansLoanIdTransactions);
         log.info("Loan repayment transaction id {}", loansLoanIdTransactions.getResourceId());
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+        getLoansLoanIdResponse = getLoanDetails(loanId);
         log.info("Loan Delinquency Range after first Repayment {}", getLoansLoanIdResponse.getDelinquencyRange());
         assertNotNull(getLoansLoanIdResponse.getDelinquencyRange());
         // First Loan Delinquency Classification remains after Repayment because the installment is not fully paid
         assertEquals(getLoansLoanIdResponse.getDelinquencyRange().getClassification(), classificationExpected02);
 
-        ArrayList<GetDelinquencyTagHistoryResponse> getDelinquencyTagsHistory = loanTransactionHelper.getLoanDelinquencyTags(requestSpec,
-                responseSpec, loanId);
+        List<GetDelinquencyTagHistoryResponse> getDelinquencyTagsHistory = getLoanDelinquencyTags(loanId);
         assertNotNull(getDelinquencyTagsHistory);
         log.info("Delinquency Tag History items {}", getDelinquencyTagsHistory.size());
         log.info("Delinquency Tag Item with Lifted On {}", getDelinquencyTagsHistory.get(0).getLiftedOnDate());
@@ -570,16 +535,16 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
         log.info("Loan Id {} with Loan status {}", getLoansLoanIdResponse.getId(), getLoansLoanIdResponse.getStatus().getCode());
 
         // Apply a repayment to get a second full paid installment
-        loansLoanIdTransactions = loanTransactionHelper.makeLoanRepayment(operationDate, 1020.0f, loanId);
+        loansLoanIdTransactions = makeLoanRepayment(loanId, "repayment", operationDate, 1020.0);
         assertNotNull(loansLoanIdTransactions);
         log.info("Loan repayment transaction id {}", loansLoanIdTransactions.getResourceId());
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+        getLoansLoanIdResponse = getLoanDetails(loanId);
         log.info("Loan Delinquency Range after second Repayment {}", getLoansLoanIdResponse.getDelinquencyRange());
         assertNotNull(getLoansLoanIdResponse);
         // The Loan Delinquency Classification after Repayment command must be null
         assertNull(getLoansLoanIdResponse.getDelinquencyRange());
 
-        getDelinquencyTagsHistory = loanTransactionHelper.getLoanDelinquencyTags(requestSpec, responseSpec, loanId);
+        getDelinquencyTagsHistory = getLoanDelinquencyTags(loanId);
         assertNotNull(getDelinquencyTagsHistory);
         log.info("Delinquency Tag History items {}", getDelinquencyTagsHistory.size());
         log.info("Delinquency Tag Item with Lifted On {}", getDelinquencyTagsHistory.get(1).getLiftedOnDate());
@@ -592,26 +557,24 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void testLoanClassificationRealtimeWithReversedRepayment() {
         // Given
-        final LoanTransactionHelper loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-
         ArrayList<Long> rangeIds = new ArrayList<>();
         // First Range
-        PostDelinquencyRangeResponse delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                .minimumAgeDays(4).maximumAgeDays(30).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+        PostDelinquencyRangeResponse delinquencyRangeResponse = delinquencyHelper
+                .createRange(new DelinquencyRangeRequest().minimumAgeDays(4).maximumAgeDays(30).locale(LoanTestData.LOCALE)
+                        .classification(Utils.randomStringGenerator("DLQ_R_", 10)));
         rangeIds.add(delinquencyRangeResponse.getResourceId());
-        DelinquencyRangeResponse range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
+        DelinquencyRangeResponse range = delinquencyHelper.getRange(delinquencyRangeResponse.getResourceId());
         final String classificationExpected = range.getClassification();
         log.info("Expected Delinquency Range classification after first repayment {}", classificationExpected);
 
-        PostDelinquencyBucketResponse delinquencyBucketResponse = DelinquencyBucketsHelper
+        PostDelinquencyBucketResponse delinquencyBucketResponse = delinquencyHelper
                 .createBucket(new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds));
         assertNotNull(delinquencyBucketResponse);
-        final DelinquencyBucketResponse delinquencyBucket = DelinquencyBucketsHelper.getBucket(delinquencyBucketResponse.getResourceId());
+        final DelinquencyBucketResponse delinquencyBucket = delinquencyHelper.getBucket(delinquencyBucketResponse.getResourceId());
 
         // Client and Loan account creation
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-        final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper,
-                delinquencyBucket.getId(), null);
+        final Long clientId = createClient(CLIENT_ACTIVATION_DATE);
+        final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(delinquencyBucket.getId(), null);
         assertNotNull(getLoanProductsProductResponse);
         log.info("Loan Product Bucket Name: {}", getLoanProductsProductResponse.getDelinquencyBucket().getName());
         assertEquals(getLoanProductsProductResponse.getDelinquencyBucket().getName(), delinquencyBucket.getName());
@@ -624,12 +587,9 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
         String operationDate = Utils.dateFormatter.format(transactionDate);
 
         // Create Loan Account
-        final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                getLoanProductsProductResponse.getId().toString(), operationDate, null);
+        final Long loanId = createLoanAccount(clientId, getLoanProductsProductResponse.getId(), operationDate, null);
 
-        GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        loanTransactionHelper.printRepaymentSchedule(getLoansLoanIdResponse);
-        loanTransactionHelper.printDelinquencyData(getLoansLoanIdResponse);
+        GetLoansLoanIdResponse getLoansLoanIdResponse = getLoanDetails(loanId);
 
         log.info("Loan Delinquency Range after Disbursement in null? {}", (getLoansLoanIdResponse.getDelinquencyRange() == null));
         assertNotNull(getLoansLoanIdResponse);
@@ -638,21 +598,17 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
         // First Loan Delinquency Classification after Disbursement command
         assertEquals(getLoansLoanIdResponse.getDelinquencyRange().getClassification(), classificationExpected);
 
-        loanTransactionHelper.printRepaymentSchedule(getLoansLoanIdResponse);
-
         // Apply a repayment to get a full paid installment
         operationDate = Utils.dateFormatter.format(todaysDate);
-        PostLoansLoanIdTransactionsResponse loansLoanIdTransactions = loanTransactionHelper.makeLoanRepayment(operationDate, 1050.0f,
-                loanId);
+        PostLoansLoanIdTransactionsResponse loansLoanIdTransactions = makeLoanRepayment(loanId, "repayment", operationDate, 1050.0);
         assertNotNull(loansLoanIdTransactions);
         log.info("Loan repayment transaction id {}", loansLoanIdTransactions.getResourceId());
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+        getLoansLoanIdResponse = getLoanDetails(loanId);
         log.info("Loan Delinquency Range after Repayment {}", getLoansLoanIdResponse.getDelinquencyRange());
         // Loan Delinquency Classification removed after Repayment because the installment is fully paid
         assertNull(getLoansLoanIdResponse.getDelinquencyRange());
 
-        ArrayList<GetDelinquencyTagHistoryResponse> getDelinquencyTagsHistory = loanTransactionHelper.getLoanDelinquencyTags(requestSpec,
-                responseSpec, loanId);
+        List<GetDelinquencyTagHistoryResponse> getDelinquencyTagsHistory = getLoanDelinquencyTags(loanId);
         assertNotNull(getDelinquencyTagsHistory);
         log.info("Delinquency Tag History items {}", getDelinquencyTagsHistory.size());
         log.info("Delinquency Tag Item with Lifted On {}", getDelinquencyTagsHistory.get(0).getLiftedOnDate());
@@ -662,16 +618,16 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
         log.info("Loan Id {} with Loan status {}", getLoansLoanIdResponse.getId(), getLoansLoanIdResponse.getStatus().getCode());
 
         // Reverse the Previous Loan Repayment
-        PostLoansLoanIdTransactionsResponse loansLoanIdReverseTransactions = loanTransactionHelper.reverseLoanTransaction(loanId,
-                loansLoanIdTransactions.getResourceId(), operationDate, responseSpec);
+        PostLoansLoanIdTransactionsResponse loansLoanIdReverseTransactions = reverseLoanTransaction(loanId,
+                loansLoanIdTransactions.getResourceId(), operationDate);
         assertNotNull(loansLoanIdReverseTransactions);
         log.info("Loan repayment reverse transaction id {}", loansLoanIdReverseTransactions.getResourceId());
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+        getLoansLoanIdResponse = getLoanDetails(loanId);
         log.info("Loan Delinquency Range after Reverse Repayment {}", getLoansLoanIdResponse.getDelinquencyRange());
         // Loan Delinquency Classification goes back after Repayment because the installment is not paid
         assertEquals(getLoansLoanIdResponse.getDelinquencyRange().getClassification(), classificationExpected);
 
-        getDelinquencyTagsHistory = loanTransactionHelper.getLoanDelinquencyTags(requestSpec, responseSpec, loanId);
+        getDelinquencyTagsHistory = getLoanDelinquencyTags(loanId);
         assertNotNull(getDelinquencyTagsHistory);
         log.info("Delinquency Tag History items {}", getDelinquencyTagsHistory.size());
         log.info("Delinquency Tag Item with Lifted On {}", getDelinquencyTagsHistory.get(1).getLiftedOnDate());
@@ -685,43 +641,39 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void testLoanClassificationJob() {
         try {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+            updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
 
             LocalDate businessDate = Utils.getLocalDateOfTenant();
             businessDate = businessDate.minusDays(37);
             log.info("Current date {}", businessDate);
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, businessDate);
-
-            final LoanTransactionHelper loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-            final SchedulerJobHelper schedulerJobHelper = new SchedulerJobHelper(requestSpec);
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), dateTimeFormatter.format(businessDate));
 
             ArrayList<Long> rangeIds = new ArrayList<>();
             // First Range
-            PostDelinquencyRangeResponse delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                    .minimumAgeDays(1).maximumAgeDays(3).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+            PostDelinquencyRangeResponse delinquencyRangeResponse = delinquencyHelper
+                    .createRange(new DelinquencyRangeRequest().minimumAgeDays(1).maximumAgeDays(3).locale(LoanTestData.LOCALE)
+                            .classification(Utils.randomStringGenerator("DLQ_R_", 10)));
             rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-            DelinquencyRangeResponse range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
+            DelinquencyRangeResponse range = delinquencyHelper.getRange(delinquencyRangeResponse.getResourceId());
 
             // Second Range
-            delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(4)
-                    .maximumAgeDays(60).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+            delinquencyRangeResponse = delinquencyHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(4).maximumAgeDays(60)
+                    .locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
             rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-            range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
+            range = delinquencyHelper.getRange(delinquencyRangeResponse.getResourceId());
             final String classificationExpected = range.getClassification();
             log.info("Expected Delinquency Range classification {}", classificationExpected);
 
-            PostDelinquencyBucketResponse delinquencyBucketResponse = DelinquencyBucketsHelper
+            PostDelinquencyBucketResponse delinquencyBucketResponse = delinquencyHelper
                     .createBucket(new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds));
-            final DelinquencyBucketResponse delinquencyBucket = DelinquencyBucketsHelper
-                    .getBucket(delinquencyBucketResponse.getResourceId());
+            final DelinquencyBucketResponse delinquencyBucket = delinquencyHelper.getBucket(delinquencyBucketResponse.getResourceId());
 
             // Client and Loan account creation
-            final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper,
-                    delinquencyBucket.getId(), null);
+            final Long clientId = createClient(CLIENT_ACTIVATION_DATE);
+            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(delinquencyBucket.getId(), null);
             assertNotNull(getLoanProductsProductResponse);
             log.info("Loan Product Bucket Name: {}", getLoanProductsProductResponse.getDelinquencyBucket().getName());
             assertEquals(getLoanProductsProductResponse.getDelinquencyBucket().getName(), delinquencyBucket.getName());
@@ -732,31 +684,26 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
             String operationDate = Utils.dateFormatter.format(transactionDate);
 
             // Create Loan Account
-            final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                    getLoanProductsProductResponse.getId().toString(), operationDate, null);
+            final Long loanId = createLoanAccount(clientId, getLoanProductsProductResponse.getId(), operationDate, null);
 
             // Run first time the Job
             final String jobName = "Loan Delinquency Classification";
-            schedulerJobHelper.executeAndAwaitJob(jobName);
+            schedulerHelper.executeAndAwaitJob(jobName);
 
             // Get loan details expecting to have not a delinquency classification
-            GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-            loanTransactionHelper.printDelinquencyData(getLoansLoanIdResponse);
+            GetLoansLoanIdResponse getLoansLoanIdResponse = getLoanDetails(loanId);
             final DelinquencyRangeData firstTestCase = getLoansLoanIdResponse.getDelinquencyRange();
             log.info("Loan Delinquency Range is null {}", (firstTestCase == null));
-            loanTransactionHelper.printRepaymentSchedule(getLoansLoanIdResponse);
 
             // Move the Business date to get older the loan and to have an overdue loan
             businessDate = businessDate.plusMonths(1);
             log.info("Current date {}", businessDate);
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, businessDate);
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), dateTimeFormatter.format(businessDate));
             // Run Second time the Job
-            schedulerJobHelper.executeAndAwaitJob(jobName);
+            schedulerHelper.executeAndAwaitJob(jobName);
 
             // Get loan details expecting to have a delinquency classification
-            getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-            loanTransactionHelper.printRepaymentSchedule(getLoansLoanIdResponse);
-            loanTransactionHelper.printDelinquencyData(getLoansLoanIdResponse);
+            getLoansLoanIdResponse = getLoanDetails(loanId);
 
             final DelinquencyRangeData secondTestCase = getLoansLoanIdResponse.getDelinquencyRange();
             assertNotNull(secondTestCase);
@@ -770,7 +717,7 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(secondTestCase.getClassification(), classificationExpected);
 
         } finally {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+            updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(false));
         }
     }
@@ -778,41 +725,37 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void testLoanClassificationStepAsPartOfCOB() {
         try {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+            updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
 
             LocalDate bussinesLocalDate = Utils.getDateAsLocalDate("01 April 2012");
             log.info("Current date {}", bussinesLocalDate);
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, bussinesLocalDate);
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), dateTimeFormatter.format(bussinesLocalDate));
 
             // Given
-            final LoanTransactionHelper loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-            final SchedulerJobHelper schedulerJobHelper = new SchedulerJobHelper(requestSpec);
-
             ArrayList<Long> rangeIds = new ArrayList<>();
             // First Range
-            PostDelinquencyRangeResponse delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                    .minimumAgeDays(1).maximumAgeDays(3).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+            PostDelinquencyRangeResponse delinquencyRangeResponse = delinquencyHelper
+                    .createRange(new DelinquencyRangeRequest().minimumAgeDays(1).maximumAgeDays(3).locale(LoanTestData.LOCALE)
+                            .classification(Utils.randomStringGenerator("DLQ_R_", 10)));
             rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-            DelinquencyRangeResponse range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
+            DelinquencyRangeResponse range = delinquencyHelper.getRange(delinquencyRangeResponse.getResourceId());
             final String classificationExpected = range.getClassification();
             // Second Range
-            delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(4)
-                    .maximumAgeDays(60).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+            delinquencyRangeResponse = delinquencyHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(4).maximumAgeDays(60)
+                    .locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
             rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-            range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
+            range = delinquencyHelper.getRange(delinquencyRangeResponse.getResourceId());
 
-            PostDelinquencyBucketResponse delinquencyBucketResponse = DelinquencyBucketsHelper
+            PostDelinquencyBucketResponse delinquencyBucketResponse = delinquencyHelper
                     .createBucket(new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds));
-            final DelinquencyBucketResponse delinquencyBucket = DelinquencyBucketsHelper
-                    .getBucket(delinquencyBucketResponse.getResourceId());
+            final DelinquencyBucketResponse delinquencyBucket = delinquencyHelper.getBucket(delinquencyBucketResponse.getResourceId());
 
             // Client and Loan account creation
-            final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper,
-                    delinquencyBucket.getId(), null);
+            final Long clientId = createClient(CLIENT_ACTIVATION_DATE);
+            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(delinquencyBucket.getId(), null);
             assertNotNull(getLoanProductsProductResponse);
             log.info("Loan Product Bucket Name: {}", getLoanProductsProductResponse.getDelinquencyBucket().getName());
             assertEquals(getLoanProductsProductResponse.getDelinquencyBucket().getName(), delinquencyBucket.getName());
@@ -822,12 +765,11 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
             String operationDate = Utils.dateFormatter.format(transactionDate);
 
             // Create Loan Account
-            final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                    getLoanProductsProductResponse.getId().toString(), operationDate, null);
+            final Long loanId = createLoanAccount(clientId, getLoanProductsProductResponse.getId(), operationDate, null);
 
             // COB Step Validation
-            final JobBusinessStepConfigData jobBusinessStepConfigData = BusinessStepConfigurationHelper
-                    .getConfiguredBusinessStepsByJobName(requestSpec, responseSpec, BusinessConfigurationApiTest.LOAN_JOB_NAME);
+            final JobBusinessStepConfigData jobBusinessStepConfigData = businessStepHelper
+                    .getConfiguredBusinessStepsByJobName(BusinessConfigurationApiTest.LOAN_JOB_NAME);
             assertNotNull(jobBusinessStepConfigData);
             assertEquals(BusinessConfigurationApiTest.LOAN_JOB_NAME, jobBusinessStepConfigData.getJobName());
             assertTrue(jobBusinessStepConfigData.getBusinessSteps().size() > 0);
@@ -835,31 +777,22 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
                     businessStep -> BusinessConfigurationApiTest.LOAN_DELINQUENCY_CLASSIFICATION.equals(businessStep.getStepName())));
 
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
 
             // Get loan details expecting to have not a delinquency classification
-            GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+            GetLoansLoanIdResponse getLoansLoanIdResponse = getLoanDetails(loanId);
             final DelinquencyRangeData firstTestCase = getLoansLoanIdResponse.getDelinquencyRange();
             log.info("Loan Delinquency Range is null {}", (firstTestCase == null));
-            GetLoansLoanIdRepaymentSchedule getLoanRepaymentSchedule = getLoansLoanIdResponse.getRepaymentSchedule();
-            if (getLoanRepaymentSchedule != null) {
-                log.info("Loan with {} periods", getLoanRepaymentSchedule.getPeriods().size());
-                for (GetLoansLoanIdRepaymentPeriod period : getLoanRepaymentSchedule.getPeriods()) {
-                    log.info("Period number {} for due date {} and outstanding {}", period.getPeriod(), period.getDueDate(),
-                            period.getTotalOutstandingForPeriod());
-                }
-            }
 
             // Move the Business date to get older the loan and to have an overdue loan
             bussinesLocalDate = bussinesLocalDate.plusDays(3);
 
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, bussinesLocalDate);
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), dateTimeFormatter.format(bussinesLocalDate));
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
 
             // Get loan details expecting to have a delinquency classification
-            getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-            loanTransactionHelper.printRepaymentSchedule(getLoansLoanIdResponse);
+            getLoansLoanIdResponse = getLoanDetails(loanId);
             final DelinquencyRangeData secondTestCase = getLoansLoanIdResponse.getDelinquencyRange();
             assertNotNull(secondTestCase);
             log.info("Loan Delinquency Range is {}", secondTestCase.getClassification());
@@ -871,7 +804,7 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(getLoanProductsProductResponse.getDelinquencyBucket().getName(), delinquencyBucket.getName());
             assertEquals(secondTestCase.getClassification(), classificationExpected);
         } finally {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+            updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(false));
         }
     }
@@ -879,41 +812,37 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void testLoanClassificationToValidateNegatives() {
         try {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+            updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
 
             LocalDate bussinesLocalDate = Utils.getDateAsLocalDate("01 January 2012");
             log.info("Current date {}", bussinesLocalDate);
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, bussinesLocalDate);
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), dateTimeFormatter.format(bussinesLocalDate));
 
             // Given
-            final LoanTransactionHelper loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-            final SchedulerJobHelper schedulerJobHelper = new SchedulerJobHelper(requestSpec);
-
             ArrayList<Long> rangeIds = new ArrayList<>();
             // First Range
-            PostDelinquencyRangeResponse delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                    .minimumAgeDays(1).maximumAgeDays(3).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+            PostDelinquencyRangeResponse delinquencyRangeResponse = delinquencyHelper
+                    .createRange(new DelinquencyRangeRequest().minimumAgeDays(1).maximumAgeDays(3).locale(LoanTestData.LOCALE)
+                            .classification(Utils.randomStringGenerator("DLQ_R_", 10)));
             rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-            DelinquencyRangeResponse range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
+            DelinquencyRangeResponse range = delinquencyHelper.getRange(delinquencyRangeResponse.getResourceId());
 
             // Second Range
-            delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(4)
-                    .maximumAgeDays(60).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+            delinquencyRangeResponse = delinquencyHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(4).maximumAgeDays(60)
+                    .locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
             rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-            range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
+            range = delinquencyHelper.getRange(delinquencyRangeResponse.getResourceId());
 
-            PostDelinquencyBucketResponse delinquencyBucketResponse = DelinquencyBucketsHelper
+            PostDelinquencyBucketResponse delinquencyBucketResponse = delinquencyHelper
                     .createBucket(new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds));
-            final DelinquencyBucketResponse delinquencyBucket = DelinquencyBucketsHelper
-                    .getBucket(delinquencyBucketResponse.getResourceId());
+            final DelinquencyBucketResponse delinquencyBucket = delinquencyHelper.getBucket(delinquencyBucketResponse.getResourceId());
 
             // Client and Loan account creation
-            final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper,
-                    delinquencyBucket.getId(), "3");
+            final Long clientId = createClient(CLIENT_ACTIVATION_DATE);
+            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(delinquencyBucket.getId(), 3);
             assertNotNull(getLoanProductsProductResponse);
             log.info("Loan Product Bucket Name: {}", getLoanProductsProductResponse.getDelinquencyBucket().getName());
             assertEquals(getLoanProductsProductResponse.getDelinquencyBucket().getName(), delinquencyBucket.getName());
@@ -923,24 +852,21 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
             String operationDate = Utils.dateFormatter.format(transactionDate);
 
             // Create Loan Account
-            final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                    getLoanProductsProductResponse.getId().toString(), operationDate, null);
+            final Long loanId = createLoanAccount(clientId, getLoanProductsProductResponse.getId(), operationDate, null);
 
             // Get loan details expecting to have a delinquency classification
-            GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+            GetLoansLoanIdResponse getLoansLoanIdResponse = getLoanDetails(loanId);
             final DelinquencyRangeData firstTestCase = getLoansLoanIdResponse.getDelinquencyRange();
             log.info("Loan Delinquency Range is null {}", (firstTestCase == null));
-            loanTransactionHelper.printRepaymentSchedule(getLoansLoanIdResponse);
 
             bussinesLocalDate = Utils.getDateAsLocalDate("31 January 2012");
 
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, bussinesLocalDate);
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), dateTimeFormatter.format(bussinesLocalDate));
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
 
             // Get loan details expecting to have a delinquency classification
-            getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-            loanTransactionHelper.printDelinquencyData(getLoansLoanIdResponse);
+            getLoansLoanIdResponse = getLoanDetails(loanId);
 
             GetLoansLoanIdDelinquencySummary getLoansLoanIdCollectionData = getLoansLoanIdResponse.getDelinquent();
             assertNotNull(getLoansLoanIdCollectionData);
@@ -948,7 +874,7 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(0, getLoansLoanIdCollectionData.getPastDueDays());
 
         } finally {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+            updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(false));
         }
     }
@@ -956,41 +882,37 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void testLoanClassificationUsingAgeingArrears() {
         try {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+            updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
 
             LocalDate bussinesLocalDate = Utils.getDateAsLocalDate("01 January 2012");
             log.info("Current date {}", bussinesLocalDate);
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, bussinesLocalDate);
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), dateTimeFormatter.format(bussinesLocalDate));
 
             // Given
-            final LoanTransactionHelper loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-            final SchedulerJobHelper schedulerJobHelper = new SchedulerJobHelper(requestSpec);
-
             ArrayList<Long> rangeIds = new ArrayList<>();
             // First Range
-            PostDelinquencyRangeResponse delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                    .minimumAgeDays(1).maximumAgeDays(3).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+            PostDelinquencyRangeResponse delinquencyRangeResponse = delinquencyHelper
+                    .createRange(new DelinquencyRangeRequest().minimumAgeDays(1).maximumAgeDays(3).locale(LoanTestData.LOCALE)
+                            .classification(Utils.randomStringGenerator("DLQ_R_", 10)));
             rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-            DelinquencyRangeResponse range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
+            DelinquencyRangeResponse range = delinquencyHelper.getRange(delinquencyRangeResponse.getResourceId());
 
             // Second Range
-            delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(4)
-                    .maximumAgeDays(60).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+            delinquencyRangeResponse = delinquencyHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(4).maximumAgeDays(60)
+                    .locale(LoanTestData.LOCALE).classification(Utils.randomStringGenerator("DLQ_R_", 10)));
             rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-            range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
+            range = delinquencyHelper.getRange(delinquencyRangeResponse.getResourceId());
 
-            PostDelinquencyBucketResponse delinquencyBucketResponse = DelinquencyBucketsHelper
+            PostDelinquencyBucketResponse delinquencyBucketResponse = delinquencyHelper
                     .createBucket(new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds));
-            final DelinquencyBucketResponse delinquencyBucket = DelinquencyBucketsHelper
-                    .getBucket(delinquencyBucketResponse.getResourceId());
+            final DelinquencyBucketResponse delinquencyBucket = delinquencyHelper.getBucket(delinquencyBucketResponse.getResourceId());
 
             // Client and Loan account creation
-            final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper,
-                    delinquencyBucket.getId(), "3");
+            final Long clientId = createClient(CLIENT_ACTIVATION_DATE);
+            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(delinquencyBucket.getId(), 3);
             assertNotNull(getLoanProductsProductResponse);
             log.info("Loan Product Arrears: {}", getLoanProductsProductResponse.getInArrearsTolerance());
             assertEquals(3, getLoanProductsProductResponse.getInArrearsTolerance());
@@ -1000,34 +922,30 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
             String operationDate = Utils.dateFormatter.format(transactionDate);
 
             // Create Loan Account
-            final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                    getLoanProductsProductResponse.getId().toString(), operationDate, "3");
+            final Long loanId = createLoanAccount(clientId, getLoanProductsProductResponse.getId(), operationDate, 3);
 
             // Get loan details expecting to have a delinquency classification
-            GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+            GetLoansLoanIdResponse getLoansLoanIdResponse = getLoanDetails(loanId);
             final DelinquencyRangeData firstTestCase = getLoansLoanIdResponse.getDelinquencyRange();
             log.info("Loan Delinquency Range is null {}", (firstTestCase == null));
-            loanTransactionHelper.printRepaymentSchedule(getLoansLoanIdResponse);
             log.info("Loan Account Arrears {}", getLoansLoanIdResponse.getInArrearsTolerance());
             assertEquals(3, getLoansLoanIdResponse.getInArrearsTolerance());
 
             // Update the Loan Product
-            updateLoanProduct(loanTransactionHelper, getLoanProductsProductResponse.getId(), 0);
-            GetLoanProductsProductIdResponse loanProductsProductIdResponseUpd = loanTransactionHelper
-                    .getLoanProduct(getLoanProductsProductResponse.getId().intValue());
+            updateLoanProductInArrearsTolerance(getLoanProductsProductResponse.getId(), 0);
+            GetLoanProductsProductIdResponse loanProductsProductIdResponseUpd = retrieveLoanProduct(getLoanProductsProductResponse.getId());
             assertNotNull(loanProductsProductIdResponseUpd);
             log.info("Loan Product Arrears: {}", loanProductsProductIdResponseUpd.getInArrearsTolerance());
             assertEquals(0, loanProductsProductIdResponseUpd.getInArrearsTolerance());
 
             bussinesLocalDate = Utils.getDateAsLocalDate("31 January 2012");
 
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, bussinesLocalDate);
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), dateTimeFormatter.format(bussinesLocalDate));
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
 
             // Get loan details expecting to have a delinquency classification
-            getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-            loanTransactionHelper.printDelinquencyData(getLoansLoanIdResponse);
+            getLoansLoanIdResponse = getLoanDetails(loanId);
 
             GetLoansLoanIdDelinquencySummary getLoansLoanIdCollectionData = getLoansLoanIdResponse.getDelinquent();
             assertNotNull(getLoansLoanIdCollectionData);
@@ -1035,7 +953,7 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(0, getLoansLoanIdCollectionData.getPastDueDays());
 
         } finally {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+            updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(false));
         }
     }
@@ -1043,46 +961,39 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void testDelinquencyWithPauseLettingPauseExpire() {
         runAt("01 January 2012", () -> {
-            Long delinquencyBucketId = DelinquencyBucketsHelper.createDefaultBucket();
+            Long delinquencyBucketId = delinquencyHelper.createDefaultBucket();
 
-            LocalDate bussinesLocalDate = Utils.getDateAsLocalDate("01 January 2012");
-
-            final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper,
-                    delinquencyBucketId, "3");
+            final Long clientId = createClient(CLIENT_ACTIVATION_DATE);
+            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(delinquencyBucketId, 3);
             assertNotNull(getLoanProductsProductResponse);
             log.info("Loan Product Arrears: {}", getLoanProductsProductResponse.getInArrearsTolerance());
             assertEquals(3, getLoanProductsProductResponse.getInArrearsTolerance());
 
-            final LocalDate transactionDate = bussinesLocalDate;
-            String operationDate = Utils.dateFormatter.format(transactionDate);
+            final String operationDate = "01 January 2012";
 
-            final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                    getLoanProductsProductResponse.getId().toString(), operationDate, "3");
+            final Long loanId = createLoanAccount(clientId, getLoanProductsProductResponse.getId(), operationDate, 3);
 
-            GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+            GetLoansLoanIdResponse getLoansLoanIdResponse = getLoanDetails(loanId);
             final DelinquencyRangeData firstTestCase = getLoansLoanIdResponse.getDelinquencyRange();
             log.info("Loan Delinquency Range is null {}", (firstTestCase == null));
-            loanTransactionHelper.printRepaymentSchedule(getLoansLoanIdResponse);
             log.info("Loan Account Arrears {}", getLoansLoanIdResponse.getInArrearsTolerance());
             assertEquals(3, getLoansLoanIdResponse.getInArrearsTolerance());
 
             updateBusinessDate("06 February 2012");
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
             verifyDelinquency(loanId, "01 February 2012", 1033.33, 5);
 
-            PostLoansDelinquencyActionResponse pauseDelinquencyResponse = loanTransactionHelper
-                    .createLoanDelinquencyAction(loanId.longValue(), PAUSE, "06 February 2012", "10 February 2012");
+            createLoanDelinquencyAction(loanId, PAUSE, "06 February 2012", "10 February 2012");
 
             updateBusinessDate("09 February 2012");
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
             verifyDelinquency(loanId, "01 February 2012", 1033.33, 5);
 
             updateBusinessDate("12 March 2012");
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
             verifyDelinquency(loanId, "01 February 2012", 2049.99, 36);
         });
     }
@@ -1090,49 +1001,42 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void testDelinquencyWithPauseResumeBeforePauseExpires() {
         runAt("01 January 2012", () -> {
-            Long delinquencyBucketId = DelinquencyBucketsHelper.createDefaultBucket();
-            LocalDate bussinesLocalDate = Utils.getDateAsLocalDate("01 January 2012");
+            Long delinquencyBucketId = delinquencyHelper.createDefaultBucket();
 
-            final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper,
-                    delinquencyBucketId, "3");
+            final Long clientId = createClient(CLIENT_ACTIVATION_DATE);
+            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(delinquencyBucketId, 3);
             assertNotNull(getLoanProductsProductResponse);
             log.info("Loan Product Arrears: {}", getLoanProductsProductResponse.getInArrearsTolerance());
             assertEquals(3, getLoanProductsProductResponse.getInArrearsTolerance());
 
-            final LocalDate transactionDate = bussinesLocalDate;
-            String operationDate = Utils.dateFormatter.format(transactionDate);
+            final String operationDate = "01 January 2012";
 
-            final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                    getLoanProductsProductResponse.getId().toString(), operationDate, "3");
+            final Long loanId = createLoanAccount(clientId, getLoanProductsProductResponse.getId(), operationDate, 3);
 
-            GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+            GetLoansLoanIdResponse getLoansLoanIdResponse = getLoanDetails(loanId);
             final DelinquencyRangeData firstTestCase = getLoansLoanIdResponse.getDelinquencyRange();
             log.info("Loan Delinquency Range is null {}", (firstTestCase == null));
-            loanTransactionHelper.printRepaymentSchedule(getLoansLoanIdResponse);
             log.info("Loan Account Arrears {}", getLoansLoanIdResponse.getInArrearsTolerance());
             assertEquals(3, getLoansLoanIdResponse.getInArrearsTolerance());
 
             updateBusinessDate("06 February 2012");
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
             verifyDelinquency(loanId, "01 February 2012", 1033.33, 5);
 
-            PostLoansDelinquencyActionResponse pauseDelinquencyResponse = loanTransactionHelper
-                    .createLoanDelinquencyAction(loanId.longValue(), PAUSE, "06 February 2012", "10 March 2012");
+            createLoanDelinquencyAction(loanId, PAUSE, "06 February 2012", "10 March 2012");
 
             updateBusinessDate("09 February 2012");
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
             verifyDelinquency(loanId, "01 February 2012", 1033.33, 5);
 
-            bussinesLocalDate = Utils.getDateAsLocalDate("10 February 2012");
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, bussinesLocalDate);
-            loanTransactionHelper.createLoanDelinquencyAction(loanId.longValue(), RESUME, "10 February 2012");
+            updateBusinessDate("10 February 2012");
+            createLoanDelinquencyAction(loanId, RESUME, "10 February 2012");
 
             updateBusinessDate("12 March 2012");
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
             verifyDelinquency(loanId, "01 February 2012", 2049.99, 36);
         });
     }
@@ -1141,144 +1045,121 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     public void testDelinquencyWithMultiplePausePeriods() {
         runAt("01 January 2012", () -> {
 
-            Long delinquencyBucketId = DelinquencyBucketsHelper.createDefaultBucket();
+            Long delinquencyBucketId = delinquencyHelper.createDefaultBucket();
 
-            final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper,
-                    delinquencyBucketId, "3");
+            final Long clientId = createClient(CLIENT_ACTIVATION_DATE);
+            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(delinquencyBucketId, 3);
             assertNotNull(getLoanProductsProductResponse);
             log.info("Loan Product Arrears: {}", getLoanProductsProductResponse.getInArrearsTolerance());
             assertEquals(3, getLoanProductsProductResponse.getInArrearsTolerance());
 
-            final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                    getLoanProductsProductResponse.getId().toString(), "01 January 2012", "3");
+            final Long loanId = createLoanAccount(clientId, getLoanProductsProductResponse.getId(), "01 January 2012", 3);
 
-            GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+            GetLoansLoanIdResponse getLoansLoanIdResponse = getLoanDetails(loanId);
             final DelinquencyRangeData firstTestCase = getLoansLoanIdResponse.getDelinquencyRange();
             log.info("Loan Delinquency Range is null {}", (firstTestCase == null));
-            loanTransactionHelper.printRepaymentSchedule(getLoansLoanIdResponse);
             log.info("Loan Account Arrears {}", getLoansLoanIdResponse.getInArrearsTolerance());
             assertEquals(3, getLoansLoanIdResponse.getInArrearsTolerance());
 
             // delinquent days: 5
             updateBusinessDate("06 February 2012");
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
             verifyDelinquency(loanId, "01 February 2012", 1033.33, 5);
 
             // Add delinquency pause on 06 February 2012
-            PostLoansDelinquencyActionResponse pauseDelinquencyResponse = loanTransactionHelper
-                    .createLoanDelinquencyAction(loanId.longValue(), PAUSE, "06 February 2012", "10 March 2012");
+            createLoanDelinquencyAction(loanId, PAUSE, "06 February 2012", "10 March 2012");
             updateBusinessDate("09 February 2012");
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
             verifyDelinquency(loanId, "01 February 2012", 1033.33, 5);
 
             // Add delinquency resume on 10 February 2012
             updateBusinessDate("10 February 2012");
-            loanTransactionHelper.createLoanDelinquencyAction(loanId.longValue(), RESUME, "10 February 2012");
+            createLoanDelinquencyAction(loanId, RESUME, "10 February 2012");
 
             updateBusinessDate("13 February 2012");
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
             verifyDelinquency(loanId, "01 February 2012", 1033.33, 8);
 
             // Add new pause on 13 February 2012
-            pauseDelinquencyResponse = loanTransactionHelper.createLoanDelinquencyAction(loanId.longValue(), PAUSE, "13 February 2012",
-                    "18 February 2012");
+            createLoanDelinquencyAction(loanId, PAUSE, "13 February 2012", "18 February 2012");
 
             updateBusinessDate("23 February 2012");
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
             verifyDelinquency(loanId, "01 February 2012", 1033.33, 13);
 
             // Add new pause on 23 February 2012
-            pauseDelinquencyResponse = loanTransactionHelper.createLoanDelinquencyAction(loanId.longValue(), PAUSE, "23 February 2012",
-                    "28 February 2012");
+            createLoanDelinquencyAction(loanId, PAUSE, "23 February 2012", "28 February 2012");
             updateBusinessDate("25 February 2012");
-            loanTransactionHelper.createLoanDelinquencyAction(loanId.longValue(), RESUME, "25 February 2012");
+            createLoanDelinquencyAction(loanId, RESUME, "25 February 2012");
             updateBusinessDate("12 March 2012");
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
             verifyDelinquency(loanId, "01 February 2012", 2049.99, 29);
         });
-    }
-
-    private void verifyDelinquency(Integer loanId, String date, Double amount, int delinquentDays) {
-        GetLoansLoanIdResponse getLoansLoanIdResponse;
-        GetLoansLoanIdDelinquencySummary delinquent;
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        loanTransactionHelper.printDelinquencyData(getLoansLoanIdResponse);
-        delinquent = getLoansLoanIdResponse.getDelinquent();
-        assertEquals(amount, Utils.getDoubleValue(delinquent.getDelinquentAmount()));
-        assertEquals(LocalDate.parse(date, dateTimeFormatter), delinquent.getDelinquentDate());
-        assertEquals(delinquentDays, delinquent.getDelinquentDays());
     }
 
     @Test
     public void testDelinquencyWithMultiplePausePeriodsWithInstallmentLevelDelinquency() {
         runAt("01 January 2012", () -> {
-            Long delinquencyBucketId = DelinquencyBucketsHelper.createDefaultBucket();
+            Long delinquencyBucketId = delinquencyHelper.createDefaultBucket();
 
-            final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
+            final Long clientId = createClient(CLIENT_ACTIVATION_DATE);
             final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProductWithInstallmentLevelDelinquency(
-                    loanTransactionHelper, delinquencyBucketId, "3");
+                    delinquencyBucketId, 3);
             assertNotNull(getLoanProductsProductResponse);
             log.info("Loan Product Arrears: {}", getLoanProductsProductResponse.getInArrearsTolerance());
             assertEquals(3, getLoanProductsProductResponse.getInArrearsTolerance());
 
-            final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                    getLoanProductsProductResponse.getId().toString(), "01 January 2012", "3");
+            final Long loanId = createLoanAccount(clientId, getLoanProductsProductResponse.getId(), "01 January 2012", 3);
 
-            GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+            GetLoansLoanIdResponse getLoansLoanIdResponse = getLoanDetails(loanId);
             final DelinquencyRangeData firstTestCase = getLoansLoanIdResponse.getDelinquencyRange();
             log.info("Loan Delinquency Range is null {}", (firstTestCase == null));
-            loanTransactionHelper.printRepaymentSchedule(getLoansLoanIdResponse);
             log.info("Loan Account Arrears {}", getLoansLoanIdResponse.getInArrearsTolerance());
             assertEquals(3, getLoansLoanIdResponse.getInArrearsTolerance());
 
             // delinquent days: 5
             updateBusinessDate("06 February 2012");
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
             verifyDelinquency(loanId, "01 February 2012", 1033.33, 5);
 
-            PostLoansDelinquencyActionResponse pauseDelinquencyResponse = loanTransactionHelper
-                    .createLoanDelinquencyAction(loanId.longValue(), PAUSE, "06 February 2012", "10 March 2012");
+            createLoanDelinquencyAction(loanId, PAUSE, "06 February 2012", "10 March 2012");
 
             updateBusinessDate("09 February 2012");
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
             verifyDelinquency(loanId, "01 February 2012", 1033.33, 5);
 
             updateBusinessDate("10 February 2012");
-            loanTransactionHelper.createLoanDelinquencyAction(loanId.longValue(), RESUME, "10 February 2012");
+            createLoanDelinquencyAction(loanId, RESUME, "10 February 2012");
 
             updateBusinessDate("13 February 2012");
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
             verifyDelinquency(loanId, "01 February 2012", 1033.33, 8);
 
-            pauseDelinquencyResponse = loanTransactionHelper.createLoanDelinquencyAction(loanId.longValue(), PAUSE, "13 February 2012",
-                    "18 February 2012");
+            createLoanDelinquencyAction(loanId, PAUSE, "13 February 2012", "18 February 2012");
 
             updateBusinessDate("23 February 2012");
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
             verifyDelinquency(loanId, "01 February 2012", 1033.33, 13);
 
-            pauseDelinquencyResponse = loanTransactionHelper.createLoanDelinquencyAction(loanId.longValue(), PAUSE, "23 February 2012",
-                    "28 February 2012");
+            createLoanDelinquencyAction(loanId, PAUSE, "23 February 2012", "28 February 2012");
 
             updateBusinessDate("25 February 2012");
-            loanTransactionHelper.createLoanDelinquencyAction(loanId.longValue(), RESUME, "25 February 2012");
+            createLoanDelinquencyAction(loanId, RESUME, "25 February 2012");
 
             updateBusinessDate("14 March 2012");
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
 
-            getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-            loanTransactionHelper.printDelinquencyData(getLoansLoanIdResponse);
+            getLoansLoanIdResponse = getLoanDetails(loanId);
             GetLoansLoanIdDelinquencySummary delinquent = getLoansLoanIdResponse.getDelinquent();
 
             SoftAssertions softly = new SoftAssertions();
@@ -1308,23 +1189,21 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     public void testLoanClassificationOnlyForActiveLoan() {
 
         // Given
-        final LoanTransactionHelper loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-
         ArrayList<Long> rangeIds = new ArrayList<>();
         // First Range
-        PostDelinquencyRangeResponse delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                .minimumAgeDays(4).maximumAgeDays(30).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+        PostDelinquencyRangeResponse delinquencyRangeResponse = delinquencyHelper
+                .createRange(new DelinquencyRangeRequest().minimumAgeDays(4).maximumAgeDays(30).locale(LoanTestData.LOCALE)
+                        .classification(Utils.randomStringGenerator("DLQ_R_", 10)));
         rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-        PostDelinquencyBucketResponse delinquencyBucketResponse = DelinquencyBucketsHelper
+        PostDelinquencyBucketResponse delinquencyBucketResponse = delinquencyHelper
                 .createBucket(new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds));
         assertNotNull(delinquencyBucketResponse);
-        final DelinquencyBucketResponse delinquencyBucket = DelinquencyBucketsHelper.getBucket(delinquencyBucketResponse.getResourceId());
+        final DelinquencyBucketResponse delinquencyBucket = delinquencyHelper.getBucket(delinquencyBucketResponse.getResourceId());
 
         // Client and Loan account creation
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-        final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper,
-                delinquencyBucket.getId(), null);
+        final Long clientId = createClient(CLIENT_ACTIVATION_DATE);
+        final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(delinquencyBucket.getId(), null);
         assertNotNull(getLoanProductsProductResponse);
 
         final LocalDate todaysDate = Utils.getLocalDateOfTenant();
@@ -1333,20 +1212,19 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
         String operationDate = Utils.dateFormatter.format(transactionDate);
 
         // Create Loan Application
-        final Integer loanId = createLoanApplication(loanTransactionHelper, clientId.toString(),
-                getLoanProductsProductResponse.getId().toString(), operationDate, null);
+        final Long loanId = createLoanApplication(clientId, getLoanProductsProductResponse.getId(), operationDate, null);
 
         // Evaluate default delinquent values in No Active Loan
-        GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+        GetLoansLoanIdResponse getLoansLoanIdResponse = getLoanDetails(loanId);
         assertNotNull(getLoansLoanIdResponse);
         assertNotNull(getLoansLoanIdResponse.getDelinquent());
         assertEquals(0, getLoansLoanIdResponse.getDelinquent().getDelinquentDays());
         assertEquals(0.0, Utils.getDoubleValue(getLoansLoanIdResponse.getDelinquent().getDelinquentAmount()));
 
         // Loan Disbursement
-        disburseLoanAccount(loanTransactionHelper, loanId, operationDate);
+        disburseLoanWithAmount(loanId, operationDate, PRINCIPAL_AMOUNT);
         // Evaluate default delinquent values in No Active Loan
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
+        getLoansLoanIdResponse = getLoanDetails(loanId);
         assertNotNull(getLoansLoanIdResponse);
         assertNotNull(getLoansLoanIdResponse.getDelinquent());
         assertNotEquals(0, getLoansLoanIdResponse.getDelinquent().getDelinquentDays());
@@ -1356,49 +1234,43 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void testLoanClassificationOnlyForActiveLoanWithCOB() {
         try {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+            updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
             final String operationDate = "01 January 2012";
 
             LocalDate bussinesLocalDate = Utils.getDateAsLocalDate(operationDate);
             log.info("Current date {}", bussinesLocalDate);
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, bussinesLocalDate);
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), dateTimeFormatter.format(bussinesLocalDate));
 
             // Given
-            final LoanTransactionHelper loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-            final SchedulerJobHelper schedulerJobHelper = new SchedulerJobHelper(requestSpec);
-
             ArrayList<Long> rangeIds = new ArrayList<>();
             // First Range
-            PostDelinquencyRangeResponse delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                    .minimumAgeDays(4).maximumAgeDays(30).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+            PostDelinquencyRangeResponse delinquencyRangeResponse = delinquencyHelper
+                    .createRange(new DelinquencyRangeRequest().minimumAgeDays(4).maximumAgeDays(30).locale(LoanTestData.LOCALE)
+                            .classification(Utils.randomStringGenerator("DLQ_R_", 10)));
             rangeIds.add(delinquencyRangeResponse.getResourceId());
 
-            PostDelinquencyBucketResponse delinquencyBucketResponse = DelinquencyBucketsHelper
+            PostDelinquencyBucketResponse delinquencyBucketResponse = delinquencyHelper
                     .createBucket(new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds));
             assertNotNull(delinquencyBucketResponse);
-            final DelinquencyBucketResponse delinquencyBucket = DelinquencyBucketsHelper
-                    .getBucket(delinquencyBucketResponse.getResourceId());
+            final DelinquencyBucketResponse delinquencyBucket = delinquencyHelper.getBucket(delinquencyBucketResponse.getResourceId());
 
             // Client creation
-            final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, operationDate);
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper,
-                    delinquencyBucket.getId(), null);
+            final Long clientId = createClient(operationDate);
+            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(delinquencyBucket.getId(), null);
             assertNotNull(getLoanProductsProductResponse);
 
             // Create Loan Application
-            final Integer loanId = createLoanApplication(loanTransactionHelper, clientId.toString(),
-                    getLoanProductsProductResponse.getId().toString(), operationDate, null);
+            final Long loanId = createLoanApplication(clientId, getLoanProductsProductResponse.getId(), operationDate, null);
 
             // run cob for business date 01 January 2012
             bussinesLocalDate = Utils.getDateAsLocalDate(operationDate);
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, bussinesLocalDate);
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), dateTimeFormatter.format(bussinesLocalDate));
             // Run the Loan inline COB Job
-            inlineLoanCOBHelper.executeInlineCOB(Long.valueOf(loanId));
+            executeInlineCOB(loanId);
 
             // Loan delinquency data
-            GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-            loanTransactionHelper.printDelinquencyData(getLoansLoanIdResponse);
+            GetLoansLoanIdResponse getLoansLoanIdResponse = getLoanDetails(loanId);
             GetLoansLoanIdDelinquencySummary delinquent = getLoansLoanIdResponse.getDelinquent();
             assertNotNull(getLoansLoanIdResponse);
             assertNotNull(delinquent);
@@ -1406,7 +1278,7 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
             assertEquals(0.0, Utils.getDoubleValue(delinquent.getDelinquentAmount()));
 
         } finally {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+            updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(false));
         }
     }
@@ -1414,25 +1286,22 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void testLoanDelinquencyDataWithAmountPerPortions() {
         // Given
-        final LoanTransactionHelper loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-
         ArrayList<Long> rangeIds = new ArrayList<>();
         // First Range
-        PostDelinquencyRangeResponse delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                .minimumAgeDays(4).maximumAgeDays(30).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+        PostDelinquencyRangeResponse delinquencyRangeResponse = delinquencyHelper
+                .createRange(new DelinquencyRangeRequest().minimumAgeDays(4).maximumAgeDays(30).locale(LoanTestData.LOCALE)
+                        .classification(Utils.randomStringGenerator("DLQ_R_", 10)));
         rangeIds.add(delinquencyRangeResponse.getResourceId());
-        DelinquencyRangeResponse range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
 
-        PostDelinquencyBucketResponse delinquencyBucketResponse = DelinquencyBucketsHelper
+        PostDelinquencyBucketResponse delinquencyBucketResponse = delinquencyHelper
                 .createBucket(new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds));
         assertNotNull(delinquencyBucketResponse);
-        final DelinquencyBucketResponse delinquencyBucket = DelinquencyBucketsHelper.getBucket(delinquencyBucketResponse.getResourceId());
+        final DelinquencyBucketResponse delinquencyBucket = delinquencyHelper.getBucket(delinquencyBucketResponse.getResourceId());
 
         // Client and Loan account creation
-        final Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+        final Long clientId = createClient();
 
-        final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper,
-                delinquencyBucket.getId(), null);
+        final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(delinquencyBucket.getId(), null);
         assertNotNull(getLoanProductsProductResponse);
         log.info("Loan Product Bucket Name: {}", getLoanProductsProductResponse.getDelinquencyBucket().getName());
         assertEquals(getLoanProductsProductResponse.getDelinquencyBucket().getName(), delinquencyBucket.getName());
@@ -1447,20 +1316,20 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
         final Double amount = 2000.0;
         PostLoansRequest applicationRequest = applyLoanRequest(clientId, getLoanProductsProductResponse.getId(), operationDate, amount, 4);
 
-        applicationRequest = applicationRequest.numberOfRepayments(5).loanTermFrequency(5).loanTermFrequencyType(2)
-                .interestRatePerPeriod(BigDecimal.valueOf(12.3)).interestCalculationPeriodType(DAYS).repaymentEvery(1)
-                .repaymentFrequencyType(2);
+        applicationRequest = applicationRequest.numberOfRepayments(5).loanTermFrequency(5)
+                .loanTermFrequencyType(RepaymentFrequencyType.MONTHS).interestRatePerPeriod(BigDecimal.valueOf(12.3))
+                .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY).repaymentEvery(1)
+                .repaymentFrequencyType(RepaymentFrequencyType.MONTHS);
 
-        PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
-        final Long loanId = loanResponse.getResourceId();
+        final Long loanId = applyForLoan(applicationRequest);
 
-        loanTransactionHelper.approveLoan(loanId, new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(amount))
-                .dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
+        approveLoan(loanId, new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(amount)).dateFormat(DATETIME_PATTERN)
+                .approvedOnDate(operationDate).locale(LoanTestData.LOCALE));
 
-        loanTransactionHelper.disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
-                .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(amount)).locale("en"));
+        disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate(operationDate).dateFormat(DATETIME_PATTERN)
+                .transactionAmount(BigDecimal.valueOf(amount)).locale(LoanTestData.LOCALE));
 
-        GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
         log.info("Loan Delinquency Range after Disbursement {}", loanDetails.getDelinquencyRange().getClassification());
         assertNotNull(loanDetails.getDelinquent());
         log.info("Loan Delinquency Data {} {}", loanDetails.getDelinquent().getDelinquentPrincipal(),
@@ -1471,111 +1340,151 @@ public class DelinquencyBucketsIntegrationTest extends BaseLoanIntegrationTest {
         assertEquals(new BigDecimal("246"), loanDetails.getDelinquent().getDelinquentInterest().stripTrailingZeros());
 
         // Apply a partial repayment to move only the interest
-        PostLoansLoanIdTransactionsResponse loansLoanIdTransactions = loanTransactionHelper.makeLoanRepayment(operationDate, 120f,
-                loanId.intValue());
+        PostLoansLoanIdTransactionsResponse loansLoanIdTransactions = makeLoanRepayment(loanId, "repayment", operationDate, 120.0);
         assertNotNull(loansLoanIdTransactions);
         log.info("Loan repayment transaction id {}", loansLoanIdTransactions.getResourceId());
 
-        loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+        loanDetails = getLoanDetails(loanId);
         assertNotNull(loanDetails.getDelinquent());
         assertNotNull(loanDetails.getDelinquencyRange().getClassification());
         assertEquals(new BigDecimal("312.95"), loanDetails.getDelinquent().getDelinquentPrincipal().stripTrailingZeros());
         assertEquals(new BigDecimal("126"), loanDetails.getDelinquent().getDelinquentInterest().stripTrailingZeros());
 
         // Apply a repayment to cover interest and part of the principal
-        loansLoanIdTransactions = loanTransactionHelper.makeLoanRepayment(operationDate, 330.72f, loanId.intValue());
+        loansLoanIdTransactions = makeLoanRepayment(loanId, "repayment", operationDate, 330.72);
         assertNotNull(loansLoanIdTransactions);
         log.info("Loan repayment transaction id {}", loansLoanIdTransactions.getResourceId());
 
-        loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+        loanDetails = getLoanDetails(loanId);
         assertNotNull(loanDetails.getDelinquent());
         assertNotNull(loanDetails.getDelinquencyRange().getClassification());
         assertEquals(new BigDecimal("108.23"), loanDetails.getDelinquent().getDelinquentPrincipal().stripTrailingZeros());
         assertEquals(BigDecimal.ZERO, loanDetails.getDelinquent().getDelinquentInterest().stripTrailingZeros());
 
         // Apply a repayment to cover the remain principal
-        loansLoanIdTransactions = loanTransactionHelper.makeLoanRepayment(operationDate, 108.23f, loanId.intValue());
+        loansLoanIdTransactions = makeLoanRepayment(loanId, "repayment", operationDate, 108.23);
         assertNotNull(loansLoanIdTransactions);
         log.info("Loan repayment transaction id {}", loansLoanIdTransactions.getResourceId());
         // Loan without Delinquency Classification
-        loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+        loanDetails = getLoanDetails(loanId);
         assertNotNull(loanDetails.getDelinquent());
         assertNull(loanDetails.getDelinquencyRange());
         assertEquals(BigDecimal.ZERO, loanDetails.getDelinquent().getDelinquentPrincipal().stripTrailingZeros());
         assertEquals(BigDecimal.ZERO, loanDetails.getDelinquent().getDelinquentInterest().stripTrailingZeros());
 
         // Undo the last repayment transaction we must to have pending the principal
-        PostLoansLoanIdTransactionsResponse reverseRepayment = loanTransactionHelper.reverseLoanTransaction(loanId,
-                loansLoanIdTransactions.getResourceId(), new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat("dd MMMM yyyy")
-                        .transactionDate(operationDate).transactionAmount(0.0).locale("en"));
+        PostLoansLoanIdTransactionsResponse reverseRepayment = reverseLoanTransaction(loanId, loansLoanIdTransactions.getResourceId(),
+                new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate(operationDate)
+                        .transactionAmount(0.0).locale(LoanTestData.LOCALE));
         assertNotNull(reverseRepayment);
-        loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+        loanDetails = getLoanDetails(loanId);
         assertNotNull(loanDetails.getDelinquent());
         assertNotNull(loanDetails.getDelinquencyRange().getClassification());
         assertEquals(new BigDecimal("108.23"), loanDetails.getDelinquent().getDelinquentPrincipal().stripTrailingZeros());
         assertEquals(BigDecimal.ZERO, loanDetails.getDelinquent().getDelinquentInterest().stripTrailingZeros());
     }
 
-    private GetLoanProductsProductIdResponse createLoanProduct(final LoanTransactionHelper loanTransactionHelper,
-            final Long delinquencyBucketId, final String inArrearsTolerance) {
-        final HashMap<String, Object> loanProductMap = new LoanProductTestBuilder().withDaysInMonth("30").withDaysInYear("360")
-                .withInArrearsTolerance(inArrearsTolerance).build(null, delinquencyBucketId);
-        final Integer loanProductId = loanTransactionHelper.getLoanProductId(Utils.convertToJson(loanProductMap));
-        return loanTransactionHelper.getLoanProduct(loanProductId);
+    private void verifyDelinquency(Long loanId, String date, Double amount, int delinquentDays) {
+        GetLoansLoanIdResponse getLoansLoanIdResponse = getLoanDetails(loanId);
+        GetLoansLoanIdDelinquencySummary delinquent = getLoansLoanIdResponse.getDelinquent();
+        assertEquals(amount, Utils.getDoubleValue(delinquent.getDelinquentAmount()));
+        assertEquals(LocalDate.parse(date, dateTimeFormatter), delinquent.getDelinquentDate());
+        assertEquals(delinquentDays, delinquent.getDelinquentDays());
     }
 
-    private GetLoanProductsProductIdResponse createLoanProductWithInstallmentLevelDelinquency(
-            final LoanTransactionHelper loanTransactionHelper, final Long delinquencyBucketId, final String inArrearsTolerance) {
-        final HashMap<String, Object> loanProductMap = new LoanProductTestBuilder().withInArrearsTolerance(inArrearsTolerance).build(null,
-                delinquencyBucketId);
-        loanProductMap.put("enableInstallmentLevelDelinquency", true);
-        final Integer loanProductId = loanTransactionHelper.getLoanProductId(Utils.convertToJson(loanProductMap));
-        return loanTransactionHelper.getLoanProduct(loanProductId);
+    private PostLoansDelinquencyActionResponse createLoanDelinquencyAction(Long loanId, DelinquencyAction action, String startDate,
+            String endDate) {
+        return loanHelper.createLoanDelinquencyAction(loanId, action.name(), startDate, endDate);
     }
 
-    private PutLoanProductsProductIdResponse updateLoanProduct(LoanTransactionHelper loanTransactionHelper, Long id,
+    private PostLoansDelinquencyActionResponse createLoanDelinquencyAction(Long loanId, DelinquencyAction action, String startDate) {
+        return loanHelper.createLoanDelinquencyAction(loanId, action.name(), startDate, null);
+    }
+
+    /**
+     * Mirrors the legacy {@code LoanProductTestBuilder} defaults with 30-days months / 360-days years, as used by the
+     * original RestAssured version of this test class.
+     */
+    private GetLoanProductsProductIdResponse createLoanProduct(final Long delinquencyBucketId, final Integer inArrearsTolerance) {
+        final PostLoanProductsRequest request = baseDelinquencyLoanProductRequest(delinquencyBucketId, inArrearsTolerance)
+                .daysInMonthType(DaysInMonthType.DAYS_30).daysInYearType(DaysInYearType.DAYS_360);
+        return retrieveLoanProduct(createLoanProduct(request));
+    }
+
+    private GetLoanProductsProductIdResponse createLoanProductWithInstallmentLevelDelinquency(final Long delinquencyBucketId,
             final Integer inArrearsTolerance) {
-        final PutLoanProductsProductIdRequest requestModifyLoan = new PutLoanProductsProductIdRequest()
-                .inArrearsTolerance(inArrearsTolerance);
-        return loanTransactionHelper.updateLoanProduct(id, requestModifyLoan);
+        final PostLoanProductsRequest request = baseDelinquencyLoanProductRequest(delinquencyBucketId, inArrearsTolerance)
+                .enableInstallmentLevelDelinquency(true);
+        return retrieveLoanProduct(createLoanProduct(request));
     }
 
-    private Integer createLoanApplication(final LoanTransactionHelper loanTransactionHelper, final String clientId,
-            final String loanProductId, final String operationDate, final String inArrearsTolerance) {
-        final String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal(principalAmount).withLoanTermFrequency("12")
-                .withLoanTermFrequencyAsMonths().withNumberOfRepayments("12").withRepaymentEveryAfter("1")
-                .withRepaymentFrequencyTypeAsMonths() //
-                .withInterestRatePerPeriod("2") //
-                .withExpectedDisbursementDate(operationDate) //
-                .withInterestTypeAsDecliningBalance() //
-                .withSubmittedOnDate(operationDate) //
-                .withInArrearsTolerance(inArrearsTolerance) //
-                .build(clientId, loanProductId, null);
-        final Integer loanId = loanTransactionHelper.getLoanId(loanApplicationJSON);
-        loanTransactionHelper.approveLoan(operationDate, principalAmount, loanId, null);
+    private PostLoanProductsRequest baseDelinquencyLoanProductRequest(final Long delinquencyBucketId, final Integer inArrearsTolerance) {
+        return new PostLoanProductsRequest().name(Utils.uniqueRandomStringGenerator("LOAN_PRODUCT_", 6))//
+                .shortName(Utils.uniqueRandomStringGenerator("", 4))//
+                .currencyCode("USD")//
+                .locale(LoanTestData.LOCALE)//
+                .digitsAfterDecimal(2)//
+                .inMultiplesOf(0)//
+                .principal(PRINCIPAL_AMOUNT)//
+                .minPrincipal(1000.0)//
+                .maxPrincipal(10000000.0)//
+                .numberOfRepayments(5)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(RepaymentFrequencyType.MONTHS_L)//
+                .interestRatePerPeriod(2.0)//
+                .interestRateFrequencyType(InterestRateFrequencyType.MONTHS)//
+                .amortizationType(AmortizationType.EQUAL_INSTALLMENTS)//
+                .interestType(InterestType.FLAT)//
+                .interestCalculationPeriodType(InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)//
+                .inArrearsTolerance(inArrearsTolerance)//
+                .transactionProcessingStrategyCode(DEFAULT_STRATEGY)//
+                .accountingRule(ACCOUNTING_RULE_NONE)//
+                .isEqualAmortization(false)//
+                .overdueDaysForNPA(5)//
+                .daysInMonthType(DaysInMonthType.ACTUAL)//
+                .daysInYearType(DaysInYearType.ACTUAL)//
+                .loanScheduleType(LoanScheduleType.CUMULATIVE.name())//
+                .isInterestRecalculationEnabled(false)//
+                .delinquencyBucketId(delinquencyBucketId);
+    }
+
+    private PutLoanProductsProductIdResponse updateLoanProductInArrearsTolerance(final Long productId, final Integer inArrearsTolerance) {
+        return updateLoanProduct(productId, new PutLoanProductsProductIdRequest().inArrearsTolerance(inArrearsTolerance));
+    }
+
+    /**
+     * Mirrors the legacy {@code LoanApplicationTestBuilder} application of the original test class: 10k principal over
+     * 12 monthly repayments at 2% declining-balance interest with equal-principal amortization.
+     */
+    private Long createLoanApplication(final Long clientId, final Long loanProductId, final String operationDate,
+            final Integer inArrearsTolerance) {
+        final PostLoansRequest applicationRequest = new PostLoansRequest().clientId(clientId).productId(loanProductId)
+                .principal(BigDecimal.valueOf(PRINCIPAL_AMOUNT)).loanTermFrequency(12).loanTermFrequencyType(RepaymentFrequencyType.MONTHS)
+                .numberOfRepayments(12).repaymentEvery(1).repaymentFrequencyType(RepaymentFrequencyType.MONTHS)
+                .interestRatePerPeriod(BigDecimal.valueOf(2)).interestType(InterestType.DECLINING_BALANCE)
+                .amortizationType(AmortizationType.EQUAL_PRINCIPAL)
+                .interestCalculationPeriodType(InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)
+                .transactionProcessingStrategyCode(DEFAULT_STRATEGY).expectedDisbursementDate(operationDate).submittedOnDate(operationDate)
+                .loanType("individual").dateFormat(DATETIME_PATTERN).locale(LoanTestData.LOCALE)
+                .inArrearsTolerance(inArrearsTolerance == null ? null : BigDecimal.valueOf(inArrearsTolerance));
+        final Long loanId = applyForLoan(applicationRequest);
+        approveLoan(loanId, approveLoanRequest(PRINCIPAL_AMOUNT, operationDate));
         return loanId;
     }
 
-    private void disburseLoanAccount(final LoanTransactionHelper loanTransactionHelper, final Integer loanId, final String operationDate) {
-        loanTransactionHelper.disburseLoanWithNetDisbursalAmount(operationDate, loanId, principalAmount);
-    }
-
-    private Integer createLoanAccount(final LoanTransactionHelper loanTransactionHelper, final String clientId, final String loanProductId,
-            final String operationDate, final String inArrearsTolerance) {
-        final Integer loanId = createLoanApplication(loanTransactionHelper, clientId, loanProductId, operationDate, inArrearsTolerance);
-        disburseLoanAccount(loanTransactionHelper, loanId, operationDate);
+    private Long createLoanAccount(final Long clientId, final Long loanProductId, final String operationDate,
+            final Integer inArrearsTolerance) {
+        final Long loanId = createLoanApplication(clientId, loanProductId, operationDate, inArrearsTolerance);
+        disburseLoanWithAmount(loanId, operationDate, PRINCIPAL_AMOUNT);
         return loanId;
     }
 
-    private String getChargeApplyJSON(final Integer chargeId, final String dueDate) {
-        final HashMap<String, Object> map = new HashMap<>();
-        map.put("chargeId", chargeId);
-        map.put("amount", 12.0f);
-        map.put("dueDate", dueDate);
-        map.put("dateFormat", Utils.DATE_FORMAT);
-        map.put("locale", CommonConstants.LOCALE);
-        final String chargeApplyJSON = new Gson().toJson(map);
-        log.info("{}", chargeApplyJSON);
-        return chargeApplyJSON;
+    /**
+     * Detaches the delinquency bucket from a loan product. Needs a body that carries an explicit JSON null, which the
+     * generated request model cannot produce - see {@link LoanProductCommandsApi}.
+     */
+    private void clearDelinquencyBucket(final Long loanProductId) {
+        ok(() -> FineractFeignClientHelper.getFineractFeignClient().create(LoanProductCommandsApi.class)
+                .clearDelinquencyBucket(loanProductId, new LoanProductCommandsApi.ClearDelinquencyBucketRequest()));
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/ExternalBusinessEventTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/ExternalBusinessEventTest.java
@@ -20,11 +20,6 @@ package org.apache.fineract.integrationtests;
 
 import static org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder.DEFAULT_STRATEGY;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
@@ -49,16 +44,23 @@ import org.apache.fineract.client.models.PostUpdateRescheduleLoansRequest;
 import org.apache.fineract.client.models.PutLoansLoanIdRequest;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
 import org.apache.fineract.infrastructure.event.external.data.ExternalEventResponse;
-import org.apache.fineract.integrationtests.common.BusinessStepHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignBusinessStepHelper;
+import org.apache.fineract.integrationtests.client.feign.modules.ChargeRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.AmortizationType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.DaysInMonthType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.DaysInYearType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestCalculationPeriodType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.RecalculationRestFrequencyType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.RepaymentFrequencyType;
 import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.LoanRescheduleRequestHelper;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.externalevents.ExternalEventHelper;
 import org.apache.fineract.integrationtests.common.externalevents.ExternalEventsExtension;
 import org.apache.fineract.integrationtests.common.externalevents.LoanAdjustTransactionBusinessEvent;
 import org.apache.fineract.integrationtests.common.externalevents.LoanBusinessEvent;
 import org.apache.fineract.integrationtests.common.externalevents.LoanTransactionBusinessEvent;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -69,29 +71,20 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 @Slf4j
 @ExtendWith({ ExternalEventsExtension.class })
-public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
+public class ExternalBusinessEventTest extends FeignLoanTestBase {
 
-    private static final String DATETIME_PATTERN = "dd MMMM yyyy";
+    private static final FeignBusinessStepHelper businessStepHelper = new FeignBusinessStepHelper(
+            FineractFeignClientHelper.getFineractFeignClient());
     private static PostClientsResponse client;
-    private static LoanTransactionHelper loanTransactionHelper;
     private static Long loanProductId;
-    private static ResponseSpecification responseSpec;
-    private static RequestSpecification requestSpec;
-    Long chargeId = createCharge(111.0, "USD").getResourceId();
-    private final ExternalEventHelper externalEventHelper = new ExternalEventHelper();
+    private static Long chargeId;
 
     @BeforeAll
     public static void beforeAll() {
-        Utils.initializeRESTAssured();
-        requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        requestSpec.header("Fineract-Platform-TenantId", "default");
-        responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        ClientHelper clientHelper = new ClientHelper(requestSpec, responseSpec);
-        loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-        BusinessStepHelper businessStepHelper = new BusinessStepHelper();
         client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
         loanProductId = createLoanProductPeriodicWithInterest();
+        // A single reusable charge for the whole class - the tests only reference it, they never mutate it.
+        chargeId = chargesHelper.createCharge(ChargeRequestBuilders.loanSpecifiedDueDateFee(111.0, "USD")).getResourceId();
         // setup COB Business Steps to prevent test failing due other integration test configurations
         businessStepHelper.updateSteps("LOAN_CLOSE_OF_BUSINESS", "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION",
                 "CHECK_LOAN_REPAYMENT_DUE", "CHECK_LOAN_REPAYMENT_OVERDUE", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
@@ -106,49 +99,48 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             Long loanId = applyForLoanApplicationWithInterest(client.getClientId(), loanProductId, BigDecimal.valueOf(1000), "1 March 2023",
                     "1 March 2023");
             loanIdRef.set(loanId);
-            loanTransactionHelper.approveLoan("1 March 2023", loanId.intValue());
+            approveLoan("1 March 2023", loanId.intValue());
 
             deleteAllExternalEvents();
 
-            loanTransactionHelper.disburseLoan("1 March 2023", loanId.intValue(), "400", null);
+            disburseLoan("1 March 2023", loanId.intValue(), "400", null);
 
         });
         runAt("15 March 2023", () -> {
             deleteAllExternalEvents();
 
-            loanTransactionHelper.makeLoanRepayment("15 March 2023", 125.0F, loanIdRef.get().intValue());
+            makeLoanRepayment(loanIdRef.get(), "repayment", "15 March 2023", 125.0);
 
             verifyBusinessEvents(new LoanBusinessEvent("LoanBalanceChangedBusinessEvent", "15 March 2023", 300, 400.0, 289.13));
         });
         runAt("1 April 2023", () -> {
 
-            loanTransactionHelper.disburseLoan("1 April 2023", loanIdRef.get().intValue(), "600", null);
+            disburseLoan("1 April 2023", loanIdRef.get().intValue(), "600", null);
 
         });
         runAt("15 April 2023", () -> {
             deleteAllExternalEvents();
 
-            loanTransactionHelper.makeLoanRepayment("15 April 2023", 125.0F, loanIdRef.get().intValue());
+            makeLoanRepayment(loanIdRef.get(), "repayment", "15 April 2023", 125.0);
 
             verifyBusinessEvents(new LoanBusinessEvent("LoanBalanceChangedBusinessEvent", "15 April 2023", 300, 1000.0, 758.15));
 
             deleteAllExternalEvents();
 
-            Long transactionId = loanTransactionHelper.makeLoanRepayment("15 April 2023", 1000F, loanIdRef.get().intValue())
-                    .getResourceId();
+            Long transactionId = makeLoanRepayment(loanIdRef.get(), "repayment", "15 April 2023", 1000.0).getResourceId();
             Assertions.assertNotNull(transactionId);
 
             verifyBusinessEvents(new LoanBusinessEvent("LoanBalanceChangedBusinessEvent", "15 April 2023", 700, 1000.0, 0.0));
 
             deleteAllExternalEvents();
 
-            loanTransactionHelper.reverseRepayment(loanIdRef.get().intValue(), transactionId.intValue(), "15 April 2023");
+            reverseRepayment(loanIdRef.get(), transactionId, "15 April 2023");
 
             verifyBusinessEvents(new LoanBusinessEvent("LoanBalanceChangedBusinessEvent", "15 April 2023", 300, 1000.0, 758.15));
 
             deleteAllExternalEvents();
 
-            loanTransactionHelper.makeLoanRepayment("15 April 2023", 830.22F, loanIdRef.get().intValue());
+            makeLoanRepayment(loanIdRef.get(), "repayment", "15 April 2023", 830.22);
 
             verifyBusinessEvents(new LoanBusinessEvent("LoanBalanceChangedBusinessEvent", "15 April 2023", 700, 1000.0, 0.0));
 
@@ -166,7 +158,7 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
         runAt("1 January 2021", () -> {
             externalEventHelper.enableBusinessEvent("LoanChargeAdjustmentPostBusinessEvent");
             externalEventHelper.enableBusinessEvent("LoanTransactionMakeRepaymentPostBusinessEvent");
-            PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(create4IProgressive().currencyCode("USD"));
+            PostLoanProductsResponse loanProduct = loanHelper.createLoanProduct(create4IProgressive().currencyCode("USD"));
             Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 600.0, 9.99,
                     4, null);
             Assertions.assertNotNull(loanId);
@@ -177,11 +169,10 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
 
             deleteAllExternalEvents();
             // resourceId is chargeId
-            Long transactionId = loanTransactionHelper
-                    .chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(111.0).locale("en"))
+            Long transactionId = chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(111.0).locale("en"))
                     .getSubResourceId();
 
-            List<ExternalEventResponse> allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            List<ExternalEventResponse> allExternalEvents = externalEventHelper.getAllExternalEvents();
             List<ExternalEventResponse> list = allExternalEvents.stream()
                     .filter(x -> "LoanChargeAdjustmentPostBusinessEvent".equals(x.getType())).toList();
             Assertions.assertEquals(1, list.size());
@@ -207,7 +198,7 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
         runAt("1 January 2021", () -> {
             externalEventHelper.enableBusinessEvent("LoanChargeAdjustmentPostBusinessEvent");
             externalEventHelper.enableBusinessEvent("LoanTransactionMakeRepaymentPostBusinessEvent");
-            PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(create4IProgressive().currencyCode("USD"));
+            PostLoanProductsResponse loanProduct = loanHelper.createLoanProduct(create4IProgressive().currencyCode("USD"));
             Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 600.0, 9.99,
                     4, null);
             Assertions.assertNotNull(loanId);
@@ -219,11 +210,10 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             // check first part
             deleteAllExternalEvents();
             // resourceId is chargeId
-            Long transactionId = loanTransactionHelper
-                    .chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(69.0).locale("en"))
+            Long transactionId = chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(69.0).locale("en"))
                     .getSubResourceId();
 
-            List<ExternalEventResponse> allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            List<ExternalEventResponse> allExternalEvents = externalEventHelper.getAllExternalEvents();
             List<ExternalEventResponse> list = allExternalEvents.stream()
                     .filter(x -> "LoanChargeAdjustmentPostBusinessEvent".equals(x.getType())).toList();
             Assertions.assertEquals(1, list.size());
@@ -240,11 +230,10 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             // check second part
             deleteAllExternalEvents();
             // resourceId is chargeId
-            transactionId = loanTransactionHelper
-                    .chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(42.0).locale("en"))
+            transactionId = chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(42.0).locale("en"))
                     .getSubResourceId();
 
-            allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            allExternalEvents = externalEventHelper.getAllExternalEvents();
             list = allExternalEvents.stream().filter(x -> "LoanChargeAdjustmentPostBusinessEvent".equals(x.getType())).toList();
             Assertions.assertEquals(1, list.size());
             event = list.get(0);
@@ -259,8 +248,8 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             Assertions.assertFalse((Boolean) event.getPayLoad().get("reversed"));
 
             // check that third part cannot post for that charge, because it already fully adjusted
-            Assertions.assertThrows(RuntimeException.class, () -> loanTransactionHelper.chargeAdjustment(loanId, chargeId,
-                    new PostLoansLoanIdChargesChargeIdRequest().amount(1.0).locale("en")));
+            Assertions.assertThrows(RuntimeException.class,
+                    () -> chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(1.0).locale("en")));
         });
     }
 
@@ -275,7 +264,7 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
         runAt("1 January 2021", () -> {
             externalEventHelper.enableBusinessEvent("LoanChargeAdjustmentPostBusinessEvent");
             externalEventHelper.enableBusinessEvent("LoanTransactionMakeRepaymentPostBusinessEvent");
-            PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(create4IProgressive().currencyCode("USD"));
+            PostLoanProductsResponse loanProduct = loanHelper.createLoanProduct(create4IProgressive().currencyCode("USD"));
             Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 600.0, 9.99,
                     4, null);
             Assertions.assertNotNull(loanId);
@@ -286,9 +275,9 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
 
             // check repayment
             deleteAllExternalEvents();
-            Long transactionId = loanTransactionHelper.makeLoanRepayment("01 January 2021", 300.0F, loanId.intValue()).getResourceId();
+            Long transactionId = makeLoanRepayment(loanId, "repayment", "01 January 2021", 300.0).getResourceId();
 
-            List<ExternalEventResponse> allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            List<ExternalEventResponse> allExternalEvents = externalEventHelper.getAllExternalEvents();
             List<ExternalEventResponse> list = allExternalEvents.stream()
                     .filter(x -> "LoanTransactionMakeRepaymentPostBusinessEvent".equals(x.getType())).toList();
             Assertions.assertEquals(1, list.size());
@@ -307,11 +296,10 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             // check first part
             deleteAllExternalEvents();
             // resourceId is chargeId
-            transactionId = loanTransactionHelper
-                    .chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(69.0).locale("en"))
+            transactionId = chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(69.0).locale("en"))
                     .getSubResourceId();
 
-            allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            allExternalEvents = externalEventHelper.getAllExternalEvents();
             list = allExternalEvents.stream().filter(x -> "LoanChargeAdjustmentPostBusinessEvent".equals(x.getType())).toList();
             Assertions.assertEquals(1, list.size());
             event = list.get(0);
@@ -322,11 +310,10 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             // check second part
             deleteAllExternalEvents();
             // resourceId is chargeId
-            transactionId = loanTransactionHelper
-                    .chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(42.0).locale("en"))
+            transactionId = chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(42.0).locale("en"))
                     .getSubResourceId();
 
-            allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            allExternalEvents = externalEventHelper.getAllExternalEvents();
             list = allExternalEvents.stream().filter(x -> "LoanChargeAdjustmentPostBusinessEvent".equals(x.getType())).toList();
             Assertions.assertEquals(1, list.size());
             event = list.get(0);
@@ -335,8 +322,8 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             Assertions.assertEquals(0, ((List<?>) loanChargePaidByList).size());
 
             // check that third part cannot post for that charge, because it already fully adjusted
-            Assertions.assertThrows(RuntimeException.class, () -> loanTransactionHelper.chargeAdjustment(loanId, chargeId,
-                    new PostLoansLoanIdChargesChargeIdRequest().amount(1.0).locale("en")));
+            Assertions.assertThrows(RuntimeException.class,
+                    () -> chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(1.0).locale("en")));
         });
     }
 
@@ -350,7 +337,7 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
         runAt("1 January 2021", () -> {
             externalEventHelper.enableBusinessEvent("LoanChargeAdjustmentPostBusinessEvent");
             externalEventHelper.enableBusinessEvent("LoanTransactionMakeRepaymentPostBusinessEvent");
-            PostLoanProductsResponse loanProduct = loanProductHelper
+            PostLoanProductsResponse loanProduct = loanHelper
                     .createLoanProduct(create4IProgressive().isInterestRecalculationEnabled(false).currencyCode("USD"));
             Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 600.0, 9.99,
                     4, null);
@@ -362,11 +349,10 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
 
             deleteAllExternalEvents();
             // resourceId is chargeId
-            Long transactionId = loanTransactionHelper
-                    .chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(111.0).locale("en"))
+            Long transactionId = chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(111.0).locale("en"))
                     .getSubResourceId();
 
-            List<ExternalEventResponse> allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            List<ExternalEventResponse> allExternalEvents = externalEventHelper.getAllExternalEvents();
             List<ExternalEventResponse> list = allExternalEvents.stream()
                     .filter(x -> "LoanChargeAdjustmentPostBusinessEvent".equals(x.getType())).toList();
             Assertions.assertEquals(1, list.size());
@@ -392,7 +378,7 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
         runAt("1 January 2021", () -> {
             externalEventHelper.enableBusinessEvent("LoanChargeAdjustmentPostBusinessEvent");
             externalEventHelper.enableBusinessEvent("LoanTransactionMakeRepaymentPostBusinessEvent");
-            PostLoanProductsResponse loanProduct = loanProductHelper
+            PostLoanProductsResponse loanProduct = loanHelper
                     .createLoanProduct(create4IProgressive().isInterestRecalculationEnabled(false).currencyCode("USD"));
             Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 600.0, 9.99,
                     4, null);
@@ -405,11 +391,10 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             // check first part
             deleteAllExternalEvents();
             // resourceId is chargeId
-            Long transactionId = loanTransactionHelper
-                    .chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(69.0).locale("en"))
+            Long transactionId = chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(69.0).locale("en"))
                     .getSubResourceId();
 
-            List<ExternalEventResponse> allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            List<ExternalEventResponse> allExternalEvents = externalEventHelper.getAllExternalEvents();
             List<ExternalEventResponse> list = allExternalEvents.stream()
                     .filter(x -> "LoanChargeAdjustmentPostBusinessEvent".equals(x.getType())).toList();
             Assertions.assertEquals(1, list.size());
@@ -426,11 +411,10 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             // check second part
             deleteAllExternalEvents();
             // resourceId is chargeId
-            transactionId = loanTransactionHelper
-                    .chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(42.0).locale("en"))
+            transactionId = chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(42.0).locale("en"))
                     .getSubResourceId();
 
-            allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            allExternalEvents = externalEventHelper.getAllExternalEvents();
             list = allExternalEvents.stream().filter(x -> "LoanChargeAdjustmentPostBusinessEvent".equals(x.getType())).toList();
             Assertions.assertEquals(1, list.size());
             event = list.get(0);
@@ -444,8 +428,8 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             Assertions.assertEquals(transactionId, toLong(chargePaidBy.get("transactionId")));
 
             // check that third part cannot post for that charge, because it already fully adjusted
-            Assertions.assertThrows(RuntimeException.class, () -> loanTransactionHelper.chargeAdjustment(loanId, chargeId,
-                    new PostLoansLoanIdChargesChargeIdRequest().amount(1.0).locale("en")));
+            Assertions.assertThrows(RuntimeException.class,
+                    () -> chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(1.0).locale("en")));
         });
     }
 
@@ -460,7 +444,7 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
         runAt("1 January 2021", () -> {
             externalEventHelper.enableBusinessEvent("LoanChargeAdjustmentPostBusinessEvent");
             externalEventHelper.enableBusinessEvent("LoanTransactionMakeRepaymentPostBusinessEvent");
-            PostLoanProductsResponse loanProduct = loanProductHelper
+            PostLoanProductsResponse loanProduct = loanHelper
                     .createLoanProduct(create4IProgressive().isInterestRecalculationEnabled(false).currencyCode("USD"));
             Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 600.0, 9.99,
                     4, null);
@@ -472,9 +456,9 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
 
             // check repayment
             deleteAllExternalEvents();
-            Long transactionId = loanTransactionHelper.makeLoanRepayment("01 January 2021", 300.0F, loanId.intValue()).getResourceId();
+            Long transactionId = makeLoanRepayment(loanId, "repayment", "01 January 2021", 300.0).getResourceId();
 
-            List<ExternalEventResponse> allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            List<ExternalEventResponse> allExternalEvents = externalEventHelper.getAllExternalEvents();
             List<ExternalEventResponse> list = allExternalEvents.stream()
                     .filter(x -> "LoanTransactionMakeRepaymentPostBusinessEvent".equals(x.getType())).toList();
             Assertions.assertEquals(1, list.size());
@@ -493,11 +477,10 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             // check first part
             deleteAllExternalEvents();
             // resourceId is chargeId
-            transactionId = loanTransactionHelper
-                    .chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(69.0).locale("en"))
+            transactionId = chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(69.0).locale("en"))
                     .getSubResourceId();
 
-            allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            allExternalEvents = externalEventHelper.getAllExternalEvents();
             list = allExternalEvents.stream().filter(x -> "LoanChargeAdjustmentPostBusinessEvent".equals(x.getType())).toList();
             Assertions.assertEquals(1, list.size());
             event = list.get(0);
@@ -508,11 +491,10 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             // check second part
             deleteAllExternalEvents();
             // resourceId is chargeId
-            transactionId = loanTransactionHelper
-                    .chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(42.0).locale("en"))
+            transactionId = chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(42.0).locale("en"))
                     .getSubResourceId();
 
-            allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            allExternalEvents = externalEventHelper.getAllExternalEvents();
             list = allExternalEvents.stream().filter(x -> "LoanChargeAdjustmentPostBusinessEvent".equals(x.getType())).toList();
             Assertions.assertEquals(1, list.size());
             event = list.get(0);
@@ -521,8 +503,8 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             Assertions.assertEquals(0, ((List<?>) loanChargePaidByList).size());
 
             // check that third part cannot post for that charge, because it already fully adjusted
-            Assertions.assertThrows(RuntimeException.class, () -> loanTransactionHelper.chargeAdjustment(loanId, chargeId,
-                    new PostLoansLoanIdChargesChargeIdRequest().amount(1.0).locale("en")));
+            Assertions.assertThrows(RuntimeException.class,
+                    () -> chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(1.0).locale("en")));
         });
     }
 
@@ -535,7 +517,7 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
         runAt("1 January 2021", () -> {
             externalEventHelper.enableBusinessEvent("LoanChargeAdjustmentPostBusinessEvent");
             externalEventHelper.enableBusinessEvent("LoanTransactionMakeRepaymentPostBusinessEvent");
-            PostLoanProductsResponse loanProduct = loanProductHelper
+            PostLoanProductsResponse loanProduct = loanHelper
                     .createLoanProduct(create4IProgressive().isInterestRecalculationEnabled(false).currencyCode("USD"));
             Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 600.0, 0.0, 4,
                     null);
@@ -547,11 +529,10 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
 
             deleteAllExternalEvents();
             // resourceId is chargeId
-            Long transactionId = loanTransactionHelper
-                    .chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(111.0).locale("en"))
+            Long transactionId = chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(111.0).locale("en"))
                     .getSubResourceId();
 
-            List<ExternalEventResponse> allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            List<ExternalEventResponse> allExternalEvents = externalEventHelper.getAllExternalEvents();
             List<ExternalEventResponse> list = allExternalEvents.stream()
                     .filter(x -> "LoanChargeAdjustmentPostBusinessEvent".equals(x.getType())).toList();
             Assertions.assertEquals(1, list.size());
@@ -576,7 +557,7 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
         runAt("1 January 2021", () -> {
             externalEventHelper.enableBusinessEvent("LoanChargeAdjustmentPostBusinessEvent");
             externalEventHelper.enableBusinessEvent("LoanTransactionMakeRepaymentPostBusinessEvent");
-            PostLoanProductsResponse loanProduct = loanProductHelper
+            PostLoanProductsResponse loanProduct = loanHelper
                     .createLoanProduct(create4IProgressive().isInterestRecalculationEnabled(false).currencyCode("USD"));
             Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 600.0, 0.0, 4,
                     null);
@@ -589,11 +570,10 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             // check first part
             deleteAllExternalEvents();
             // resourceId is chargeId
-            Long transactionId = loanTransactionHelper
-                    .chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(69.0).locale("en"))
+            Long transactionId = chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(69.0).locale("en"))
                     .getSubResourceId();
 
-            List<ExternalEventResponse> allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            List<ExternalEventResponse> allExternalEvents = externalEventHelper.getAllExternalEvents();
             List<ExternalEventResponse> list = allExternalEvents.stream()
                     .filter(x -> "LoanChargeAdjustmentPostBusinessEvent".equals(x.getType())).toList();
             Assertions.assertEquals(1, list.size());
@@ -610,11 +590,10 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             // check second part
             deleteAllExternalEvents();
             // resourceId is chargeId
-            transactionId = loanTransactionHelper
-                    .chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(42.0).locale("en"))
+            transactionId = chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(42.0).locale("en"))
                     .getSubResourceId();
 
-            allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            allExternalEvents = externalEventHelper.getAllExternalEvents();
             list = allExternalEvents.stream().filter(x -> "LoanChargeAdjustmentPostBusinessEvent".equals(x.getType())).toList();
             Assertions.assertEquals(1, list.size());
             event = list.get(0);
@@ -628,8 +607,8 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             Assertions.assertEquals(transactionId, toLong(chargePaidBy.get("transactionId")));
 
             // check that third part cannot post for that charge, because it already fully adjusted
-            Assertions.assertThrows(RuntimeException.class, () -> loanTransactionHelper.chargeAdjustment(loanId, chargeId,
-                    new PostLoansLoanIdChargesChargeIdRequest().amount(1.0).locale("en")));
+            Assertions.assertThrows(RuntimeException.class,
+                    () -> chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(1.0).locale("en")));
         });
     }
 
@@ -643,7 +622,7 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
         runAt("1 January 2021", () -> {
             externalEventHelper.enableBusinessEvent("LoanChargeAdjustmentPostBusinessEvent");
             externalEventHelper.enableBusinessEvent("LoanTransactionMakeRepaymentPostBusinessEvent");
-            PostLoanProductsResponse loanProduct = loanProductHelper
+            PostLoanProductsResponse loanProduct = loanHelper
                     .createLoanProduct(create4IProgressive().isInterestRecalculationEnabled(false).currencyCode("USD"));
             Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 600.0, 0.0, 4,
                     null);
@@ -655,9 +634,9 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
 
             // check repayment
             deleteAllExternalEvents();
-            Long transactionId = loanTransactionHelper.makeLoanRepayment("01 January 2021", 300.0F, loanId.intValue()).getResourceId();
+            Long transactionId = makeLoanRepayment(loanId, "repayment", "01 January 2021", 300.0).getResourceId();
 
-            List<ExternalEventResponse> allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            List<ExternalEventResponse> allExternalEvents = externalEventHelper.getAllExternalEvents();
             List<ExternalEventResponse> list = allExternalEvents.stream()
                     .filter(x -> "LoanTransactionMakeRepaymentPostBusinessEvent".equals(x.getType())).toList();
             Assertions.assertEquals(1, list.size());
@@ -676,11 +655,10 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             // check first part
             deleteAllExternalEvents();
             // resourceId is chargeId
-            transactionId = loanTransactionHelper
-                    .chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(69.0).locale("en"))
+            transactionId = chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(69.0).locale("en"))
                     .getSubResourceId();
 
-            allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            allExternalEvents = externalEventHelper.getAllExternalEvents();
             list = allExternalEvents.stream().filter(x -> "LoanChargeAdjustmentPostBusinessEvent".equals(x.getType())).toList();
             Assertions.assertEquals(1, list.size());
             event = list.get(0);
@@ -691,11 +669,10 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             // check second part
             deleteAllExternalEvents();
             // resourceId is chargeId
-            transactionId = loanTransactionHelper
-                    .chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(42.0).locale("en"))
+            transactionId = chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(42.0).locale("en"))
                     .getSubResourceId();
 
-            allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            allExternalEvents = externalEventHelper.getAllExternalEvents();
             list = allExternalEvents.stream().filter(x -> "LoanChargeAdjustmentPostBusinessEvent".equals(x.getType())).toList();
             Assertions.assertEquals(1, list.size());
             event = list.get(0);
@@ -704,8 +681,8 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             Assertions.assertEquals(0, ((List<?>) loanChargePaidByList).size());
 
             // check that third part cannot post for that charge, because it already fully adjusted
-            Assertions.assertThrows(RuntimeException.class, () -> loanTransactionHelper.chargeAdjustment(loanId, chargeId,
-                    new PostLoansLoanIdChargesChargeIdRequest().amount(1.0).locale("en")));
+            Assertions.assertThrows(RuntimeException.class,
+                    () -> chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(1.0).locale("en")));
         });
     }
 
@@ -724,24 +701,24 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
     public void testInterestBearingProgressiveInterestRecalculationReopenDueReverseRepayment() {
         runAt("17 January 2025", () -> {
             externalEventHelper.enableBusinessEvent("LoanAdjustTransactionBusinessEvent");
-            final PostLoanProductsResponse loanProductsResponse = loanProductHelper.createLoanProduct(create4IProgressive() //
+            final PostLoanProductsResponse loanProductsResponse = loanHelper.createLoanProduct(create4IProgressive() //
                     .description("Interest bearing Progressive Loan USD, Accrual Activity Posting, NO InterestRecalculation") //
                     .enableAccrualActivityPosting(true) //
                     .daysInMonthType(DaysInMonthType.ACTUAL) //
                     .daysInYearType(DaysInYearType.ACTUAL) //
                     .isInterestRecalculationEnabled(false));//
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applyLP2ProgressiveLoanRequest(client.getClientId(),
+            PostLoansResponse postLoansResponse = loanHelper.applyForLoan(applyLP2ProgressiveLoanRequest(client.getClientId(),
                     loanProductsResponse.getResourceId(), "17 August 2024", 450.0, 25.0, 6, null));
             Long loanId = postLoansResponse.getLoanId();
             Assertions.assertNotNull(loanId);
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(450.0, "17 August 2024"));
+            approveLoan(loanId, approveLoanRequest(450.0, "17 August 2024"));
             disburseLoan(loanId, BigDecimal.valueOf(450.0), "17 August 2024");
             verifyTransactions(loanId, //
                     transaction(450.0, "Disbursement", "17 August 2024") //
             );
-            Long repaymentId = loanTransactionHelper.makeLoanRepayment("17 January 2025", 600.0f, loanId.intValue()).getResourceId();
+            Long repaymentId = makeLoanRepayment(loanId, "repayment", "17 January 2025", 600.0).getResourceId();
             Assertions.assertNotNull(repaymentId);
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getOverpaid);
             verifyTransactions(loanId, //
                     transaction(450.0, "Disbursement", "17 August 2024"), //
@@ -753,9 +730,9 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
                     transaction(4.75, "Accrual Activity", "17 December 2024"), //
                     transaction(4.99, "Accrual Activity", "17 January 2025")); //
             deleteAllExternalEvents();
-            loanTransactionHelper.reverseRepayment(loanId.intValue(), repaymentId.intValue(), "17 January 2025");
+            reverseRepayment(loanId, repaymentId, "17 January 2025");
 
-            List<ExternalEventResponse> allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            List<ExternalEventResponse> allExternalEvents = externalEventHelper.getAllExternalEvents();
             // Verify that there were no reverse-replay event
             List<ExternalEventResponse> list = allExternalEvents.stream() //
                     .filter(x -> "LoanAdjustTransactionBusinessEvent".equals(x.getType()) //
@@ -774,7 +751,7 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             Assertions.assertTrue((Boolean) ((Map) list.get(0).getPayLoad().get("transactionToAdjust")).get("reversed"));
             Assertions.assertTrue((Boolean) ((Map) list.get(1).getPayLoad().get("transactionToAdjust")).get("reversed"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getActive);
             verifyTransactions(loanId, transaction(450.0, "Disbursement", "17 August 2024"), //
                     transaction(33.52, "Accrual", "17 January 2025"), //
@@ -791,7 +768,7 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         enableLoanInterestRefundPstBusinessEvent(true);
         runAt("1 January 2021", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
+            PostLoanProductsResponse loanProduct = loanHelper
                     .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
                             .daysInYearType(DaysInYearType.ACTUAL) //
                             .supportedInterestRefundTypes(new ArrayList<>()).addSupportedInterestRefundTypesItem("MERCHANT_ISSUED_REFUND") //
@@ -808,8 +785,8 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
 
             deleteAllExternalEvents();
 
-            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = loanTransactionHelper
-                    .makeLoanRepayment("MerchantIssuedRefund", "22 January 2021", 1000F, loanId.intValue());
+            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = makeLoanRepayment(loanId, "MerchantIssuedRefund",
+                    "22 January 2021", 1000.0);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse.getResourceId());
 
@@ -827,18 +804,18 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             Long loanId = applyForLoanApplicationWithInterest(client.getClientId(), loanProductId, BigDecimal.valueOf(4000), "1 March 2023",
                     "1 March 2024");
             loanIdRef.set(loanId);
-            loanTransactionHelper.approveLoan("1 March 2024", loanId.intValue());
+            approveLoan("1 March 2024", loanId.intValue());
 
-            loanTransactionHelper.disburseLoan("1 March 2024", loanId.intValue(), "400", null);
+            disburseLoan("1 March 2024", loanId.intValue(), "400", null);
 
-            PostCreateRescheduleLoansResponse rescheduleLoansResponse = LoanRescheduleRequestHelper
-                    .createLoanRescheduleRequest(new PostCreateRescheduleLoansRequest().loanId(loanIdRef.get()).dateFormat(DATETIME_PATTERN)
+            PostCreateRescheduleLoansResponse rescheduleLoansResponse = loanHelper
+                    .createRescheduleRequest(new PostCreateRescheduleLoansRequest().loanId(loanIdRef.get()).dateFormat(DATETIME_PATTERN)
                             .locale("en").submittedOnDate("1 March 2024").newInterestRate(BigDecimal.ONE).rescheduleReasonId(1L)
                             .rescheduleFromDate("1 April 2024"));
 
             deleteAllExternalEvents();
 
-            LoanRescheduleRequestHelper.approveLoanRescheduleRequest(rescheduleLoansResponse.getResourceId(),
+            approveRescheduleRequest(rescheduleLoansResponse.getResourceId(),
                     new PostUpdateRescheduleLoansRequest().approvedOnDate("1 March 2024").locale("en").dateFormat(DATETIME_PATTERN));
 
             verifyBusinessEvents(new LoanBusinessEvent("LoanRescheduledDueAdjustScheduleBusinessEvent", "01 March 2024", 300, 400.0, 400.0,
@@ -853,7 +830,7 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
         final AtomicReference<Long> loanIdRef = new AtomicReference<>();
         final AtomicReference<Long> repaymentTransactionIdRef = new AtomicReference<>();
 
-        final PostLoanProductsResponse loanProductsResponse = loanProductHelper.createLoanProduct(create4IProgressive());
+        final PostLoanProductsResponse loanProductsResponse = loanHelper.createLoanProduct(create4IProgressive());
 
         runAt("01 January 2025", () -> {
             Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProductsResponse.getResourceId(), "01 January 2025",
@@ -866,8 +843,8 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
         runAt("01 February 2025", () -> {
             final Long loanId = loanIdRef.get();
             executeInlineCOB(loanId);
-            final PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(loanId,
-                    "Repayment", "01 February 2025", 260.0);
+            final PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = makeLoanRepayment(loanId, "Repayment",
+                    "01 February 2025", 260.0);
             repaymentTransactionIdRef.set(postLoansLoanIdTransactionsResponse.getResourceId());
         });
         runAt("04 February 2025", () -> {
@@ -883,9 +860,9 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             configureLoanAccrualTransactionCreatedBusinessEvent(true);
             deleteAllExternalEvents();
 
-            loanTransactionHelper.reverseLoanTransaction(loanId, repaymentTransactionIdRef.get(), "01 February 2025");
+            reverseLoanTransaction(loanId, repaymentTransactionIdRef.get(), "01 February 2025");
 
-            List<ExternalEventResponse> allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            List<ExternalEventResponse> allExternalEvents = externalEventHelper.getAllExternalEvents();
             // Verify no BulkEvent was created
             Assertions.assertEquals(0, allExternalEvents.stream().filter(e -> e.getType().equals("BulkBusinessEvent")).count());
             verifyBusinessEvents(//
@@ -907,7 +884,7 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
 
             PostLoansRequest loanRequest = applyForLoanApplication(client.getClientId(), loanProductId, BigDecimal.valueOf(4000),
                     "1 March 2023", "1 March 2024");
-            PostLoansResponse applicationResponse = loanTransactionHelper.applyLoan(loanRequest);
+            PostLoansResponse applicationResponse = loanHelper.applyForLoan(loanRequest);
             Long loanId = applicationResponse.getResourceId();
             Assertions.assertNotNull(loanId);
 
@@ -917,9 +894,9 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
                     .expectedDisbursementDate("1 March 2024").repaymentFrequencyType(2).numberOfRepayments(4).loanTermFrequency(4)
                     .loanTermFrequencyType(2).loanType("individual").dateFormat("dd MMMM yyyy").locale("en_GB");
 
-            loanTransactionHelper.modifyApplicationForLoan(loanId, "modify", modification);
+            modifyLoanApplication(loanId, "modify", modification);
 
-            List<ExternalEventResponse> modifiedEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec).stream()
+            List<ExternalEventResponse> modifiedEvents = externalEventHelper.getAllExternalEvents().stream()
                     .filter(e -> "LoanApplicationModifiedBusinessEvent".equals(e.getType())).toList();
 
             Assertions.assertEquals(1, modifiedEvents.size());
@@ -937,13 +914,14 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
 
             PostLoansRequest loanRequest = applyForLoanApplication(client.getClientId(), loanProductId, BigDecimal.valueOf(4000),
                     "1 March 2023", "01 March 2024");
-            PostLoansResponse applicationResponse = loanTransactionHelper.applyLoan(loanRequest);
+            PostLoansResponse applicationResponse = loanHelper.applyForLoan(loanRequest);
             Long loanId = applicationResponse.getLoanId();
             Assertions.assertNotNull(loanId);
 
-            loanTransactionHelper.withdrawLoanApplicationByClient("01 March 2024", loanId.intValue());
+            withdrawLoan(loanId, new PostLoansLoanIdRequest().withdrawnOnDate("01 March 2024").dateFormat(DATETIME_PATTERN).locale("en")
+                    .note(" Loan Withdrawn By Client!!!"));
 
-            List<ExternalEventResponse> events = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec).stream()
+            List<ExternalEventResponse> events = externalEventHelper.getAllExternalEvents().stream()
                     .filter(e -> "LoanWithdrawnByApplicantBusinessEvent".equals(e.getType())).toList();
 
             Assertions.assertEquals(1, events.size());
@@ -982,7 +960,7 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             externalEventHelper.enableBusinessEvent("LoanAdjustTransactionBusinessEvent");
             AtomicReference<Long> loanIdRef = new AtomicReference<>();
             runAt("15 January 2025", () -> {
-                PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(create4IProgressive()
+                PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(create4IProgressive()
                         .isInterestRecalculationEnabled(true).recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY)
                         .recalculationRestFrequencyInterval(1));
 
@@ -990,8 +968,8 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
                         430.0, 9.9, 4, null);
                 loanIdRef.set(loanId);
 
-                loanTransactionHelper.disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("15 January 2025")
-                        .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(430.0)).locale("en"));
+                disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("15 January 2025").dateFormat(DATETIME_PATTERN)
+                        .transactionAmount(BigDecimal.valueOf(430.0)).locale("en"));
 
                 verifyTransactions(loanId, transaction(430.0, "Disbursement", "15 January 2025") //
                 );
@@ -1016,10 +994,10 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
                 verifyTransactions(loanId, transaction(430.0, "Disbursement", "15 January 2025"), //
                         transaction(0.11, "Accrual", "16 January 2025"));
                 deleteAllExternalEvents();
-                PostLoansLoanIdTransactionsResponse interestPaymentWaiverResponse = loanTransactionHelper.makeLoanRepayment(loanId,
-                        "InterestPaymentWaiver", "17 January 2025", 10.0);
+                PostLoansLoanIdTransactionsResponse interestPaymentWaiverResponse = makeLoanRepayment(loanId, "InterestPaymentWaiver",
+                        "17 January 2025", 10.0);
 
-                List<ExternalEventResponse> allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+                List<ExternalEventResponse> allExternalEvents = externalEventHelper.getAllExternalEvents();
                 List<ExternalEventResponse> adjustments = allExternalEvents.stream()
                         .filter(e -> "LoanAdjustTransactionBusinessEvent".equals(e.getType())).toList();
                 Assertions.assertEquals(0, adjustments.size());
@@ -1055,7 +1033,7 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
     private static Long createLoanProductPeriodicWithInterest() {
         String name = Utils.uniqueRandomStringGenerator("LOAN_PRODUCT_", 6);
         String shortName = Utils.uniqueRandomStringGenerator("", 4);
-        Long resourceId = loanTransactionHelper.createLoanProduct(new PostLoanProductsRequest() //
+        Long resourceId = loanHelper.createLoanProduct(new PostLoanProductsRequest() //
                 .name(name) //
                 .shortName(shortName) //
                 .multiDisburseLoan(true) //
@@ -1099,7 +1077,7 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
                 .interestCalculationPeriodType(0).dateFormat("dd MMMM yyyy").transactionProcessingStrategyCode(DEFAULT_STRATEGY)
                 .loanType("individual").submittedOnDate(submittedOnDate).expectedDisbursementDate(expectedDisburmentDate).clientId(clientId)
                 .productId(loanProductId);
-        Long loanId = loanTransactionHelper.applyLoan(loanRequest).getLoanId();
+        Long loanId = loanHelper.applyForLoan(loanRequest).getLoanId();
         log.info("Test MultiDisbursed Loan with Interest. clientId: {} loanId: {}", client.getClientId(), loanId);
         return loanId;
     }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/ExternalBusinessEventTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/ExternalBusinessEventTest.java
@@ -20,11 +20,6 @@ package org.apache.fineract.integrationtests;
 
 import static org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder.DEFAULT_STRATEGY;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
@@ -49,16 +44,23 @@ import org.apache.fineract.client.models.PostUpdateRescheduleLoansRequest;
 import org.apache.fineract.client.models.PutLoansLoanIdRequest;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
 import org.apache.fineract.infrastructure.event.external.data.ExternalEventResponse;
-import org.apache.fineract.integrationtests.common.BusinessStepHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignBusinessStepHelper;
+import org.apache.fineract.integrationtests.client.feign.modules.ChargeRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.AmortizationType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.DaysInMonthType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.DaysInYearType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestCalculationPeriodType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.RecalculationRestFrequencyType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.RepaymentFrequencyType;
 import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.LoanRescheduleRequestHelper;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.externalevents.ExternalEventHelper;
 import org.apache.fineract.integrationtests.common.externalevents.ExternalEventsExtension;
 import org.apache.fineract.integrationtests.common.externalevents.LoanAdjustTransactionBusinessEvent;
 import org.apache.fineract.integrationtests.common.externalevents.LoanBusinessEvent;
 import org.apache.fineract.integrationtests.common.externalevents.LoanTransactionBusinessEvent;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -69,29 +71,20 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 @Slf4j
 @ExtendWith({ ExternalEventsExtension.class })
-public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
+public class ExternalBusinessEventTest extends FeignLoanTestBase {
 
-    private static final String DATETIME_PATTERN = "dd MMMM yyyy";
+    private static final FeignBusinessStepHelper businessStepHelper = new FeignBusinessStepHelper(
+            FineractFeignClientHelper.getFineractFeignClient());
     private static PostClientsResponse client;
-    private static LoanTransactionHelper loanTransactionHelper;
     private static Long loanProductId;
-    private static ResponseSpecification responseSpec;
-    private static RequestSpecification requestSpec;
-    Long chargeId = createCharge(111.0, "USD").getResourceId();
-    private final ExternalEventHelper externalEventHelper = new ExternalEventHelper();
+    private static Long chargeId;
 
     @BeforeAll
     public static void beforeAll() {
-        Utils.initializeRESTAssured();
-        requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        requestSpec.header("Fineract-Platform-TenantId", "default");
-        responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        ClientHelper clientHelper = new ClientHelper(requestSpec, responseSpec);
-        loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-        BusinessStepHelper businessStepHelper = new BusinessStepHelper();
         client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
         loanProductId = createLoanProductPeriodicWithInterest();
+        // A single reusable charge for the whole class - the tests only reference it, they never mutate it.
+        chargeId = chargesHelper.createCharge(ChargeRequestBuilders.loanSpecifiedDueDateFee(111.0, "USD")).getResourceId();
         // setup COB Business Steps to prevent test failing due other integration test configurations
         businessStepHelper.updateSteps("LOAN_CLOSE_OF_BUSINESS", "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION",
                 "CHECK_LOAN_REPAYMENT_DUE", "CHECK_LOAN_REPAYMENT_OVERDUE", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
@@ -106,49 +99,48 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             Long loanId = applyForLoanApplicationWithInterest(client.getClientId(), loanProductId, BigDecimal.valueOf(1000), "1 March 2023",
                     "1 March 2023");
             loanIdRef.set(loanId);
-            loanTransactionHelper.approveLoan("1 March 2023", loanId.intValue());
+            approveLoan("1 March 2023", loanId.intValue());
 
             deleteAllExternalEvents();
 
-            loanTransactionHelper.disburseLoan("1 March 2023", loanId.intValue(), "400", null);
+            disburseLoan("1 March 2023", loanId.intValue(), "400", null);
 
         });
         runAt("15 March 2023", () -> {
             deleteAllExternalEvents();
 
-            loanTransactionHelper.makeLoanRepayment("15 March 2023", 125.0F, loanIdRef.get().intValue());
+            makeLoanRepayment(loanIdRef.get(), "repayment", "15 March 2023", 125.0);
 
             verifyBusinessEvents(new LoanBusinessEvent("LoanBalanceChangedBusinessEvent", "15 March 2023", 300, 400.0, 289.13));
         });
         runAt("1 April 2023", () -> {
 
-            loanTransactionHelper.disburseLoan("1 April 2023", loanIdRef.get().intValue(), "600", null);
+            disburseLoan("1 April 2023", loanIdRef.get().intValue(), "600", null);
 
         });
         runAt("15 April 2023", () -> {
             deleteAllExternalEvents();
 
-            loanTransactionHelper.makeLoanRepayment("15 April 2023", 125.0F, loanIdRef.get().intValue());
+            makeLoanRepayment(loanIdRef.get(), "repayment", "15 April 2023", 125.0);
 
             verifyBusinessEvents(new LoanBusinessEvent("LoanBalanceChangedBusinessEvent", "15 April 2023", 300, 1000.0, 758.15));
 
             deleteAllExternalEvents();
 
-            Long transactionId = loanTransactionHelper.makeLoanRepayment("15 April 2023", 1000F, loanIdRef.get().intValue())
-                    .getResourceId();
+            Long transactionId = makeLoanRepayment(loanIdRef.get(), "repayment", "15 April 2023", 1000.0).getResourceId();
             Assertions.assertNotNull(transactionId);
 
             verifyBusinessEvents(new LoanBusinessEvent("LoanBalanceChangedBusinessEvent", "15 April 2023", 700, 1000.0, 0.0));
 
             deleteAllExternalEvents();
 
-            loanTransactionHelper.reverseRepayment(loanIdRef.get().intValue(), transactionId.intValue(), "15 April 2023");
+            reverseRepayment(loanIdRef.get(), transactionId, "15 April 2023");
 
             verifyBusinessEvents(new LoanBusinessEvent("LoanBalanceChangedBusinessEvent", "15 April 2023", 300, 1000.0, 758.15));
 
             deleteAllExternalEvents();
 
-            loanTransactionHelper.makeLoanRepayment("15 April 2023", 830.22F, loanIdRef.get().intValue());
+            makeLoanRepayment(loanIdRef.get(), "repayment", "15 April 2023", 830.22);
 
             verifyBusinessEvents(new LoanBusinessEvent("LoanBalanceChangedBusinessEvent", "15 April 2023", 700, 1000.0, 0.0));
 
@@ -166,7 +158,7 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
         runAt("1 January 2021", () -> {
             externalEventHelper.enableBusinessEvent("LoanChargeAdjustmentPostBusinessEvent");
             externalEventHelper.enableBusinessEvent("LoanTransactionMakeRepaymentPostBusinessEvent");
-            PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(create4IProgressive().currencyCode("USD"));
+            PostLoanProductsResponse loanProduct = loanHelper.createLoanProduct(create4IProgressive().currencyCode("USD"));
             Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 600.0, 9.99,
                     4, null);
             Assertions.assertNotNull(loanId);
@@ -177,11 +169,10 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
 
             deleteAllExternalEvents();
             // resourceId is chargeId
-            Long transactionId = loanTransactionHelper
-                    .chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(111.0).locale("en"))
+            Long transactionId = chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(111.0).locale("en"))
                     .getSubResourceId();
 
-            List<ExternalEventResponse> allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            List<ExternalEventResponse> allExternalEvents = externalEventHelper.getAllExternalEvents();
             List<ExternalEventResponse> list = allExternalEvents.stream()
                     .filter(x -> "LoanChargeAdjustmentPostBusinessEvent".equals(x.getType())).toList();
             Assertions.assertEquals(1, list.size());
@@ -192,8 +183,8 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             Map<?, ?> chargePaidBy = (Map<?, ?>) ((List<?>) loanChargePaidByList).get(0);
             Assertions.assertInstanceOf(Map.class, chargePaidBy);
             Assertions.assertEquals(111.0D, chargePaidBy.get("amount"));
-            Assertions.assertEquals(chargeId.doubleValue(), chargePaidBy.get("chargeId"));
-            Assertions.assertEquals(transactionId.doubleValue(), chargePaidBy.get("transactionId"));
+            Assertions.assertEquals(chargeId.doubleValue(), ((Number) chargePaidBy.get("chargeId")).doubleValue());
+            Assertions.assertEquals(transactionId.doubleValue(), ((Number) chargePaidBy.get("transactionId")).doubleValue());
         });
     }
 
@@ -207,7 +198,7 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
         runAt("1 January 2021", () -> {
             externalEventHelper.enableBusinessEvent("LoanChargeAdjustmentPostBusinessEvent");
             externalEventHelper.enableBusinessEvent("LoanTransactionMakeRepaymentPostBusinessEvent");
-            PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(create4IProgressive().currencyCode("USD"));
+            PostLoanProductsResponse loanProduct = loanHelper.createLoanProduct(create4IProgressive().currencyCode("USD"));
             Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 600.0, 9.99,
                     4, null);
             Assertions.assertNotNull(loanId);
@@ -219,11 +210,10 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             // check first part
             deleteAllExternalEvents();
             // resourceId is chargeId
-            Long transactionId = loanTransactionHelper
-                    .chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(69.0).locale("en"))
+            Long transactionId = chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(69.0).locale("en"))
                     .getSubResourceId();
 
-            List<ExternalEventResponse> allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            List<ExternalEventResponse> allExternalEvents = externalEventHelper.getAllExternalEvents();
             List<ExternalEventResponse> list = allExternalEvents.stream()
                     .filter(x -> "LoanChargeAdjustmentPostBusinessEvent".equals(x.getType())).toList();
             Assertions.assertEquals(1, list.size());
@@ -234,17 +224,16 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             Map<?, ?> chargePaidBy = (Map<?, ?>) ((List<?>) loanChargePaidByList).get(0);
             Assertions.assertInstanceOf(Map.class, chargePaidBy);
             Assertions.assertEquals(69.0D, chargePaidBy.get("amount"));
-            Assertions.assertEquals(chargeId.doubleValue(), chargePaidBy.get("chargeId"));
-            Assertions.assertEquals(transactionId.doubleValue(), chargePaidBy.get("transactionId"));
+            Assertions.assertEquals(chargeId.doubleValue(), ((Number) chargePaidBy.get("chargeId")).doubleValue());
+            Assertions.assertEquals(transactionId.doubleValue(), ((Number) chargePaidBy.get("transactionId")).doubleValue());
 
             // check second part
             deleteAllExternalEvents();
             // resourceId is chargeId
-            transactionId = loanTransactionHelper
-                    .chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(42.0).locale("en"))
+            transactionId = chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(42.0).locale("en"))
                     .getSubResourceId();
 
-            allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            allExternalEvents = externalEventHelper.getAllExternalEvents();
             list = allExternalEvents.stream().filter(x -> "LoanChargeAdjustmentPostBusinessEvent".equals(x.getType())).toList();
             Assertions.assertEquals(1, list.size());
             event = list.get(0);
@@ -254,13 +243,13 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             chargePaidBy = (Map<?, ?>) ((List<?>) loanChargePaidByList).get(0);
             Assertions.assertInstanceOf(Map.class, chargePaidBy);
             Assertions.assertEquals(42.0D, chargePaidBy.get("amount"));
-            Assertions.assertEquals(chargeId.doubleValue(), chargePaidBy.get("chargeId"));
-            Assertions.assertEquals(transactionId.doubleValue(), chargePaidBy.get("transactionId"));
+            Assertions.assertEquals(chargeId.doubleValue(), ((Number) chargePaidBy.get("chargeId")).doubleValue());
+            Assertions.assertEquals(transactionId.doubleValue(), ((Number) chargePaidBy.get("transactionId")).doubleValue());
             Assertions.assertFalse((Boolean) event.getPayLoad().get("reversed"));
 
             // check that third part cannot post for that charge, because it already fully adjusted
-            Assertions.assertThrows(RuntimeException.class, () -> loanTransactionHelper.chargeAdjustment(loanId, chargeId,
-                    new PostLoansLoanIdChargesChargeIdRequest().amount(1.0).locale("en")));
+            Assertions.assertThrows(RuntimeException.class,
+                    () -> chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(1.0).locale("en")));
         });
     }
 
@@ -275,7 +264,7 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
         runAt("1 January 2021", () -> {
             externalEventHelper.enableBusinessEvent("LoanChargeAdjustmentPostBusinessEvent");
             externalEventHelper.enableBusinessEvent("LoanTransactionMakeRepaymentPostBusinessEvent");
-            PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(create4IProgressive().currencyCode("USD"));
+            PostLoanProductsResponse loanProduct = loanHelper.createLoanProduct(create4IProgressive().currencyCode("USD"));
             Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 600.0, 9.99,
                     4, null);
             Assertions.assertNotNull(loanId);
@@ -286,9 +275,9 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
 
             // check repayment
             deleteAllExternalEvents();
-            Long transactionId = loanTransactionHelper.makeLoanRepayment("01 January 2021", 300.0F, loanId.intValue()).getResourceId();
+            Long transactionId = makeLoanRepayment(loanId, "repayment", "01 January 2021", 300.0).getResourceId();
 
-            List<ExternalEventResponse> allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            List<ExternalEventResponse> allExternalEvents = externalEventHelper.getAllExternalEvents();
             List<ExternalEventResponse> list = allExternalEvents.stream()
                     .filter(x -> "LoanTransactionMakeRepaymentPostBusinessEvent".equals(x.getType())).toList();
             Assertions.assertEquals(1, list.size());
@@ -301,17 +290,16 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             Map<?, ?> chargePaidBy = (Map<?, ?>) ((List<?>) loanChargePaidByList).get(0);
             Assertions.assertInstanceOf(Map.class, chargePaidBy);
             Assertions.assertEquals(111.0D, chargePaidBy.get("amount"));
-            Assertions.assertEquals(chargeId.doubleValue(), chargePaidBy.get("chargeId"));
-            Assertions.assertEquals(transactionId.doubleValue(), chargePaidBy.get("transactionId"));
+            Assertions.assertEquals(chargeId.doubleValue(), ((Number) chargePaidBy.get("chargeId")).doubleValue());
+            Assertions.assertEquals(transactionId.doubleValue(), ((Number) chargePaidBy.get("transactionId")).doubleValue());
 
             // check first part
             deleteAllExternalEvents();
             // resourceId is chargeId
-            transactionId = loanTransactionHelper
-                    .chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(69.0).locale("en"))
+            transactionId = chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(69.0).locale("en"))
                     .getSubResourceId();
 
-            allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            allExternalEvents = externalEventHelper.getAllExternalEvents();
             list = allExternalEvents.stream().filter(x -> "LoanChargeAdjustmentPostBusinessEvent".equals(x.getType())).toList();
             Assertions.assertEquals(1, list.size());
             event = list.get(0);
@@ -322,11 +310,10 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             // check second part
             deleteAllExternalEvents();
             // resourceId is chargeId
-            transactionId = loanTransactionHelper
-                    .chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(42.0).locale("en"))
+            transactionId = chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(42.0).locale("en"))
                     .getSubResourceId();
 
-            allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            allExternalEvents = externalEventHelper.getAllExternalEvents();
             list = allExternalEvents.stream().filter(x -> "LoanChargeAdjustmentPostBusinessEvent".equals(x.getType())).toList();
             Assertions.assertEquals(1, list.size());
             event = list.get(0);
@@ -335,8 +322,8 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             Assertions.assertEquals(0, ((List<?>) loanChargePaidByList).size());
 
             // check that third part cannot post for that charge, because it already fully adjusted
-            Assertions.assertThrows(RuntimeException.class, () -> loanTransactionHelper.chargeAdjustment(loanId, chargeId,
-                    new PostLoansLoanIdChargesChargeIdRequest().amount(1.0).locale("en")));
+            Assertions.assertThrows(RuntimeException.class,
+                    () -> chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(1.0).locale("en")));
         });
     }
 
@@ -350,7 +337,7 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
         runAt("1 January 2021", () -> {
             externalEventHelper.enableBusinessEvent("LoanChargeAdjustmentPostBusinessEvent");
             externalEventHelper.enableBusinessEvent("LoanTransactionMakeRepaymentPostBusinessEvent");
-            PostLoanProductsResponse loanProduct = loanProductHelper
+            PostLoanProductsResponse loanProduct = loanHelper
                     .createLoanProduct(create4IProgressive().isInterestRecalculationEnabled(false).currencyCode("USD"));
             Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 600.0, 9.99,
                     4, null);
@@ -362,11 +349,10 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
 
             deleteAllExternalEvents();
             // resourceId is chargeId
-            Long transactionId = loanTransactionHelper
-                    .chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(111.0).locale("en"))
+            Long transactionId = chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(111.0).locale("en"))
                     .getSubResourceId();
 
-            List<ExternalEventResponse> allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            List<ExternalEventResponse> allExternalEvents = externalEventHelper.getAllExternalEvents();
             List<ExternalEventResponse> list = allExternalEvents.stream()
                     .filter(x -> "LoanChargeAdjustmentPostBusinessEvent".equals(x.getType())).toList();
             Assertions.assertEquals(1, list.size());
@@ -377,8 +363,8 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             Map<?, ?> chargePaidBy = (Map<?, ?>) ((List<?>) loanChargePaidByList).get(0);
             Assertions.assertInstanceOf(Map.class, chargePaidBy);
             Assertions.assertEquals(111.0D, chargePaidBy.get("amount"));
-            Assertions.assertEquals(chargeId.doubleValue(), chargePaidBy.get("chargeId"));
-            Assertions.assertEquals(transactionId.doubleValue(), chargePaidBy.get("transactionId"));
+            Assertions.assertEquals(chargeId.doubleValue(), ((Number) chargePaidBy.get("chargeId")).doubleValue());
+            Assertions.assertEquals(transactionId.doubleValue(), ((Number) chargePaidBy.get("transactionId")).doubleValue());
         });
     }
 
@@ -392,7 +378,7 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
         runAt("1 January 2021", () -> {
             externalEventHelper.enableBusinessEvent("LoanChargeAdjustmentPostBusinessEvent");
             externalEventHelper.enableBusinessEvent("LoanTransactionMakeRepaymentPostBusinessEvent");
-            PostLoanProductsResponse loanProduct = loanProductHelper
+            PostLoanProductsResponse loanProduct = loanHelper
                     .createLoanProduct(create4IProgressive().isInterestRecalculationEnabled(false).currencyCode("USD"));
             Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 600.0, 9.99,
                     4, null);
@@ -405,11 +391,10 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             // check first part
             deleteAllExternalEvents();
             // resourceId is chargeId
-            Long transactionId = loanTransactionHelper
-                    .chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(69.0).locale("en"))
+            Long transactionId = chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(69.0).locale("en"))
                     .getSubResourceId();
 
-            List<ExternalEventResponse> allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            List<ExternalEventResponse> allExternalEvents = externalEventHelper.getAllExternalEvents();
             List<ExternalEventResponse> list = allExternalEvents.stream()
                     .filter(x -> "LoanChargeAdjustmentPostBusinessEvent".equals(x.getType())).toList();
             Assertions.assertEquals(1, list.size());
@@ -420,17 +405,16 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             Map<?, ?> chargePaidBy = (Map<?, ?>) ((List<?>) loanChargePaidByList).get(0);
             Assertions.assertInstanceOf(Map.class, chargePaidBy);
             Assertions.assertEquals(69.0D, chargePaidBy.get("amount"));
-            Assertions.assertEquals(chargeId.doubleValue(), chargePaidBy.get("chargeId"));
-            Assertions.assertEquals(transactionId.doubleValue(), chargePaidBy.get("transactionId"));
+            Assertions.assertEquals(chargeId.doubleValue(), ((Number) chargePaidBy.get("chargeId")).doubleValue());
+            Assertions.assertEquals(transactionId.doubleValue(), ((Number) chargePaidBy.get("transactionId")).doubleValue());
 
             // check second part
             deleteAllExternalEvents();
             // resourceId is chargeId
-            transactionId = loanTransactionHelper
-                    .chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(42.0).locale("en"))
+            transactionId = chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(42.0).locale("en"))
                     .getSubResourceId();
 
-            allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            allExternalEvents = externalEventHelper.getAllExternalEvents();
             list = allExternalEvents.stream().filter(x -> "LoanChargeAdjustmentPostBusinessEvent".equals(x.getType())).toList();
             Assertions.assertEquals(1, list.size());
             event = list.get(0);
@@ -440,12 +424,12 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             chargePaidBy = (Map<?, ?>) ((List<?>) loanChargePaidByList).get(0);
             Assertions.assertInstanceOf(Map.class, chargePaidBy);
             Assertions.assertEquals(42.0D, chargePaidBy.get("amount"));
-            Assertions.assertEquals(chargeId.doubleValue(), chargePaidBy.get("chargeId"));
-            Assertions.assertEquals(transactionId.doubleValue(), chargePaidBy.get("transactionId"));
+            Assertions.assertEquals(chargeId.doubleValue(), ((Number) chargePaidBy.get("chargeId")).doubleValue());
+            Assertions.assertEquals(transactionId.doubleValue(), ((Number) chargePaidBy.get("transactionId")).doubleValue());
 
             // check that third part cannot post for that charge, because it already fully adjusted
-            Assertions.assertThrows(RuntimeException.class, () -> loanTransactionHelper.chargeAdjustment(loanId, chargeId,
-                    new PostLoansLoanIdChargesChargeIdRequest().amount(1.0).locale("en")));
+            Assertions.assertThrows(RuntimeException.class,
+                    () -> chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(1.0).locale("en")));
         });
     }
 
@@ -460,7 +444,7 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
         runAt("1 January 2021", () -> {
             externalEventHelper.enableBusinessEvent("LoanChargeAdjustmentPostBusinessEvent");
             externalEventHelper.enableBusinessEvent("LoanTransactionMakeRepaymentPostBusinessEvent");
-            PostLoanProductsResponse loanProduct = loanProductHelper
+            PostLoanProductsResponse loanProduct = loanHelper
                     .createLoanProduct(create4IProgressive().isInterestRecalculationEnabled(false).currencyCode("USD"));
             Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 600.0, 9.99,
                     4, null);
@@ -472,9 +456,9 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
 
             // check repayment
             deleteAllExternalEvents();
-            Long transactionId = loanTransactionHelper.makeLoanRepayment("01 January 2021", 300.0F, loanId.intValue()).getResourceId();
+            Long transactionId = makeLoanRepayment(loanId, "repayment", "01 January 2021", 300.0).getResourceId();
 
-            List<ExternalEventResponse> allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            List<ExternalEventResponse> allExternalEvents = externalEventHelper.getAllExternalEvents();
             List<ExternalEventResponse> list = allExternalEvents.stream()
                     .filter(x -> "LoanTransactionMakeRepaymentPostBusinessEvent".equals(x.getType())).toList();
             Assertions.assertEquals(1, list.size());
@@ -487,17 +471,16 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             Map<?, ?> chargePaidBy = (Map<?, ?>) ((List<?>) loanChargePaidByList).get(0);
             Assertions.assertInstanceOf(Map.class, chargePaidBy);
             Assertions.assertEquals(111.0D, chargePaidBy.get("amount"));
-            Assertions.assertEquals(chargeId.doubleValue(), chargePaidBy.get("chargeId"));
-            Assertions.assertEquals(transactionId.doubleValue(), chargePaidBy.get("transactionId"));
+            Assertions.assertEquals(chargeId.doubleValue(), ((Number) chargePaidBy.get("chargeId")).doubleValue());
+            Assertions.assertEquals(transactionId.doubleValue(), ((Number) chargePaidBy.get("transactionId")).doubleValue());
 
             // check first part
             deleteAllExternalEvents();
             // resourceId is chargeId
-            transactionId = loanTransactionHelper
-                    .chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(69.0).locale("en"))
+            transactionId = chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(69.0).locale("en"))
                     .getSubResourceId();
 
-            allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            allExternalEvents = externalEventHelper.getAllExternalEvents();
             list = allExternalEvents.stream().filter(x -> "LoanChargeAdjustmentPostBusinessEvent".equals(x.getType())).toList();
             Assertions.assertEquals(1, list.size());
             event = list.get(0);
@@ -508,11 +491,10 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             // check second part
             deleteAllExternalEvents();
             // resourceId is chargeId
-            transactionId = loanTransactionHelper
-                    .chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(42.0).locale("en"))
+            transactionId = chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(42.0).locale("en"))
                     .getSubResourceId();
 
-            allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            allExternalEvents = externalEventHelper.getAllExternalEvents();
             list = allExternalEvents.stream().filter(x -> "LoanChargeAdjustmentPostBusinessEvent".equals(x.getType())).toList();
             Assertions.assertEquals(1, list.size());
             event = list.get(0);
@@ -521,8 +503,8 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             Assertions.assertEquals(0, ((List<?>) loanChargePaidByList).size());
 
             // check that third part cannot post for that charge, because it already fully adjusted
-            Assertions.assertThrows(RuntimeException.class, () -> loanTransactionHelper.chargeAdjustment(loanId, chargeId,
-                    new PostLoansLoanIdChargesChargeIdRequest().amount(1.0).locale("en")));
+            Assertions.assertThrows(RuntimeException.class,
+                    () -> chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(1.0).locale("en")));
         });
     }
 
@@ -535,7 +517,7 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
         runAt("1 January 2021", () -> {
             externalEventHelper.enableBusinessEvent("LoanChargeAdjustmentPostBusinessEvent");
             externalEventHelper.enableBusinessEvent("LoanTransactionMakeRepaymentPostBusinessEvent");
-            PostLoanProductsResponse loanProduct = loanProductHelper
+            PostLoanProductsResponse loanProduct = loanHelper
                     .createLoanProduct(create4IProgressive().isInterestRecalculationEnabled(false).currencyCode("USD"));
             Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 600.0, 0.0, 4,
                     null);
@@ -547,11 +529,10 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
 
             deleteAllExternalEvents();
             // resourceId is chargeId
-            Long transactionId = loanTransactionHelper
-                    .chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(111.0).locale("en"))
+            Long transactionId = chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(111.0).locale("en"))
                     .getSubResourceId();
 
-            List<ExternalEventResponse> allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            List<ExternalEventResponse> allExternalEvents = externalEventHelper.getAllExternalEvents();
             List<ExternalEventResponse> list = allExternalEvents.stream()
                     .filter(x -> "LoanChargeAdjustmentPostBusinessEvent".equals(x.getType())).toList();
             Assertions.assertEquals(1, list.size());
@@ -562,8 +543,8 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             Map<?, ?> chargePaidBy = (Map<?, ?>) ((List<?>) loanChargePaidByList).get(0);
             Assertions.assertInstanceOf(Map.class, chargePaidBy);
             Assertions.assertEquals(111.0D, chargePaidBy.get("amount"));
-            Assertions.assertEquals(chargeId.doubleValue(), chargePaidBy.get("chargeId"));
-            Assertions.assertEquals(transactionId.doubleValue(), chargePaidBy.get("transactionId"));
+            Assertions.assertEquals(chargeId.doubleValue(), ((Number) chargePaidBy.get("chargeId")).doubleValue());
+            Assertions.assertEquals(transactionId.doubleValue(), ((Number) chargePaidBy.get("transactionId")).doubleValue());
         });
     }
 
@@ -576,7 +557,7 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
         runAt("1 January 2021", () -> {
             externalEventHelper.enableBusinessEvent("LoanChargeAdjustmentPostBusinessEvent");
             externalEventHelper.enableBusinessEvent("LoanTransactionMakeRepaymentPostBusinessEvent");
-            PostLoanProductsResponse loanProduct = loanProductHelper
+            PostLoanProductsResponse loanProduct = loanHelper
                     .createLoanProduct(create4IProgressive().isInterestRecalculationEnabled(false).currencyCode("USD"));
             Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 600.0, 0.0, 4,
                     null);
@@ -589,11 +570,10 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             // check first part
             deleteAllExternalEvents();
             // resourceId is chargeId
-            Long transactionId = loanTransactionHelper
-                    .chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(69.0).locale("en"))
+            Long transactionId = chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(69.0).locale("en"))
                     .getSubResourceId();
 
-            List<ExternalEventResponse> allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            List<ExternalEventResponse> allExternalEvents = externalEventHelper.getAllExternalEvents();
             List<ExternalEventResponse> list = allExternalEvents.stream()
                     .filter(x -> "LoanChargeAdjustmentPostBusinessEvent".equals(x.getType())).toList();
             Assertions.assertEquals(1, list.size());
@@ -604,17 +584,16 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             Map<?, ?> chargePaidBy = (Map<?, ?>) ((List<?>) loanChargePaidByList).get(0);
             Assertions.assertInstanceOf(Map.class, chargePaidBy);
             Assertions.assertEquals(69.0D, chargePaidBy.get("amount"));
-            Assertions.assertEquals(chargeId.doubleValue(), chargePaidBy.get("chargeId"));
-            Assertions.assertEquals(transactionId.doubleValue(), chargePaidBy.get("transactionId"));
+            Assertions.assertEquals(chargeId.doubleValue(), ((Number) chargePaidBy.get("chargeId")).doubleValue());
+            Assertions.assertEquals(transactionId.doubleValue(), ((Number) chargePaidBy.get("transactionId")).doubleValue());
 
             // check second part
             deleteAllExternalEvents();
             // resourceId is chargeId
-            transactionId = loanTransactionHelper
-                    .chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(42.0).locale("en"))
+            transactionId = chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(42.0).locale("en"))
                     .getSubResourceId();
 
-            allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            allExternalEvents = externalEventHelper.getAllExternalEvents();
             list = allExternalEvents.stream().filter(x -> "LoanChargeAdjustmentPostBusinessEvent".equals(x.getType())).toList();
             Assertions.assertEquals(1, list.size());
             event = list.get(0);
@@ -624,12 +603,12 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             chargePaidBy = (Map<?, ?>) ((List<?>) loanChargePaidByList).get(0);
             Assertions.assertInstanceOf(Map.class, chargePaidBy);
             Assertions.assertEquals(42.0D, chargePaidBy.get("amount"));
-            Assertions.assertEquals(chargeId.doubleValue(), chargePaidBy.get("chargeId"));
-            Assertions.assertEquals(transactionId.doubleValue(), chargePaidBy.get("transactionId"));
+            Assertions.assertEquals(chargeId.doubleValue(), ((Number) chargePaidBy.get("chargeId")).doubleValue());
+            Assertions.assertEquals(transactionId.doubleValue(), ((Number) chargePaidBy.get("transactionId")).doubleValue());
 
             // check that third part cannot post for that charge, because it already fully adjusted
-            Assertions.assertThrows(RuntimeException.class, () -> loanTransactionHelper.chargeAdjustment(loanId, chargeId,
-                    new PostLoansLoanIdChargesChargeIdRequest().amount(1.0).locale("en")));
+            Assertions.assertThrows(RuntimeException.class,
+                    () -> chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(1.0).locale("en")));
         });
     }
 
@@ -643,7 +622,7 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
         runAt("1 January 2021", () -> {
             externalEventHelper.enableBusinessEvent("LoanChargeAdjustmentPostBusinessEvent");
             externalEventHelper.enableBusinessEvent("LoanTransactionMakeRepaymentPostBusinessEvent");
-            PostLoanProductsResponse loanProduct = loanProductHelper
+            PostLoanProductsResponse loanProduct = loanHelper
                     .createLoanProduct(create4IProgressive().isInterestRecalculationEnabled(false).currencyCode("USD"));
             Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 600.0, 0.0, 4,
                     null);
@@ -655,9 +634,9 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
 
             // check repayment
             deleteAllExternalEvents();
-            Long transactionId = loanTransactionHelper.makeLoanRepayment("01 January 2021", 300.0F, loanId.intValue()).getResourceId();
+            Long transactionId = makeLoanRepayment(loanId, "repayment", "01 January 2021", 300.0).getResourceId();
 
-            List<ExternalEventResponse> allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            List<ExternalEventResponse> allExternalEvents = externalEventHelper.getAllExternalEvents();
             List<ExternalEventResponse> list = allExternalEvents.stream()
                     .filter(x -> "LoanTransactionMakeRepaymentPostBusinessEvent".equals(x.getType())).toList();
             Assertions.assertEquals(1, list.size());
@@ -670,17 +649,16 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             Map<?, ?> chargePaidBy = (Map<?, ?>) ((List<?>) loanChargePaidByList).get(0);
             Assertions.assertInstanceOf(Map.class, chargePaidBy);
             Assertions.assertEquals(111.0D, chargePaidBy.get("amount"));
-            Assertions.assertEquals(chargeId.doubleValue(), chargePaidBy.get("chargeId"));
-            Assertions.assertEquals(transactionId.doubleValue(), chargePaidBy.get("transactionId"));
+            Assertions.assertEquals(chargeId.doubleValue(), ((Number) chargePaidBy.get("chargeId")).doubleValue());
+            Assertions.assertEquals(transactionId.doubleValue(), ((Number) chargePaidBy.get("transactionId")).doubleValue());
 
             // check first part
             deleteAllExternalEvents();
             // resourceId is chargeId
-            transactionId = loanTransactionHelper
-                    .chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(69.0).locale("en"))
+            transactionId = chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(69.0).locale("en"))
                     .getSubResourceId();
 
-            allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            allExternalEvents = externalEventHelper.getAllExternalEvents();
             list = allExternalEvents.stream().filter(x -> "LoanChargeAdjustmentPostBusinessEvent".equals(x.getType())).toList();
             Assertions.assertEquals(1, list.size());
             event = list.get(0);
@@ -691,11 +669,10 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             // check second part
             deleteAllExternalEvents();
             // resourceId is chargeId
-            transactionId = loanTransactionHelper
-                    .chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(42.0).locale("en"))
+            transactionId = chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(42.0).locale("en"))
                     .getSubResourceId();
 
-            allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            allExternalEvents = externalEventHelper.getAllExternalEvents();
             list = allExternalEvents.stream().filter(x -> "LoanChargeAdjustmentPostBusinessEvent".equals(x.getType())).toList();
             Assertions.assertEquals(1, list.size());
             event = list.get(0);
@@ -704,8 +681,8 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             Assertions.assertEquals(0, ((List<?>) loanChargePaidByList).size());
 
             // check that third part cannot post for that charge, because it already fully adjusted
-            Assertions.assertThrows(RuntimeException.class, () -> loanTransactionHelper.chargeAdjustment(loanId, chargeId,
-                    new PostLoansLoanIdChargesChargeIdRequest().amount(1.0).locale("en")));
+            Assertions.assertThrows(RuntimeException.class,
+                    () -> chargeAdjustment(loanId, chargeId, new PostLoansLoanIdChargesChargeIdRequest().amount(1.0).locale("en")));
         });
     }
 
@@ -724,24 +701,24 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
     public void testInterestBearingProgressiveInterestRecalculationReopenDueReverseRepayment() {
         runAt("17 January 2025", () -> {
             externalEventHelper.enableBusinessEvent("LoanAdjustTransactionBusinessEvent");
-            final PostLoanProductsResponse loanProductsResponse = loanProductHelper.createLoanProduct(create4IProgressive() //
+            final PostLoanProductsResponse loanProductsResponse = loanHelper.createLoanProduct(create4IProgressive() //
                     .description("Interest bearing Progressive Loan USD, Accrual Activity Posting, NO InterestRecalculation") //
                     .enableAccrualActivityPosting(true) //
                     .daysInMonthType(DaysInMonthType.ACTUAL) //
                     .daysInYearType(DaysInYearType.ACTUAL) //
                     .isInterestRecalculationEnabled(false));//
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applyLP2ProgressiveLoanRequest(client.getClientId(),
+            PostLoansResponse postLoansResponse = loanHelper.applyForLoan(applyLP2ProgressiveLoanRequest(client.getClientId(),
                     loanProductsResponse.getResourceId(), "17 August 2024", 450.0, 25.0, 6, null));
             Long loanId = postLoansResponse.getLoanId();
             Assertions.assertNotNull(loanId);
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(450.0, "17 August 2024"));
+            approveLoan(loanId, approveLoanRequest(450.0, "17 August 2024"));
             disburseLoan(loanId, BigDecimal.valueOf(450.0), "17 August 2024");
             verifyTransactions(loanId, //
                     transaction(450.0, "Disbursement", "17 August 2024") //
             );
-            Long repaymentId = loanTransactionHelper.makeLoanRepayment("17 January 2025", 600.0f, loanId.intValue()).getResourceId();
+            Long repaymentId = makeLoanRepayment(loanId, "repayment", "17 January 2025", 600.0).getResourceId();
             Assertions.assertNotNull(repaymentId);
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getOverpaid);
             verifyTransactions(loanId, //
                     transaction(450.0, "Disbursement", "17 August 2024"), //
@@ -753,9 +730,9 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
                     transaction(4.75, "Accrual Activity", "17 December 2024"), //
                     transaction(4.99, "Accrual Activity", "17 January 2025")); //
             deleteAllExternalEvents();
-            loanTransactionHelper.reverseRepayment(loanId.intValue(), repaymentId.intValue(), "17 January 2025");
+            reverseRepayment(loanId, repaymentId, "17 January 2025");
 
-            List<ExternalEventResponse> allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            List<ExternalEventResponse> allExternalEvents = externalEventHelper.getAllExternalEvents();
             // Verify that there were no reverse-replay event
             List<ExternalEventResponse> list = allExternalEvents.stream() //
                     .filter(x -> "LoanAdjustTransactionBusinessEvent".equals(x.getType()) //
@@ -774,7 +751,7 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             Assertions.assertTrue((Boolean) ((Map) list.get(0).getPayLoad().get("transactionToAdjust")).get("reversed"));
             Assertions.assertTrue((Boolean) ((Map) list.get(1).getPayLoad().get("transactionToAdjust")).get("reversed"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getActive);
             verifyTransactions(loanId, transaction(450.0, "Disbursement", "17 August 2024"), //
                     transaction(33.52, "Accrual", "17 January 2025"), //
@@ -791,7 +768,7 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         enableLoanInterestRefundPstBusinessEvent(true);
         runAt("1 January 2021", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
+            PostLoanProductsResponse loanProduct = loanHelper
                     .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
                             .daysInYearType(DaysInYearType.ACTUAL) //
                             .supportedInterestRefundTypes(new ArrayList<>()).addSupportedInterestRefundTypesItem("MERCHANT_ISSUED_REFUND") //
@@ -808,8 +785,8 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
 
             deleteAllExternalEvents();
 
-            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = loanTransactionHelper
-                    .makeLoanRepayment("MerchantIssuedRefund", "22 January 2021", 1000F, loanId.intValue());
+            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = makeLoanRepayment(loanId, "MerchantIssuedRefund",
+                    "22 January 2021", 1000.0);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse.getResourceId());
 
@@ -827,18 +804,18 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             Long loanId = applyForLoanApplicationWithInterest(client.getClientId(), loanProductId, BigDecimal.valueOf(4000), "1 March 2023",
                     "1 March 2024");
             loanIdRef.set(loanId);
-            loanTransactionHelper.approveLoan("1 March 2024", loanId.intValue());
+            approveLoan("1 March 2024", loanId.intValue());
 
-            loanTransactionHelper.disburseLoan("1 March 2024", loanId.intValue(), "400", null);
+            disburseLoan("1 March 2024", loanId.intValue(), "400", null);
 
-            PostCreateRescheduleLoansResponse rescheduleLoansResponse = LoanRescheduleRequestHelper
-                    .createLoanRescheduleRequest(new PostCreateRescheduleLoansRequest().loanId(loanIdRef.get()).dateFormat(DATETIME_PATTERN)
+            PostCreateRescheduleLoansResponse rescheduleLoansResponse = loanHelper
+                    .createRescheduleRequest(new PostCreateRescheduleLoansRequest().loanId(loanIdRef.get()).dateFormat(DATETIME_PATTERN)
                             .locale("en").submittedOnDate("1 March 2024").newInterestRate(BigDecimal.ONE).rescheduleReasonId(1L)
                             .rescheduleFromDate("1 April 2024"));
 
             deleteAllExternalEvents();
 
-            LoanRescheduleRequestHelper.approveLoanRescheduleRequest(rescheduleLoansResponse.getResourceId(),
+            approveRescheduleRequest(rescheduleLoansResponse.getResourceId(),
                     new PostUpdateRescheduleLoansRequest().approvedOnDate("1 March 2024").locale("en").dateFormat(DATETIME_PATTERN));
 
             verifyBusinessEvents(new LoanBusinessEvent("LoanRescheduledDueAdjustScheduleBusinessEvent", "01 March 2024", 300, 400.0, 400.0,
@@ -853,7 +830,7 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
         final AtomicReference<Long> loanIdRef = new AtomicReference<>();
         final AtomicReference<Long> repaymentTransactionIdRef = new AtomicReference<>();
 
-        final PostLoanProductsResponse loanProductsResponse = loanProductHelper.createLoanProduct(create4IProgressive());
+        final PostLoanProductsResponse loanProductsResponse = loanHelper.createLoanProduct(create4IProgressive());
 
         runAt("01 January 2025", () -> {
             Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProductsResponse.getResourceId(), "01 January 2025",
@@ -866,8 +843,8 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
         runAt("01 February 2025", () -> {
             final Long loanId = loanIdRef.get();
             executeInlineCOB(loanId);
-            final PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(loanId,
-                    "Repayment", "01 February 2025", 260.0);
+            final PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = makeLoanRepayment(loanId, "Repayment",
+                    "01 February 2025", 260.0);
             repaymentTransactionIdRef.set(postLoansLoanIdTransactionsResponse.getResourceId());
         });
         runAt("04 February 2025", () -> {
@@ -883,9 +860,9 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             configureLoanAccrualTransactionCreatedBusinessEvent(true);
             deleteAllExternalEvents();
 
-            loanTransactionHelper.reverseLoanTransaction(loanId, repaymentTransactionIdRef.get(), "01 February 2025");
+            reverseLoanTransaction(loanId, repaymentTransactionIdRef.get(), "01 February 2025");
 
-            List<ExternalEventResponse> allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+            List<ExternalEventResponse> allExternalEvents = externalEventHelper.getAllExternalEvents();
             // Verify no BulkEvent was created
             Assertions.assertEquals(0, allExternalEvents.stream().filter(e -> e.getType().equals("BulkBusinessEvent")).count());
             verifyBusinessEvents(//
@@ -907,7 +884,7 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
 
             PostLoansRequest loanRequest = applyForLoanApplication(client.getClientId(), loanProductId, BigDecimal.valueOf(4000),
                     "1 March 2023", "1 March 2024");
-            PostLoansResponse applicationResponse = loanTransactionHelper.applyLoan(loanRequest);
+            PostLoansResponse applicationResponse = loanHelper.applyForLoan(loanRequest);
             Long loanId = applicationResponse.getResourceId();
             Assertions.assertNotNull(loanId);
 
@@ -917,9 +894,9 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
                     .expectedDisbursementDate("1 March 2024").repaymentFrequencyType(2).numberOfRepayments(4).loanTermFrequency(4)
                     .loanTermFrequencyType(2).loanType("individual").dateFormat("dd MMMM yyyy").locale("en_GB");
 
-            loanTransactionHelper.modifyApplicationForLoan(loanId, "modify", modification);
+            modifyLoanApplication(loanId, "modify", modification);
 
-            List<ExternalEventResponse> modifiedEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec).stream()
+            List<ExternalEventResponse> modifiedEvents = externalEventHelper.getAllExternalEvents().stream()
                     .filter(e -> "LoanApplicationModifiedBusinessEvent".equals(e.getType())).toList();
 
             Assertions.assertEquals(1, modifiedEvents.size());
@@ -937,13 +914,14 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
 
             PostLoansRequest loanRequest = applyForLoanApplication(client.getClientId(), loanProductId, BigDecimal.valueOf(4000),
                     "1 March 2023", "01 March 2024");
-            PostLoansResponse applicationResponse = loanTransactionHelper.applyLoan(loanRequest);
+            PostLoansResponse applicationResponse = loanHelper.applyForLoan(loanRequest);
             Long loanId = applicationResponse.getLoanId();
             Assertions.assertNotNull(loanId);
 
-            loanTransactionHelper.withdrawLoanApplicationByClient("01 March 2024", loanId.intValue());
+            withdrawLoan(loanId, new PostLoansLoanIdRequest().withdrawnOnDate("01 March 2024").dateFormat(DATETIME_PATTERN).locale("en")
+                    .note(" Loan Withdrawn By Client!!!"));
 
-            List<ExternalEventResponse> events = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec).stream()
+            List<ExternalEventResponse> events = externalEventHelper.getAllExternalEvents().stream()
                     .filter(e -> "LoanWithdrawnByApplicantBusinessEvent".equals(e.getType())).toList();
 
             Assertions.assertEquals(1, events.size());
@@ -982,7 +960,7 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
             externalEventHelper.enableBusinessEvent("LoanAdjustTransactionBusinessEvent");
             AtomicReference<Long> loanIdRef = new AtomicReference<>();
             runAt("15 January 2025", () -> {
-                PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(create4IProgressive()
+                PostLoanProductsResponse loanProductResponse = loanHelper.createLoanProduct(create4IProgressive()
                         .isInterestRecalculationEnabled(true).recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY)
                         .recalculationRestFrequencyInterval(1));
 
@@ -990,8 +968,8 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
                         430.0, 9.9, 4, null);
                 loanIdRef.set(loanId);
 
-                loanTransactionHelper.disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("15 January 2025")
-                        .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(430.0)).locale("en"));
+                disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("15 January 2025").dateFormat(DATETIME_PATTERN)
+                        .transactionAmount(BigDecimal.valueOf(430.0)).locale("en"));
 
                 verifyTransactions(loanId, transaction(430.0, "Disbursement", "15 January 2025") //
                 );
@@ -1016,10 +994,10 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
                 verifyTransactions(loanId, transaction(430.0, "Disbursement", "15 January 2025"), //
                         transaction(0.11, "Accrual", "16 January 2025"));
                 deleteAllExternalEvents();
-                PostLoansLoanIdTransactionsResponse interestPaymentWaiverResponse = loanTransactionHelper.makeLoanRepayment(loanId,
-                        "InterestPaymentWaiver", "17 January 2025", 10.0);
+                PostLoansLoanIdTransactionsResponse interestPaymentWaiverResponse = makeLoanRepayment(loanId, "InterestPaymentWaiver",
+                        "17 January 2025", 10.0);
 
-                List<ExternalEventResponse> allExternalEvents = ExternalEventHelper.getAllExternalEvents(requestSpec, responseSpec);
+                List<ExternalEventResponse> allExternalEvents = externalEventHelper.getAllExternalEvents();
                 List<ExternalEventResponse> adjustments = allExternalEvents.stream()
                         .filter(e -> "LoanAdjustTransactionBusinessEvent".equals(e.getType())).toList();
                 Assertions.assertEquals(0, adjustments.size());
@@ -1055,7 +1033,7 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
     private static Long createLoanProductPeriodicWithInterest() {
         String name = Utils.uniqueRandomStringGenerator("LOAN_PRODUCT_", 6);
         String shortName = Utils.uniqueRandomStringGenerator("", 4);
-        Long resourceId = loanTransactionHelper.createLoanProduct(new PostLoanProductsRequest() //
+        Long resourceId = loanHelper.createLoanProduct(new PostLoanProductsRequest() //
                 .name(name) //
                 .shortName(shortName) //
                 .multiDisburseLoan(true) //
@@ -1099,7 +1077,7 @@ public class ExternalBusinessEventTest extends BaseLoanIntegrationTest {
                 .interestCalculationPeriodType(0).dateFormat("dd MMMM yyyy").transactionProcessingStrategyCode(DEFAULT_STRATEGY)
                 .loanType("individual").submittedOnDate(submittedOnDate).expectedDisbursementDate(expectedDisburmentDate).clientId(clientId)
                 .productId(loanProductId);
-        Long loanId = loanTransactionHelper.applyLoan(loanRequest).getLoanId();
+        Long loanId = loanHelper.applyForLoan(loanRequest).getLoanId();
         log.info("Test MultiDisbursed Loan with Interest. clientId: {} loanId: {}", client.getClientId(), loanId);
         return loanId;
     }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/InstallmentLevelDelinquencyAPIIntegrationTests.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/InstallmentLevelDelinquencyAPIIntegrationTests.java
@@ -25,36 +25,37 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.fineract.client.models.BusinessDateUpdateRequest;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
 import org.apache.fineract.client.models.GetLoansLoanIdLoanInstallmentLevelDelinquency;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
 import org.apache.fineract.client.models.PostLoanProductsRequest;
-import org.apache.fineract.client.models.PostLoanProductsResponse;
 import org.apache.fineract.client.models.PostLoansResponse;
 import org.apache.fineract.client.models.PutLoanProductsProductIdRequest;
 import org.apache.fineract.client.models.PutLoansLoanIdRequest;
 import org.apache.fineract.client.models.PutLoansLoanIdResponse;
-import org.apache.fineract.client.util.CallFailedRuntimeException;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.SchedulerJobHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignDelinquencyHelper;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.products.DelinquencyBucketsHelper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 
 @Slf4j
 @Order(1)
-public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanIntegrationTest {
+public class InstallmentLevelDelinquencyAPIIntegrationTests extends FeignLoanTestBase {
+
+    private final FeignDelinquencyHelper delinquencyHelper = new FeignDelinquencyHelper(FineractFeignClientHelper.getFineractFeignClient());
 
     @Test
     public void testInstallmentLevelDelinquencyFourRangesInTheBucket() {
         runAt("31 May 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create DelinquencyBuckets
-            Long delinquencyBucketId = DelinquencyBucketsHelper.createBucket(List.of(//
+            Long delinquencyBucketId = delinquencyHelper.createBucket(List.of(//
                     Pair.of(1, 10), //
                     Pair.of(11, 30), //
                     Pair.of(31, 60), //
@@ -63,13 +64,13 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
 
             // Create Loan Product
             PostLoanProductsRequest loanProductsRequest = create1InstallmentAmountInMultiplesOf4Period1MonthLongWithInterestAndAmortizationProduct(
-                    InterestType.FLAT, AmortizationType.EQUAL_INSTALLMENTS);
+                    LoanTestData.InterestType.FLAT, LoanTestData.AmortizationType.EQUAL_INSTALLMENTS);
             loanProductsRequest.setEnableInstallmentLevelDelinquency(true);
             loanProductsRequest.setDelinquencyBucketId(delinquencyBucketId.longValue());
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+            Long productId = createLoanProduct(loanProductsRequest);
 
             // Apply and Approve Loan
-            Long loanId = applyAndApproveLoan(clientId, loanProductResponse.getResourceId(), "01 January 2023", 1250.0, 4);
+            Long loanId = applyAndApproveLoan(clientId, productId, "01 January 2023", 1250.0, 4);
 
             // Disburse Loan
             disburseLoan(loanId, BigDecimal.valueOf(1250), "01 January 2023");
@@ -114,23 +115,23 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
     public void testInstallmentLevelDelinquencyTwoRangesInTheBucket() {
         runAt("31 May 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create DelinquencyBuckets
-            Long delinquencyBucketId = DelinquencyBucketsHelper.createBucket(List.of(//
+            Long delinquencyBucketId = delinquencyHelper.createBucket(List.of(//
                     Pair.of(1, 60), //
                     Pair.of(61, null)//
             ));
 
             // Create Loan Product
             PostLoanProductsRequest loanProductsRequest = create1InstallmentAmountInMultiplesOf4Period1MonthLongWithInterestAndAmortizationProduct(
-                    InterestType.FLAT, AmortizationType.EQUAL_INSTALLMENTS);
+                    LoanTestData.InterestType.FLAT, LoanTestData.AmortizationType.EQUAL_INSTALLMENTS);
             loanProductsRequest.setEnableInstallmentLevelDelinquency(true);
             loanProductsRequest.setDelinquencyBucketId(delinquencyBucketId.longValue());
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+            Long productId = createLoanProduct(loanProductsRequest);
 
             // Apply and Approve Loan
-            Long loanId = applyAndApproveLoan(clientId, loanProductResponse.getResourceId(), "01 January 2023", 1250.0, 4);
+            Long loanId = applyAndApproveLoan(clientId, productId, "01 January 2023", 1250.0, 4);
 
             // Disburse Loan
             disburseLoan(loanId, BigDecimal.valueOf(1250), "01 January 2023");
@@ -164,23 +165,23 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
     public void testInstallmentLevelDelinquencyIsTurnedOff() {
         runAt("31 May 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create DelinquencyBuckets
-            Long delinquencyBucketId = DelinquencyBucketsHelper.createBucket(List.of(//
+            Long delinquencyBucketId = delinquencyHelper.createBucket(List.of(//
                     Pair.of(1, 60), //
                     Pair.of(61, null)//
             ));
 
             // Create Loan Product
             PostLoanProductsRequest loanProductsRequest = create1InstallmentAmountInMultiplesOf4Period1MonthLongWithInterestAndAmortizationProduct(
-                    InterestType.FLAT, AmortizationType.EQUAL_INSTALLMENTS);
+                    LoanTestData.InterestType.FLAT, LoanTestData.AmortizationType.EQUAL_INSTALLMENTS);
             loanProductsRequest.setEnableInstallmentLevelDelinquency(false);
             loanProductsRequest.setDelinquencyBucketId(delinquencyBucketId.longValue());
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+            Long productId = createLoanProduct(loanProductsRequest);
 
             // Apply and Approve Loan
-            Long loanId = applyAndApproveLoan(clientId, loanProductResponse.getResourceId(), "01 January 2023", 1250.0, 4);
+            Long loanId = applyAndApproveLoan(clientId, productId, "01 January 2023", 1250.0, 4);
 
             // Disburse Loan
             disburseLoan(loanId, BigDecimal.valueOf(1250), "01 January 2023");
@@ -203,23 +204,23 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
     public void testInstallmentLevelDelinquencyUpdatedWhenCOBIsExecuted() {
         runAt("01 February 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create DelinquencyBuckets
-            Long delinquencyBucketId = DelinquencyBucketsHelper.createBucket(List.of(//
+            Long delinquencyBucketId = delinquencyHelper.createBucket(List.of(//
                     Pair.of(1, 1), //
                     Pair.of(2, null)//
             ));
 
             // Create Loan Product
             PostLoanProductsRequest loanProductsRequest = create1InstallmentAmountInMultiplesOf4Period1MonthLongWithInterestAndAmortizationProduct(
-                    InterestType.FLAT, AmortizationType.EQUAL_INSTALLMENTS);
+                    LoanTestData.InterestType.FLAT, LoanTestData.AmortizationType.EQUAL_INSTALLMENTS);
             loanProductsRequest.setEnableInstallmentLevelDelinquency(true);
             loanProductsRequest.setDelinquencyBucketId(delinquencyBucketId.longValue());
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+            Long productId = createLoanProduct(loanProductsRequest);
 
             // Apply and Approve Loan
-            Long loanId = applyAndApproveLoan(clientId, loanProductResponse.getResourceId(), "01 January 2023", 1250.0, 4);
+            Long loanId = applyAndApproveLoan(clientId, productId, "01 January 2023", 1250.0, 4);
 
             // Disburse Loan
             disburseLoan(loanId, BigDecimal.valueOf(1250), "01 January 2023");
@@ -249,10 +250,10 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
     public void testInstallmentLevelDelinquencyTurnedOnForProductAndOffForLoan() {
         runAt("31 May 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create DelinquencyBuckets
-            Long delinquencyBucketId = DelinquencyBucketsHelper.createBucket(List.of(//
+            Long delinquencyBucketId = delinquencyHelper.createBucket(List.of(//
                     Pair.of(1, 10), //
                     Pair.of(11, 30), //
                     Pair.of(31, 60), //
@@ -261,14 +262,14 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
 
             // Create Loan Product
             PostLoanProductsRequest loanProductsRequest = create1InstallmentAmountInMultiplesOf4Period1MonthLongWithInterestAndAmortizationProduct(
-                    InterestType.FLAT, AmortizationType.EQUAL_INSTALLMENTS);
+                    LoanTestData.InterestType.FLAT, LoanTestData.AmortizationType.EQUAL_INSTALLMENTS);
             // set installment level delinquency as true
             loanProductsRequest.setEnableInstallmentLevelDelinquency(true);
             loanProductsRequest.setDelinquencyBucketId(delinquencyBucketId.longValue());
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+            Long productId = createLoanProduct(loanProductsRequest);
 
             // Apply and Approve Loan, turn loan level installment delinquency as false
-            Long loanId = applyAndApproveLoan(clientId, loanProductResponse.getResourceId(), "01 January 2023", 1250.0, 4,
+            Long loanId = applyAndApproveLoan(clientId, productId, "01 January 2023", 1250.0, 4,
                     req -> req.setEnableInstallmentLevelDelinquency(false));
 
             // Disburse Loan
@@ -294,10 +295,10 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
     public void testInstallmentLevelDelinquencyTurnedOffForProductAndOnForLoan() {
         runAt("31 May 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create DelinquencyBuckets
-            Long delinquencyBucketId = DelinquencyBucketsHelper.createBucket(List.of(//
+            Long delinquencyBucketId = delinquencyHelper.createBucket(List.of(//
                     Pair.of(1, 10), //
                     Pair.of(11, 30), //
                     Pair.of(31, 60), //
@@ -306,14 +307,14 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
 
             // Create Loan Product
             PostLoanProductsRequest loanProductsRequest = create1InstallmentAmountInMultiplesOf4Period1MonthLongWithInterestAndAmortizationProduct(
-                    InterestType.FLAT, AmortizationType.EQUAL_INSTALLMENTS);
+                    LoanTestData.InterestType.FLAT, LoanTestData.AmortizationType.EQUAL_INSTALLMENTS);
             // set installment level delinquency as false
             loanProductsRequest.setEnableInstallmentLevelDelinquency(false);
             loanProductsRequest.setDelinquencyBucketId(delinquencyBucketId.longValue());
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+            Long productId = createLoanProduct(loanProductsRequest);
 
             // Apply and Approve Loan, turn loan level installment delinquency as true
-            Long loanId = applyAndApproveLoan(clientId, loanProductResponse.getResourceId(), "01 January 2023", 1250.0, 4,
+            Long loanId = applyAndApproveLoan(clientId, productId, "01 January 2023", 1250.0, 4,
                     req -> req.setEnableInstallmentLevelDelinquency(true));
 
             // Disburse Loan
@@ -343,10 +344,10 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
     public void testLoanInheritsInstallmentLevelSettingFromLoanProductIfNotSet() {
         runAt("31 May 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create DelinquencyBuckets
-            Long delinquencyBucketId = DelinquencyBucketsHelper.createBucket(List.of(//
+            Long delinquencyBucketId = delinquencyHelper.createBucket(List.of(//
                     Pair.of(1, 10), //
                     Pair.of(11, 30), //
                     Pair.of(31, 60), //
@@ -355,14 +356,14 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
 
             // Create Loan Product
             PostLoanProductsRequest loanProductsRequest = create1InstallmentAmountInMultiplesOf4Period1MonthLongWithInterestAndAmortizationProduct(
-                    InterestType.FLAT, AmortizationType.EQUAL_INSTALLMENTS);
+                    LoanTestData.InterestType.FLAT, LoanTestData.AmortizationType.EQUAL_INSTALLMENTS);
             // set installment level delinquency as true
             loanProductsRequest.setEnableInstallmentLevelDelinquency(true);
             loanProductsRequest.setDelinquencyBucketId(delinquencyBucketId.longValue());
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+            Long productId = createLoanProduct(loanProductsRequest);
 
             // Apply and Approve Loan, do not set installment level delinquency
-            Long loanId = applyAndApproveLoan(clientId, loanProductResponse.getResourceId(), "01 January 2023", 1250.0, 4);
+            Long loanId = applyAndApproveLoan(clientId, productId, "01 January 2023", 1250.0, 4);
 
             // Disburse Loan
             disburseLoan(loanId, BigDecimal.valueOf(1250), "01 January 2023");
@@ -392,17 +393,17 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
 
         runAt("31 May 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create Loan Product
             PostLoanProductsRequest loanProductsRequest = create1InstallmentAmountInMultiplesOf4Period1MonthLongWithInterestAndAmortizationProduct(
-                    InterestType.FLAT, AmortizationType.EQUAL_INSTALLMENTS);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+                    LoanTestData.InterestType.FLAT, LoanTestData.AmortizationType.EQUAL_INSTALLMENTS);
+            Long productId = createLoanProduct(loanProductsRequest);
 
             // Apply For Loan with installment level delinquency setting
             CallFailedRuntimeException callFailedRuntimeException = Assertions.assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.applyLoan(applyLoanRequest(clientId, loanProductResponse.getResourceId(), "01 January 2023",
-                            1250.0, 4, req -> req.setEnableInstallmentLevelDelinquency(true))));
+                    () -> applyForLoan(applyLoanRequest(clientId, productId, "01 January 2023", 1250.0, 4,
+                            req -> req.setEnableInstallmentLevelDelinquency(true))));
 
             Assertions.assertTrue(callFailedRuntimeException.getMessage().contains(
                     "Installment level delinquency cannot be enabled for a loan if Delinquency bucket is not configured for loan product"));
@@ -415,10 +416,10 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
     public void testLoanInstallmentLevelSettingModification() {
         runAt("31 May 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create DelinquencyBuckets
-            Long delinquencyBucketId = DelinquencyBucketsHelper.createBucket(List.of(//
+            Long delinquencyBucketId = delinquencyHelper.createBucket(List.of(//
                     Pair.of(1, 10), //
                     Pair.of(11, 30), //
                     Pair.of(31, 60), //
@@ -427,32 +428,30 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
 
             // Create Loan Product
             PostLoanProductsRequest loanProductsRequest = create1InstallmentAmountInMultiplesOf4Period1MonthLongWithInterestAndAmortizationProduct(
-                    InterestType.FLAT, AmortizationType.EQUAL_INSTALLMENTS);
+                    LoanTestData.InterestType.FLAT, LoanTestData.AmortizationType.EQUAL_INSTALLMENTS);
 
             // set delinquency bucket
             loanProductsRequest.setDelinquencyBucketId(delinquencyBucketId.longValue());
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+            Long productId = createLoanProduct(loanProductsRequest);
 
             // Apply for loan
-            Long loanId = loanTransactionHelper
-                    .applyLoan(applyLoanRequest(clientId, loanProductResponse.getResourceId(), "01 January 2023", 1250.0, 4))
-                    .getResourceId();
+            Long loanId = applyForLoan(applyLoanRequest(clientId, productId, "01 January 2023", 1250.0, 4));
 
             // verify installment level delinquency setting for loan
-            GetLoansLoanIdResponse loanResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId.intValue());
+            GetLoansLoanIdResponse loanResponse = getLoanDetails(loanId);
             assertThat(loanResponse.getEnableInstallmentLevelDelinquency()).isFalse();
 
             // Modify installment level delinquency as true for loan
-            PutLoansLoanIdResponse loansModificationResponse = loanTransactionHelper.modifyApplicationForLoan(loanId, "modify",
-                    new PutLoansLoanIdRequest().clientId(clientId).productId(loanProductResponse.getResourceId()).loanType("individual")
+            PutLoansLoanIdResponse loansModificationResponse = modifyLoanApplication(loanId, "modify",
+                    new PutLoansLoanIdRequest().clientId(clientId).productId(productId).loanType("individual")
                             .enableInstallmentLevelDelinquency(true).locale("en").dateFormat(DATETIME_PATTERN));
 
             // verify installment level delinquency setting for loan
-            loanResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId.intValue());
+            loanResponse = getLoanDetails(loanId);
             assertThat(loanResponse.getEnableInstallmentLevelDelinquency()).isTrue();
 
             // Approve Loan
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(1250.0, "01 January 2023"));
+            approveLoan(loanId, approveLoanRequest(1250.0, "01 January 2023"));
 
             // Disburse Loan
             disburseLoan(loanId, BigDecimal.valueOf(1250), "01 January 2023");
@@ -483,24 +482,20 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
 
         runAt("31 May 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create Loan Product without delinquency bucket
             PostLoanProductsRequest loanProductsRequest = create1InstallmentAmountInMultiplesOf4Period1MonthLongWithInterestAndAmortizationProduct(
-                    InterestType.FLAT, AmortizationType.EQUAL_INSTALLMENTS);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+                    LoanTestData.InterestType.FLAT, LoanTestData.AmortizationType.EQUAL_INSTALLMENTS);
+            Long productId = createLoanProduct(loanProductsRequest);
 
             // Apply for loan
-            Long loanId = loanTransactionHelper
-                    .applyLoan(applyLoanRequest(clientId, loanProductResponse.getResourceId(), "01 January 2023", 1250.0, 4))
-                    .getResourceId();
+            Long loanId = applyForLoan(applyLoanRequest(clientId, productId, "01 January 2023", 1250.0, 4));
 
             // Modify Loan with installment level delinquency setting
             CallFailedRuntimeException callFailedRuntimeException = Assertions.assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.modifyApplicationForLoan(loanId, "modify",
-                            new PutLoansLoanIdRequest().clientId(clientId).productId(loanProductResponse.getResourceId())
-                                    .loanType("individual").enableInstallmentLevelDelinquency(true).locale("en")
-                                    .dateFormat(DATETIME_PATTERN)));
+                    () -> modifyLoanApplication(loanId, "modify", new PutLoansLoanIdRequest().clientId(clientId).productId(productId)
+                            .loanType("individual").enableInstallmentLevelDelinquency(true).locale("en").dateFormat(DATETIME_PATTERN)));
 
             Assertions.assertTrue(callFailedRuntimeException.getMessage().contains(
                     "Installment level delinquency cannot be enabled for a loan if Delinquency bucket is not configured for loan product"));
@@ -512,10 +507,10 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
     public void testCalculateRepaymentScheduleWorksWithInstallmentLevelDelinquencySetting() {
         runAt("31 May 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create DelinquencyBuckets
-            Long delinquencyBucketId = DelinquencyBucketsHelper.createBucket(List.of(//
+            Long delinquencyBucketId = delinquencyHelper.createBucket(List.of(//
                     Pair.of(1, 10), //
                     Pair.of(11, 30), //
                     Pair.of(31, 60), //
@@ -524,17 +519,16 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
 
             // Create Loan Product
             PostLoanProductsRequest loanProductsRequest = create1InstallmentAmountInMultiplesOf4Period1MonthLongWithInterestAndAmortizationProduct(
-                    InterestType.FLAT, AmortizationType.EQUAL_INSTALLMENTS);
+                    LoanTestData.InterestType.FLAT, LoanTestData.AmortizationType.EQUAL_INSTALLMENTS);
 
             // set installment level delinquency as false
             loanProductsRequest.setEnableInstallmentLevelDelinquency(false);
             loanProductsRequest.setDelinquencyBucketId(delinquencyBucketId.longValue());
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+            Long productId = createLoanProduct(loanProductsRequest);
 
             // run calculateLoanSchedule command works, while Applying for loan with installment level delinquency
-            PostLoansResponse loansResponse = loanTransactionHelper
-                    .calculateRepaymentScheduleForApplyLoan(applyLoanRequest(clientId, loanProductResponse.getResourceId(),
-                            "01 January 2023", 1250.0, 4, req -> req.setEnableInstallmentLevelDelinquency(true)), "calculateLoanSchedule");
+            PostLoansResponse loansResponse = calculateLoanSchedule(applyLoanRequest(clientId, productId, "01 January 2023", 1250.0, 4,
+                    req -> req.setEnableInstallmentLevelDelinquency(true)));
 
             assertThat(loansResponse).isNotNull();
             assertNotNull(loansResponse.getPeriods());
@@ -549,17 +543,17 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
 
         runAt("31 May 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create Loan Product without delinquency bucket
             PostLoanProductsRequest loanProductsRequest = create1InstallmentAmountInMultiplesOf4Period1MonthLongWithInterestAndAmortizationProduct(
-                    InterestType.FLAT, AmortizationType.EQUAL_INSTALLMENTS);
+                    LoanTestData.InterestType.FLAT, LoanTestData.AmortizationType.EQUAL_INSTALLMENTS);
             // set installment level delinquency as true
             loanProductsRequest.setEnableInstallmentLevelDelinquency(true);
 
             // Create loan product with installment level delinquency setting
             CallFailedRuntimeException callFailedRuntimeException = Assertions.assertThrows(CallFailedRuntimeException.class,
-                    () -> loanProductHelper.createLoanProduct(loanProductsRequest));
+                    () -> createLoanProduct(loanProductsRequest));
 
             Assertions.assertTrue(callFailedRuntimeException.getMessage()
                     .contains("Installment level delinquency cannot be enabled if Delinquency bucket is not configured for loan product"));
@@ -573,17 +567,17 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
 
         runAt("31 May 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create Loan Product without delinquency bucket
             PostLoanProductsRequest loanProductsRequest = create1InstallmentAmountInMultiplesOf4Period1MonthLongWithInterestAndAmortizationProduct(
-                    InterestType.FLAT, AmortizationType.EQUAL_INSTALLMENTS);
+                    LoanTestData.InterestType.FLAT, LoanTestData.AmortizationType.EQUAL_INSTALLMENTS);
 
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+            Long productId = createLoanProduct(loanProductsRequest);
 
             // Update loan product with installment level delinquency setting
             CallFailedRuntimeException callFailedRuntimeException = Assertions.assertThrows(CallFailedRuntimeException.class,
-                    () -> loanProductHelper.updateLoanProductById(loanProductResponse.getResourceId(),
+                    () -> updateLoanProduct(productId,
                             new PutLoanProductsProductIdRequest().enableInstallmentLevelDelinquency(true).locale("en")));
 
             Assertions.assertTrue(callFailedRuntimeException.getMessage()
@@ -594,9 +588,8 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
     }
 
     private void updateBusinessDateAndExecuteCOBJob(String date) {
-        businessDateHelper.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                .date(date).dateFormat(DATETIME_PATTERN).locale("en"));
-        SchedulerJobHelper.executeAndAwaitJob("Loan COB");
+        updateBusinessDate(date);
+        schedulerHelper.executeAndAwaitJob("Loan COB");
     }
 
     @AllArgsConstructor
@@ -613,7 +606,7 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
 
     private void verifyDelinquency(Long loanId, Integer loanLevelDelinquentDays, String loanLevelDelinquentAmount,
             DelinquencyData... expectedInstallmentLevelDelinquencyData) {
-        GetLoansLoanIdResponse loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId.intValue());
+        GetLoansLoanIdResponse loan = getLoanDetails(loanId);
         assertThat(loan.getDelinquent()).isNotNull();
         List<GetLoansLoanIdLoanInstallmentLevelDelinquency> installmentLevelDelinquency = loan.getDelinquent()
                 .getInstallmentLevelDelinquency();

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/InstallmentLevelDelinquencyAPIIntegrationTests.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/InstallmentLevelDelinquencyAPIIntegrationTests.java
@@ -25,36 +25,35 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.fineract.client.models.BusinessDateUpdateRequest;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
 import org.apache.fineract.client.models.GetLoansLoanIdLoanInstallmentLevelDelinquency;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
 import org.apache.fineract.client.models.PostLoanProductsRequest;
-import org.apache.fineract.client.models.PostLoanProductsResponse;
 import org.apache.fineract.client.models.PostLoansResponse;
 import org.apache.fineract.client.models.PutLoanProductsProductIdRequest;
 import org.apache.fineract.client.models.PutLoansLoanIdRequest;
 import org.apache.fineract.client.models.PutLoansLoanIdResponse;
-import org.apache.fineract.client.util.CallFailedRuntimeException;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.SchedulerJobHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignDelinquencyHelper;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.products.DelinquencyBucketsHelper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 @Slf4j
-public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanIntegrationTest {
+public class InstallmentLevelDelinquencyAPIIntegrationTests extends FeignLoanTestBase {
 
-    private SchedulerJobHelper schedulerJobHelper = new SchedulerJobHelper(this.requestSpec);
+    private final FeignDelinquencyHelper delinquencyHelper = new FeignDelinquencyHelper(FineractFeignClientHelper.getFineractFeignClient());
 
     @Test
     public void testInstallmentLevelDelinquencyFourRangesInTheBucket() {
         runAt("31 May 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create DelinquencyBuckets
-            Long delinquencyBucketId = DelinquencyBucketsHelper.createBucket(List.of(//
+            Long delinquencyBucketId = delinquencyHelper.createBucket(List.of(//
                     Pair.of(1, 10), //
                     Pair.of(11, 30), //
                     Pair.of(31, 60), //
@@ -63,13 +62,13 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
 
             // Create Loan Product
             PostLoanProductsRequest loanProductsRequest = create1InstallmentAmountInMultiplesOf4Period1MonthLongWithInterestAndAmortizationProduct(
-                    InterestType.FLAT, AmortizationType.EQUAL_INSTALLMENTS);
+                    LoanTestData.InterestType.FLAT, LoanTestData.AmortizationType.EQUAL_INSTALLMENTS);
             loanProductsRequest.setEnableInstallmentLevelDelinquency(true);
             loanProductsRequest.setDelinquencyBucketId(delinquencyBucketId.longValue());
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+            Long productId = createLoanProduct(loanProductsRequest);
 
             // Apply and Approve Loan
-            Long loanId = applyAndApproveLoan(clientId, loanProductResponse.getResourceId(), "01 January 2023", 1250.0, 4);
+            Long loanId = applyAndApproveLoan(clientId, productId, "01 January 2023", 1250.0, 4);
 
             // Disburse Loan
             disburseLoan(loanId, BigDecimal.valueOf(1250), "01 January 2023");
@@ -114,23 +113,23 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
     public void testInstallmentLevelDelinquencyTwoRangesInTheBucket() {
         runAt("31 May 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create DelinquencyBuckets
-            Long delinquencyBucketId = DelinquencyBucketsHelper.createBucket(List.of(//
+            Long delinquencyBucketId = delinquencyHelper.createBucket(List.of(//
                     Pair.of(1, 60), //
                     Pair.of(61, null)//
             ));
 
             // Create Loan Product
             PostLoanProductsRequest loanProductsRequest = create1InstallmentAmountInMultiplesOf4Period1MonthLongWithInterestAndAmortizationProduct(
-                    InterestType.FLAT, AmortizationType.EQUAL_INSTALLMENTS);
+                    LoanTestData.InterestType.FLAT, LoanTestData.AmortizationType.EQUAL_INSTALLMENTS);
             loanProductsRequest.setEnableInstallmentLevelDelinquency(true);
             loanProductsRequest.setDelinquencyBucketId(delinquencyBucketId.longValue());
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+            Long productId = createLoanProduct(loanProductsRequest);
 
             // Apply and Approve Loan
-            Long loanId = applyAndApproveLoan(clientId, loanProductResponse.getResourceId(), "01 January 2023", 1250.0, 4);
+            Long loanId = applyAndApproveLoan(clientId, productId, "01 January 2023", 1250.0, 4);
 
             // Disburse Loan
             disburseLoan(loanId, BigDecimal.valueOf(1250), "01 January 2023");
@@ -164,23 +163,23 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
     public void testInstallmentLevelDelinquencyIsTurnedOff() {
         runAt("31 May 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create DelinquencyBuckets
-            Long delinquencyBucketId = DelinquencyBucketsHelper.createBucket(List.of(//
+            Long delinquencyBucketId = delinquencyHelper.createBucket(List.of(//
                     Pair.of(1, 60), //
                     Pair.of(61, null)//
             ));
 
             // Create Loan Product
             PostLoanProductsRequest loanProductsRequest = create1InstallmentAmountInMultiplesOf4Period1MonthLongWithInterestAndAmortizationProduct(
-                    InterestType.FLAT, AmortizationType.EQUAL_INSTALLMENTS);
+                    LoanTestData.InterestType.FLAT, LoanTestData.AmortizationType.EQUAL_INSTALLMENTS);
             loanProductsRequest.setEnableInstallmentLevelDelinquency(false);
             loanProductsRequest.setDelinquencyBucketId(delinquencyBucketId.longValue());
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+            Long productId = createLoanProduct(loanProductsRequest);
 
             // Apply and Approve Loan
-            Long loanId = applyAndApproveLoan(clientId, loanProductResponse.getResourceId(), "01 January 2023", 1250.0, 4);
+            Long loanId = applyAndApproveLoan(clientId, productId, "01 January 2023", 1250.0, 4);
 
             // Disburse Loan
             disburseLoan(loanId, BigDecimal.valueOf(1250), "01 January 2023");
@@ -203,23 +202,23 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
     public void testInstallmentLevelDelinquencyUpdatedWhenCOBIsExecuted() {
         runAt("01 February 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create DelinquencyBuckets
-            Long delinquencyBucketId = DelinquencyBucketsHelper.createBucket(List.of(//
+            Long delinquencyBucketId = delinquencyHelper.createBucket(List.of(//
                     Pair.of(1, 1), //
                     Pair.of(2, null)//
             ));
 
             // Create Loan Product
             PostLoanProductsRequest loanProductsRequest = create1InstallmentAmountInMultiplesOf4Period1MonthLongWithInterestAndAmortizationProduct(
-                    InterestType.FLAT, AmortizationType.EQUAL_INSTALLMENTS);
+                    LoanTestData.InterestType.FLAT, LoanTestData.AmortizationType.EQUAL_INSTALLMENTS);
             loanProductsRequest.setEnableInstallmentLevelDelinquency(true);
             loanProductsRequest.setDelinquencyBucketId(delinquencyBucketId.longValue());
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+            Long productId = createLoanProduct(loanProductsRequest);
 
             // Apply and Approve Loan
-            Long loanId = applyAndApproveLoan(clientId, loanProductResponse.getResourceId(), "01 January 2023", 1250.0, 4);
+            Long loanId = applyAndApproveLoan(clientId, productId, "01 January 2023", 1250.0, 4);
 
             // Disburse Loan
             disburseLoan(loanId, BigDecimal.valueOf(1250), "01 January 2023");
@@ -249,10 +248,10 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
     public void testInstallmentLevelDelinquencyTurnedOnForProductAndOffForLoan() {
         runAt("31 May 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create DelinquencyBuckets
-            Long delinquencyBucketId = DelinquencyBucketsHelper.createBucket(List.of(//
+            Long delinquencyBucketId = delinquencyHelper.createBucket(List.of(//
                     Pair.of(1, 10), //
                     Pair.of(11, 30), //
                     Pair.of(31, 60), //
@@ -261,14 +260,14 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
 
             // Create Loan Product
             PostLoanProductsRequest loanProductsRequest = create1InstallmentAmountInMultiplesOf4Period1MonthLongWithInterestAndAmortizationProduct(
-                    InterestType.FLAT, AmortizationType.EQUAL_INSTALLMENTS);
+                    LoanTestData.InterestType.FLAT, LoanTestData.AmortizationType.EQUAL_INSTALLMENTS);
             // set installment level delinquency as true
             loanProductsRequest.setEnableInstallmentLevelDelinquency(true);
             loanProductsRequest.setDelinquencyBucketId(delinquencyBucketId.longValue());
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+            Long productId = createLoanProduct(loanProductsRequest);
 
             // Apply and Approve Loan, turn loan level installment delinquency as false
-            Long loanId = applyAndApproveLoan(clientId, loanProductResponse.getResourceId(), "01 January 2023", 1250.0, 4,
+            Long loanId = applyAndApproveLoan(clientId, productId, "01 January 2023", 1250.0, 4,
                     req -> req.setEnableInstallmentLevelDelinquency(false));
 
             // Disburse Loan
@@ -294,10 +293,10 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
     public void testInstallmentLevelDelinquencyTurnedOffForProductAndOnForLoan() {
         runAt("31 May 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create DelinquencyBuckets
-            Long delinquencyBucketId = DelinquencyBucketsHelper.createBucket(List.of(//
+            Long delinquencyBucketId = delinquencyHelper.createBucket(List.of(//
                     Pair.of(1, 10), //
                     Pair.of(11, 30), //
                     Pair.of(31, 60), //
@@ -306,14 +305,14 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
 
             // Create Loan Product
             PostLoanProductsRequest loanProductsRequest = create1InstallmentAmountInMultiplesOf4Period1MonthLongWithInterestAndAmortizationProduct(
-                    InterestType.FLAT, AmortizationType.EQUAL_INSTALLMENTS);
+                    LoanTestData.InterestType.FLAT, LoanTestData.AmortizationType.EQUAL_INSTALLMENTS);
             // set installment level delinquency as false
             loanProductsRequest.setEnableInstallmentLevelDelinquency(false);
             loanProductsRequest.setDelinquencyBucketId(delinquencyBucketId.longValue());
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+            Long productId = createLoanProduct(loanProductsRequest);
 
             // Apply and Approve Loan, turn loan level installment delinquency as true
-            Long loanId = applyAndApproveLoan(clientId, loanProductResponse.getResourceId(), "01 January 2023", 1250.0, 4,
+            Long loanId = applyAndApproveLoan(clientId, productId, "01 January 2023", 1250.0, 4,
                     req -> req.setEnableInstallmentLevelDelinquency(true));
 
             // Disburse Loan
@@ -343,10 +342,10 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
     public void testLoanInheritsInstallmentLevelSettingFromLoanProductIfNotSet() {
         runAt("31 May 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create DelinquencyBuckets
-            Long delinquencyBucketId = DelinquencyBucketsHelper.createBucket(List.of(//
+            Long delinquencyBucketId = delinquencyHelper.createBucket(List.of(//
                     Pair.of(1, 10), //
                     Pair.of(11, 30), //
                     Pair.of(31, 60), //
@@ -355,14 +354,14 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
 
             // Create Loan Product
             PostLoanProductsRequest loanProductsRequest = create1InstallmentAmountInMultiplesOf4Period1MonthLongWithInterestAndAmortizationProduct(
-                    InterestType.FLAT, AmortizationType.EQUAL_INSTALLMENTS);
+                    LoanTestData.InterestType.FLAT, LoanTestData.AmortizationType.EQUAL_INSTALLMENTS);
             // set installment level delinquency as true
             loanProductsRequest.setEnableInstallmentLevelDelinquency(true);
             loanProductsRequest.setDelinquencyBucketId(delinquencyBucketId.longValue());
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+            Long productId = createLoanProduct(loanProductsRequest);
 
             // Apply and Approve Loan, do not set installment level delinquency
-            Long loanId = applyAndApproveLoan(clientId, loanProductResponse.getResourceId(), "01 January 2023", 1250.0, 4);
+            Long loanId = applyAndApproveLoan(clientId, productId, "01 January 2023", 1250.0, 4);
 
             // Disburse Loan
             disburseLoan(loanId, BigDecimal.valueOf(1250), "01 January 2023");
@@ -392,17 +391,17 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
 
         runAt("31 May 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create Loan Product
             PostLoanProductsRequest loanProductsRequest = create1InstallmentAmountInMultiplesOf4Period1MonthLongWithInterestAndAmortizationProduct(
-                    InterestType.FLAT, AmortizationType.EQUAL_INSTALLMENTS);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+                    LoanTestData.InterestType.FLAT, LoanTestData.AmortizationType.EQUAL_INSTALLMENTS);
+            Long productId = createLoanProduct(loanProductsRequest);
 
             // Apply For Loan with installment level delinquency setting
             CallFailedRuntimeException callFailedRuntimeException = Assertions.assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.applyLoan(applyLoanRequest(clientId, loanProductResponse.getResourceId(), "01 January 2023",
-                            1250.0, 4, req -> req.setEnableInstallmentLevelDelinquency(true))));
+                    () -> applyForLoan(applyLoanRequest(clientId, productId, "01 January 2023", 1250.0, 4,
+                            req -> req.setEnableInstallmentLevelDelinquency(true))));
 
             Assertions.assertTrue(callFailedRuntimeException.getMessage().contains(
                     "Installment level delinquency cannot be enabled for a loan if Delinquency bucket is not configured for loan product"));
@@ -415,10 +414,10 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
     public void testLoanInstallmentLevelSettingModification() {
         runAt("31 May 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create DelinquencyBuckets
-            Long delinquencyBucketId = DelinquencyBucketsHelper.createBucket(List.of(//
+            Long delinquencyBucketId = delinquencyHelper.createBucket(List.of(//
                     Pair.of(1, 10), //
                     Pair.of(11, 30), //
                     Pair.of(31, 60), //
@@ -427,32 +426,30 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
 
             // Create Loan Product
             PostLoanProductsRequest loanProductsRequest = create1InstallmentAmountInMultiplesOf4Period1MonthLongWithInterestAndAmortizationProduct(
-                    InterestType.FLAT, AmortizationType.EQUAL_INSTALLMENTS);
+                    LoanTestData.InterestType.FLAT, LoanTestData.AmortizationType.EQUAL_INSTALLMENTS);
 
             // set delinquency bucket
             loanProductsRequest.setDelinquencyBucketId(delinquencyBucketId.longValue());
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+            Long productId = createLoanProduct(loanProductsRequest);
 
             // Apply for loan
-            Long loanId = loanTransactionHelper
-                    .applyLoan(applyLoanRequest(clientId, loanProductResponse.getResourceId(), "01 January 2023", 1250.0, 4))
-                    .getResourceId();
+            Long loanId = applyForLoan(applyLoanRequest(clientId, productId, "01 January 2023", 1250.0, 4));
 
             // verify installment level delinquency setting for loan
-            GetLoansLoanIdResponse loanResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId.intValue());
+            GetLoansLoanIdResponse loanResponse = getLoanDetails(loanId);
             assertThat(loanResponse.getEnableInstallmentLevelDelinquency()).isFalse();
 
             // Modify installment level delinquency as true for loan
-            PutLoansLoanIdResponse loansModificationResponse = loanTransactionHelper.modifyApplicationForLoan(loanId, "modify",
-                    new PutLoansLoanIdRequest().clientId(clientId).productId(loanProductResponse.getResourceId()).loanType("individual")
+            PutLoansLoanIdResponse loansModificationResponse = modifyLoanApplication(loanId, "modify",
+                    new PutLoansLoanIdRequest().clientId(clientId).productId(productId).loanType("individual")
                             .enableInstallmentLevelDelinquency(true).locale("en").dateFormat(DATETIME_PATTERN));
 
             // verify installment level delinquency setting for loan
-            loanResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId.intValue());
+            loanResponse = getLoanDetails(loanId);
             assertThat(loanResponse.getEnableInstallmentLevelDelinquency()).isTrue();
 
             // Approve Loan
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(1250.0, "01 January 2023"));
+            approveLoan(loanId, approveLoanRequest(1250.0, "01 January 2023"));
 
             // Disburse Loan
             disburseLoan(loanId, BigDecimal.valueOf(1250), "01 January 2023");
@@ -483,24 +480,20 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
 
         runAt("31 May 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create Loan Product without delinquency bucket
             PostLoanProductsRequest loanProductsRequest = create1InstallmentAmountInMultiplesOf4Period1MonthLongWithInterestAndAmortizationProduct(
-                    InterestType.FLAT, AmortizationType.EQUAL_INSTALLMENTS);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+                    LoanTestData.InterestType.FLAT, LoanTestData.AmortizationType.EQUAL_INSTALLMENTS);
+            Long productId = createLoanProduct(loanProductsRequest);
 
             // Apply for loan
-            Long loanId = loanTransactionHelper
-                    .applyLoan(applyLoanRequest(clientId, loanProductResponse.getResourceId(), "01 January 2023", 1250.0, 4))
-                    .getResourceId();
+            Long loanId = applyForLoan(applyLoanRequest(clientId, productId, "01 January 2023", 1250.0, 4));
 
             // Modify Loan with installment level delinquency setting
             CallFailedRuntimeException callFailedRuntimeException = Assertions.assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.modifyApplicationForLoan(loanId, "modify",
-                            new PutLoansLoanIdRequest().clientId(clientId).productId(loanProductResponse.getResourceId())
-                                    .loanType("individual").enableInstallmentLevelDelinquency(true).locale("en")
-                                    .dateFormat(DATETIME_PATTERN)));
+                    () -> modifyLoanApplication(loanId, "modify", new PutLoansLoanIdRequest().clientId(clientId).productId(productId)
+                            .loanType("individual").enableInstallmentLevelDelinquency(true).locale("en").dateFormat(DATETIME_PATTERN)));
 
             Assertions.assertTrue(callFailedRuntimeException.getMessage().contains(
                     "Installment level delinquency cannot be enabled for a loan if Delinquency bucket is not configured for loan product"));
@@ -512,10 +505,10 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
     public void testCalculateRepaymentScheduleWorksWithInstallmentLevelDelinquencySetting() {
         runAt("31 May 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create DelinquencyBuckets
-            Long delinquencyBucketId = DelinquencyBucketsHelper.createBucket(List.of(//
+            Long delinquencyBucketId = delinquencyHelper.createBucket(List.of(//
                     Pair.of(1, 10), //
                     Pair.of(11, 30), //
                     Pair.of(31, 60), //
@@ -524,17 +517,16 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
 
             // Create Loan Product
             PostLoanProductsRequest loanProductsRequest = create1InstallmentAmountInMultiplesOf4Period1MonthLongWithInterestAndAmortizationProduct(
-                    InterestType.FLAT, AmortizationType.EQUAL_INSTALLMENTS);
+                    LoanTestData.InterestType.FLAT, LoanTestData.AmortizationType.EQUAL_INSTALLMENTS);
 
             // set installment level delinquency as false
             loanProductsRequest.setEnableInstallmentLevelDelinquency(false);
             loanProductsRequest.setDelinquencyBucketId(delinquencyBucketId.longValue());
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+            Long productId = createLoanProduct(loanProductsRequest);
 
             // run calculateLoanSchedule command works, while Applying for loan with installment level delinquency
-            PostLoansResponse loansResponse = loanTransactionHelper
-                    .calculateRepaymentScheduleForApplyLoan(applyLoanRequest(clientId, loanProductResponse.getResourceId(),
-                            "01 January 2023", 1250.0, 4, req -> req.setEnableInstallmentLevelDelinquency(true)), "calculateLoanSchedule");
+            PostLoansResponse loansResponse = calculateLoanSchedule(applyLoanRequest(clientId, productId, "01 January 2023", 1250.0, 4,
+                    req -> req.setEnableInstallmentLevelDelinquency(true)));
 
             assertThat(loansResponse).isNotNull();
             assertNotNull(loansResponse.getPeriods());
@@ -549,17 +541,17 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
 
         runAt("31 May 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create Loan Product without delinquency bucket
             PostLoanProductsRequest loanProductsRequest = create1InstallmentAmountInMultiplesOf4Period1MonthLongWithInterestAndAmortizationProduct(
-                    InterestType.FLAT, AmortizationType.EQUAL_INSTALLMENTS);
+                    LoanTestData.InterestType.FLAT, LoanTestData.AmortizationType.EQUAL_INSTALLMENTS);
             // set installment level delinquency as true
             loanProductsRequest.setEnableInstallmentLevelDelinquency(true);
 
             // Create loan product with installment level delinquency setting
             CallFailedRuntimeException callFailedRuntimeException = Assertions.assertThrows(CallFailedRuntimeException.class,
-                    () -> loanProductHelper.createLoanProduct(loanProductsRequest));
+                    () -> createLoanProduct(loanProductsRequest));
 
             Assertions.assertTrue(callFailedRuntimeException.getMessage()
                     .contains("Installment level delinquency cannot be enabled if Delinquency bucket is not configured for loan product"));
@@ -573,17 +565,17 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
 
         runAt("31 May 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             // Create Loan Product without delinquency bucket
             PostLoanProductsRequest loanProductsRequest = create1InstallmentAmountInMultiplesOf4Period1MonthLongWithInterestAndAmortizationProduct(
-                    InterestType.FLAT, AmortizationType.EQUAL_INSTALLMENTS);
+                    LoanTestData.InterestType.FLAT, LoanTestData.AmortizationType.EQUAL_INSTALLMENTS);
 
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+            Long productId = createLoanProduct(loanProductsRequest);
 
             // Update loan product with installment level delinquency setting
             CallFailedRuntimeException callFailedRuntimeException = Assertions.assertThrows(CallFailedRuntimeException.class,
-                    () -> loanProductHelper.updateLoanProductById(loanProductResponse.getResourceId(),
+                    () -> updateLoanProduct(productId,
                             new PutLoanProductsProductIdRequest().enableInstallmentLevelDelinquency(true).locale("en")));
 
             Assertions.assertTrue(callFailedRuntimeException.getMessage()
@@ -594,9 +586,8 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
     }
 
     private void updateBusinessDateAndExecuteCOBJob(String date) {
-        businessDateHelper.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                .date(date).dateFormat(DATETIME_PATTERN).locale("en"));
-        schedulerJobHelper.executeAndAwaitJob("Loan COB");
+        updateBusinessDate(date);
+        schedulerHelper.executeAndAwaitJob("Loan COB");
     }
 
     @AllArgsConstructor
@@ -613,7 +604,7 @@ public class InstallmentLevelDelinquencyAPIIntegrationTests extends BaseLoanInte
 
     private void verifyDelinquency(Long loanId, Integer loanLevelDelinquentDays, String loanLevelDelinquentAmount,
             DelinquencyData... expectedInstallmentLevelDelinquencyData) {
-        GetLoansLoanIdResponse loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId.intValue());
+        GetLoansLoanIdResponse loan = getLoanDetails(loanId);
         assertThat(loan.getDelinquent()).isNotNull();
         List<GetLoansLoanIdLoanInstallmentLevelDelinquency> installmentLevelDelinquency = loan.getDelinquent()
                 .getInstallmentLevelDelinquency();

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/InterestRecognitionFromDistbusementDateTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/InterestRecognitionFromDistbusementDateTest.java
@@ -23,48 +23,16 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
 import org.apache.fineract.client.models.GetLoanProductsProductIdResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
-import org.apache.fineract.client.models.PostClientsResponse;
 import org.apache.fineract.client.models.PostLoanProductsRequest;
-import org.apache.fineract.client.models.PostLoanProductsResponse;
 import org.apache.fineract.client.models.PostLoansRequest;
-import org.apache.fineract.client.models.PostLoansResponse;
-import org.apache.fineract.client.util.CallFailedRuntimeException;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.Utils;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
 import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public class InterestRecognitionFromDistbusementDateTest extends BaseLoanIntegrationTest {
-
-    private static final Logger LOG = LoggerFactory.getLogger(InterestRecognitionFromDistbusementDateTest.class);
-    private static final String DATETIME_PATTERN = "dd MMMM yyyy";
-    private static ResponseSpecification responseSpec;
-    private static RequestSpecification requestSpec;
-    private static LoanTransactionHelper loanTransactionHelper;
-    private static Integer commonLoanProductId;
-    private static PostClientsResponse client;
-
-    @BeforeAll
-    public static void setup() {
-        Utils.initializeRESTAssured();
-        requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        requestSpec.header("Fineract-Platform-TenantId", "default");
-        responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-        ClientHelper clientHelper = new ClientHelper(requestSpec, responseSpec);
-    }
+public class InterestRecognitionFromDistbusementDateTest extends FeignLoanTestBase {
 
     // UC1: Create Loan Product using Progressive Loan Schedule Type and interestChargedFromDisbursementDate flag
     // 1. Create a Loan product with Adv. Pment. Alloc. (PROGRESSIVE) without interestChargedFromDisbursementDate
@@ -75,27 +43,24 @@ public class InterestRecognitionFromDistbusementDateTest extends BaseLoanIntegra
         final String operationDate = "1 January 2025";
         runAt(operationDate, () -> {
             // Create a Loan Product Adv. Pment. Alloc. (PROGRESSIVE) withou interestChargedFromDisbursementDate
-            LOG.info("Create a Loan Product Adv. Pment. Alloc. (PROGRESSIVE) not using interestChargedFromDisbursementDate flag");
+            // Create a Loan Product Adv. Pment. Alloc. (PROGRESSIVE) without interestChargedFromDisbursementDate
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .numberOfRepayments(6);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-            GetLoanProductsProductIdResponse loanProductData = loanProductHelper
-                    .retrieveLoanProductById(loanProductResponse.getResourceId());
+            Long loanProductId = createLoanProduct(product);
+            GetLoanProductsProductIdResponse loanProductData = retrieveLoanProduct(loanProductId);
             assertEquals(Boolean.FALSE, loanProductData.getInterestRecognitionOnDisbursementDate());
 
             // Create a Loan Product Adv. Pment. Alloc. (PROGRESSIVE) using interestChargedFromDisbursementDate in true
-            LOG.info("Create a Loan Product Adv. Pment. Alloc. (PROGRESSIVE) using interestChargedFromDisbursementDate flag");
             product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation().numberOfRepayments(6)
                     .interestRecognitionOnDisbursementDate(true);
-            loanProductResponse = loanProductHelper.createLoanProduct(product);
-            loanProductData = loanProductHelper.retrieveLoanProductById(loanProductResponse.getResourceId());
+            loanProductId = createLoanProduct(product);
+            loanProductData = retrieveLoanProduct(loanProductId);
             assertEquals(Boolean.TRUE, loanProductData.getInterestRecognitionOnDisbursementDate());
 
             // Try to create a Loan Product (CUMULATIVE) using interestChargedFromDisbursementDate in true
-            LOG.info("Try to create a Loan Product (CUMULATIVE) using interestChargedFromDisbursementDate flag");
-            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class, () -> loanProductHelper.createLoanProduct(
+            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class, () -> createLoanProduct(
                     createOnePeriod30DaysPeriodicAccrualProduct(8.0).numberOfRepayments(6).interestRecognitionOnDisbursementDate(true)));
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage()
                     .contains("interestRecognitionOnDisbursementDate.is.only.supported.for.progressive.loan.schedule.type"));
         });
@@ -111,32 +76,27 @@ public class InterestRecognitionFromDistbusementDateTest extends BaseLoanIntegra
         runAt(operationDate, () -> {
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .numberOfRepayments(6).interestRecognitionOnDisbursementDate(true);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-            GetLoanProductsProductIdResponse loanProductData = loanProductHelper
-                    .retrieveLoanProductById(loanProductResponse.getResourceId());
+            Long loanProductId = createLoanProduct(product);
+            GetLoanProductsProductIdResponse loanProductData = retrieveLoanProduct(loanProductId);
 
-            client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
-
-            PostLoansRequest applicationRequest = applyLoanRequest(client.getClientId(), loanProductResponse.getResourceId(), operationDate,
-                    100.0, 4).transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY);
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            Long clientId = createClient();
 
             // Create a Loan account and inherit the interestChargedFromDisbursementDate flag
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, operationDate, 100.0, 4)
+                    .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY);
+            Long loanId = applyForLoan(applicationRequest);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             assertEquals(loanProductData.getInterestRecognitionOnDisbursementDate(),
                     loanDetails.getInterestRecognitionOnDisbursementDate());
 
             // Create a Loan account and override the interestChargedFromDisbursementDate flag
-            applicationRequest = applyLoanRequest(client.getClientId(), loanProductResponse.getResourceId(), operationDate, 100.0, 4)
+            applicationRequest = applyLoanRequest(clientId, loanProductId, operationDate, 100.0, 4)
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)
                     .interestRecognitionOnDisbursementDate(false);
-            loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
-
-            // Create a Loan account and inherit the interestChargedFromDisbursementDate flag
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanId = applyForLoan(applicationRequest);
+            loanDetails = getLoanDetails(loanId);
             assertNotEquals(loanProductData.getInterestRecognitionOnDisbursementDate(),
                     loanDetails.getInterestRecognitionOnDisbursementDate());
         });
     }
-
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/InterestRecognitionFromDistbusementDateTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/InterestRecognitionFromDistbusementDateTest.java
@@ -23,48 +23,16 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
 import org.apache.fineract.client.models.GetLoanProductsProductIdResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
-import org.apache.fineract.client.models.PostClientsResponse;
 import org.apache.fineract.client.models.PostLoanProductsRequest;
-import org.apache.fineract.client.models.PostLoanProductsResponse;
 import org.apache.fineract.client.models.PostLoansRequest;
-import org.apache.fineract.client.models.PostLoansResponse;
-import org.apache.fineract.client.util.CallFailedRuntimeException;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.Utils;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
 import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public class InterestRecognitionFromDistbusementDateTest extends BaseLoanIntegrationTest {
-
-    private static final Logger LOG = LoggerFactory.getLogger(InterestRecognitionFromDistbusementDateTest.class);
-    private static final String DATETIME_PATTERN = "dd MMMM yyyy";
-    private static ResponseSpecification responseSpec;
-    private static RequestSpecification requestSpec;
-    private static LoanTransactionHelper loanTransactionHelper;
-    private static Integer commonLoanProductId;
-    private static PostClientsResponse client;
-
-    @BeforeAll
-    public static void setup() {
-        Utils.initializeRESTAssured();
-        requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        requestSpec.header("Fineract-Platform-TenantId", "default");
-        responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-        ClientHelper clientHelper = new ClientHelper(requestSpec, responseSpec);
-    }
+public class InterestRecognitionFromDistbusementDateTest extends FeignLoanTestBase {
 
     // UC1: Create Loan Product using Progressive Loan Schedule Type and interestChargedFromDisbursementDate flag
     // 1. Create a Loan product with Adv. Pment. Alloc. (PROGRESSIVE) without interestChargedFromDisbursementDate
@@ -74,28 +42,24 @@ public class InterestRecognitionFromDistbusementDateTest extends BaseLoanIntegra
     public void uc1() {
         final String operationDate = "1 January 2025";
         runAt(operationDate, () -> {
-            // Create a Loan Product Adv. Pment. Alloc. (PROGRESSIVE) withou interestChargedFromDisbursementDate
-            LOG.info("Create a Loan Product Adv. Pment. Alloc. (PROGRESSIVE) not using interestChargedFromDisbursementDate flag");
+            // Create a Loan Product Adv. Pment. Alloc. (PROGRESSIVE) without interestChargedFromDisbursementDate
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .numberOfRepayments(6);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-            GetLoanProductsProductIdResponse loanProductData = loanProductHelper
-                    .retrieveLoanProductById(loanProductResponse.getResourceId());
+            Long loanProductId = createLoanProduct(product);
+            GetLoanProductsProductIdResponse loanProductData = retrieveLoanProduct(loanProductId);
             assertEquals(Boolean.FALSE, loanProductData.getInterestRecognitionOnDisbursementDate());
 
             // Create a Loan Product Adv. Pment. Alloc. (PROGRESSIVE) using interestChargedFromDisbursementDate in true
-            LOG.info("Create a Loan Product Adv. Pment. Alloc. (PROGRESSIVE) using interestChargedFromDisbursementDate flag");
             product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation().numberOfRepayments(6)
                     .interestRecognitionOnDisbursementDate(true);
-            loanProductResponse = loanProductHelper.createLoanProduct(product);
-            loanProductData = loanProductHelper.retrieveLoanProductById(loanProductResponse.getResourceId());
+            loanProductId = createLoanProduct(product);
+            loanProductData = retrieveLoanProduct(loanProductId);
             assertEquals(Boolean.TRUE, loanProductData.getInterestRecognitionOnDisbursementDate());
 
             // Try to create a Loan Product (CUMULATIVE) using interestChargedFromDisbursementDate in true
-            LOG.info("Try to create a Loan Product (CUMULATIVE) using interestChargedFromDisbursementDate flag");
-            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class, () -> loanProductHelper.createLoanProduct(
+            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class, () -> createLoanProduct(
                     createOnePeriod30DaysPeriodicAccrualProduct(8.0).numberOfRepayments(6).interestRecognitionOnDisbursementDate(true)));
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage()
                     .contains("interestRecognitionOnDisbursementDate.is.only.supported.for.progressive.loan.schedule.type"));
         });
@@ -111,32 +75,27 @@ public class InterestRecognitionFromDistbusementDateTest extends BaseLoanIntegra
         runAt(operationDate, () -> {
             PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
                     .numberOfRepayments(6).interestRecognitionOnDisbursementDate(true);
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-            GetLoanProductsProductIdResponse loanProductData = loanProductHelper
-                    .retrieveLoanProductById(loanProductResponse.getResourceId());
+            Long loanProductId = createLoanProduct(product);
+            GetLoanProductsProductIdResponse loanProductData = retrieveLoanProduct(loanProductId);
 
-            client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
-
-            PostLoansRequest applicationRequest = applyLoanRequest(client.getClientId(), loanProductResponse.getResourceId(), operationDate,
-                    100.0, 4).transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY);
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            Long clientId = createClient();
 
             // Create a Loan account and inherit the interestChargedFromDisbursementDate flag
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, operationDate, 100.0, 4)
+                    .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY);
+            Long loanId = applyForLoan(applicationRequest);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             assertEquals(loanProductData.getInterestRecognitionOnDisbursementDate(),
                     loanDetails.getInterestRecognitionOnDisbursementDate());
 
             // Create a Loan account and override the interestChargedFromDisbursementDate flag
-            applicationRequest = applyLoanRequest(client.getClientId(), loanProductResponse.getResourceId(), operationDate, 100.0, 4)
+            applicationRequest = applyLoanRequest(clientId, loanProductId, operationDate, 100.0, 4)
                     .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)
                     .interestRecognitionOnDisbursementDate(false);
-            loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
-
-            // Create a Loan account and inherit the interestChargedFromDisbursementDate flag
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanId = applyForLoan(applicationRequest);
+            loanDetails = getLoanDetails(loanId);
             assertNotEquals(loanProductData.getInterestRecognitionOnDisbursementDate(),
                     loanDetails.getInterestRecognitionOnDisbursementDate());
         });
     }
-
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/JournalEntryReversalOrderingIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/JournalEntryReversalOrderingIntegrationTest.java
@@ -22,131 +22,84 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
-import java.util.ArrayList;
-import java.util.HashMap;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import org.apache.fineract.client.models.JournalEntryTransactionItem;
+import org.apache.fineract.client.models.PostLoanProductsRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsResponse;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.accounting.Account;
-import org.apache.fineract.integrationtests.common.accounting.AccountHelper;
-import org.apache.fineract.integrationtests.common.accounting.JournalEntryHelper;
-import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanTestLifecycleExtension;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.junit.jupiter.api.BeforeEach;
+import org.apache.fineract.client.models.PostLoansRequest;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith(LoanTestLifecycleExtension.class)
-public class JournalEntryReversalOrderingIntegrationTest extends BaseLoanIntegrationTest {
-
-    private ResponseSpecification responseSpec;
-    private RequestSpecification requestSpec;
-    private LoanTransactionHelper loanTransactionHelper;
-    private JournalEntryHelper journalEntryHelper;
-    private AccountHelper accountHelper;
-    private ClientHelper clientHelper;
-
-    @BeforeEach
-    public void setup() {
-        Utils.initializeRESTAssured();
-        this.requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        this.requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        this.responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        this.loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-        this.journalEntryHelper = new JournalEntryHelper(this.requestSpec, this.responseSpec);
-        this.accountHelper = new AccountHelper(this.requestSpec, this.responseSpec);
-        this.clientHelper = new ClientHelper(this.requestSpec, this.responseSpec);
-    }
+public class JournalEntryReversalOrderingIntegrationTest extends FeignLoanTestBase {
 
     @Test
     public void testJournalEntryReversalOrdering() {
+        // Given: Setup loan with periodic accrual accounting enabled
         // Given: Setup loan with accounting enabled
-        final Account assetAccount = this.accountHelper.createAssetAccount();
-        final Account incomeAccount = this.accountHelper.createIncomeAccount();
-        final Account expenseAccount = this.accountHelper.createExpenseAccount();
-        final Account overpaymentAccount = this.accountHelper.createLiabilityAccount();
+        Long loanProductId = createLoanProduct(createLoanProductWithAccounting());
+        Long clientId = createClient();
+        Long loanId = applyForLoan(applyForLoanApplication(clientId, loanProductId, "10 January 2023", 10000.0));
 
-        final Integer loanProductID = createLoanProductWithAccounting(assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
-        final Integer clientID = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId().intValue();
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, "10 January 2023", "10000");
-
-        loanTransactionHelper.approveLoan("10 January 2023", loanID);
-        loanTransactionHelper.disburseLoanWithNetDisbursalAmount("10 January 2023", loanID, "10000");
+        approveLoan(loanId, approveLoanRequest(10000.0, "10 January 2023"));
+        disburseLoan(loanId, "10 January 2023", 10000.0);
 
         // When: Make a repayment transaction
-        final PostLoansLoanIdTransactionsResponse repaymentResponse = loanTransactionHelper.makeLoanRepayment("11 January 2023", 1000.0f,
-                loanID);
-        assertNotNull(repaymentResponse);
-        final Long repaymentTransactionId = repaymentResponse.getResourceId();
+        Long repaymentTransactionId = addRepaymentForLoan(loanId, 1000.0, "11 January 2023");
+        assertNotNull(repaymentTransactionId);
 
         // Capture original journal entries
-        ArrayList<HashMap> originalEntries = journalEntryHelper.getJournalEntriesByTransactionId("L" + repaymentTransactionId.toString());
+        List<JournalEntryTransactionItem> originalEntries = getJournalEntries("L" + repaymentTransactionId).getPageItems();
         assertNotNull(originalEntries);
         assertTrue(originalEntries.size() > 0, "Should have journal entries for repayment");
-        final int originalEntryCount = originalEntries.size();
+        int originalEntryCount = originalEntries.size();
 
         // When: Reverse the repayment transaction
-        PostLoansLoanIdTransactionsResponse reversalResponse = loanTransactionHelper.reverseLoanTransaction(loanID.longValue(),
-                repaymentTransactionId, "12 January 2023");
+        PostLoansLoanIdTransactionsResponse reversalResponse = reverseLoanTransaction(loanId, repaymentTransactionId, "12 January 2023");
         assertNotNull(reversalResponse);
 
         // Then: Verify journal entries after reversal maintain consistent ordering
-        ArrayList<HashMap> entriesAfterReversal = journalEntryHelper
-                .getJournalEntriesByTransactionId("L" + repaymentTransactionId.toString());
+        List<JournalEntryTransactionItem> entriesAfterReversal = getJournalEntries("L" + repaymentTransactionId).getPageItems();
         assertNotNull(entriesAfterReversal);
 
         // Verify we have both original and reversal entries
         assertEquals(originalEntryCount * 2, entriesAfterReversal.size(),
                 "After reversal should have double the entries (original + reversal)");
 
+        // Verify consistent ordering by transaction date, created date and id
         // Verify consistent ordering by entry date, created date time, and id
         verifyJournalEntriesOrdering(entriesAfterReversal);
     }
 
-    private void verifyJournalEntriesOrdering(ArrayList<HashMap> entries) {
+    private void verifyJournalEntriesOrdering(List<JournalEntryTransactionItem> entries) {
         Long previousId = null;
-        String previousTransactionDate = null;
-        String previousCreatedDate = null;
+        LocalDate previousTransactionDate = null;
+        LocalDate previousCreatedDate = null;
 
-        for (HashMap entry : entries) {
-            String transactionDate = extractDateString(entry.get("transactionDate"));
-            String createdDate = extractDateString(entry.get("createdDate"));
-            Long id = ((Number) entry.get("id")).longValue();
+        for (JournalEntryTransactionItem entry : entries) {
+            LocalDate transactionDate = entry.getTransactionDate();
+            LocalDate createdDate = entry.getCreatedDate();
+            Long id = entry.getId();
 
-            if (previousTransactionDate != null) {
+            if (previousTransactionDate != null && transactionDate.isEqual(previousTransactionDate)
+                    && createdDate.isEqual(previousCreatedDate)) {
+                // Same transaction and created dates, verify ID ordering (descending)
                 // Entries should be ordered by:
                 // 1. Transaction date (ascending)
                 // 2. Created date (ascending) when transaction dates are equal
                 // 3. ID (descending) when both dates are equal
-                int transactionDateComparison = transactionDate.compareTo(previousTransactionDate);
-
-                if (transactionDateComparison < 0) {
-                    // Current transaction date is earlier - this is correct ascending order
-                } else if (transactionDateComparison == 0) {
-                    // Same transaction date, check created date
-                    int createdDateComparison = createdDate.compareTo(previousCreatedDate);
-
-                    if (createdDateComparison < 0) {
-                        // Current created date is earlier - this is correct ascending order
-                    } else if (createdDateComparison == 0) {
-                        // Same transaction and created dates, verify ID ordering (descending)
-                        assertTrue(id < previousId, String.format("Journal entries with same dates should be ordered by ID (descending). "
-                                + "Current ID: %d, Previous ID: %d", id, previousId));
-                    } else {
-                        // Created date is later but transaction date is same - verify this is expected
-                        // This is acceptable as entries can be created at different times
-                    }
-                } else {
-                    // Transaction date is later - this is correct for reversal entries
-                    // Reversal entries have a later transaction date than original entries
-                }
+                // Current transaction date is earlier - this is correct ascending order
+                // Same transaction date, check created date
+                // Current created date is earlier - this is correct ascending order
+                // Created date is later but transaction date is same - verify this is expected
+                // This is acceptable as entries can be created at different times
+                // Transaction date is later - this is correct for reversal entries
+                // Reversal entries have a later transaction date than original entries
+                assertTrue(id < previousId, String.format(
+                        "Journal entries with same dates should be ordered by ID (descending). " + "Current ID: %d, Previous ID: %d", id,
+                        previousId));
             }
 
             previousTransactionDate = transactionDate;
@@ -155,30 +108,24 @@ public class JournalEntryReversalOrderingIntegrationTest extends BaseLoanIntegra
         }
     }
 
-    private String extractDateString(Object dateObject) {
-        if (dateObject instanceof ArrayList) {
-            return dateObject.toString();
-        } else {
-            return (String) dateObject;
-        }
+    private PostLoanProductsRequest createLoanProductWithAccounting() {
+        return createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct()//
+                .principal(10000.0)//
+                .numberOfRepayments(12)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS_L)//
+                .interestRatePerPeriod(1.0)//
+                .interestRateFrequencyType(LoanTestData.InterestRateFrequencyType.MONTHS)//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_PRINCIPAL)//
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE)//
+                .multiDisburseLoan(false)//
+                .disallowExpectedDisbursements(false);
     }
 
-    private Integer createLoanProductWithAccounting(final Account assetAccount, final Account incomeAccount, final Account expenseAccount,
-            final Account overpaymentAccount) {
-        final String loanProductJSON = new LoanProductTestBuilder().withPrincipal("10000").withRepaymentAfterEvery("1")
-                .withNumberOfRepayments("12").withRepaymentTypeAsMonth().withinterestRatePerPeriod("1")
-                .withInterestRateFrequencyTypeAsMonths().withAmortizationTypeAsEqualPrincipalPayment().withInterestTypeAsDecliningBalance()
-                .withAccountingRulePeriodicAccrual(new Account[] { assetAccount, incomeAccount, expenseAccount, overpaymentAccount })
-                .build(null);
-        return this.loanTransactionHelper.getLoanProductId(loanProductJSON);
-    }
-
-    private Integer applyForLoanApplication(final Integer clientID, final Integer loanProductID, final String submittedOnDate,
-            final String principal) {
-        final String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal(principal).withLoanTermFrequency("12")
-                .withLoanTermFrequencyAsMonths().withNumberOfRepayments("12").withRepaymentEveryAfter("1")
-                .withRepaymentFrequencyTypeAsMonths().withInterestRatePerPeriod("1").withExpectedDisbursementDate(submittedOnDate)
-                .withSubmittedOnDate(submittedOnDate).withLoanType("individual").build(clientID.toString(), loanProductID.toString(), null);
-        return this.loanTransactionHelper.getLoanId(loanApplicationJSON);
+    private PostLoansRequest applyForLoanApplication(Long clientId, Long loanProductId, String submittedOnDate, double principal) {
+        return applyLoanRequest(clientId, loanProductId, submittedOnDate, principal, 12,
+                request -> request.repaymentEvery(1).repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)
+                        .loanTermFrequency(12).loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)
+                        .interestRatePerPeriod(BigDecimal.ONE));
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/JournalEntryReversalOrderingIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/JournalEntryReversalOrderingIntegrationTest.java
@@ -22,131 +22,71 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
-import java.util.ArrayList;
-import java.util.HashMap;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import org.apache.fineract.client.models.JournalEntryTransactionItem;
+import org.apache.fineract.client.models.PostLoanProductsRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsResponse;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.accounting.Account;
-import org.apache.fineract.integrationtests.common.accounting.AccountHelper;
-import org.apache.fineract.integrationtests.common.accounting.JournalEntryHelper;
-import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanTestLifecycleExtension;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.junit.jupiter.api.BeforeEach;
+import org.apache.fineract.client.models.PostLoansRequest;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith(LoanTestLifecycleExtension.class)
-public class JournalEntryReversalOrderingIntegrationTest extends BaseLoanIntegrationTest {
-
-    private ResponseSpecification responseSpec;
-    private RequestSpecification requestSpec;
-    private LoanTransactionHelper loanTransactionHelper;
-    private JournalEntryHelper journalEntryHelper;
-    private AccountHelper accountHelper;
-    private ClientHelper clientHelper;
-
-    @BeforeEach
-    public void setup() {
-        Utils.initializeRESTAssured();
-        this.requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        this.requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        this.responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        this.loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-        this.journalEntryHelper = new JournalEntryHelper(this.requestSpec, this.responseSpec);
-        this.accountHelper = new AccountHelper(this.requestSpec, this.responseSpec);
-        this.clientHelper = new ClientHelper(this.requestSpec, this.responseSpec);
-    }
+public class JournalEntryReversalOrderingIntegrationTest extends FeignLoanTestBase {
 
     @Test
     public void testJournalEntryReversalOrdering() {
-        // Given: Setup loan with accounting enabled
-        final Account assetAccount = this.accountHelper.createAssetAccount();
-        final Account incomeAccount = this.accountHelper.createIncomeAccount();
-        final Account expenseAccount = this.accountHelper.createExpenseAccount();
-        final Account overpaymentAccount = this.accountHelper.createLiabilityAccount();
+        // Given: Setup loan with periodic accrual accounting enabled
+        Long loanProductId = createLoanProduct(createLoanProductWithAccounting());
+        Long clientId = createClient();
+        Long loanId = applyForLoan(applyForLoanApplication(clientId, loanProductId, "10 January 2023", 10000.0));
 
-        final Integer loanProductID = createLoanProductWithAccounting(assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
-        final Integer clientID = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId().intValue();
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, "10 January 2023", "10000");
-
-        loanTransactionHelper.approveLoan("10 January 2023", loanID);
-        loanTransactionHelper.disburseLoanWithNetDisbursalAmount("10 January 2023", loanID, "10000");
+        approveLoan(loanId, approveLoanRequest(10000.0, "10 January 2023"));
+        disburseLoan(loanId, "10 January 2023", 10000.0);
 
         // When: Make a repayment transaction
-        final PostLoansLoanIdTransactionsResponse repaymentResponse = loanTransactionHelper.makeLoanRepayment("11 January 2023", 1000.0f,
-                loanID);
-        assertNotNull(repaymentResponse);
-        final Long repaymentTransactionId = repaymentResponse.getResourceId();
+        Long repaymentTransactionId = addRepaymentForLoan(loanId, 1000.0, "11 January 2023");
+        assertNotNull(repaymentTransactionId);
 
         // Capture original journal entries
-        ArrayList<HashMap> originalEntries = journalEntryHelper.getJournalEntriesByTransactionId("L" + repaymentTransactionId.toString());
+        List<JournalEntryTransactionItem> originalEntries = getJournalEntries("L" + repaymentTransactionId).getPageItems();
         assertNotNull(originalEntries);
         assertTrue(originalEntries.size() > 0, "Should have journal entries for repayment");
-        final int originalEntryCount = originalEntries.size();
+        int originalEntryCount = originalEntries.size();
 
         // When: Reverse the repayment transaction
-        PostLoansLoanIdTransactionsResponse reversalResponse = loanTransactionHelper.reverseLoanTransaction(loanID.longValue(),
-                repaymentTransactionId, "12 January 2023");
+        PostLoansLoanIdTransactionsResponse reversalResponse = reverseLoanTransaction(loanId, repaymentTransactionId, "12 January 2023");
         assertNotNull(reversalResponse);
 
         // Then: Verify journal entries after reversal maintain consistent ordering
-        ArrayList<HashMap> entriesAfterReversal = journalEntryHelper
-                .getJournalEntriesByTransactionId("L" + repaymentTransactionId.toString());
+        List<JournalEntryTransactionItem> entriesAfterReversal = getJournalEntries("L" + repaymentTransactionId).getPageItems();
         assertNotNull(entriesAfterReversal);
 
         // Verify we have both original and reversal entries
         assertEquals(originalEntryCount * 2, entriesAfterReversal.size(),
                 "After reversal should have double the entries (original + reversal)");
 
-        // Verify consistent ordering by entry date, created date time, and id
+        // Verify consistent ordering by transaction date, created date and id
         verifyJournalEntriesOrdering(entriesAfterReversal);
     }
 
-    private void verifyJournalEntriesOrdering(ArrayList<HashMap> entries) {
+    private void verifyJournalEntriesOrdering(List<JournalEntryTransactionItem> entries) {
         Long previousId = null;
-        String previousTransactionDate = null;
-        String previousCreatedDate = null;
+        LocalDate previousTransactionDate = null;
+        LocalDate previousCreatedDate = null;
 
-        for (HashMap entry : entries) {
-            String transactionDate = extractDateString(entry.get("transactionDate"));
-            String createdDate = extractDateString(entry.get("createdDate"));
-            Long id = ((Number) entry.get("id")).longValue();
+        for (JournalEntryTransactionItem entry : entries) {
+            LocalDate transactionDate = entry.getTransactionDate();
+            LocalDate createdDate = entry.getCreatedDate();
+            Long id = entry.getId();
 
-            if (previousTransactionDate != null) {
-                // Entries should be ordered by:
-                // 1. Transaction date (ascending)
-                // 2. Created date (ascending) when transaction dates are equal
-                // 3. ID (descending) when both dates are equal
-                int transactionDateComparison = transactionDate.compareTo(previousTransactionDate);
-
-                if (transactionDateComparison < 0) {
-                    // Current transaction date is earlier - this is correct ascending order
-                } else if (transactionDateComparison == 0) {
-                    // Same transaction date, check created date
-                    int createdDateComparison = createdDate.compareTo(previousCreatedDate);
-
-                    if (createdDateComparison < 0) {
-                        // Current created date is earlier - this is correct ascending order
-                    } else if (createdDateComparison == 0) {
-                        // Same transaction and created dates, verify ID ordering (descending)
-                        assertTrue(id < previousId, String.format("Journal entries with same dates should be ordered by ID (descending). "
-                                + "Current ID: %d, Previous ID: %d", id, previousId));
-                    } else {
-                        // Created date is later but transaction date is same - verify this is expected
-                        // This is acceptable as entries can be created at different times
-                    }
-                } else {
-                    // Transaction date is later - this is correct for reversal entries
-                    // Reversal entries have a later transaction date than original entries
-                }
+            if (previousTransactionDate != null && transactionDate.isEqual(previousTransactionDate)
+                    && createdDate.isEqual(previousCreatedDate)) {
+                // Same transaction and created dates, verify ID ordering (descending)
+                assertTrue(id < previousId, String.format(
+                        "Journal entries with same dates should be ordered by ID (descending). " + "Current ID: %d, Previous ID: %d", id,
+                        previousId));
             }
 
             previousTransactionDate = transactionDate;
@@ -155,30 +95,24 @@ public class JournalEntryReversalOrderingIntegrationTest extends BaseLoanIntegra
         }
     }
 
-    private String extractDateString(Object dateObject) {
-        if (dateObject instanceof ArrayList) {
-            return dateObject.toString();
-        } else {
-            return (String) dateObject;
-        }
+    private PostLoanProductsRequest createLoanProductWithAccounting() {
+        return createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct()//
+                .principal(10000.0)//
+                .numberOfRepayments(12)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS_L)//
+                .interestRatePerPeriod(1.0)//
+                .interestRateFrequencyType(LoanTestData.InterestRateFrequencyType.MONTHS)//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_PRINCIPAL)//
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE)//
+                .multiDisburseLoan(false)//
+                .disallowExpectedDisbursements(false);
     }
 
-    private Integer createLoanProductWithAccounting(final Account assetAccount, final Account incomeAccount, final Account expenseAccount,
-            final Account overpaymentAccount) {
-        final String loanProductJSON = new LoanProductTestBuilder().withPrincipal("10000").withRepaymentAfterEvery("1")
-                .withNumberOfRepayments("12").withRepaymentTypeAsMonth().withinterestRatePerPeriod("1")
-                .withInterestRateFrequencyTypeAsMonths().withAmortizationTypeAsEqualPrincipalPayment().withInterestTypeAsDecliningBalance()
-                .withAccountingRulePeriodicAccrual(new Account[] { assetAccount, incomeAccount, expenseAccount, overpaymentAccount })
-                .build(null);
-        return this.loanTransactionHelper.getLoanProductId(loanProductJSON);
-    }
-
-    private Integer applyForLoanApplication(final Integer clientID, final Integer loanProductID, final String submittedOnDate,
-            final String principal) {
-        final String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal(principal).withLoanTermFrequency("12")
-                .withLoanTermFrequencyAsMonths().withNumberOfRepayments("12").withRepaymentEveryAfter("1")
-                .withRepaymentFrequencyTypeAsMonths().withInterestRatePerPeriod("1").withExpectedDisbursementDate(submittedOnDate)
-                .withSubmittedOnDate(submittedOnDate).withLoanType("individual").build(clientID.toString(), loanProductID.toString(), null);
-        return this.loanTransactionHelper.getLoanId(loanApplicationJSON);
+    private PostLoansRequest applyForLoanApplication(Long clientId, Long loanProductId, String submittedOnDate, double principal) {
+        return applyLoanRequest(clientId, loanProductId, submittedOnDate, principal, 12,
+                request -> request.repaymentEvery(1).repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)
+                        .loanTermFrequency(12).loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)
+                        .interestRatePerPeriod(BigDecimal.ONE));
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanAccountArrearsAgeingCOBBusinessStepTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanAccountArrearsAgeingCOBBusinessStepTest.java
@@ -22,149 +22,108 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
+import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.util.HashMap;
-import java.util.UUID;
-import org.apache.fineract.client.models.DelinquencyBucketResponse;
-import org.apache.fineract.client.models.GetLoanProductsProductIdResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdSummary;
+import org.apache.fineract.client.models.JobBusinessStepConfigData;
+import org.apache.fineract.client.models.PostLoansRequest;
 import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
-import org.apache.fineract.cob.data.JobBusinessStepConfigData;
-import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
-import org.apache.fineract.integrationtests.common.BusinessDateHelper;
-import org.apache.fineract.integrationtests.common.BusinessStepConfigurationHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.SchedulerJobHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignBusinessStepHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignDelinquencyHelper;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
 import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.apache.fineract.integrationtests.common.products.DelinquencyBucketsHelper;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 
 @Order(1)
-public class LoanAccountArrearsAgeingCOBBusinessStepTest extends BaseLoanIntegrationTest {
+public class LoanAccountArrearsAgeingCOBBusinessStepTest extends FeignLoanTestBase {
 
-    private ResponseSpecification responseSpec;
-    private RequestSpecification requestSpec;
-    private ClientHelper clientHelper;
-    private LoanTransactionHelper loanTransactionHelper;
-    public static final String UPDATE_LOAN_ARREARS_AGING = "UPDATE_LOAN_ARREARS_AGING";
+    private static final String LOAN_JOB_NAME = "LOAN_CLOSE_OF_BUSINESS";
+    private static final String UPDATE_LOAN_ARREARS_AGING = "UPDATE_LOAN_ARREARS_AGING";
 
-    @BeforeEach
-    public void setup() {
-        Utils.initializeRESTAssured();
-        this.requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        this.requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        this.responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        this.loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-        this.clientHelper = new ClientHelper(this.requestSpec, this.responseSpec);
-    }
+    private final FeignDelinquencyHelper delinquencyHelper = new FeignDelinquencyHelper(FineractFeignClientHelper.getFineractFeignClient());
+    private final FeignBusinessStepHelper businessStepHelper = new FeignBusinessStepHelper(
+            FineractFeignClientHelper.getFineractFeignClient());
 
     @Test
     public void loanArrearsAgeingCOBBusinessStepTest() {
         // Set Business Date
         try {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+            updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
 
             LocalDate businessDate = Utils.getLocalDateOfTenant();
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, businessDate);
+            updateBusinessDate(dateTimeFormatter.format(businessDate));
 
             LocalDate operationDate = businessDate.minusDays(40);
-            String loanOperationDate = Utils.dateFormatter.format(operationDate);
+            String loanOperationDate = dateTimeFormatter.format(operationDate);
 
+            Long clientId = createClient();
             // create Client
-            final Integer clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId().intValue();
-
-            // create Loan Product
-
             // Delinquency Bucket
-            final Long delinquencyBucketId = DelinquencyBucketsHelper.createDefaultBucket();
-            final DelinquencyBucketResponse delinquencyBucket = DelinquencyBucketsHelper.getBucket(delinquencyBucketId);
-
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper,
-                    delinquencyBucketId);
-            assertNotNull(getLoanProductsProductResponse);
-
-            // Loan1 ExternalId
-            String loan1ExternalIdStr = UUID.randomUUID().toString();
+            Long delinquencyBucketId = delinquencyHelper.createDefaultBucket();
+            // create Loan Product
+            Long loanProductId = createLoanProduct(dueDateRespectiveNoAccountingNoInterestProduct(1000, 30, 1, 0,
+                    LoanProductTestBuilder.DUE_PENALTY_FEE_INTEREST_PRINCIPAL_IN_ADVANCE_PRINCIPAL_PENALTY_FEE_INTEREST_STRATEGY)
+                    .delinquencyBucketId(delinquencyBucketId));
 
             // create Loan Account for Client with Loan Product type 1
-            Long loanProductId = getLoanProductsProductResponse.getId();
-            final Integer loanId_1 = createLoanAccount(loanOperationDate, clientId, loanProductId, loan1ExternalIdStr);
-
-            String loan2ExternalIdStr = UUID.randomUUID().toString();
-            final Integer loanId_2 = createLoanAccount(loanOperationDate, clientId, loanProductId, loan2ExternalIdStr);
+            Long loanId1 = createArrearsLoanAccount(clientId, loanProductId, loanOperationDate);
+            Long loanId2 = createArrearsLoanAccount(clientId, loanProductId, loanOperationDate);
 
             // Run Loan cob with verfying business step for Update Arrears ageing details
-
             // COB Step Validation
-            final JobBusinessStepConfigData jobBusinessStepConfigData = BusinessStepConfigurationHelper
-                    .getConfiguredBusinessStepsByJobName(requestSpec, responseSpec, BusinessConfigurationApiTest.LOAN_JOB_NAME);
+            JobBusinessStepConfigData jobBusinessStepConfigData = businessStepHelper.getConfiguredBusinessStepsByJobName(LOAN_JOB_NAME);
             assertNotNull(jobBusinessStepConfigData);
-            assertEquals(BusinessConfigurationApiTest.LOAN_JOB_NAME, jobBusinessStepConfigData.getJobName());
+            assertEquals(LOAN_JOB_NAME, jobBusinessStepConfigData.getJobName());
             assertTrue(jobBusinessStepConfigData.getBusinessSteps().size() > 0);
             assertTrue(jobBusinessStepConfigData.getBusinessSteps().stream()
                     .anyMatch(businessStep -> UPDATE_LOAN_ARREARS_AGING.equals(businessStep.getStepName())));
 
             // Run the Loan COB Job
-            final String jobName = "Loan COB";
-            SchedulerJobHelper.executeAndAwaitJob(jobName);
+            schedulerHelper.executeAndAwaitJob("Loan COB");
 
+            // verify Arrears details are updated for both loans
+            verifyArrearsSummary(loanId1);
             // verify Arrears details are updated for both the loans, by verifying loan summary fields for
             // principalOverdue,totalOverdue,overdueSinceddate
-
             // Retrieve Loan 1 with loanId
-            GetLoansLoanIdResponse loan1Details = loanTransactionHelper.getLoanDetails((long) loanId_1);
-            GetLoansLoanIdSummary loan1Summary = loan1Details.getSummary();
-            assertNotNull(loan1Summary);
-            assertNotNull(loan1Summary.getOverdueSinceDate());
-            assertEquals(1000.00, Utils.getDoubleValue(loan1Summary.getPrincipalOverdue()));
-            assertEquals(1000.00, Utils.getDoubleValue(loan1Summary.getTotalOverdue()));
-
             // Retrieve Loan 2 with loanId
-            GetLoansLoanIdResponse loan2Details = loanTransactionHelper.getLoanDetails((long) loanId_2);
-            GetLoansLoanIdSummary loan2Summary = loan2Details.getSummary();
-            assertNotNull(loan2Summary);
-            assertNotNull(loan2Summary.getOverdueSinceDate());
-            assertEquals(1000.00, Utils.getDoubleValue(loan2Summary.getPrincipalOverdue()));
-            assertEquals(1000.00, Utils.getDoubleValue(loan2Summary.getTotalOverdue()));
+            verifyArrearsSummary(loanId2);
         } finally {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+            updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(false));
         }
     }
 
-    private GetLoanProductsProductIdResponse createLoanProduct(final LoanTransactionHelper loanTransactionHelper,
-            final Long delinquencyBucketId) {
-        final HashMap<String, Object> loanProductMap = new LoanProductTestBuilder().build(null, delinquencyBucketId);
-        final Integer loanProductId = loanTransactionHelper.getLoanProductId(Utils.convertToJson(loanProductMap));
-        return loanTransactionHelper.getLoanProduct(loanProductId);
+    private void verifyArrearsSummary(final Long loanId) {
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
+        GetLoansLoanIdSummary loanSummary = loanDetails.getSummary();
+        assertNotNull(loanSummary);
+        assertNotNull(loanSummary.getOverdueSinceDate());
+        assertEquals(1000.00, Utils.getDoubleValue(loanSummary.getPrincipalOverdue()));
+        assertEquals(1000.00, Utils.getDoubleValue(loanSummary.getTotalOverdue()));
     }
 
-    private Integer createLoanAccount(final String operationDate, final Integer clientID, final Long loanProductID,
-            final String externalId) {
-
-        String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal("1000").withLoanTermFrequency("1")
-                .withLoanTermFrequencyAsMonths().withNumberOfRepayments("1").withRepaymentEveryAfter("1")
-                .withRepaymentFrequencyTypeAsMonths().withInterestRatePerPeriod("0").withInterestTypeAsFlatBalance()
-                .withAmortizationTypeAsEqualPrincipalPayments().withInterestCalculationPeriodTypeSameAsRepaymentPeriod()
-                .withExpectedDisbursementDate(operationDate).withSubmittedOnDate(operationDate).withLoanType("individual")
-                .withExternalId(externalId).build(clientID.toString(), loanProductID.toString(), null);
-
-        final Integer loanId = loanTransactionHelper.getLoanId(loanApplicationJSON);
-        loanTransactionHelper.approveLoan(operationDate, "1000", loanId, null);
-        loanTransactionHelper.disburseLoanWithNetDisbursalAmount(operationDate, loanId, "1000");
+    private Long createArrearsLoanAccount(final Long clientId, final Long productId, final String operationDate) {
+        PostLoansRequest request = new PostLoansRequest().clientId(clientId).productId(productId).principal(new BigDecimal("1000"))
+                .loanTermFrequency(30).loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.DAYS).numberOfRepayments(1)
+                .repaymentEvery(30).repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.DAYS).interestRatePerPeriod(BigDecimal.ZERO)
+                .interestType(LoanTestData.InterestType.FLAT).amortizationType(LoanTestData.AmortizationType.EQUAL_PRINCIPAL)
+                .transactionProcessingStrategyCode(
+                        LoanApplicationTestBuilder.DUE_PENALTY_FEE_INTEREST_PRINCIPAL_IN_ADVANCE_PRINCIPAL_PENALTY_FEE_INTEREST_STRATEGY)
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)
+                .expectedDisbursementDate(operationDate).submittedOnDate(operationDate).dateFormat(LoanTestData.DATETIME_PATTERN)
+                .locale(LoanTestData.LOCALE).loanType("individual");
+        Long loanId = applyForLoan(request);
+        approveLoan(loanId, approveLoanRequest(1000.0, operationDate));
+        disburseLoan(loanId, BigDecimal.valueOf(1000), operationDate);
         return loanId;
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanAccountArrearsAgeingCOBBusinessStepTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanAccountArrearsAgeingCOBBusinessStepTest.java
@@ -22,148 +22,96 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
+import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.util.HashMap;
-import java.util.UUID;
-import org.apache.fineract.client.models.DelinquencyBucketResponse;
-import org.apache.fineract.client.models.GetLoanProductsProductIdResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdSummary;
+import org.apache.fineract.client.models.JobBusinessStepConfigData;
+import org.apache.fineract.client.models.PostLoansRequest;
 import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
-import org.apache.fineract.cob.data.JobBusinessStepConfigData;
-import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
-import org.apache.fineract.integrationtests.common.BusinessDateHelper;
-import org.apache.fineract.integrationtests.common.BusinessStepConfigurationHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.SchedulerJobHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignBusinessStepHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignDelinquencyHelper;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
 import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.apache.fineract.integrationtests.common.products.DelinquencyBucketsHelper;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class LoanAccountArrearsAgeingCOBBusinessStepTest extends BaseLoanIntegrationTest {
+public class LoanAccountArrearsAgeingCOBBusinessStepTest extends FeignLoanTestBase {
 
-    private ResponseSpecification responseSpec;
-    private RequestSpecification requestSpec;
-    private ClientHelper clientHelper;
-    private LoanTransactionHelper loanTransactionHelper;
-    public static final String UPDATE_LOAN_ARREARS_AGING = "UPDATE_LOAN_ARREARS_AGING";
+    private static final String LOAN_JOB_NAME = "LOAN_CLOSE_OF_BUSINESS";
+    private static final String UPDATE_LOAN_ARREARS_AGING = "UPDATE_LOAN_ARREARS_AGING";
 
-    @BeforeEach
-    public void setup() {
-        Utils.initializeRESTAssured();
-        this.requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        this.requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        this.responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        this.loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-        this.clientHelper = new ClientHelper(this.requestSpec, this.responseSpec);
-    }
+    private final FeignDelinquencyHelper delinquencyHelper = new FeignDelinquencyHelper(FineractFeignClientHelper.getFineractFeignClient());
+    private final FeignBusinessStepHelper businessStepHelper = new FeignBusinessStepHelper(
+            FineractFeignClientHelper.getFineractFeignClient());
 
     @Test
     public void loanArrearsAgeingCOBBusinessStepTest() {
-        // Set Business Date
         try {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+            updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
 
             LocalDate businessDate = Utils.getLocalDateOfTenant();
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, businessDate);
+            updateBusinessDate(dateTimeFormatter.format(businessDate));
 
             LocalDate operationDate = businessDate.minusDays(40);
-            String loanOperationDate = Utils.dateFormatter.format(operationDate);
+            String loanOperationDate = dateTimeFormatter.format(operationDate);
 
-            // create Client
-            final Integer clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId().intValue();
+            Long clientId = createClient();
+            Long delinquencyBucketId = delinquencyHelper.createDefaultBucket();
+            Long loanProductId = createLoanProduct(dueDateRespectiveNoAccountingNoInterestProduct(1000, 30, 1, 0,
+                    LoanProductTestBuilder.DUE_PENALTY_FEE_INTEREST_PRINCIPAL_IN_ADVANCE_PRINCIPAL_PENALTY_FEE_INTEREST_STRATEGY)
+                    .delinquencyBucketId(delinquencyBucketId));
 
-            // create Loan Product
-
-            // Delinquency Bucket
-            final Long delinquencyBucketId = DelinquencyBucketsHelper.createDefaultBucket();
-            final DelinquencyBucketResponse delinquencyBucket = DelinquencyBucketsHelper.getBucket(delinquencyBucketId);
-
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper,
-                    delinquencyBucketId);
-            assertNotNull(getLoanProductsProductResponse);
-
-            // Loan1 ExternalId
-            String loan1ExternalIdStr = UUID.randomUUID().toString();
-
-            // create Loan Account for Client with Loan Product type 1
-            Long loanProductId = getLoanProductsProductResponse.getId();
-            final Integer loanId_1 = createLoanAccount(loanOperationDate, clientId, loanProductId, loan1ExternalIdStr);
-
-            String loan2ExternalIdStr = UUID.randomUUID().toString();
-            final Integer loanId_2 = createLoanAccount(loanOperationDate, clientId, loanProductId, loan2ExternalIdStr);
-
-            // Run Loan cob with verfying business step for Update Arrears ageing details
-            final SchedulerJobHelper schedulerJobHelper = new SchedulerJobHelper(requestSpec);
+            Long loanId1 = createArrearsLoanAccount(clientId, loanProductId, loanOperationDate);
+            Long loanId2 = createArrearsLoanAccount(clientId, loanProductId, loanOperationDate);
 
             // COB Step Validation
-            final JobBusinessStepConfigData jobBusinessStepConfigData = BusinessStepConfigurationHelper
-                    .getConfiguredBusinessStepsByJobName(requestSpec, responseSpec, BusinessConfigurationApiTest.LOAN_JOB_NAME);
+            JobBusinessStepConfigData jobBusinessStepConfigData = businessStepHelper.getConfiguredBusinessStepsByJobName(LOAN_JOB_NAME);
             assertNotNull(jobBusinessStepConfigData);
-            assertEquals(BusinessConfigurationApiTest.LOAN_JOB_NAME, jobBusinessStepConfigData.getJobName());
+            assertEquals(LOAN_JOB_NAME, jobBusinessStepConfigData.getJobName());
             assertTrue(jobBusinessStepConfigData.getBusinessSteps().size() > 0);
             assertTrue(jobBusinessStepConfigData.getBusinessSteps().stream()
                     .anyMatch(businessStep -> UPDATE_LOAN_ARREARS_AGING.equals(businessStep.getStepName())));
 
             // Run the Loan COB Job
-            final String jobName = "Loan COB";
-            schedulerJobHelper.executeAndAwaitJob(jobName);
+            schedulerHelper.executeAndAwaitJob("Loan COB");
 
-            // verify Arrears details are updated for both the loans, by verifying loan summary fields for
-            // principalOverdue,totalOverdue,overdueSinceddate
-
-            // Retrieve Loan 1 with loanId
-            GetLoansLoanIdResponse loan1Details = loanTransactionHelper.getLoanDetails((long) loanId_1);
-            GetLoansLoanIdSummary loan1Summary = loan1Details.getSummary();
-            assertNotNull(loan1Summary);
-            assertNotNull(loan1Summary.getOverdueSinceDate());
-            assertEquals(1000.00, Utils.getDoubleValue(loan1Summary.getPrincipalOverdue()));
-            assertEquals(1000.00, Utils.getDoubleValue(loan1Summary.getTotalOverdue()));
-
-            // Retrieve Loan 2 with loanId
-            GetLoansLoanIdResponse loan2Details = loanTransactionHelper.getLoanDetails((long) loanId_2);
-            GetLoansLoanIdSummary loan2Summary = loan2Details.getSummary();
-            assertNotNull(loan2Summary);
-            assertNotNull(loan2Summary.getOverdueSinceDate());
-            assertEquals(1000.00, Utils.getDoubleValue(loan2Summary.getPrincipalOverdue()));
-            assertEquals(1000.00, Utils.getDoubleValue(loan2Summary.getTotalOverdue()));
+            // verify Arrears details are updated for both loans
+            verifyArrearsSummary(loanId1);
+            verifyArrearsSummary(loanId2);
         } finally {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+            updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(false));
         }
     }
 
-    private GetLoanProductsProductIdResponse createLoanProduct(final LoanTransactionHelper loanTransactionHelper,
-            final Long delinquencyBucketId) {
-        final HashMap<String, Object> loanProductMap = new LoanProductTestBuilder().build(null, delinquencyBucketId);
-        final Integer loanProductId = loanTransactionHelper.getLoanProductId(Utils.convertToJson(loanProductMap));
-        return loanTransactionHelper.getLoanProduct(loanProductId);
+    private void verifyArrearsSummary(final Long loanId) {
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
+        GetLoansLoanIdSummary loanSummary = loanDetails.getSummary();
+        assertNotNull(loanSummary);
+        assertNotNull(loanSummary.getOverdueSinceDate());
+        assertEquals(1000.00, Utils.getDoubleValue(loanSummary.getPrincipalOverdue()));
+        assertEquals(1000.00, Utils.getDoubleValue(loanSummary.getTotalOverdue()));
     }
 
-    private Integer createLoanAccount(final String operationDate, final Integer clientID, final Long loanProductID,
-            final String externalId) {
-
-        String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal("1000").withLoanTermFrequency("1")
-                .withLoanTermFrequencyAsMonths().withNumberOfRepayments("1").withRepaymentEveryAfter("1")
-                .withRepaymentFrequencyTypeAsMonths().withInterestRatePerPeriod("0").withInterestTypeAsFlatBalance()
-                .withAmortizationTypeAsEqualPrincipalPayments().withInterestCalculationPeriodTypeSameAsRepaymentPeriod()
-                .withExpectedDisbursementDate(operationDate).withSubmittedOnDate(operationDate).withLoanType("individual")
-                .withExternalId(externalId).build(clientID.toString(), loanProductID.toString(), null);
-
-        final Integer loanId = loanTransactionHelper.getLoanId(loanApplicationJSON);
-        loanTransactionHelper.approveLoan(operationDate, "1000", loanId, null);
-        loanTransactionHelper.disburseLoanWithNetDisbursalAmount(operationDate, loanId, "1000");
+    private Long createArrearsLoanAccount(final Long clientId, final Long productId, final String operationDate) {
+        PostLoansRequest request = new PostLoansRequest().clientId(clientId).productId(productId).principal(new BigDecimal("1000"))
+                .loanTermFrequency(30).loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.DAYS).numberOfRepayments(1)
+                .repaymentEvery(30).repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.DAYS).interestRatePerPeriod(BigDecimal.ZERO)
+                .interestType(LoanTestData.InterestType.FLAT).amortizationType(LoanTestData.AmortizationType.EQUAL_PRINCIPAL)
+                .transactionProcessingStrategyCode(
+                        LoanApplicationTestBuilder.DUE_PENALTY_FEE_INTEREST_PRINCIPAL_IN_ADVANCE_PRINCIPAL_PENALTY_FEE_INTEREST_STRATEGY)
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)
+                .expectedDisbursementDate(operationDate).submittedOnDate(operationDate).dateFormat(LoanTestData.DATETIME_PATTERN)
+                .locale(LoanTestData.LOCALE).loanType("individual");
+        Long loanId = applyForLoan(request);
+        approveLoan(loanId, approveLoanRequest(1000.0, operationDate));
+        disburseLoan(loanId, BigDecimal.valueOf(1000), operationDate);
         return loanId;
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanAccountsContainsCurrencyFieldTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanAccountsContainsCurrencyFieldTest.java
@@ -18,119 +18,75 @@
  */
 package org.apache.fineract.integrationtests;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Set;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.client.models.GetClientsClientIdAccountsResponse;
 import org.apache.fineract.client.models.GetClientsLoanAccounts;
 import org.apache.fineract.client.models.PostClientsResponse;
+import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.Utils;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.modules.ClientRequestBuilders;
 import org.apache.fineract.integrationtests.common.accounting.Account;
 import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
 import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-@Slf4j
-public class LoanAccountsContainsCurrencyFieldTest extends BaseLoanIntegrationTest {
+public class LoanAccountsContainsCurrencyFieldTest extends FeignLoanTestBase {
 
-    private ResponseSpecification responseSpec;
-    private RequestSpecification requestSpec;
-    private LoanTransactionHelper loanTransactionHelper;
-    private static final String principalAmount = "1200.00";
+    private static final String PRINCIPAL_AMOUNT = "1200.00";
     private static final String NONE = "1";
-    private static final Logger LOG = LoggerFactory.getLogger(LoanAccountsContainsCurrencyFieldTest.class);
-
-    @BeforeEach
-    public void setup() {
-        Utils.initializeRESTAssured();
-        requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-
-        loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-    }
 
     @Test
     public void testGetClientLoanAccountsUsingExternalIdContainsCurrency() {
-        String formattedDate = "01 September 2022";
+        final String activationDate = "01 September 2022";
 
         // given
-        globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
+        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID,
+                new PutGlobalConfigurationsRequest().enabled(true));
+
         // when
-        final PostClientsResponse clientResponse = ClientHelper.addClientAsPerson(ClientHelper.DEFAULT_OFFICE_ID,
-                ClientHelper.LEGALFORM_ID_PERSON, null);
+        final PostClientsResponse clientResponse = clientHelper
+                .createClient(ClientRequestBuilders.createActivePersonClient(activationDate));
         final String clientExternalId = clientResponse.getResourceExternalId();
-        final long clientId = clientResponse.getClientId();
+        final Long clientId = clientResponse.getClientId();
 
-        globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, false);
+        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID,
+                new PutGlobalConfigurationsRequest().enabled(false));
 
-        Integer loanProductId = createLoanProduct(false, NONE);
-
+        final Long loanProductId = createLoanProductFromJson(buildLoanProductJson());
         // Create Loan Account
-        final Integer loanId = createLoanAccount(loanTransactionHelper, String.valueOf(clientId), String.valueOf(loanProductId),
-                formattedDate);
+        final Long loanId = createAndApproveLoan(clientId, loanProductId, activationDate);
+        assertNotNull(loanId);
 
-        GetClientsClientIdAccountsResponse clientAccountsResponse = ClientHelper.getClientAccounts(clientExternalId);
-
-        if (clientAccountsResponse.getLoanAccounts() == null) {
-            // Handle the case where getClientAccounts returned null
-            throw new IllegalStateException("getClientAccounts returned null");
-        }
-
+        final GetClientsClientIdAccountsResponse clientAccountsResponse = clientHelper.getClientAccounts(clientExternalId);
         final Set<GetClientsLoanAccounts> loanAccounts = clientAccountsResponse.getLoanAccounts();
 
+        // Handle the case where getClientAccounts returned null
+        assertNotNull(loanAccounts, "getClientAccounts returned no loan accounts");
         // Assert if loanAccounts contains a loan account with "currency" field
-        boolean containsCurrency = false;
-        if (loanAccounts != null) {
-            containsCurrency = loanAccounts.stream().anyMatch(account -> account.getCurrency() != null);
-        }
-
-        // Perform assertion
-        assert containsCurrency;
-
+        assertTrue(loanAccounts.stream().anyMatch(account -> account.getCurrency() != null),
+                "Loan accounts should expose the currency field");
     }
 
-    private Integer createLoanAccount(final LoanTransactionHelper loanTransactionHelper, final String clientId, final String loanProductId,
-            final String operationDate) {
-        final String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal(principalAmount).withLoanTermFrequency("1")
+    private Long createAndApproveLoan(Long clientId, Long loanProductId, String operationDate) {
+        final String loanApplicationJson = new LoanApplicationTestBuilder().withPrincipal(PRINCIPAL_AMOUNT).withLoanTermFrequency("1")
                 .withLoanTermFrequencyAsMonths().withNumberOfRepayments("1").withRepaymentEveryAfter("1")
                 .withRepaymentFrequencyTypeAsMonths().withInterestRatePerPeriod("0").withInterestTypeAsFlatBalance()
                 .withAmortizationTypeAsEqualPrincipalPayments().withInterestCalculationPeriodTypeSameAsRepaymentPeriod()
                 .withExpectedDisbursementDate("03 September 2022").withSubmittedOnDate("01 September 2022").withLoanType("individual")
-                .build(clientId, loanProductId, null);
-        final Integer loanId = loanTransactionHelper.getLoanId(loanApplicationJSON);
-        loanTransactionHelper.approveLoan(operationDate, principalAmount, loanId, null);
+                .build(clientId.toString(), loanProductId.toString(), null);
+        final Long loanId = applyForLoanFromJson(loanApplicationJson);
+        approveLoan(loanId, approveLoanRequest(Double.valueOf(PRINCIPAL_AMOUNT), operationDate));
         return loanId;
     }
 
-    private Integer createLoanProduct(final boolean multiDisburseLoan, final String accountingRule, final Account... accounts) {
-        LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-        LoanProductTestBuilder builder = new LoanProductTestBuilder() //
-                .withPrincipal("12,000.00") //
-                .withNumberOfRepayments("4") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("1") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualInstallments() //
-                .withInterestTypeAsDecliningBalance() //
-                .withTranches(multiDisburseLoan) //
-                .withAccounting(accountingRule, accounts);
-        if (multiDisburseLoan) {
-            builder = builder.withInterestCalculationPeriodTypeAsRepaymentPeriod(true);
-        }
-        final String loanProductJSON = builder.build(null);
-        return loanTransactionHelper.getLoanProductId(loanProductJSON);
+    private String buildLoanProductJson() {
+        return new LoanProductTestBuilder().withPrincipal("12,000.00").withNumberOfRepayments("4").withRepaymentAfterEvery("1")
+                .withRepaymentTypeAsMonth().withinterestRatePerPeriod("1").withInterestRateFrequencyTypeAsMonths()
+                .withAmortizationTypeAsEqualInstallments().withInterestTypeAsDecliningBalance().withTranches(false)
+                .withAccounting(NONE, new Account[] {}).build(null);
     }
-
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanAccountsContainsCurrencyFieldTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanAccountsContainsCurrencyFieldTest.java
@@ -18,119 +18,70 @@
  */
 package org.apache.fineract.integrationtests;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Set;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.client.models.GetClientsClientIdAccountsResponse;
 import org.apache.fineract.client.models.GetClientsLoanAccounts;
 import org.apache.fineract.client.models.PostClientsResponse;
+import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.Utils;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.modules.ClientRequestBuilders;
 import org.apache.fineract.integrationtests.common.accounting.Account;
 import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
 import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-@Slf4j
-public class LoanAccountsContainsCurrencyFieldTest extends BaseLoanIntegrationTest {
+public class LoanAccountsContainsCurrencyFieldTest extends FeignLoanTestBase {
 
-    private ResponseSpecification responseSpec;
-    private RequestSpecification requestSpec;
-    private LoanTransactionHelper loanTransactionHelper;
-    private static final String principalAmount = "1200.00";
+    private static final String PRINCIPAL_AMOUNT = "1200.00";
     private static final String NONE = "1";
-    private static final Logger LOG = LoggerFactory.getLogger(LoanAccountsContainsCurrencyFieldTest.class);
-
-    @BeforeEach
-    public void setup() {
-        Utils.initializeRESTAssured();
-        requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-
-        loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-    }
 
     @Test
     public void testGetClientLoanAccountsUsingExternalIdContainsCurrency() {
-        String formattedDate = "01 September 2022";
+        final String activationDate = "01 September 2022";
 
-        // given
-        globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-        // when
-        final PostClientsResponse clientResponse = ClientHelper.addClientAsPerson(ClientHelper.DEFAULT_OFFICE_ID,
-                ClientHelper.LEGALFORM_ID_PERSON, null);
+        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID,
+                new PutGlobalConfigurationsRequest().enabled(true));
+
+        final PostClientsResponse clientResponse = clientHelper
+                .createClient(ClientRequestBuilders.createActivePersonClient(activationDate));
         final String clientExternalId = clientResponse.getResourceExternalId();
-        final long clientId = clientResponse.getClientId();
+        final Long clientId = clientResponse.getClientId();
 
-        globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, false);
+        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID,
+                new PutGlobalConfigurationsRequest().enabled(false));
 
-        Integer loanProductId = createLoanProduct(false, NONE);
+        final Long loanProductId = createLoanProductFromJson(buildLoanProductJson());
+        final Long loanId = createAndApproveLoan(clientId, loanProductId, activationDate);
+        assertNotNull(loanId);
 
-        // Create Loan Account
-        final Integer loanId = createLoanAccount(loanTransactionHelper, String.valueOf(clientId), String.valueOf(loanProductId),
-                formattedDate);
-
-        GetClientsClientIdAccountsResponse clientAccountsResponse = ClientHelper.getClientAccounts(clientExternalId);
-
-        if (clientAccountsResponse.getLoanAccounts() == null) {
-            // Handle the case where getClientAccounts returned null
-            throw new IllegalStateException("getClientAccounts returned null");
-        }
-
+        final GetClientsClientIdAccountsResponse clientAccountsResponse = clientHelper.getClientAccounts(clientExternalId);
         final Set<GetClientsLoanAccounts> loanAccounts = clientAccountsResponse.getLoanAccounts();
 
-        // Assert if loanAccounts contains a loan account with "currency" field
-        boolean containsCurrency = false;
-        if (loanAccounts != null) {
-            containsCurrency = loanAccounts.stream().anyMatch(account -> account.getCurrency() != null);
-        }
-
-        // Perform assertion
-        assert containsCurrency;
-
+        assertNotNull(loanAccounts, "getClientAccounts returned no loan accounts");
+        assertTrue(loanAccounts.stream().anyMatch(account -> account.getCurrency() != null),
+                "Loan accounts should expose the currency field");
     }
 
-    private Integer createLoanAccount(final LoanTransactionHelper loanTransactionHelper, final String clientId, final String loanProductId,
-            final String operationDate) {
-        final String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal(principalAmount).withLoanTermFrequency("1")
+    private Long createAndApproveLoan(Long clientId, Long loanProductId, String operationDate) {
+        final String loanApplicationJson = new LoanApplicationTestBuilder().withPrincipal(PRINCIPAL_AMOUNT).withLoanTermFrequency("1")
                 .withLoanTermFrequencyAsMonths().withNumberOfRepayments("1").withRepaymentEveryAfter("1")
                 .withRepaymentFrequencyTypeAsMonths().withInterestRatePerPeriod("0").withInterestTypeAsFlatBalance()
                 .withAmortizationTypeAsEqualPrincipalPayments().withInterestCalculationPeriodTypeSameAsRepaymentPeriod()
                 .withExpectedDisbursementDate("03 September 2022").withSubmittedOnDate("01 September 2022").withLoanType("individual")
-                .build(clientId, loanProductId, null);
-        final Integer loanId = loanTransactionHelper.getLoanId(loanApplicationJSON);
-        loanTransactionHelper.approveLoan(operationDate, principalAmount, loanId, null);
+                .build(clientId.toString(), loanProductId.toString(), null);
+        final Long loanId = applyForLoanFromJson(loanApplicationJson);
+        approveLoan(loanId, approveLoanRequest(Double.valueOf(PRINCIPAL_AMOUNT), operationDate));
         return loanId;
     }
 
-    private Integer createLoanProduct(final boolean multiDisburseLoan, final String accountingRule, final Account... accounts) {
-        LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-        LoanProductTestBuilder builder = new LoanProductTestBuilder() //
-                .withPrincipal("12,000.00") //
-                .withNumberOfRepayments("4") //
-                .withRepaymentAfterEvery("1") //
-                .withRepaymentTypeAsMonth() //
-                .withinterestRatePerPeriod("1") //
-                .withInterestRateFrequencyTypeAsMonths() //
-                .withAmortizationTypeAsEqualInstallments() //
-                .withInterestTypeAsDecliningBalance() //
-                .withTranches(multiDisburseLoan) //
-                .withAccounting(accountingRule, accounts);
-        if (multiDisburseLoan) {
-            builder = builder.withInterestCalculationPeriodTypeAsRepaymentPeriod(true);
-        }
-        final String loanProductJSON = builder.build(null);
-        return loanTransactionHelper.getLoanProductId(loanProductJSON);
+    private String buildLoanProductJson() {
+        return new LoanProductTestBuilder().withPrincipal("12,000.00").withNumberOfRepayments("4").withRepaymentAfterEvery("1")
+                .withRepaymentTypeAsMonth().withinterestRatePerPeriod("1").withInterestRateFrequencyTypeAsMonths()
+                .withAmortizationTypeAsEqualInstallments().withInterestTypeAsDecliningBalance().withTranches(false)
+                .withAccounting(NONE, new Account[] {}).build(null);
     }
-
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanAccrualReversalOnClosedLoanTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanAccrualReversalOnClosedLoanTest.java
@@ -31,12 +31,10 @@ import java.util.concurrent.atomic.AtomicReference;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdTransactions;
-import org.apache.fineract.client.models.PostClientsResponse;
-import org.apache.fineract.client.models.PostLoanProductsResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsTransactionIdRequest;
-import org.apache.fineract.integrationtests.common.ClientHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.junit.jupiter.api.Test;
 
@@ -47,7 +45,7 @@ import org.junit.jupiter.api.Test;
  * reversing existing ACCRUAL transactions. Reversing accruals breaks downstream event reconciliation.
  */
 @Slf4j
-public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest {
+public class LoanAccrualReversalOnClosedLoanTest extends FeignLoanTestBase {
 
     private static final String LOCALE = "en";
 
@@ -63,10 +61,10 @@ public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest
 
         // Step 1: Create loan product with interest refund support and accrual activity posting
         runAt("01 November 2024", () -> {
-            final PostClientsResponse client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
-            clientIdRef.set(client.getClientId());
+            final Long clientId = createClient();
+            clientIdRef.set(clientId);
 
-            final PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(create4IProgressive()//
+            final Long loanProductId = createLoanProduct(create4IProgressive()//
                     .currencyCode("USD")//
                     .principal(220.0).minPrincipal(100.0).maxPrincipal(1000.0)//
                     .numberOfRepayments(4).repaymentEvery(1)//
@@ -80,8 +78,7 @@ public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest
             ))//
             );
 
-            Long loanId = applyAndApproveProgressiveLoan(clientIdRef.get(), loanProduct.getResourceId(), "01 November 2024", 220.0, 12.0, 4,
-                    null);
+            Long loanId = applyAndApproveProgressiveLoan(clientIdRef.get(), loanProductId, "01 November 2024", 220.0, 12.0, 4, null);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(220.0), "01 November 2024");
             log.info("Loan disbursed: id={}, amount=220.0", loanId);
@@ -105,13 +102,13 @@ public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest
         // Step 3: Final repayment closes the loan
         runAt("01 March 2025", () -> {
             executeInlineCOB(loanId);
-            GetLoansLoanIdResponse details = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse details = getLoanDetails(loanId);
             var installment = details.getRepaymentSchedule().getPeriods().stream().filter(p -> p.getPeriod() != null && p.getPeriod() == 4)
                     .findFirst().orElseThrow();
             double amount = Utils.getDoubleValue(installment.getTotalDueForPeriod());
             addRepaymentForLoan(loanId, amount, "01 March 2025");
 
-            GetLoansLoanIdResponse loanAfterClose = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanAfterClose = getLoanDetails(loanId);
             assertTrue(loanAfterClose.getStatus().getClosedObligationsMet(),
                     "Loan should be CLOSED but is: " + loanAfterClose.getStatus().getCode());
             log.info("Loan closed on 01 March 2025");
@@ -121,12 +118,11 @@ public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest
 
         // Step 4: Goodwill credit (backdated) makes loan overpaid — mirrors production 10/29 goodwill credit
         runAt("15 March 2025", () -> {
-            PostLoansLoanIdTransactionsResponse gwcResponse = loanTransactionHelper.makeGoodwillCredit(loanId,
-                    new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate("15 March 2025").locale(LOCALE)
-                            .transactionAmount(0.5));
+            PostLoansLoanIdTransactionsResponse gwcResponse = makeGoodwillCredit(loanId, new PostLoansLoanIdTransactionsRequest()
+                    .dateFormat(DATETIME_PATTERN).transactionDate("15 March 2025").locale(LOCALE).transactionAmount(0.5));
             assertNotNull(gwcResponse.getResourceId());
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             assertTrue(loanDetails.getStatus().getOverpaid(),
                     "Loan should be OVERPAID after goodwill credit but is: " + loanDetails.getStatus().getCode());
             log.info("Goodwill credit of 0.50 applied → loan OVERPAID");
@@ -134,12 +130,11 @@ public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest
 
         // Step 5: Merchant issued refund with automatic interest refund — mirrors production merchant refunds
         runAt("16 March 2025", () -> {
-            PostLoansLoanIdTransactionsResponse mirResponse = loanTransactionHelper.makeMerchantIssuedRefund(loanId,
-                    new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate("16 March 2025").locale(LOCALE)
-                            .transactionAmount(100.0));
+            PostLoansLoanIdTransactionsResponse mirResponse = makeMerchantIssuedRefund(loanId, new PostLoansLoanIdTransactionsRequest()
+                    .dateFormat(DATETIME_PATTERN).transactionDate("16 March 2025").locale(LOCALE).transactionAmount(100.0));
             assertNotNull(mirResponse.getResourceId());
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             assertTrue(loanDetails.getStatus().getOverpaid(), "Loan should still be OVERPAID but is: " + loanDetails.getStatus().getCode());
             log.info("Merchant issued refund of 100.0 → loan still OVERPAID");
 
@@ -153,14 +148,13 @@ public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest
             executeInlineCOB(loanId);
 
             // Get the overpayment amount
-            GetLoansLoanIdResponse details = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse details = getLoanDetails(loanId);
             double overpayment = Utils.getDoubleValue(details.getTotalOverpaid());
             log.info("Total overpaid: {}", overpayment);
             assertTrue(overpayment > 0, "Should have overpayment");
 
-            PostLoansLoanIdTransactionsResponse cbrResponse = loanTransactionHelper.makeCreditBalanceRefund(loanId,
-                    new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate("17 March 2025").locale(LOCALE)
-                            .transactionAmount(overpayment));
+            PostLoansLoanIdTransactionsResponse cbrResponse = makeCreditBalanceRefund(loanId, new PostLoansLoanIdTransactionsRequest()
+                    .dateFormat(DATETIME_PATTERN).transactionDate("17 March 2025").locale(LOCALE).transactionAmount(overpayment));
             assertNotNull(cbrResponse.getResourceId());
             cbrTxnIdRef.set(cbrResponse.getResourceId());
             log.info("CBR created for {} → txn id: {}", overpayment, cbrResponse.getResourceId());
@@ -180,10 +174,10 @@ public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest
             Long cbrTxnId = cbrTxnIdRef.get();
             log.info("=== Reversing CBR transaction: {} ===", cbrTxnId);
 
-            loanTransactionHelper.reverseLoanTransaction(loanId, cbrTxnId, new PostLoansLoanIdTransactionsTransactionIdRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("20 March 2025").transactionAmount(0.0).locale(LOCALE));
+            reverseLoanTransaction(loanId, cbrTxnId, new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("20 March 2025").transactionAmount(0.0).locale(LOCALE));
 
-            GetLoansLoanIdResponse afterReversal = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse afterReversal = getLoanDetails(loanId);
             log.info("Status after CBR reversal: {}", afterReversal.getStatus().getCode());
             logAccrualState(loanId, "After CBR reversal (before re-create)");
 
@@ -191,9 +185,8 @@ public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest
             double overpayment = Utils.getDoubleValue(afterReversal.getTotalOverpaid());
             log.info("Overpayment after CBR reversal: {}", overpayment);
             if (overpayment > 0) {
-                PostLoansLoanIdTransactionsResponse newCbr = loanTransactionHelper.makeCreditBalanceRefund(loanId,
-                        new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate("20 March 2025")
-                                .locale(LOCALE).transactionAmount(overpayment));
+                PostLoansLoanIdTransactionsResponse newCbr = makeCreditBalanceRefund(loanId, new PostLoansLoanIdTransactionsRequest()
+                        .dateFormat(DATETIME_PATTERN).transactionDate("20 March 2025").locale(LOCALE).transactionAmount(overpayment));
                 assertNotNull(newCbr.getResourceId());
                 newCbrTxnIdRef.set(newCbr.getResourceId());
                 log.info("New CBR created: {}", newCbr.getResourceId());
@@ -208,14 +201,14 @@ public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest
             if (newCbrId != null) {
                 log.info("=== Second CBR reversal cycle: {} ===", newCbrId);
 
-                loanTransactionHelper.reverseLoanTransaction(loanId, newCbrId, new PostLoansLoanIdTransactionsTransactionIdRequest()
-                        .dateFormat(DATETIME_PATTERN).transactionDate("25 March 2025").transactionAmount(0.0).locale(LOCALE));
+                reverseLoanTransaction(loanId, newCbrId, new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN)
+                        .transactionDate("25 March 2025").transactionAmount(0.0).locale(LOCALE));
 
-                GetLoansLoanIdResponse afterReversal = loanTransactionHelper.getLoanDetails(loanId);
+                GetLoansLoanIdResponse afterReversal = getLoanDetails(loanId);
                 double overpayment = Utils.getDoubleValue(afterReversal.getTotalOverpaid());
                 if (overpayment > 0) {
-                    loanTransactionHelper.makeCreditBalanceRefund(loanId, new PostLoansLoanIdTransactionsRequest()
-                            .dateFormat(DATETIME_PATTERN).transactionDate("25 March 2025").locale(LOCALE).transactionAmount(overpayment));
+                    makeCreditBalanceRefund(loanId, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                            .transactionDate("25 March 2025").locale(LOCALE).transactionAmount(overpayment));
                 }
                 logAccrualState(loanId, "After second CBR reversal cycle");
             }
@@ -225,7 +218,7 @@ public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest
         runAt("26 March 2025", () -> {
             executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             assertNotNull(loanDetails.getTransactions());
 
             logAllTransactions(loanId, "Final state");
@@ -246,15 +239,14 @@ public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest
         AtomicLong loanIdRef = new AtomicLong();
 
         runAt("01 November 2024", () -> {
-            final PostClientsResponse client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+            final Long clientId = createClient();
 
-            final PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(create4IProgressive()//
+            final Long loanProductId = createLoanProduct(create4IProgressive()//
                     .currencyCode("USD").principal(220.0).minPrincipal(100.0).maxPrincipal(1000.0)//
                     .numberOfRepayments(4).repaymentEvery(1).interestRatePerPeriod(12.0).interestRateFrequencyType(3)//
                     .enableAccrualActivityPosting(true));
 
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "01 November 2024", 220.0, 12.0,
-                    4, null);
+            Long loanId = applyAndApproveProgressiveLoan(clientId, loanProductId, "01 November 2024", 220.0, 12.0, 4, null);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(220.0), "01 November 2024");
         });
@@ -273,45 +265,44 @@ public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest
 
         runAt("01 March 2025", () -> {
             executeInlineCOB(loanId);
-            GetLoansLoanIdResponse details = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse details = getLoanDetails(loanId);
             var installment = details.getRepaymentSchedule().getPeriods().stream().filter(p -> p.getPeriod() != null && p.getPeriod() == 4)
                     .findFirst().orElseThrow();
             addRepaymentForLoan(loanId, Utils.getDoubleValue(installment.getTotalDueForPeriod()), "01 March 2025");
-            assertTrue(loanTransactionHelper.getLoanDetails(loanId).getStatus().getClosedObligationsMet());
+            assertTrue(getLoanDetails(loanId).getStatus().getClosedObligationsMet());
         });
 
         // Merchant refund → CBR → reverse CBR → new CBR
         AtomicReference<Long> cbrIdRef = new AtomicReference<>();
         runAt("15 March 2025", () -> {
-            loanTransactionHelper.makeMerchantIssuedRefund(loanId, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+            makeMerchantIssuedRefund(loanId, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
                     .transactionDate("15 March 2025").locale(LOCALE).transactionAmount(50.0));
         });
 
         runAt("16 March 2025", () -> {
             executeInlineCOB(loanId);
-            GetLoansLoanIdResponse details = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse details = getLoanDetails(loanId);
             double overpayment = Utils.getDoubleValue(details.getTotalOverpaid());
-            PostLoansLoanIdTransactionsResponse cbr = loanTransactionHelper.makeCreditBalanceRefund(loanId,
-                    new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate("16 March 2025").locale(LOCALE)
-                            .transactionAmount(overpayment));
+            PostLoansLoanIdTransactionsResponse cbr = makeCreditBalanceRefund(loanId, new PostLoansLoanIdTransactionsRequest()
+                    .dateFormat(DATETIME_PATTERN).transactionDate("16 March 2025").locale(LOCALE).transactionAmount(overpayment));
             cbrIdRef.set(cbr.getResourceId());
         });
 
         runAt("20 March 2025", () -> {
-            loanTransactionHelper.reverseLoanTransaction(loanId, cbrIdRef.get(), new PostLoansLoanIdTransactionsTransactionIdRequest()
+            reverseLoanTransaction(loanId, cbrIdRef.get(), new PostLoansLoanIdTransactionsTransactionIdRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("20 March 2025").transactionAmount(0.0).locale(LOCALE));
 
-            GetLoansLoanIdResponse afterReversal = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse afterReversal = getLoanDetails(loanId);
             double overpayment = Utils.getDoubleValue(afterReversal.getTotalOverpaid());
             if (overpayment > 0) {
-                loanTransactionHelper.makeCreditBalanceRefund(loanId, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                makeCreditBalanceRefund(loanId, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
                         .transactionDate("20 March 2025").locale(LOCALE).transactionAmount(overpayment));
             }
         });
 
         runAt("21 March 2025", () -> {
             executeInlineCOB(loanId);
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             assertNoReversedAccruals(loanDetails);
         });
     }
@@ -325,9 +316,9 @@ public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest
         AtomicLong loanIdRef = new AtomicLong();
 
         runAt("01 November 2024", () -> {
-            final PostClientsResponse client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+            final Long clientId = createClient();
 
-            final PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(create4IProgressive()//
+            final Long loanProductId = createLoanProduct(create4IProgressive()//
                     .currencyCode("USD").principal(220.0).minPrincipal(100.0).maxPrincipal(1000.0)//
                     .numberOfRepayments(4).repaymentEvery(1).interestRatePerPeriod(12.0).interestRateFrequencyType(3)//
                     .enableAccrualActivityPosting(true)//
@@ -339,8 +330,7 @@ public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest
             ))//
             );
 
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "01 November 2024", 220.0, 12.0,
-                    4, null);
+            Long loanId = applyAndApproveProgressiveLoan(clientId, loanProductId, "01 November 2024", 220.0, 12.0, 4, null);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(220.0), "01 November 2024");
             log.info("[Backdated CBR] Loan disbursed: id={}", loanId);
@@ -360,11 +350,11 @@ public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest
 
         runAt("01 March 2025", () -> {
             executeInlineCOB(loanId);
-            GetLoansLoanIdResponse details = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse details = getLoanDetails(loanId);
             var installment = details.getRepaymentSchedule().getPeriods().stream().filter(p -> p.getPeriod() != null && p.getPeriod() == 4)
                     .findFirst().orElseThrow();
             addRepaymentForLoan(loanId, Utils.getDoubleValue(installment.getTotalDueForPeriod()), "01 March 2025");
-            assertTrue(loanTransactionHelper.getLoanDetails(loanId).getStatus().getClosedObligationsMet());
+            assertTrue(getLoanDetails(loanId).getStatus().getClosedObligationsMet());
             log.info("[Backdated CBR] Loan closed on 01 March 2025");
         });
 
@@ -372,22 +362,21 @@ public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest
 
         // Goodwill credit + merchant refund → overpaid
         runAt("15 March 2025", () -> {
-            loanTransactionHelper.makeGoodwillCredit(loanId, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+            makeGoodwillCredit(loanId, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
                     .transactionDate("15 March 2025").locale(LOCALE).transactionAmount(0.5));
-            loanTransactionHelper.makeMerchantIssuedRefund(loanId, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+            makeMerchantIssuedRefund(loanId, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
                     .transactionDate("15 March 2025").locale(LOCALE).transactionAmount(100.0));
-            assertTrue(loanTransactionHelper.getLoanDetails(loanId).getStatus().getOverpaid());
+            assertTrue(getLoanDetails(loanId).getStatus().getOverpaid());
         });
 
         // CBR on March 16
         AtomicReference<Long> cbrIdRef = new AtomicReference<>();
         runAt("16 March 2025", () -> {
             executeInlineCOB(loanId);
-            GetLoansLoanIdResponse details = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse details = getLoanDetails(loanId);
             double overpayment = Utils.getDoubleValue(details.getTotalOverpaid());
-            PostLoansLoanIdTransactionsResponse cbr = loanTransactionHelper.makeCreditBalanceRefund(loanId,
-                    new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate("16 March 2025").locale(LOCALE)
-                            .transactionAmount(overpayment));
+            PostLoansLoanIdTransactionsResponse cbr = makeCreditBalanceRefund(loanId, new PostLoansLoanIdTransactionsRequest()
+                    .dateFormat(DATETIME_PATTERN).transactionDate("16 March 2025").locale(LOCALE).transactionAmount(overpayment));
             cbrIdRef.set(cbr.getResourceId());
             logAccrualState(loanId, "After first CBR on March 16");
         });
@@ -398,16 +387,16 @@ public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest
         runAt("15 April 2025", () -> {
             log.info("[Backdated CBR] Reversing CBR {} and re-creating backdated to 16 March 2025", cbrIdRef.get());
 
-            loanTransactionHelper.reverseLoanTransaction(loanId, cbrIdRef.get(), new PostLoansLoanIdTransactionsTransactionIdRequest()
+            reverseLoanTransaction(loanId, cbrIdRef.get(), new PostLoansLoanIdTransactionsTransactionIdRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("15 April 2025").transactionAmount(0.0).locale(LOCALE));
 
             logAccrualState(loanId, "After CBR reversal on April 15");
 
-            GetLoansLoanIdResponse afterReversal = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse afterReversal = getLoanDetails(loanId);
             double overpayment = Utils.getDoubleValue(afterReversal.getTotalOverpaid());
             if (overpayment > 0) {
                 // Re-create CBR backdated to original date — this is the production pattern
-                loanTransactionHelper.makeCreditBalanceRefund(loanId,
+                makeCreditBalanceRefund(loanId,
                         new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate("16 March 2025") // BACKDATED
                                 .locale(LOCALE).transactionAmount(overpayment));
                 log.info("[Backdated CBR] New CBR created backdated to 16 March 2025");
@@ -418,7 +407,7 @@ public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest
 
         runAt("16 April 2025", () -> {
             executeInlineCOB(loanId);
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logAllTransactions(loanId, "Final backdated CBR");
             assertNoReversedAccruals(loanDetails);
         });
@@ -433,16 +422,15 @@ public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest
         AtomicLong loanIdRef = new AtomicLong();
 
         runAt("01 November 2024", () -> {
-            final PostClientsResponse client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+            final Long clientId = createClient();
 
-            final PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(create4ICumulative()//
+            final Long loanProductId = createLoanProduct(create4ICumulative()//
                     .currencyCode("USD").principal(220.0).minPrincipal(100.0).maxPrincipal(1000.0)//
                     .numberOfRepayments(4).repaymentEvery(1).interestRatePerPeriod(12.0).interestRateFrequencyType(3)//
                     .enableAccrualActivityPosting(true)//
             );
 
-            Long loanId = applyAndApproveCumulativeLoan(client.getClientId(), loanProduct.getResourceId(), "01 November 2024", 220.0, 12.0,
-                    4, null);
+            Long loanId = applyAndApproveCumulativeLoan(clientId, loanProductId, "01 November 2024", 220.0, 12.0, 4, null);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(220.0), "01 November 2024");
             log.info("[Cumulative+Backdated] Loan disbursed: id={}", loanId);
@@ -461,11 +449,11 @@ public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest
 
         runAt("01 March 2025", () -> {
             executeInlineCOB(loanId);
-            GetLoansLoanIdResponse details = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse details = getLoanDetails(loanId);
             var installment = details.getRepaymentSchedule().getPeriods().stream().filter(p -> p.getPeriod() != null && p.getPeriod() == 4)
                     .findFirst().orElseThrow();
             addRepaymentForLoan(loanId, Utils.getDoubleValue(installment.getTotalDueForPeriod()), "01 March 2025");
-            assertTrue(loanTransactionHelper.getLoanDetails(loanId).getStatus().getClosedObligationsMet());
+            assertTrue(getLoanDetails(loanId).getStatus().getClosedObligationsMet());
             log.info("[Cumulative+Backdated] Loan closed");
         });
 
@@ -474,19 +462,18 @@ public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest
         // Merchant refund → overpaid
         AtomicReference<Long> cbrIdRef = new AtomicReference<>();
         runAt("15 March 2025", () -> {
-            loanTransactionHelper.makeMerchantIssuedRefund(loanId, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+            makeMerchantIssuedRefund(loanId, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
                     .transactionDate("15 March 2025").locale(LOCALE).transactionAmount(50.0));
-            assertTrue(loanTransactionHelper.getLoanDetails(loanId).getStatus().getOverpaid());
+            assertTrue(getLoanDetails(loanId).getStatus().getOverpaid());
         });
 
         // CBR
         runAt("16 March 2025", () -> {
             executeInlineCOB(loanId);
-            GetLoansLoanIdResponse details = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse details = getLoanDetails(loanId);
             double overpayment = Utils.getDoubleValue(details.getTotalOverpaid());
-            PostLoansLoanIdTransactionsResponse cbr = loanTransactionHelper.makeCreditBalanceRefund(loanId,
-                    new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate("16 March 2025").locale(LOCALE)
-                            .transactionAmount(overpayment));
+            PostLoansLoanIdTransactionsResponse cbr = makeCreditBalanceRefund(loanId, new PostLoansLoanIdTransactionsRequest()
+                    .dateFormat(DATETIME_PATTERN).transactionDate("16 March 2025").locale(LOCALE).transactionAmount(overpayment));
             cbrIdRef.set(cbr.getResourceId());
             logAccrualState(loanId, "After CBR");
         });
@@ -496,15 +483,15 @@ public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest
         // Reverse and re-create backdated
         runAt("15 April 2025", () -> {
             log.info("[Cumulative+Backdated] Reversing CBR and re-creating backdated");
-            loanTransactionHelper.reverseLoanTransaction(loanId, cbrIdRef.get(), new PostLoansLoanIdTransactionsTransactionIdRequest()
+            reverseLoanTransaction(loanId, cbrIdRef.get(), new PostLoansLoanIdTransactionsTransactionIdRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("15 April 2025").transactionAmount(0.0).locale(LOCALE));
 
             logAccrualState(loanId, "After CBR reversal");
 
-            GetLoansLoanIdResponse afterReversal = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse afterReversal = getLoanDetails(loanId);
             double overpayment = Utils.getDoubleValue(afterReversal.getTotalOverpaid());
             if (overpayment > 0) {
-                loanTransactionHelper.makeCreditBalanceRefund(loanId,
+                makeCreditBalanceRefund(loanId,
                         new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate("16 March 2025") // BACKDATED
                                 .locale(LOCALE).transactionAmount(overpayment));
             }
@@ -513,7 +500,7 @@ public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest
 
         runAt("16 April 2025", () -> {
             executeInlineCOB(loanId);
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logAllTransactions(loanId, "Final cumulative+backdated");
             assertNoReversedAccruals(loanDetails);
         });
@@ -533,16 +520,15 @@ public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest
         AtomicLong loanIdRef = new AtomicLong();
 
         runAt("01 November 2024", () -> {
-            final PostClientsResponse client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+            final Long clientId = createClient();
 
-            final PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(create4ICumulative()//
+            final Long loanProductId = createLoanProduct(create4ICumulative()//
                     .currencyCode("USD").principal(220.0).minPrincipal(100.0).maxPrincipal(1000.0)//
                     .numberOfRepayments(4).repaymentEvery(1).interestRatePerPeriod(12.0).interestRateFrequencyType(3)//
                     .enableAccrualActivityPosting(true)//
             );
 
-            Long loanId = applyAndApproveCumulativeLoan(client.getClientId(), loanProduct.getResourceId(), "01 November 2024", 220.0, 12.0,
-                    4, null);
+            Long loanId = applyAndApproveCumulativeLoan(clientId, loanProductId, "01 November 2024", 220.0, 12.0, 4, null);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(220.0), "01 November 2024");
             log.info("[AccrualFix] Loan disbursed: id={}", loanId);
@@ -569,7 +555,7 @@ public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest
         // Since installment 4 interest is unaccrued, the final accrual will have non-zero amount
         // and will be placed at overpaidOnDate (after lastDueDate) → POST-DUE-DATE ACCRUAL
         runAt("05 March 2025", () -> {
-            GetLoansLoanIdResponse details = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse details = getLoanDetails(loanId);
             var installment = details.getRepaymentSchedule().getPeriods().stream().filter(p -> p.getPeriod() != null && p.getPeriod() == 4)
                     .findFirst().orElseThrow();
             double installmentAmount = Utils.getDoubleValue(installment.getTotalDueForPeriod());
@@ -580,7 +566,7 @@ public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest
 
             addRepaymentForLoan(loanId, overpayAmount, "05 March 2025");
 
-            GetLoansLoanIdResponse afterPay = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse afterPay = getLoanDetails(loanId);
             log.info("[AccrualFix] Status after overpayment: {}", afterPay.getStatus().getCode());
             assertTrue(afterPay.getStatus().getOverpaid(), "Loan should be OVERPAID but is: " + afterPay.getStatus().getCode());
 
@@ -590,13 +576,12 @@ public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest
         // CBR to refund overpayment
         AtomicReference<Long> cbrIdRef = new AtomicReference<>();
         runAt("15 March 2025", () -> {
-            GetLoansLoanIdResponse details = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse details = getLoanDetails(loanId);
             double overpayment = Utils.getDoubleValue(details.getTotalOverpaid());
             log.info("[AccrualFix] Overpayment: {}, creating CBR", overpayment);
             assertTrue(overpayment > 0, "Should have overpayment");
-            PostLoansLoanIdTransactionsResponse cbr = loanTransactionHelper.makeCreditBalanceRefund(loanId,
-                    new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate("15 March 2025").locale(LOCALE)
-                            .transactionAmount(overpayment));
+            PostLoansLoanIdTransactionsResponse cbr = makeCreditBalanceRefund(loanId, new PostLoansLoanIdTransactionsRequest()
+                    .dateFormat(DATETIME_PATTERN).transactionDate("15 March 2025").locale(LOCALE).transactionAmount(overpayment));
             cbrIdRef.set(cbr.getResourceId());
             logAccrualState(loanId, "After CBR");
         });
@@ -606,13 +591,13 @@ public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest
         runAt("20 March 2025", () -> {
             log.info("[AccrualFix] === Undoing CBR {} ===", cbrIdRef.get());
 
-            loanTransactionHelper.reverseLoanTransaction(loanId, cbrIdRef.get(), new PostLoansLoanIdTransactionsTransactionIdRequest()
+            reverseLoanTransaction(loanId, cbrIdRef.get(), new PostLoansLoanIdTransactionsTransactionIdRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("20 March 2025").transactionAmount(0.0).locale(LOCALE));
 
             logAccrualState(loanId, "After CBR undo — checking for accrual reversal");
             logAllTransactions(loanId, "After CBR undo");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
 
             // This assertion should FAIL if the bug exists — accruals should NOT be reversed
             assertNoReversedAccruals(loanDetails);
@@ -630,17 +615,16 @@ public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest
         AtomicLong loanIdRef = new AtomicLong();
 
         runAt("01 November 2024", () -> {
-            final PostClientsResponse client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+            final Long clientId = createClient();
 
             // Cumulative loan WITH interest recalculation — matches production scenario
-            final PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(create4ICumulative()//
+            final Long loanProductId = createLoanProduct(create4ICumulative()//
                     .currencyCode("USD").principal(220.0).minPrincipal(100.0).maxPrincipal(1000.0)//
                     .numberOfRepayments(4).repaymentEvery(1).interestRatePerPeriod(12.0).interestRateFrequencyType(3)//
                     .enableAccrualActivityPosting(true)//
             );
 
-            Long loanId = applyAndApproveCumulativeLoan(client.getClientId(), loanProduct.getResourceId(), "01 November 2024", 220.0, 12.0,
-                    4, null);
+            Long loanId = applyAndApproveCumulativeLoan(clientId, loanProductId, "01 November 2024", 220.0, 12.0, 4, null);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(220.0), "01 November 2024");
             log.info("[AccrualFix] Loan disbursed: id={}", loanId);
@@ -662,7 +646,7 @@ public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest
 
         // Overpay to create post-due-date accrual and move loan to OVERPAID
         runAt("05 March 2025", () -> {
-            GetLoansLoanIdResponse details = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse details = getLoanDetails(loanId);
             var installment = details.getRepaymentSchedule().getPeriods().stream().filter(p -> p.getPeriod() != null && p.getPeriod() == 4)
                     .findFirst().orElseThrow();
             double installmentAmount = Utils.getDoubleValue(installment.getTotalDueForPeriod());
@@ -671,7 +655,7 @@ public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest
 
             addRepaymentForLoan(loanId, overpayAmount, "05 March 2025");
 
-            GetLoansLoanIdResponse afterPay = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse afterPay = getLoanDetails(loanId);
             log.info("[AccrualFix] Status after overpayment: {}", afterPay.getStatus().getCode());
             assertTrue(afterPay.getStatus().getOverpaid(), "Loan should be OVERPAID but is: " + afterPay.getStatus().getCode());
             logAccrualState(loanId, "After overpayment");
@@ -680,13 +664,12 @@ public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest
         // CBR to refund overpayment
         AtomicReference<Long> cbrIdRef = new AtomicReference<>();
         runAt("15 March 2025", () -> {
-            GetLoansLoanIdResponse details = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse details = getLoanDetails(loanId);
             double overpayment = Utils.getDoubleValue(details.getTotalOverpaid());
             log.info("[AccrualFix] Overpayment: {}, creating CBR", overpayment);
             assertTrue(overpayment > 0, "Should have overpayment");
-            PostLoansLoanIdTransactionsResponse cbr = loanTransactionHelper.makeCreditBalanceRefund(loanId,
-                    new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate("15 March 2025").locale(LOCALE)
-                            .transactionAmount(overpayment));
+            PostLoansLoanIdTransactionsResponse cbr = makeCreditBalanceRefund(loanId, new PostLoansLoanIdTransactionsRequest()
+                    .dateFormat(DATETIME_PATTERN).transactionDate("15 March 2025").locale(LOCALE).transactionAmount(overpayment));
             cbrIdRef.set(cbr.getResourceId());
             logAccrualState(loanId, "After CBR");
         });
@@ -696,13 +679,13 @@ public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest
         runAt("20 March 2025", () -> {
             log.info("[AccrualFix] === Undoing CBR {} ===", cbrIdRef.get());
 
-            loanTransactionHelper.reverseLoanTransaction(loanId, cbrIdRef.get(), new PostLoansLoanIdTransactionsTransactionIdRequest()
+            reverseLoanTransaction(loanId, cbrIdRef.get(), new PostLoansLoanIdTransactionsTransactionIdRequest()
                     .dateFormat(DATETIME_PATTERN).transactionDate("20 March 2025").transactionAmount(0.0).locale(LOCALE));
 
             logAccrualState(loanId, "After CBR undo");
             logAllTransactions(loanId, "After CBR undo");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
 
             // Accruals must never be reversed — check via assertNoReversedAccruals
             assertNoReversedAccruals(loanDetails);
@@ -721,7 +704,7 @@ public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest
     private void payInstallment(Long loanId, int installmentNumber, String date) {
         runAt(date, () -> {
             executeInlineCOB(loanId);
-            GetLoansLoanIdResponse details = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse details = getLoanDetails(loanId);
             var installment = details.getRepaymentSchedule().getPeriods().stream()
                     .filter(p -> p.getPeriod() != null && p.getPeriod() == installmentNumber).findFirst().orElseThrow();
             double amount = Utils.getDoubleValue(installment.getTotalDueForPeriod());
@@ -766,7 +749,7 @@ public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest
     }
 
     private void logAccrualState(Long loanId, String label) {
-        GetLoansLoanIdResponse details = loanTransactionHelper.getLoanDetails(loanId);
+        GetLoansLoanIdResponse details = getLoanDetails(loanId);
         List<GetLoansLoanIdTransactions> accruals = details.getTransactions().stream()
                 .filter(tx -> "loanTransactionType.accrual".equals(tx.getType().getCode())
                         || "loanTransactionType.accrualAdjustment".equals(tx.getType().getCode()))
@@ -779,7 +762,7 @@ public class LoanAccrualReversalOnClosedLoanTest extends BaseLoanIntegrationTest
     }
 
     private void logAllTransactions(Long loanId, String label) {
-        GetLoansLoanIdResponse details = loanTransactionHelper.getLoanDetails(loanId);
+        GetLoansLoanIdResponse details = getLoanDetails(loanId);
         log.info("=== All transactions [{}] ===", label);
         for (GetLoansLoanIdTransactions tx : details.getTransactions()) {
             log.info("  {}: id={}, date={}, amount={}, reversed={}", tx.getType().getValue(), tx.getId(), tx.getDate(), tx.getAmount(),

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanAccrualTransactionOnChargeSubmittedDateTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanAccrualTransactionOnChargeSubmittedDateTest.java
@@ -22,894 +22,463 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
+import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
-import org.apache.fineract.client.models.GetLoanProductsProductIdResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdRepaymentPeriod;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
-import org.apache.fineract.client.models.PostCreateRescheduleLoansRequest;
-import org.apache.fineract.client.models.PostCreateRescheduleLoansResponse;
+import org.apache.fineract.client.models.GetLoansLoanIdTransactions;
+import org.apache.fineract.client.models.PostLoanProductsRequest;
+import org.apache.fineract.client.models.PostLoansLoanIdChargesRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsResponse;
+import org.apache.fineract.client.models.PostLoansRequest;
 import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
-import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
-import org.apache.fineract.infrastructure.core.service.DateUtils;
-import org.apache.fineract.integrationtests.common.BusinessDateHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.LoanRescheduleRequestHelper;
-import org.apache.fineract.integrationtests.common.SchedulerJobHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
 import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.accounting.Account;
-import org.apache.fineract.integrationtests.common.accounting.AccountHelper;
-import org.apache.fineract.integrationtests.common.accounting.PeriodicAccrualAccountingHelper;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
-import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanRescheduleRequestTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.apache.fineract.integrationtests.inlinecob.InlineLoanCOBHelper;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 
 @Order(1)
-public class LoanAccrualTransactionOnChargeSubmittedDateTest extends BaseLoanIntegrationTest {
+public class LoanAccrualTransactionOnChargeSubmittedDateTest extends FeignLoanTestBase {
 
-    private ResponseSpecification responseSpec;
-    private RequestSpecification requestSpec;
-    private LoanTransactionHelper loanTransactionHelper;
-    private ClientHelper clientHelper;
-    private DateTimeFormatter dateFormatter = new DateTimeFormatterBuilder().appendPattern("dd MMMM yyyy").toFormatter();
-    private AccountHelper accountHelper;
-    private InlineLoanCOBHelper inlineLoanCOBHelper;
-
-    @BeforeEach
-    public void setup() {
-        Utils.initializeRESTAssured();
-        this.requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        this.requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        this.requestSpec.header("Fineract-Platform-TenantId", "default");
-        this.responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        this.loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-        this.clientHelper = new ClientHelper(this.requestSpec, this.responseSpec);
-        this.accountHelper = new AccountHelper(this.requestSpec, this.responseSpec);
-        this.inlineLoanCOBHelper = new InlineLoanCOBHelper(this.requestSpec, this.responseSpec);
-    }
+    private static final String STRATEGY = "mifos-standard-strategy";
+    private static final String CHARGE_ACCRUAL_DATE_SUBMITTED = "submitted-date";
+    private static final String CHARGE_ACCRUAL_DATE_DUE = "due-date";
 
     @Test
     public void loanAccrualTransactionOnChargeSubmittedTest_Accrual_Accounting_Api() {
         try {
-
-            // Accounts oof periodic accrual
-            final Account assetAccount = this.accountHelper.createAssetAccount();
-            final Account incomeAccount = this.accountHelper.createIncomeAccount();
-            final Account expenseAccount = this.accountHelper.createExpenseAccount();
-            final Account overpaymentAccount = this.accountHelper.createLiabilityAccount();
-
             // Set business date
-            LocalDate currentDate = LocalDate.of(2023, 3, 3);
-            final String accrualRunTillDate = dateFormatter.format(currentDate);
-
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, currentDate);
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
-                    new PutGlobalConfigurationsRequest().stringValue("submitted-date"));
+            enableSubmittedDateChargeAccrual(LocalDate.of(2023, 3, 3));
             // Loan ExternalId
             String loanExternalIdStr = UUID.randomUUID().toString();
-
             // Client and Loan account creation
-
-            final Integer clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId().intValue();
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper, assetAccount,
-                    incomeAccount, expenseAccount, overpaymentAccount);
-            assertNotNull(getLoanProductsProductResponse);
-
-            final Integer loanId = createLoanAccount(clientId, getLoanProductsProductResponse.getId(), loanExternalIdStr);
+            final Long clientId = createClient();
+            // Accounts oof periodic accrual
+            final Long loanProductId = createLoanProduct(singleRepaymentAccrualProduct());
+            final Long loanId = createSingleRepaymentLoan(clientId, loanProductId, loanExternalIdStr);
 
             // Add Charge Penalty
-            Integer penalty = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", true));
-
-            LocalDate targetDate = LocalDate.of(2023, 3, 10);
-            final String penaltyCharge1AddedDate = dateFormatter.format(targetDate);
-
-            Integer penalty1LoanChargeId = this.loanTransactionHelper.addChargesForLoan(loanId,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), penaltyCharge1AddedDate, "10"));
-
-            assertNotNull(penalty1LoanChargeId);
-
+            addPenaltyCharge(loanId, "10 March 2023", 10.0);
             // Add Charge Fee
-            Integer feeCharge = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", false));
-
-            targetDate = LocalDate.of(2023, 3, 14);
-            final String feeChargeAddedDate = dateFormatter.format(targetDate);
-            Integer feeLoanChargeId = this.loanTransactionHelper.addChargesForLoan(loanId,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(feeCharge), feeChargeAddedDate, "10"));
-
-            assertNotNull(feeLoanChargeId);
+            addFeeCharge(loanId, "14 March 2023", 10.0);
 
             // Run accrual for charge created date
-            PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting(accrualRunTillDate);
-
+            runPeriodicAccrualAccounting("03 March 2023");
             // verify accrual transaction created for charges create date
-            checkAccrualTransaction(currentDate, 0.0f, 10.0f, 10.0f, loanId);
+            checkAccrualTransaction(LocalDate.of(2023, 3, 3), 0.0, 10.0, 10.0, loanId);
 
             // Set business date
-            LocalDate futureDate = LocalDate.of(2023, 3, 4);
-            final String nextAccrualRunDate = dateFormatter.format(futureDate);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, futureDate);
-
+            updateBusinessDate("04 March 2023");
             // make repayment
-            final PostLoansLoanIdTransactionsResponse repaymentTransaction_1 = loanTransactionHelper.makeLoanRepayment(loanExternalIdStr,
-                    new PostLoansLoanIdTransactionsRequest().dateFormat("dd MMMM yyyy").transactionDate("4 March 2023").locale("en")
-                            .transactionAmount(100.0));
-
+            makeLoanRepayment(loanExternalIdStr, repaymentRequest("4 March 2023", 100.0));
             // Add Charge
-            Integer feeCharge_1 = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", false));
-
-            targetDate = LocalDate.of(2023, 3, 21);
-            final String feeChargeAddedDate_1 = dateFormatter.format(targetDate);
-            Integer feeLoanChargeId_1 = this.loanTransactionHelper.addChargesForLoan(loanId,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(feeCharge_1), feeChargeAddedDate_1, "10"));
-
-            assertNotNull(feeLoanChargeId_1);
+            addFeeCharge(loanId, "21 March 2023", 10.0);
 
             // Run accrual for charge created date
-            PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting(nextAccrualRunDate);
-
+            runPeriodicAccrualAccounting("04 March 2023");
             // verify accrual transaction created for charges create date
-            checkAccrualTransaction(futureDate, 0.0f, 10.0f, 0.0f, loanId);
-
+            checkAccrualTransaction(LocalDate.of(2023, 3, 4), 0.0, 10.0, 0.0, loanId);
         } finally {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
-                    new PutGlobalConfigurationsRequest().stringValue("due-date"));
+            resetChargeAccrualConfig();
         }
-
     }
 
     @Test
     public void loanAccrualTransactionOnChargeSubmittedTest_Add_Periodic_Accrual_Transactions_Job() {
         try {
-
-            // Accounts oof periodic accrual
-            final Account assetAccount = this.accountHelper.createAssetAccount();
-            final Account incomeAccount = this.accountHelper.createIncomeAccount();
-            final Account expenseAccount = this.accountHelper.createExpenseAccount();
-            final Account overpaymentAccount = this.accountHelper.createLiabilityAccount();
-
             // Set business date
-            LocalDate currentDate = LocalDate.of(2023, 3, 3);
-            final String accrualRunTillDate = dateFormatter.format(currentDate);
-
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, currentDate);
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
-                    new PutGlobalConfigurationsRequest().stringValue("submitted-date"));
+            enableSubmittedDateChargeAccrual(LocalDate.of(2023, 3, 3));
             // Loan ExternalId
             String loanExternalIdStr = UUID.randomUUID().toString();
-
             // Client and Loan account creation
-
-            final Integer clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId().intValue();
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper, assetAccount,
-                    incomeAccount, expenseAccount, overpaymentAccount);
-            assertNotNull(getLoanProductsProductResponse);
-
-            final Integer loanId = createLoanAccount(clientId, getLoanProductsProductResponse.getId(), loanExternalIdStr);
+            final Long clientId = createClient();
+            // Accounts oof periodic accrual
+            final Long loanProductId = createLoanProduct(singleRepaymentAccrualProduct());
+            final Long loanId = createSingleRepaymentLoan(clientId, loanProductId, loanExternalIdStr);
 
             // Add Charge Penalty
-            Integer penalty = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", true));
-
-            LocalDate targetDate = LocalDate.of(2023, 3, 10);
-            final String penaltyCharge1AddedDate = dateFormatter.format(targetDate);
-
-            Integer penalty1LoanChargeId = this.loanTransactionHelper.addChargesForLoan(loanId,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), penaltyCharge1AddedDate, "10"));
-
-            assertNotNull(penalty1LoanChargeId);
-
+            addPenaltyCharge(loanId, "10 March 2023", 10.0);
             // Add Charge Fee
-            Integer feeCharge = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", false));
-
-            targetDate = LocalDate.of(2023, 3, 14);
-            final String feeChargeAddedDate = dateFormatter.format(targetDate);
-            Integer feeLoanChargeId = this.loanTransactionHelper.addChargesForLoan(loanId,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(feeCharge), feeChargeAddedDate, "10"));
-
-            assertNotNull(feeLoanChargeId);
+            addFeeCharge(loanId, "14 March 2023", 10.0);
 
             // Run periodic accrual job for business date
             final String jobName = "Add Periodic Accrual Transactions";
-            SchedulerJobHelper.executeAndAwaitJob(jobName);
-
+            schedulerHelper.executeAndAwaitJob(jobName);
             // verify accrual transaction created for charges create date
-            checkAccrualTransaction(currentDate, 0.0f, 10.0f, 10.0f, loanId);
+            checkAccrualTransaction(LocalDate.of(2023, 3, 3), 0.0, 10.0, 10.0, loanId);
 
             // Set business date
-            LocalDate futureDate = LocalDate.of(2023, 3, 4);
-            final String nextAccrualRunDate = dateFormatter.format(futureDate);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, futureDate);
-
+            updateBusinessDate("04 March 2023");
             // make repayment
-            final PostLoansLoanIdTransactionsResponse repaymentTransaction_1 = loanTransactionHelper.makeLoanRepayment(loanExternalIdStr,
-                    new PostLoansLoanIdTransactionsRequest().dateFormat("dd MMMM yyyy").transactionDate("4 March 2023").locale("en")
-                            .transactionAmount(100.0));
-
+            makeLoanRepayment(loanExternalIdStr, repaymentRequest("4 March 2023", 100.0));
             // Add Charge
-            Integer feeCharge_1 = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", false));
-
-            targetDate = LocalDate.of(2023, 3, 21);
-            final String feeChargeAddedDate_1 = dateFormatter.format(targetDate);
-            Integer feeLoanChargeId_1 = this.loanTransactionHelper.addChargesForLoan(loanId,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(feeCharge_1), feeChargeAddedDate_1, "10"));
-
-            assertNotNull(feeLoanChargeId_1);
+            addFeeCharge(loanId, "21 March 2023", 10.0);
 
             // Run periodic accrual job for business date
-            SchedulerJobHelper.executeAndAwaitJob(jobName);
-
+            schedulerHelper.executeAndAwaitJob(jobName);
             // verify accrual transaction created for charges create date
-            checkAccrualTransaction(futureDate, 0.0f, 10.0f, 0.0f, loanId);
-
+            checkAccrualTransaction(LocalDate.of(2023, 3, 4), 0.0, 10.0, 0.0, loanId);
         } finally {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
-                    new PutGlobalConfigurationsRequest().stringValue("due-date"));
+            resetChargeAccrualConfig();
         }
     }
 
     @Test
     public void loanAccrualTransactionOnChargeSubmittedTest_Loan_COB_AddPeriodicAccrualEntriesBusinessStep() {
         try {
-
-            // Accounts oof periodic accrual
-            final Account assetAccount = this.accountHelper.createAssetAccount();
-            final Account incomeAccount = this.accountHelper.createIncomeAccount();
-            final Account expenseAccount = this.accountHelper.createExpenseAccount();
-            final Account overpaymentAccount = this.accountHelper.createLiabilityAccount();
-
             // Set business date
             LocalDate currentDate = LocalDate.of(2023, 3, 3);
-            final String accrualRunTillDate = dateFormatter.format(currentDate);
-
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, currentDate);
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
-                    new PutGlobalConfigurationsRequest().stringValue("submitted-date"));
+            enableSubmittedDateChargeAccrual(currentDate);
             // Loan ExternalId
             String loanExternalIdStr = UUID.randomUUID().toString();
-
             // Client and Loan account creation
-
-            final Integer clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId().intValue();
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper, assetAccount,
-                    incomeAccount, expenseAccount, overpaymentAccount);
-            assertNotNull(getLoanProductsProductResponse);
-
-            final Integer loanId = createLoanAccount(clientId, getLoanProductsProductResponse.getId(), loanExternalIdStr);
+            final Long clientId = createClient();
+            // Accounts oof periodic accrual
+            final Long loanProductId = createLoanProduct(singleRepaymentAccrualProduct());
+            final Long loanId = createSingleRepaymentLoan(clientId, loanProductId, loanExternalIdStr);
 
             // Add Charge Penalty
-            Integer penalty = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", true));
-
-            LocalDate targetDate = LocalDate.of(2023, 3, 10);
-            final String penaltyCharge1AddedDate = dateFormatter.format(targetDate);
-
-            Integer penalty1LoanChargeId = this.loanTransactionHelper.addChargesForLoan(loanId,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), penaltyCharge1AddedDate, "10"));
-
-            assertNotNull(penalty1LoanChargeId);
-
+            addPenaltyCharge(loanId, "10 March 2023", 10.0);
             // Add Charge Fee
-            Integer feeCharge = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", false));
-
-            targetDate = LocalDate.of(2023, 3, 14);
-            final String feeChargeAddedDate = dateFormatter.format(targetDate);
-            Integer feeLoanChargeId = this.loanTransactionHelper.addChargesForLoan(loanId,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(feeCharge), feeChargeAddedDate, "10"));
-
-            assertNotNull(feeLoanChargeId);
+            addFeeCharge(loanId, "14 March 2023", 10.0);
 
             // Run cob job for business date + 1
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, currentDate.plusDays(1));
-
+            updateBusinessDate(Utils.dateFormatter.format(currentDate.plusDays(1)));
             final String jobName = "Loan COB";
-            SchedulerJobHelper.executeAndAwaitJob(jobName);
-
+            schedulerHelper.executeAndAwaitJob(jobName);
             // verify accrual transaction created for charges create date
-            checkAccrualTransaction(currentDate, 0.0f, 10.0f, 10.0f, loanId);
+            checkAccrualTransaction(LocalDate.of(2023, 3, 3), 0.0, 10.0, 10.0, loanId);
 
             // Set business date
             LocalDate futureDate = LocalDate.of(2023, 3, 4);
-            final String nextAccrualRunDate = dateFormatter.format(futureDate);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, futureDate);
-
+            updateBusinessDate("04 March 2023");
             // make repayment
-            final PostLoansLoanIdTransactionsResponse repaymentTransaction_1 = loanTransactionHelper.makeLoanRepayment(loanExternalIdStr,
-                    new PostLoansLoanIdTransactionsRequest().dateFormat("dd MMMM yyyy").transactionDate("4 March 2023").locale("en")
-                            .transactionAmount(100.0));
-
+            makeLoanRepayment(loanExternalIdStr, repaymentRequest("4 March 2023", 100.0));
             // Add Charge
-            Integer feeCharge_1 = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", false));
-
-            targetDate = LocalDate.of(2023, 3, 21);
-            final String feeChargeAddedDate_1 = dateFormatter.format(targetDate);
-            Integer feeLoanChargeId_1 = this.loanTransactionHelper.addChargesForLoan(loanId,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(feeCharge_1), feeChargeAddedDate_1, "10"));
-
-            assertNotNull(feeLoanChargeId_1);
+            addFeeCharge(loanId, "21 March 2023", 10.0);
 
             // Run cob job for business date + 1
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, futureDate.plusDays(1));
-            SchedulerJobHelper.executeAndAwaitJob(jobName);
-
+            updateBusinessDate(Utils.dateFormatter.format(futureDate.plusDays(1)));
+            schedulerHelper.executeAndAwaitJob(jobName);
             // verify accrual transaction created for charges create date
-            checkAccrualTransaction(futureDate, 0.0f, 10.0f, 0.0f, loanId);
-
+            checkAccrualTransaction(futureDate, 0.0, 10.0, 0.0, loanId);
         } finally {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
-                    new PutGlobalConfigurationsRequest().stringValue("due-date"));
+            resetChargeAccrualConfig();
         }
     }
 
     @Test
     public void loanAccrualTransactionOnChargeSubmittedTest_Add_Accrual_Transactions_Job() {
         try {
-
-            // Accounts oof periodic accrual
-            final Account assetAccount = this.accountHelper.createAssetAccount();
-            final Account incomeAccount = this.accountHelper.createIncomeAccount();
-            final Account expenseAccount = this.accountHelper.createExpenseAccount();
-            final Account overpaymentAccount = this.accountHelper.createLiabilityAccount();
-
             // Set business date
-            LocalDate currentDate = LocalDate.of(2023, 3, 3);
-            final String accrualRunTillDate = dateFormatter.format(currentDate);
-
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, currentDate);
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
-                    new PutGlobalConfigurationsRequest().stringValue("submitted-date"));
+            enableSubmittedDateChargeAccrual(LocalDate.of(2023, 3, 3));
             // Loan ExternalId
             String loanExternalIdStr = UUID.randomUUID().toString();
-
             // Client and Loan account creation
-
-            final Integer clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId().intValue();
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper, assetAccount,
-                    incomeAccount, expenseAccount, overpaymentAccount);
-            assertNotNull(getLoanProductsProductResponse);
-
-            final Integer loanId = createLoanAccount(clientId, getLoanProductsProductResponse.getId(), loanExternalIdStr);
+            final Long clientId = createClient();
+            // Accounts oof periodic accrual
+            final Long loanProductId = createLoanProduct(singleRepaymentAccrualProduct());
+            final Long loanId = createSingleRepaymentLoan(clientId, loanProductId, loanExternalIdStr);
 
             // Add Charge Penalty
-            Integer penalty = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", true));
-
-            LocalDate targetDate = LocalDate.of(2023, 3, 10);
-            final String penaltyCharge1AddedDate = dateFormatter.format(targetDate);
-
-            Integer penalty1LoanChargeId = this.loanTransactionHelper.addChargesForLoan(loanId,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), penaltyCharge1AddedDate, "10"));
-
-            assertNotNull(penalty1LoanChargeId);
-
+            addPenaltyCharge(loanId, "10 March 2023", 10.0);
             // Add Charge Fee
-            Integer feeCharge = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", false));
-
-            targetDate = LocalDate.of(2023, 3, 14);
-            final String feeChargeAddedDate = dateFormatter.format(targetDate);
-            Integer feeLoanChargeId = this.loanTransactionHelper.addChargesForLoan(loanId,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(feeCharge), feeChargeAddedDate, "10"));
-
-            assertNotNull(feeLoanChargeId);
+            addFeeCharge(loanId, "14 March 2023", 10.0);
 
             // Run accrual entries job for business date
             final String jobName = "Add Accrual Transactions";
-            SchedulerJobHelper.executeAndAwaitJob(jobName);
-
+            schedulerHelper.executeAndAwaitJob(jobName);
             // verify accrual transaction created for charges create date
-            checkAccrualTransaction(currentDate, 0.0f, 10.0f, 10.0f, loanId);
+            checkAccrualTransaction(LocalDate.of(2023, 3, 3), 0.0, 10.0, 10.0, loanId);
 
             // Set business date
-            LocalDate futureDate = LocalDate.of(2023, 3, 4);
-            final String nextAccrualRunDate = dateFormatter.format(futureDate);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, futureDate);
-
+            updateBusinessDate("04 March 2023");
             // make repayment
-            final PostLoansLoanIdTransactionsResponse repaymentTransaction_1 = loanTransactionHelper.makeLoanRepayment(loanExternalIdStr,
-                    new PostLoansLoanIdTransactionsRequest().dateFormat("dd MMMM yyyy").transactionDate("4 March 2023").locale("en")
-                            .transactionAmount(100.0));
-
+            makeLoanRepayment(loanExternalIdStr, repaymentRequest("4 March 2023", 100.0));
             // Add Charge
-            Integer feeCharge_1 = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", false));
-
-            targetDate = LocalDate.of(2023, 3, 21);
-            final String feeChargeAddedDate_1 = dateFormatter.format(targetDate);
-            Integer feeLoanChargeId_1 = this.loanTransactionHelper.addChargesForLoan(loanId,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(feeCharge_1), feeChargeAddedDate_1, "10"));
-
-            assertNotNull(feeLoanChargeId_1);
+            addFeeCharge(loanId, "21 March 2023", 10.0);
 
             // Run accrual entries job for business date
-            SchedulerJobHelper.executeAndAwaitJob(jobName);
-
+            schedulerHelper.executeAndAwaitJob(jobName);
             // verify accrual transaction created for charges create date
-            checkAccrualTransaction(futureDate, 0.0f, 10.0f, 0.0f, loanId);
-
+            checkAccrualTransaction(LocalDate.of(2023, 3, 4), 0.0, 10.0, 0.0, loanId);
         } finally {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
-                    new PutGlobalConfigurationsRequest().stringValue("due-date"));
+            resetChargeAccrualConfig();
         }
     }
 
     @Test
     public void loanAccrualTransactionOnChargeSubmitted_With_Multiple_Repayments_Test_Add_Periodic_Accrual_Transactions_Job() {
         try {
-
-            // Accounts oof periodic accrual
-            final Account assetAccount = this.accountHelper.createAssetAccount();
-            final Account incomeAccount = this.accountHelper.createIncomeAccount();
-            final Account expenseAccount = this.accountHelper.createExpenseAccount();
-            final Account overpaymentAccount = this.accountHelper.createLiabilityAccount();
-
             // Set business date
-            LocalDate currentDate = LocalDate.of(2023, 3, 3);
-            final String accrualRunTillDate = dateFormatter.format(currentDate);
-
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, currentDate);
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
-                    new PutGlobalConfigurationsRequest().stringValue("submitted-date"));
+            enableSubmittedDateChargeAccrual(LocalDate.of(2023, 3, 3));
             // Loan ExternalId
             String loanExternalIdStr = UUID.randomUUID().toString();
-
             // Client and Loan account creation
-
-            final Integer clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId().intValue();
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProductMultipleRepayments(
-                    loanTransactionHelper, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
-            assertNotNull(getLoanProductsProductResponse);
-
-            final Integer loanId = createLoanAccountMultipleRepayments(clientId, getLoanProductsProductResponse.getId(), loanExternalIdStr);
+            final Long clientId = createClient();
+            // Accounts oof periodic accrual
+            final Long loanProductId = createLoanProduct(multipleRepaymentsAccrualProduct());
+            final Long loanId = createMultipleRepaymentsLoan(clientId, loanProductId, loanExternalIdStr, LoanTestData.InterestType.FLAT);
 
             // Add Charge Penalty
-            Integer penalty = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", true));
-
             // Due for future date in one of the schedule
-            LocalDate targetDate = LocalDate.of(2023, 3, 10);
-            final String penaltyCharge1AddedDate = dateFormatter.format(targetDate);
-
-            Integer penalty1LoanChargeId = this.loanTransactionHelper.addChargesForLoan(loanId,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), penaltyCharge1AddedDate, "10"));
-
-            assertNotNull(penalty1LoanChargeId);
-
-            // Add Charge Penalty
-            Integer penalty_1 = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", true));
-
+            addPenaltyCharge(loanId, "10 March 2023", 10.0);
             // Due for future date in different of the schedule
-            targetDate = LocalDate.of(2023, 3, 17);
-            final String penaltyChargeAddedDate = dateFormatter.format(targetDate);
-            Integer penaltyLoanChargeId = this.loanTransactionHelper.addChargesForLoan(loanId,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty_1), penaltyChargeAddedDate, "10"));
-
-            assertNotNull(penaltyLoanChargeId);
+            addPenaltyCharge(loanId, "17 March 2023", 10.0);
 
             // Run periodic accrual job for business date
             final String jobName = "Add Periodic Accrual Transactions";
-            SchedulerJobHelper.executeAndAwaitJob(jobName);
+            schedulerHelper.executeAndAwaitJob(jobName);
 
             // verify multiple accrual transactions are created on charge created date according to repayment schedule
             // to which charge due date falls
-            checkAccrualTransactionsForMultipleRepaymentSchedulesChargeDueDate(currentDate, loanId);
-
+            checkAccrualTransactionsForMultipleRepaymentSchedulesChargeDueDate(LocalDate.of(2023, 3, 3), loanId);
         } finally {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
-                    new PutGlobalConfigurationsRequest().stringValue("due-date"));
+            resetChargeAccrualConfig();
         }
     }
 
     @Test
     public void loanAccrualTransactionOnChargeSubmitted_multiple_disbursement_reversal_test_Loan_COB() {
         try {
-
-            // Accounts oof periodic accrual
-            final Account assetAccount = this.accountHelper.createAssetAccount();
-            final Account incomeAccount = this.accountHelper.createIncomeAccount();
-            final Account expenseAccount = this.accountHelper.createExpenseAccount();
-            final Account overpaymentAccount = this.accountHelper.createLiabilityAccount();
-
             // Set business date
             LocalDate currentDate = LocalDate.of(2023, 3, 3);
-
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, currentDate);
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
-                    new PutGlobalConfigurationsRequest().stringValue("submitted-date"));
+            enableSubmittedDateChargeAccrual(currentDate);
             // Loan ExternalId
             String loanExternalIdStr = UUID.randomUUID().toString();
+            final Long clientId = createClient();
+            // Accounts oof periodic accrual
+            final Long loanProductId = createLoanProduct(multipleDisbursementsAccrualProduct());
+            final Long loanId = createMultipleRepaymentsLoan(clientId, loanProductId, loanExternalIdStr,
+                    LoanTestData.InterestType.DECLINING_BALANCE, false);
 
-            // Client and Loan account creation
-
-            final Integer clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId().intValue();
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProductMultipleDisbursements(
-                    loanTransactionHelper, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
-            assertNotNull(getLoanProductsProductResponse);
-
-            final Integer loanId = createLoanAccountMultipleRepaymentsDisbursement(clientId, getLoanProductsProductResponse.getId(),
-                    loanExternalIdStr);
-
-            loanTransactionHelper.disburseLoanWithTransactionAmount("03 March 2023", loanId, "1000");
+            // first disbursement
+            disburseLoan(loanId, LoanRequestBuilders.disburseLoan(1000.0, "03 March 2023"));
 
             // Add Charge Penalty
-            Integer penalty = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", true));
-
-            LocalDate targetDate = LocalDate.of(2023, 3, 9);
-            final String penaltyCharge1AddedDate = dateFormatter.format(targetDate);
-
-            Integer penalty1LoanChargeId = this.loanTransactionHelper.addChargesForLoan(loanId,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), penaltyCharge1AddedDate, "10"));
-
-            assertNotNull(penalty1LoanChargeId);
+            addPenaltyCharge(loanId, "09 March 2023", 10.0);
 
             // Run cob job for business date + 1
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, currentDate.plusDays(1));
-
+            updateBusinessDate(Utils.dateFormatter.format(currentDate.plusDays(1)));
             final String jobName = "Loan COB";
-            SchedulerJobHelper.executeAndAwaitJob(jobName);
-
+            schedulerHelper.executeAndAwaitJob(jobName);
             // verify accrual transaction created for charges create date
-            checkAccrualTransaction(currentDate, 0.0f, 0.0f, 10.0f, loanId);
+            checkAccrualTransaction(currentDate, 0.0, 0.0, 10.0, loanId);
 
             // Set business date
             LocalDate futureDate = LocalDate.of(2023, 3, 4);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, futureDate);
-
-            loanTransactionHelper.disburseLoanWithTransactionAmount("04 March 2023", loanId, "300");
+            updateBusinessDate("04 March 2023");
+            // second disbursement regenerates the repayment schedule
+            disburseLoan(loanId, LoanRequestBuilders.disburseLoan(300.0, "04 March 2023"));
 
             // verify accrual transaction exists with same date,amount and is not reversed by regeneration of repayment
             // schedule
-            checkAccrualTransaction(currentDate, 0.0f, 0.0f, 10.0f, loanId);
-
+            checkAccrualTransaction(currentDate, 0.0, 0.0, 10.0, loanId);
         } finally {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
-                    new PutGlobalConfigurationsRequest().stringValue("due-date"));
+            resetChargeAccrualConfig();
         }
     }
 
     @Test
     public void loanAccrualTransaction_ChargeSubmittedDate_AdjustRepaymentScheduleSnoozeFeeDueDateNewFeeAddTest() {
         try {
-
-            // Accounts oof periodic accrual
-            final Account assetAccount = this.accountHelper.createAssetAccount();
-            final Account incomeAccount = this.accountHelper.createIncomeAccount();
-            final Account expenseAccount = this.accountHelper.createExpenseAccount();
-            final Account overpaymentAccount = this.accountHelper.createLiabilityAccount();
-
             // Set business date
-            LocalDate currentDate = LocalDate.of(2023, 05, 19);
-
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, currentDate);
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
-                    new PutGlobalConfigurationsRequest().stringValue("submitted-date"));
-
+            enableSubmittedDateChargeAccrual(LocalDate.of(2023, 5, 19));
             // Loan ExternalId
             String loanExternalIdStr = UUID.randomUUID().toString();
-
             // Client and Loan account creation
-
-            final Integer clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId().intValue();
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProductMultipleRepayments(
-                    loanTransactionHelper, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
-            assertNotNull(getLoanProductsProductResponse);
-
-            final Integer loanId = createLoanAccountAndDisburse(clientId, getLoanProductsProductResponse.getId(), loanExternalIdStr);
+            final Long clientId = createClient();
+            // Accounts oof periodic accrual
+            final Long loanProductId = createLoanProduct(multipleRepaymentsAccrualProduct());
+            final Long loanId = createLoanAccountAndDisburse(clientId, loanProductId, loanExternalIdStr);
 
             // set business date as date when fee charge is added/submitted
-
-            LocalDate chargeSubmittedDate = LocalDate.of(2023, 06, 12);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, chargeSubmittedDate);
-
-            LocalDate chargeDueDate = LocalDate.of(2023, 07, 18);
-            final String feeChargeDueDate = dateFormatter.format(chargeDueDate);
+            LocalDate chargeSubmittedDate = LocalDate.of(2023, 6, 12);
+            updateBusinessDate("12 June 2023");
 
             // Add Fee
-            Integer feeCharge = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", false));
-
-            Integer feeLoanChargeId = this.loanTransactionHelper.addChargesForLoan(loanId,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(feeCharge), feeChargeDueDate, "10"));
-
-            assertNotNull(feeLoanChargeId);
+            addFeeCharge(loanId, "18 July 2023", 10.0);
 
             // adjust loan schedule
-            final PostCreateRescheduleLoansRequest createRequest = new LoanRescheduleRequestTestBuilder()
-                    .updateRescheduleFromDate("18 June 2023").updateAdjustedDueDate("18 July 2023").updateSubmittedOnDate("19 May 2023")
-                    .updateGraceOnPrincipal(null).updateGraceOnInterest(null).updateExtraTerms(null).buildRequest(loanId.longValue());
-            final PostCreateRescheduleLoansResponse loanRescheduleRequestResponse = LoanRescheduleRequestHelper
-                    .createLoanRescheduleRequest(createRequest);
-            final Long loanRescheduleRequestId = loanRescheduleRequestResponse.getResourceId();
-            LoanRescheduleRequestHelper.approveLoanRescheduleRequest(loanRescheduleRequestId,
-                    new LoanRescheduleRequestTestBuilder().updateRescheduleFromDate("18 June 2023").updateAdjustedDueDate("18 July 2023")
-                            .updateSubmittedOnDate("19 May 2023").updateGraceOnPrincipal(null).updateGraceOnInterest(null)
-                            .updateExtraTerms(null).getApproveRequest());
+            Long loanRescheduleRequestId = createRescheduleRequest(
+                    LoanRequestBuilders.rescheduleRequest(loanId, "19 May 2023", "18 June 2023", "18 July 2023"));
+            approveRescheduleRequest(loanRescheduleRequestId, LoanRequestBuilders.approveReschedule("19 May 2023"));
 
-            // run cob
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, chargeSubmittedDate.plusDays(1));
-
+            // update business date
+            updateBusinessDate(Utils.dateFormatter.format(chargeSubmittedDate.plusDays(1)));
             // run inline cob for loan
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.longValue()));
-
+            executeInlineCOB(loanId);
             // verify accrual transaction created for charges create date
-            checkAccrualTransaction(chargeSubmittedDate, 0.0f, 10.0f, 0.0f, loanId);
+            checkAccrualTransaction(chargeSubmittedDate, 0.0, 10.0, 0.0, loanId);
 
             // update business date
-            currentDate = LocalDate.of(2023, 07, 18);
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, currentDate);
-
+            updateBusinessDate("18 July 2023");
             // make repayment
-            final PostLoansLoanIdTransactionsResponse repaymentTransaction_1 = loanTransactionHelper.makeLoanRepayment(loanExternalIdStr,
-                    new PostLoansLoanIdTransactionsRequest().dateFormat("dd MMMM yyyy").transactionDate("18 July 2023").locale("en")
-                            .transactionAmount(1010.0));
+            final PostLoansLoanIdTransactionsResponse repaymentTransaction = makeLoanRepayment(loanExternalIdStr,
+                    repaymentRequest("18 July 2023", 1010.0));
 
             // update business date
-            currentDate = LocalDate.of(2023, 07, 19);
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, currentDate);
-
+            LocalDate currentDate = LocalDate.of(2023, 7, 19);
+            updateBusinessDate("19 July 2023");
             // reverse repayment
-            loanTransactionHelper.reverseRepayment(loanId, repaymentTransaction_1.getResourceId().intValue(), "19 July 2023");
+            reverseLoanTransaction(loanId, repaymentTransaction.getResourceId(), "19 July 2023");
 
             // Add Charge Penalty
-            Integer penalty = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", true));
-
-            LocalDate targetDate = LocalDate.of(2023, 07, 19);
-            final String penaltyCharge1AddedDate = dateFormatter.format(targetDate);
-
-            Integer penalty1LoanChargeId = this.loanTransactionHelper.addChargesForLoan(loanId,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), penaltyCharge1AddedDate, "10"));
-
-            assertNotNull(penalty1LoanChargeId);
+            addPenaltyCharge(loanId, "19 July 2023", 10.0);
 
             // update business date
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, currentDate.plusDays(1));
-
+            updateBusinessDate(Utils.dateFormatter.format(currentDate.plusDays(1)));
             // run inline cob for loan
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.longValue()));
-
+            executeInlineCOB(loanId);
             // verify accrual transaction created for charges create date
-            checkAccrualTransaction(currentDate, 0.0f, 0.0f, 10.0f, loanId);
+            checkAccrualTransaction(currentDate, 0.0, 0.0, 10.0, loanId);
 
             // verify loan repayment schedules
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails((long) loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             assertTrue(loanDetails.getStatus().getActive());
 
             List<GetLoansLoanIdRepaymentPeriod> periods = loanDetails.getRepaymentSchedule().getPeriods();
             assertNotNull(periods);
-
             verifyPeriodDates(periods);
-
         } finally {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
-                    new PutGlobalConfigurationsRequest().stringValue("due-date"));
+            resetChargeAccrualConfig();
         }
+    }
+
+    private void enableSubmittedDateChargeAccrual(LocalDate businessDate) {
+        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+                new PutGlobalConfigurationsRequest().enabled(true));
+        updateBusinessDate(Utils.dateFormatter.format(businessDate));
+        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
+                new PutGlobalConfigurationsRequest().stringValue(CHARGE_ACCRUAL_DATE_SUBMITTED));
+    }
+
+    private void resetChargeAccrualConfig() {
+        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+                new PutGlobalConfigurationsRequest().enabled(false));
+        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
+                new PutGlobalConfigurationsRequest().stringValue(CHARGE_ACCRUAL_DATE_DUE));
+    }
+
+    private void addPenaltyCharge(Long loanId, String dueDate, double amount) {
+        Long chargeId = chargesHelper.createLoanSpecifiedDueDatePenalty(amount).getResourceId();
+        assertNotNull(addChargesForLoan(loanId, loanCharge(chargeId, dueDate, amount)).getResourceId());
+    }
+
+    private void addFeeCharge(Long loanId, String dueDate, double amount) {
+        Long chargeId = chargesHelper.createLoanSpecifiedDueDateCharge(amount).getResourceId();
+        assertNotNull(addChargesForLoan(loanId, loanCharge(chargeId, dueDate, amount)).getResourceId());
+    }
+
+    private PostLoansLoanIdChargesRequest loanCharge(Long chargeId, String dueDate, double amount) {
+        return new PostLoansLoanIdChargesRequest().chargeId(chargeId).dateFormat(DATETIME_PATTERN).locale("en").amount(amount)
+                .dueDate(dueDate);
+    }
+
+    private PostLoansLoanIdTransactionsRequest repaymentRequest(String date, double amount) {
+        return new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate(date).locale("en")
+                .transactionAmount(amount);
+    }
+
+    private PostLoanProductsRequest singleRepaymentAccrualProduct() {
+        return create4Period1MonthLongWithoutInterestProduct(STRATEGY).numberOfRepayments(1).maxNumberOfRepayments(30);
+    }
+
+    private PostLoanProductsRequest multipleRepaymentsAccrualProduct() {
+        return create4Period1MonthLongWithoutInterestProduct(STRATEGY).numberOfRepayments(1).maxNumberOfRepayments(30).repaymentEvery(1)
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.DAYS_L);
+    }
+
+    private PostLoanProductsRequest multipleDisbursementsAccrualProduct() {
+        return createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct().repaymentEvery(1)
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS_L).numberOfRepayments(1).maxNumberOfRepayments(30)
+                .transactionProcessingStrategyCode(STRATEGY).loanScheduleType("CUMULATIVE").loanScheduleProcessingType(null)
+                .paymentAllocation(null);
+    }
+
+    private Long createSingleRepaymentLoan(Long clientId, Long loanProductId, String externalId) {
+        Long loanId = applyForLoan(loanRequest(clientId, loanProductId, externalId, 1, LoanTestData.RepaymentFrequencyType.MONTHS, 1, 1,
+                LoanTestData.RepaymentFrequencyType.MONTHS, LoanTestData.InterestType.FLAT, "03 March 2023"));
+        approveLoan(loanId, LoanRequestBuilders.approveLoan(1000.0, "03 March 2023"));
+        disburseLoanWithNetDisbursalAmount(loanId, "03 March 2023", "1000");
+        return loanId;
+    }
+
+    private Long createMultipleRepaymentsLoan(Long clientId, Long loanProductId, String externalId, Integer interestType) {
+        return createMultipleRepaymentsLoan(clientId, loanProductId, externalId, interestType, true);
+    }
+
+    private Long createMultipleRepaymentsLoan(Long clientId, Long loanProductId, String externalId, Integer interestType,
+            boolean disburse) {
+        Long loanId = applyForLoan(loanRequest(clientId, loanProductId, externalId, 30, LoanTestData.RepaymentFrequencyType.DAYS, 10, 3,
+                LoanTestData.RepaymentFrequencyType.DAYS, interestType, "03 March 2023"));
+        approveLoan(loanId, LoanRequestBuilders.approveLoan(1000.0, "03 March 2023"));
+        if (disburse) {
+            disburseLoanWithNetDisbursalAmount(loanId, "03 March 2023", "1000");
+        }
+        return loanId;
+    }
+
+    private Long createLoanAccountAndDisburse(Long clientId, Long loanProductId, String externalId) {
+        Long loanId = applyForLoan(loanRequest(clientId, loanProductId, externalId, 30, LoanTestData.RepaymentFrequencyType.DAYS, 1, 30,
+                LoanTestData.RepaymentFrequencyType.DAYS, LoanTestData.InterestType.FLAT, "19 May 2023"));
+        approveLoan(loanId, LoanRequestBuilders.approveLoan(1000.0, "19 May 2023"));
+        disburseLoanWithNetDisbursalAmount(loanId, "19 May 2023", "1000");
+        return loanId;
+    }
+
+    private PostLoansRequest loanRequest(Long clientId, Long loanProductId, String externalId, int loanTermFrequency,
+            Integer loanTermFrequencyType, int numberOfRepayments, int repaymentEvery, Integer repaymentFrequencyType, Integer interestType,
+            String date) {
+        return new PostLoansRequest().clientId(clientId).productId(loanProductId).externalId(externalId).principal(new BigDecimal("1000"))
+                .loanTermFrequency(loanTermFrequency).loanTermFrequencyType(loanTermFrequencyType).numberOfRepayments(numberOfRepayments)
+                .repaymentEvery(repaymentEvery).repaymentFrequencyType(repaymentFrequencyType).interestRatePerPeriod(BigDecimal.ZERO)
+                .interestType(interestType)
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_PRINCIPAL).expectedDisbursementDate(date).submittedOnDate(date)
+                .transactionProcessingStrategyCode(STRATEGY).loanType("individual").dateFormat(DATETIME_PATTERN).locale("en");
+    }
+
+    private void checkAccrualTransaction(final LocalDate transactionDate, final double interestPortion, final double feePortion,
+            final double penaltyPortion, final Long loanId) {
+        boolean isTransactionFound = false;
+        for (GetLoansLoanIdTransactions transaction : getLoanDetails(loanId).getTransactions()) {
+            if (Boolean.TRUE.equals(transaction.getType().getAccrual()) && transactionDate.equals(transaction.getDate())) {
+                isTransactionFound = true;
+                assertEquals(interestPortion, Utils.getDoubleValue(transaction.getInterestPortion()), "Mismatch in transaction amounts");
+                assertEquals(feePortion, Utils.getDoubleValue(transaction.getFeeChargesPortion()), "Mismatch in transaction amounts");
+                assertEquals(penaltyPortion, Utils.getDoubleValue(transaction.getPenaltyChargesPortion()),
+                        "Mismatch in transaction amounts");
+                break;
+            }
+        }
+        assertTrue(isTransactionFound, "No Accrual entries are posted");
+    }
+
+    private void checkAccrualTransactionsForMultipleRepaymentSchedulesChargeDueDate(LocalDate transactionDate, Long loanId) {
+        boolean isTransactionFound = false;
+        for (GetLoansLoanIdTransactions transaction : getLoanDetails(loanId).getTransactions()) {
+            if (Boolean.TRUE.equals(transaction.getType().getAccrual()) && transactionDate.equals(transaction.getDate())) {
+                isTransactionFound = true;
+                assertEquals(0.0, Utils.getDoubleValue(transaction.getInterestPortion()), "Mismatch in transaction amounts");
+                assertEquals(0.0, Utils.getDoubleValue(transaction.getFeeChargesPortion()), "Mismatch in transaction amounts");
+                assertEquals(10.0, Utils.getDoubleValue(transaction.getPenaltyChargesPortion()), "Mismatch in transaction amounts");
+            }
+        }
+        assertTrue(isTransactionFound, "No Accrual entries are posted");
     }
 
     private void verifyPeriodDates(List<GetLoansLoanIdRepaymentPeriod> periods) {
         assertEquals(3, periods.size());
-        assertEquals(LocalDate.of(2023, 05, 19), periods.get(1).getFromDate());
-        assertEquals(LocalDate.of(2023, 07, 18), periods.get(1).getDueDate());
-        assertEquals(LocalDate.of(2023, 07, 18), periods.get(2).getFromDate());
-        assertEquals(LocalDate.of(2023, 07, 19), periods.get(2).getDueDate());
+        assertEquals(LocalDate.of(2023, 5, 19), periods.get(1).getFromDate());
+        assertEquals(LocalDate.of(2023, 7, 18), periods.get(1).getDueDate());
+        assertEquals(LocalDate.of(2023, 7, 18), periods.get(2).getFromDate());
+        assertEquals(LocalDate.of(2023, 7, 19), periods.get(2).getDueDate());
     }
-
-    private void checkAccrualTransactionsForMultipleRepaymentSchedulesChargeDueDate(LocalDate transactionDate, Integer loanId) {
-        ArrayList<HashMap> transactions = (ArrayList<HashMap>) loanTransactionHelper.getLoanTransactions(this.requestSpec,
-                this.responseSpec, loanId);
-        boolean isTransactionFound = false;
-        for (int i = 0; i < transactions.size(); i++) {
-            HashMap transactionType = (HashMap) transactions.get(i).get("type");
-            boolean isAccrualTransaction = (Boolean) transactionType.get("accrual");
-
-            if (isAccrualTransaction) {
-                ArrayList<Integer> accrualEntryDateAsArray = (ArrayList<Integer>) transactions.get(i).get("date");
-                LocalDate accrualEntryDate = LocalDate.of(accrualEntryDateAsArray.get(0), accrualEntryDateAsArray.get(1),
-                        accrualEntryDateAsArray.get(2));
-
-                if (DateUtils.isEqual(transactionDate, accrualEntryDate)) {
-                    isTransactionFound = true;
-                    verifyAmounts(0.0f, 0.0f, 10.0f, Float.valueOf(String.valueOf(transactions.get(i).get("interestPortion"))),
-                            Float.valueOf(String.valueOf(transactions.get(i).get("feeChargesPortion"))),
-                            Float.valueOf(String.valueOf(transactions.get(i).get("penaltyChargesPortion"))));
-                }
-            }
-        }
-        assertTrue(isTransactionFound, "No Accrual entries are posted");
-    }
-
-    private void verifyAmounts(final Float expectedInterestPortion, final Float expectedFeePortion, final Float expectedPenaltyPortion,
-            final Float actualInterestPortion, final Float actualFeePortion, final Float actualPenaltyPortion) {
-        assertEquals(expectedInterestPortion, actualInterestPortion, "Mismatch in transaction amounts");
-        assertEquals(expectedFeePortion, actualFeePortion, "Mismatch in transaction amounts");
-        assertEquals(expectedPenaltyPortion, actualPenaltyPortion, "Mismatch in transaction amounts");
-    }
-
-    private GetLoanProductsProductIdResponse createLoanProduct(final LoanTransactionHelper loanTransactionHelper,
-            final Account... accounts) {
-
-        final String loanProductJSON = new LoanProductTestBuilder().withPrincipal("1000").withRepaymentAfterEvery("1")
-                .withNumberOfRepayments("1").withRepaymentTypeAsMonth().withinterestRatePerPeriod("0")
-                .withInterestRateFrequencyTypeAsMonths().withAmortizationTypeAsEqualPrincipalPayment().withInterestTypeAsFlat()
-                .withAccountingRulePeriodicAccrual(accounts).withDaysInMonth("30").withDaysInYear("365").withMoratorium("0", "0")
-                .build(null);
-        final Integer loanProductId = loanTransactionHelper.getLoanProductId(loanProductJSON);
-        return loanTransactionHelper.getLoanProduct(loanProductId);
-    }
-
-    private Integer createLoanAccount(final Integer clientID, final Long loanProductID, final String externalId) {
-
-        String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal("1000").withLoanTermFrequency("1")
-                .withLoanTermFrequencyAsMonths().withNumberOfRepayments("1").withRepaymentEveryAfter("1")
-                .withRepaymentFrequencyTypeAsMonths().withInterestRatePerPeriod("0").withInterestTypeAsFlatBalance()
-                .withAmortizationTypeAsEqualPrincipalPayments().withInterestCalculationPeriodTypeSameAsRepaymentPeriod()
-                .withExpectedDisbursementDate("03 March 2023").withSubmittedOnDate("03 March 2023").withLoanType("individual")
-                .withExternalId(externalId).build(clientID.toString(), loanProductID.toString(), null);
-
-        final Integer loanId = loanTransactionHelper.getLoanId(loanApplicationJSON);
-        loanTransactionHelper.approveLoan("03 March 2023", "1000", loanId, null);
-        loanTransactionHelper.disburseLoanWithNetDisbursalAmount("03 March 2023", loanId, "1000");
-        return loanId;
-    }
-
-    private GetLoanProductsProductIdResponse createLoanProductMultipleRepayments(final LoanTransactionHelper loanTransactionHelper,
-            final Account... accounts) {
-
-        final String loanProductJSON = new LoanProductTestBuilder().withPrincipal("1000").withRepaymentAfterEvery("1")
-                .withNumberOfRepayments("1").withRepaymentTypeAsDays().withinterestRatePerPeriod("0")
-                .withInterestRateFrequencyTypeAsMonths().withAmortizationTypeAsEqualPrincipalPayment().withInterestTypeAsFlat()
-                .withAccountingRulePeriodicAccrual(accounts).withDaysInMonth("30").withDaysInYear("365").withMoratorium("0", "0")
-                .build(null);
-        final Integer loanProductId = loanTransactionHelper.getLoanProductId(loanProductJSON);
-        return loanTransactionHelper.getLoanProduct(loanProductId);
-    }
-
-    private GetLoanProductsProductIdResponse createLoanProductMultipleDisbursements(final LoanTransactionHelper loanTransactionHelper,
-            final Account... accounts) {
-
-        final String loanProductJSON = new LoanProductTestBuilder().withPrincipal("1000").withRepaymentTypeAsMonth()
-                .withRepaymentAfterEvery("1").withNumberOfRepayments("1").withRepaymentTypeAsMonth().withinterestRatePerPeriod("0")
-                .withInterestRateFrequencyTypeAsMonths().withAmortizationTypeAsEqualPrincipalPayment().withInterestTypeAsDecliningBalance()
-                .withAccountingRulePeriodicAccrual(accounts).withInterestCalculationPeriodTypeAsRepaymentPeriod(true).withDaysInMonth("30")
-                .withDaysInYear("365").withMoratorium("0", "0").withMultiDisburse().withDisallowExpectedDisbursements(true).build(null);
-        final Integer loanProductId = loanTransactionHelper.getLoanProductId(loanProductJSON);
-        return loanTransactionHelper.getLoanProduct(loanProductId);
-    }
-
-    private Integer createLoanAccountMultipleRepaymentsDisbursement(final Integer clientID, final Long loanProductID,
-            final String externalId) {
-
-        String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal("1000").withLoanTermFrequency("30")
-                .withLoanTermFrequencyAsDays().withNumberOfRepayments("10").withRepaymentEveryAfter("3").withRepaymentFrequencyTypeAsDays()
-                .withInterestRatePerPeriod("0").withInterestTypeAsDecliningBalance().withAmortizationTypeAsEqualPrincipalPayments()
-                .withInterestCalculationPeriodTypeSameAsRepaymentPeriod().withExpectedDisbursementDate("03 March 2023")
-                .withSubmittedOnDate("03 March 2023").withLoanType("individual").withExternalId(externalId)
-                .build(clientID.toString(), loanProductID.toString(), null);
-
-        final Integer loanId = loanTransactionHelper.getLoanId(loanApplicationJSON);
-        loanTransactionHelper.approveLoan("03 March 2023", "1000", loanId, null);
-        return loanId;
-    }
-
-    private Integer createLoanAccountMultipleRepayments(final Integer clientID, final Long loanProductID, final String externalId) {
-
-        String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal("1000").withLoanTermFrequency("30")
-                .withLoanTermFrequencyAsDays().withNumberOfRepayments("10").withRepaymentEveryAfter("3").withRepaymentFrequencyTypeAsDays()
-                .withInterestRatePerPeriod("0").withInterestTypeAsFlatBalance().withAmortizationTypeAsEqualPrincipalPayments()
-                .withInterestCalculationPeriodTypeSameAsRepaymentPeriod().withExpectedDisbursementDate("03 March 2023")
-                .withSubmittedOnDate("03 March 2023").withLoanType("individual").withExternalId(externalId)
-                .build(clientID.toString(), loanProductID.toString(), null);
-
-        final Integer loanId = loanTransactionHelper.getLoanId(loanApplicationJSON);
-        loanTransactionHelper.approveLoan("03 March 2023", "1000", loanId, null);
-        loanTransactionHelper.disburseLoanWithNetDisbursalAmount("03 March 2023", loanId, "1000");
-        return loanId;
-    }
-
-    private Integer createLoanAccountAndDisburse(final Integer clientID, final Long loanProductID, final String externalId) {
-
-        String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal("1000").withLoanTermFrequency("30")
-                .withLoanTermFrequencyAsDays().withNumberOfRepayments("1").withRepaymentEveryAfter("30").withRepaymentFrequencyTypeAsDays()
-                .withInterestRatePerPeriod("0").withInterestTypeAsFlatBalance().withAmortizationTypeAsEqualPrincipalPayments()
-                .withInterestCalculationPeriodTypeSameAsRepaymentPeriod().withExpectedDisbursementDate("19 May 2023")
-                .withSubmittedOnDate("19 May 2023").withLoanType("individual").withExternalId(externalId)
-                .build(clientID.toString(), loanProductID.toString(), null);
-
-        final Integer loanId = loanTransactionHelper.getLoanId(loanApplicationJSON);
-        loanTransactionHelper.approveLoan("19 May 2023", "1000", loanId, null);
-        loanTransactionHelper.disburseLoanWithNetDisbursalAmount("19 May 2023", loanId, "1000");
-        return loanId;
-    }
-
-    private void checkAccrualTransaction(final LocalDate transactionDate, final Float interestPortion, final Float feePortion,
-            final Float penaltyPortion, final Integer loanID) {
-
-        ArrayList<HashMap> transactions = (ArrayList<HashMap>) loanTransactionHelper.getLoanTransactions(this.requestSpec,
-                this.responseSpec, loanID);
-        boolean isTransactionFound = false;
-        for (int i = 0; i < transactions.size(); i++) {
-            HashMap transactionType = (HashMap) transactions.get(i).get("type");
-            boolean isAccrualTransaction = (Boolean) transactionType.get("accrual");
-
-            if (isAccrualTransaction) {
-                ArrayList<Integer> accrualEntryDateAsArray = (ArrayList<Integer>) transactions.get(i).get("date");
-                LocalDate accrualEntryDate = LocalDate.of(accrualEntryDateAsArray.get(0), accrualEntryDateAsArray.get(1),
-                        accrualEntryDateAsArray.get(2));
-
-                if (DateUtils.isEqual(transactionDate, accrualEntryDate)) {
-                    isTransactionFound = true;
-                    assertEquals(interestPortion, Float.valueOf(String.valueOf(transactions.get(i).get("interestPortion"))),
-                            "Mismatch in transaction amounts");
-                    assertEquals(feePortion, Float.valueOf(String.valueOf(transactions.get(i).get("feeChargesPortion"))),
-                            "Mismatch in transaction amounts");
-                    assertEquals(penaltyPortion, Float.valueOf(String.valueOf(transactions.get(i).get("penaltyChargesPortion"))),
-                            "Mismatch in transaction amounts");
-                    break;
-                }
-            }
-        }
-        assertTrue(isTransactionFound, "No Accrual entries are posted");
-    }
-
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanAccrualTransactionOnChargeSubmittedDateTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanAccrualTransactionOnChargeSubmittedDateTest.java
@@ -22,897 +22,378 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
+import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
-import org.apache.fineract.client.models.GetLoanProductsProductIdResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdRepaymentPeriod;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
-import org.apache.fineract.client.models.PostCreateRescheduleLoansRequest;
-import org.apache.fineract.client.models.PostCreateRescheduleLoansResponse;
+import org.apache.fineract.client.models.GetLoansLoanIdTransactions;
+import org.apache.fineract.client.models.PostLoanProductsRequest;
+import org.apache.fineract.client.models.PostLoansLoanIdChargesRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsResponse;
+import org.apache.fineract.client.models.PostLoansRequest;
 import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
-import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
-import org.apache.fineract.infrastructure.core.service.DateUtils;
-import org.apache.fineract.integrationtests.common.BusinessDateHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.LoanRescheduleRequestHelper;
-import org.apache.fineract.integrationtests.common.SchedulerJobHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
 import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.accounting.Account;
-import org.apache.fineract.integrationtests.common.accounting.AccountHelper;
-import org.apache.fineract.integrationtests.common.accounting.PeriodicAccrualAccountingHelper;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
-import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanRescheduleRequestTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.apache.fineract.integrationtests.inlinecob.InlineLoanCOBHelper;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class LoanAccrualTransactionOnChargeSubmittedDateTest extends BaseLoanIntegrationTest {
+public class LoanAccrualTransactionOnChargeSubmittedDateTest extends FeignLoanTestBase {
 
-    private ResponseSpecification responseSpec;
-    private RequestSpecification requestSpec;
-    private LoanTransactionHelper loanTransactionHelper;
-    private ClientHelper clientHelper;
-    private DateTimeFormatter dateFormatter = new DateTimeFormatterBuilder().appendPattern("dd MMMM yyyy").toFormatter();
-    private AccountHelper accountHelper;
-    private InlineLoanCOBHelper inlineLoanCOBHelper;
-
-    @BeforeEach
-    public void setup() {
-        Utils.initializeRESTAssured();
-        this.requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        this.requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        this.requestSpec.header("Fineract-Platform-TenantId", "default");
-        this.responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        this.loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-        this.clientHelper = new ClientHelper(this.requestSpec, this.responseSpec);
-        this.accountHelper = new AccountHelper(this.requestSpec, this.responseSpec);
-        this.inlineLoanCOBHelper = new InlineLoanCOBHelper(this.requestSpec, this.responseSpec);
-    }
+    private static final String STRATEGY = "mifos-standard-strategy";
+    private static final String CHARGE_ACCRUAL_DATE_SUBMITTED = "submitted-date";
+    private static final String CHARGE_ACCRUAL_DATE_DUE = "due-date";
 
     @Test
     public void loanAccrualTransactionOnChargeSubmittedTest_Accrual_Accounting_Api() {
         try {
-
-            // Accounts oof periodic accrual
-            final Account assetAccount = this.accountHelper.createAssetAccount();
-            final Account incomeAccount = this.accountHelper.createIncomeAccount();
-            final Account expenseAccount = this.accountHelper.createExpenseAccount();
-            final Account overpaymentAccount = this.accountHelper.createLiabilityAccount();
-
-            // Set business date
-            LocalDate currentDate = LocalDate.of(2023, 3, 3);
-            final String accrualRunTillDate = dateFormatter.format(currentDate);
-
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, currentDate);
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
-                    new PutGlobalConfigurationsRequest().stringValue("submitted-date"));
-            // Loan ExternalId
+            enableSubmittedDateChargeAccrual(LocalDate.of(2023, 3, 3));
             String loanExternalIdStr = UUID.randomUUID().toString();
+            final Long clientId = createClient();
+            final Long loanProductId = createLoanProduct(singleRepaymentAccrualProduct());
+            final Long loanId = createSingleRepaymentLoan(clientId, loanProductId, loanExternalIdStr);
 
-            // Client and Loan account creation
+            addPenaltyCharge(loanId, "10 March 2023", 10.0);
+            addFeeCharge(loanId, "14 March 2023", 10.0);
 
-            final Integer clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId().intValue();
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper, assetAccount,
-                    incomeAccount, expenseAccount, overpaymentAccount);
-            assertNotNull(getLoanProductsProductResponse);
+            runPeriodicAccrualAccounting("03 March 2023");
+            checkAccrualTransaction(LocalDate.of(2023, 3, 3), 0.0, 10.0, 10.0, loanId);
 
-            final Integer loanId = createLoanAccount(clientId, getLoanProductsProductResponse.getId(), loanExternalIdStr);
+            updateBusinessDate("04 March 2023");
+            makeLoanRepayment(loanExternalIdStr, repaymentRequest("4 March 2023", 100.0));
+            addFeeCharge(loanId, "21 March 2023", 10.0);
 
-            // Add Charge Penalty
-            Integer penalty = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", true));
-
-            LocalDate targetDate = LocalDate.of(2023, 3, 10);
-            final String penaltyCharge1AddedDate = dateFormatter.format(targetDate);
-
-            Integer penalty1LoanChargeId = this.loanTransactionHelper.addChargesForLoan(loanId,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), penaltyCharge1AddedDate, "10"));
-
-            assertNotNull(penalty1LoanChargeId);
-
-            // Add Charge Fee
-            Integer feeCharge = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", false));
-
-            targetDate = LocalDate.of(2023, 3, 14);
-            final String feeChargeAddedDate = dateFormatter.format(targetDate);
-            Integer feeLoanChargeId = this.loanTransactionHelper.addChargesForLoan(loanId,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(feeCharge), feeChargeAddedDate, "10"));
-
-            assertNotNull(feeLoanChargeId);
-
-            // Run accrual for charge created date
-            PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting(accrualRunTillDate);
-
-            // verify accrual transaction created for charges create date
-            checkAccrualTransaction(currentDate, 0.0f, 10.0f, 10.0f, loanId);
-
-            // Set business date
-            LocalDate futureDate = LocalDate.of(2023, 3, 4);
-            final String nextAccrualRunDate = dateFormatter.format(futureDate);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, futureDate);
-
-            // make repayment
-            final PostLoansLoanIdTransactionsResponse repaymentTransaction_1 = loanTransactionHelper.makeLoanRepayment(loanExternalIdStr,
-                    new PostLoansLoanIdTransactionsRequest().dateFormat("dd MMMM yyyy").transactionDate("4 March 2023").locale("en")
-                            .transactionAmount(100.0));
-
-            // Add Charge
-            Integer feeCharge_1 = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", false));
-
-            targetDate = LocalDate.of(2023, 3, 21);
-            final String feeChargeAddedDate_1 = dateFormatter.format(targetDate);
-            Integer feeLoanChargeId_1 = this.loanTransactionHelper.addChargesForLoan(loanId,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(feeCharge_1), feeChargeAddedDate_1, "10"));
-
-            assertNotNull(feeLoanChargeId_1);
-
-            // Run accrual for charge created date
-            PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting(nextAccrualRunDate);
-
-            // verify accrual transaction created for charges create date
-            checkAccrualTransaction(futureDate, 0.0f, 10.0f, 0.0f, loanId);
-
+            runPeriodicAccrualAccounting("04 March 2023");
+            checkAccrualTransaction(LocalDate.of(2023, 3, 4), 0.0, 10.0, 0.0, loanId);
         } finally {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
-                    new PutGlobalConfigurationsRequest().stringValue("due-date"));
+            resetChargeAccrualConfig();
         }
-
     }
 
     @Test
     public void loanAccrualTransactionOnChargeSubmittedTest_Add_Periodic_Accrual_Transactions_Job() {
         try {
-
-            final SchedulerJobHelper schedulerJobHelper = new SchedulerJobHelper(requestSpec);
-            // Accounts oof periodic accrual
-            final Account assetAccount = this.accountHelper.createAssetAccount();
-            final Account incomeAccount = this.accountHelper.createIncomeAccount();
-            final Account expenseAccount = this.accountHelper.createExpenseAccount();
-            final Account overpaymentAccount = this.accountHelper.createLiabilityAccount();
-
-            // Set business date
-            LocalDate currentDate = LocalDate.of(2023, 3, 3);
-            final String accrualRunTillDate = dateFormatter.format(currentDate);
-
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, currentDate);
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
-                    new PutGlobalConfigurationsRequest().stringValue("submitted-date"));
-            // Loan ExternalId
+            enableSubmittedDateChargeAccrual(LocalDate.of(2023, 3, 3));
             String loanExternalIdStr = UUID.randomUUID().toString();
+            final Long clientId = createClient();
+            final Long loanProductId = createLoanProduct(singleRepaymentAccrualProduct());
+            final Long loanId = createSingleRepaymentLoan(clientId, loanProductId, loanExternalIdStr);
 
-            // Client and Loan account creation
+            addPenaltyCharge(loanId, "10 March 2023", 10.0);
+            addFeeCharge(loanId, "14 March 2023", 10.0);
 
-            final Integer clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId().intValue();
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper, assetAccount,
-                    incomeAccount, expenseAccount, overpaymentAccount);
-            assertNotNull(getLoanProductsProductResponse);
-
-            final Integer loanId = createLoanAccount(clientId, getLoanProductsProductResponse.getId(), loanExternalIdStr);
-
-            // Add Charge Penalty
-            Integer penalty = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", true));
-
-            LocalDate targetDate = LocalDate.of(2023, 3, 10);
-            final String penaltyCharge1AddedDate = dateFormatter.format(targetDate);
-
-            Integer penalty1LoanChargeId = this.loanTransactionHelper.addChargesForLoan(loanId,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), penaltyCharge1AddedDate, "10"));
-
-            assertNotNull(penalty1LoanChargeId);
-
-            // Add Charge Fee
-            Integer feeCharge = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", false));
-
-            targetDate = LocalDate.of(2023, 3, 14);
-            final String feeChargeAddedDate = dateFormatter.format(targetDate);
-            Integer feeLoanChargeId = this.loanTransactionHelper.addChargesForLoan(loanId,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(feeCharge), feeChargeAddedDate, "10"));
-
-            assertNotNull(feeLoanChargeId);
-
-            // Run periodic accrual job for business date
             final String jobName = "Add Periodic Accrual Transactions";
-            schedulerJobHelper.executeAndAwaitJob(jobName);
+            schedulerHelper.executeAndAwaitJob(jobName);
+            checkAccrualTransaction(LocalDate.of(2023, 3, 3), 0.0, 10.0, 10.0, loanId);
 
-            // verify accrual transaction created for charges create date
-            checkAccrualTransaction(currentDate, 0.0f, 10.0f, 10.0f, loanId);
+            updateBusinessDate("04 March 2023");
+            makeLoanRepayment(loanExternalIdStr, repaymentRequest("4 March 2023", 100.0));
+            addFeeCharge(loanId, "21 March 2023", 10.0);
 
-            // Set business date
-            LocalDate futureDate = LocalDate.of(2023, 3, 4);
-            final String nextAccrualRunDate = dateFormatter.format(futureDate);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, futureDate);
-
-            // make repayment
-            final PostLoansLoanIdTransactionsResponse repaymentTransaction_1 = loanTransactionHelper.makeLoanRepayment(loanExternalIdStr,
-                    new PostLoansLoanIdTransactionsRequest().dateFormat("dd MMMM yyyy").transactionDate("4 March 2023").locale("en")
-                            .transactionAmount(100.0));
-
-            // Add Charge
-            Integer feeCharge_1 = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", false));
-
-            targetDate = LocalDate.of(2023, 3, 21);
-            final String feeChargeAddedDate_1 = dateFormatter.format(targetDate);
-            Integer feeLoanChargeId_1 = this.loanTransactionHelper.addChargesForLoan(loanId,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(feeCharge_1), feeChargeAddedDate_1, "10"));
-
-            assertNotNull(feeLoanChargeId_1);
-
-            // Run periodic accrual job for business date
-            schedulerJobHelper.executeAndAwaitJob(jobName);
-
-            // verify accrual transaction created for charges create date
-            checkAccrualTransaction(futureDate, 0.0f, 10.0f, 0.0f, loanId);
-
+            schedulerHelper.executeAndAwaitJob(jobName);
+            checkAccrualTransaction(LocalDate.of(2023, 3, 4), 0.0, 10.0, 0.0, loanId);
         } finally {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
-                    new PutGlobalConfigurationsRequest().stringValue("due-date"));
+            resetChargeAccrualConfig();
         }
     }
 
     @Test
     public void loanAccrualTransactionOnChargeSubmittedTest_Loan_COB_AddPeriodicAccrualEntriesBusinessStep() {
         try {
-
-            final SchedulerJobHelper schedulerJobHelper = new SchedulerJobHelper(requestSpec);
-            // Accounts oof periodic accrual
-            final Account assetAccount = this.accountHelper.createAssetAccount();
-            final Account incomeAccount = this.accountHelper.createIncomeAccount();
-            final Account expenseAccount = this.accountHelper.createExpenseAccount();
-            final Account overpaymentAccount = this.accountHelper.createLiabilityAccount();
-
-            // Set business date
             LocalDate currentDate = LocalDate.of(2023, 3, 3);
-            final String accrualRunTillDate = dateFormatter.format(currentDate);
-
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, currentDate);
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
-                    new PutGlobalConfigurationsRequest().stringValue("submitted-date"));
-            // Loan ExternalId
+            enableSubmittedDateChargeAccrual(currentDate);
             String loanExternalIdStr = UUID.randomUUID().toString();
+            final Long clientId = createClient();
+            final Long loanProductId = createLoanProduct(singleRepaymentAccrualProduct());
+            final Long loanId = createSingleRepaymentLoan(clientId, loanProductId, loanExternalIdStr);
 
-            // Client and Loan account creation
+            addPenaltyCharge(loanId, "10 March 2023", 10.0);
+            addFeeCharge(loanId, "14 March 2023", 10.0);
 
-            final Integer clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId().intValue();
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper, assetAccount,
-                    incomeAccount, expenseAccount, overpaymentAccount);
-            assertNotNull(getLoanProductsProductResponse);
-
-            final Integer loanId = createLoanAccount(clientId, getLoanProductsProductResponse.getId(), loanExternalIdStr);
-
-            // Add Charge Penalty
-            Integer penalty = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", true));
-
-            LocalDate targetDate = LocalDate.of(2023, 3, 10);
-            final String penaltyCharge1AddedDate = dateFormatter.format(targetDate);
-
-            Integer penalty1LoanChargeId = this.loanTransactionHelper.addChargesForLoan(loanId,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), penaltyCharge1AddedDate, "10"));
-
-            assertNotNull(penalty1LoanChargeId);
-
-            // Add Charge Fee
-            Integer feeCharge = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", false));
-
-            targetDate = LocalDate.of(2023, 3, 14);
-            final String feeChargeAddedDate = dateFormatter.format(targetDate);
-            Integer feeLoanChargeId = this.loanTransactionHelper.addChargesForLoan(loanId,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(feeCharge), feeChargeAddedDate, "10"));
-
-            assertNotNull(feeLoanChargeId);
-
-            // Run cob job for business date + 1
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, currentDate.plusDays(1));
-
+            updateBusinessDate(Utils.dateFormatter.format(currentDate.plusDays(1)));
             final String jobName = "Loan COB";
-            schedulerJobHelper.executeAndAwaitJob(jobName);
+            schedulerHelper.executeAndAwaitJob(jobName);
+            checkAccrualTransaction(LocalDate.of(2023, 3, 3), 0.0, 10.0, 10.0, loanId);
 
-            // verify accrual transaction created for charges create date
-            checkAccrualTransaction(currentDate, 0.0f, 10.0f, 10.0f, loanId);
-
-            // Set business date
             LocalDate futureDate = LocalDate.of(2023, 3, 4);
-            final String nextAccrualRunDate = dateFormatter.format(futureDate);
+            updateBusinessDate("04 March 2023");
+            makeLoanRepayment(loanExternalIdStr, repaymentRequest("4 March 2023", 100.0));
+            addFeeCharge(loanId, "21 March 2023", 10.0);
 
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, futureDate);
-
-            // make repayment
-            final PostLoansLoanIdTransactionsResponse repaymentTransaction_1 = loanTransactionHelper.makeLoanRepayment(loanExternalIdStr,
-                    new PostLoansLoanIdTransactionsRequest().dateFormat("dd MMMM yyyy").transactionDate("4 March 2023").locale("en")
-                            .transactionAmount(100.0));
-
-            // Add Charge
-            Integer feeCharge_1 = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", false));
-
-            targetDate = LocalDate.of(2023, 3, 21);
-            final String feeChargeAddedDate_1 = dateFormatter.format(targetDate);
-            Integer feeLoanChargeId_1 = this.loanTransactionHelper.addChargesForLoan(loanId,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(feeCharge_1), feeChargeAddedDate_1, "10"));
-
-            assertNotNull(feeLoanChargeId_1);
-
-            // Run cob job for business date + 1
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, futureDate.plusDays(1));
-            schedulerJobHelper.executeAndAwaitJob(jobName);
-
-            // verify accrual transaction created for charges create date
-            checkAccrualTransaction(futureDate, 0.0f, 10.0f, 0.0f, loanId);
-
+            updateBusinessDate(Utils.dateFormatter.format(futureDate.plusDays(1)));
+            schedulerHelper.executeAndAwaitJob(jobName);
+            checkAccrualTransaction(futureDate, 0.0, 10.0, 0.0, loanId);
         } finally {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
-                    new PutGlobalConfigurationsRequest().stringValue("due-date"));
+            resetChargeAccrualConfig();
         }
     }
 
     @Test
     public void loanAccrualTransactionOnChargeSubmittedTest_Add_Accrual_Transactions_Job() {
         try {
-
-            final SchedulerJobHelper schedulerJobHelper = new SchedulerJobHelper(requestSpec);
-            // Accounts oof periodic accrual
-            final Account assetAccount = this.accountHelper.createAssetAccount();
-            final Account incomeAccount = this.accountHelper.createIncomeAccount();
-            final Account expenseAccount = this.accountHelper.createExpenseAccount();
-            final Account overpaymentAccount = this.accountHelper.createLiabilityAccount();
-
-            // Set business date
-            LocalDate currentDate = LocalDate.of(2023, 3, 3);
-            final String accrualRunTillDate = dateFormatter.format(currentDate);
-
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, currentDate);
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
-                    new PutGlobalConfigurationsRequest().stringValue("submitted-date"));
-            // Loan ExternalId
+            enableSubmittedDateChargeAccrual(LocalDate.of(2023, 3, 3));
             String loanExternalIdStr = UUID.randomUUID().toString();
+            final Long clientId = createClient();
+            final Long loanProductId = createLoanProduct(singleRepaymentAccrualProduct());
+            final Long loanId = createSingleRepaymentLoan(clientId, loanProductId, loanExternalIdStr);
 
-            // Client and Loan account creation
+            addPenaltyCharge(loanId, "10 March 2023", 10.0);
+            addFeeCharge(loanId, "14 March 2023", 10.0);
 
-            final Integer clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId().intValue();
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper, assetAccount,
-                    incomeAccount, expenseAccount, overpaymentAccount);
-            assertNotNull(getLoanProductsProductResponse);
-
-            final Integer loanId = createLoanAccount(clientId, getLoanProductsProductResponse.getId(), loanExternalIdStr);
-
-            // Add Charge Penalty
-            Integer penalty = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", true));
-
-            LocalDate targetDate = LocalDate.of(2023, 3, 10);
-            final String penaltyCharge1AddedDate = dateFormatter.format(targetDate);
-
-            Integer penalty1LoanChargeId = this.loanTransactionHelper.addChargesForLoan(loanId,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), penaltyCharge1AddedDate, "10"));
-
-            assertNotNull(penalty1LoanChargeId);
-
-            // Add Charge Fee
-            Integer feeCharge = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", false));
-
-            targetDate = LocalDate.of(2023, 3, 14);
-            final String feeChargeAddedDate = dateFormatter.format(targetDate);
-            Integer feeLoanChargeId = this.loanTransactionHelper.addChargesForLoan(loanId,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(feeCharge), feeChargeAddedDate, "10"));
-
-            assertNotNull(feeLoanChargeId);
-
-            // Run accrual entries job for business date
             final String jobName = "Add Accrual Transactions";
-            schedulerJobHelper.executeAndAwaitJob(jobName);
+            schedulerHelper.executeAndAwaitJob(jobName);
+            checkAccrualTransaction(LocalDate.of(2023, 3, 3), 0.0, 10.0, 10.0, loanId);
 
-            // verify accrual transaction created for charges create date
-            checkAccrualTransaction(currentDate, 0.0f, 10.0f, 10.0f, loanId);
+            updateBusinessDate("04 March 2023");
+            makeLoanRepayment(loanExternalIdStr, repaymentRequest("4 March 2023", 100.0));
+            addFeeCharge(loanId, "21 March 2023", 10.0);
 
-            // Set business date
-            LocalDate futureDate = LocalDate.of(2023, 3, 4);
-            final String nextAccrualRunDate = dateFormatter.format(futureDate);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, futureDate);
-
-            // make repayment
-            final PostLoansLoanIdTransactionsResponse repaymentTransaction_1 = loanTransactionHelper.makeLoanRepayment(loanExternalIdStr,
-                    new PostLoansLoanIdTransactionsRequest().dateFormat("dd MMMM yyyy").transactionDate("4 March 2023").locale("en")
-                            .transactionAmount(100.0));
-
-            // Add Charge
-            Integer feeCharge_1 = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", false));
-
-            targetDate = LocalDate.of(2023, 3, 21);
-            final String feeChargeAddedDate_1 = dateFormatter.format(targetDate);
-            Integer feeLoanChargeId_1 = this.loanTransactionHelper.addChargesForLoan(loanId,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(feeCharge_1), feeChargeAddedDate_1, "10"));
-
-            assertNotNull(feeLoanChargeId_1);
-
-            // Run accrual entries job for business date
-            schedulerJobHelper.executeAndAwaitJob(jobName);
-
-            // verify accrual transaction created for charges create date
-            checkAccrualTransaction(futureDate, 0.0f, 10.0f, 0.0f, loanId);
-
+            schedulerHelper.executeAndAwaitJob(jobName);
+            checkAccrualTransaction(LocalDate.of(2023, 3, 4), 0.0, 10.0, 0.0, loanId);
         } finally {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
-                    new PutGlobalConfigurationsRequest().stringValue("due-date"));
+            resetChargeAccrualConfig();
         }
     }
 
     @Test
     public void loanAccrualTransactionOnChargeSubmitted_With_Multiple_Repayments_Test_Add_Periodic_Accrual_Transactions_Job() {
         try {
-
-            final SchedulerJobHelper schedulerJobHelper = new SchedulerJobHelper(requestSpec);
-            // Accounts oof periodic accrual
-            final Account assetAccount = this.accountHelper.createAssetAccount();
-            final Account incomeAccount = this.accountHelper.createIncomeAccount();
-            final Account expenseAccount = this.accountHelper.createExpenseAccount();
-            final Account overpaymentAccount = this.accountHelper.createLiabilityAccount();
-
-            // Set business date
-            LocalDate currentDate = LocalDate.of(2023, 3, 3);
-            final String accrualRunTillDate = dateFormatter.format(currentDate);
-
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, currentDate);
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
-                    new PutGlobalConfigurationsRequest().stringValue("submitted-date"));
-            // Loan ExternalId
+            enableSubmittedDateChargeAccrual(LocalDate.of(2023, 3, 3));
             String loanExternalIdStr = UUID.randomUUID().toString();
-
-            // Client and Loan account creation
-
-            final Integer clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId().intValue();
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProductMultipleRepayments(
-                    loanTransactionHelper, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
-            assertNotNull(getLoanProductsProductResponse);
-
-            final Integer loanId = createLoanAccountMultipleRepayments(clientId, getLoanProductsProductResponse.getId(), loanExternalIdStr);
-
-            // Add Charge Penalty
-            Integer penalty = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", true));
+            final Long clientId = createClient();
+            final Long loanProductId = createLoanProduct(multipleRepaymentsAccrualProduct());
+            final Long loanId = createMultipleRepaymentsLoan(clientId, loanProductId, loanExternalIdStr, LoanTestData.InterestType.FLAT);
 
             // Due for future date in one of the schedule
-            LocalDate targetDate = LocalDate.of(2023, 3, 10);
-            final String penaltyCharge1AddedDate = dateFormatter.format(targetDate);
-
-            Integer penalty1LoanChargeId = this.loanTransactionHelper.addChargesForLoan(loanId,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), penaltyCharge1AddedDate, "10"));
-
-            assertNotNull(penalty1LoanChargeId);
-
-            // Add Charge Penalty
-            Integer penalty_1 = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", true));
-
+            addPenaltyCharge(loanId, "10 March 2023", 10.0);
             // Due for future date in different of the schedule
-            targetDate = LocalDate.of(2023, 3, 17);
-            final String penaltyChargeAddedDate = dateFormatter.format(targetDate);
-            Integer penaltyLoanChargeId = this.loanTransactionHelper.addChargesForLoan(loanId,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty_1), penaltyChargeAddedDate, "10"));
+            addPenaltyCharge(loanId, "17 March 2023", 10.0);
 
-            assertNotNull(penaltyLoanChargeId);
-
-            // Run periodic accrual job for business date
             final String jobName = "Add Periodic Accrual Transactions";
-            schedulerJobHelper.executeAndAwaitJob(jobName);
+            schedulerHelper.executeAndAwaitJob(jobName);
 
             // verify multiple accrual transactions are created on charge created date according to repayment schedule
             // to which charge due date falls
-            checkAccrualTransactionsForMultipleRepaymentSchedulesChargeDueDate(currentDate, loanId);
-
+            checkAccrualTransactionsForMultipleRepaymentSchedulesChargeDueDate(LocalDate.of(2023, 3, 3), loanId);
         } finally {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
-                    new PutGlobalConfigurationsRequest().stringValue("due-date"));
+            resetChargeAccrualConfig();
         }
     }
 
     @Test
     public void loanAccrualTransactionOnChargeSubmitted_multiple_disbursement_reversal_test_Loan_COB() {
         try {
-
-            final SchedulerJobHelper schedulerJobHelper = new SchedulerJobHelper(requestSpec);
-            // Accounts oof periodic accrual
-            final Account assetAccount = this.accountHelper.createAssetAccount();
-            final Account incomeAccount = this.accountHelper.createIncomeAccount();
-            final Account expenseAccount = this.accountHelper.createExpenseAccount();
-            final Account overpaymentAccount = this.accountHelper.createLiabilityAccount();
-
-            // Set business date
             LocalDate currentDate = LocalDate.of(2023, 3, 3);
-
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, currentDate);
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
-                    new PutGlobalConfigurationsRequest().stringValue("submitted-date"));
-            // Loan ExternalId
+            enableSubmittedDateChargeAccrual(currentDate);
             String loanExternalIdStr = UUID.randomUUID().toString();
+            final Long clientId = createClient();
+            final Long loanProductId = createLoanProduct(multipleDisbursementsAccrualProduct());
+            final Long loanId = createMultipleRepaymentsLoan(clientId, loanProductId, loanExternalIdStr,
+                    LoanTestData.InterestType.DECLINING_BALANCE, false);
 
-            // Client and Loan account creation
+            disburseLoan(loanId, LoanRequestBuilders.disburseLoan(1000.0, "03 March 2023"));
 
-            final Integer clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId().intValue();
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProductMultipleDisbursements(
-                    loanTransactionHelper, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
-            assertNotNull(getLoanProductsProductResponse);
+            addPenaltyCharge(loanId, "09 March 2023", 10.0);
 
-            final Integer loanId = createLoanAccountMultipleRepaymentsDisbursement(clientId, getLoanProductsProductResponse.getId(),
-                    loanExternalIdStr);
-
-            loanTransactionHelper.disburseLoanWithTransactionAmount("03 March 2023", loanId, "1000");
-
-            // Add Charge Penalty
-            Integer penalty = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", true));
-
-            LocalDate targetDate = LocalDate.of(2023, 3, 9);
-            final String penaltyCharge1AddedDate = dateFormatter.format(targetDate);
-
-            Integer penalty1LoanChargeId = this.loanTransactionHelper.addChargesForLoan(loanId,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), penaltyCharge1AddedDate, "10"));
-
-            assertNotNull(penalty1LoanChargeId);
-
-            // Run cob job for business date + 1
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, currentDate.plusDays(1));
-
+            updateBusinessDate(Utils.dateFormatter.format(currentDate.plusDays(1)));
             final String jobName = "Loan COB";
-            schedulerJobHelper.executeAndAwaitJob(jobName);
+            schedulerHelper.executeAndAwaitJob(jobName);
+            checkAccrualTransaction(currentDate, 0.0, 0.0, 10.0, loanId);
 
-            // verify accrual transaction created for charges create date
-            checkAccrualTransaction(currentDate, 0.0f, 0.0f, 10.0f, loanId);
-
-            // Set business date
             LocalDate futureDate = LocalDate.of(2023, 3, 4);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, futureDate);
-
-            loanTransactionHelper.disburseLoanWithTransactionAmount("04 March 2023", loanId, "300");
+            updateBusinessDate("04 March 2023");
+            disburseLoan(loanId, LoanRequestBuilders.disburseLoan(300.0, "04 March 2023"));
 
             // verify accrual transaction exists with same date,amount and is not reversed by regeneration of repayment
             // schedule
-            checkAccrualTransaction(currentDate, 0.0f, 0.0f, 10.0f, loanId);
-
+            checkAccrualTransaction(currentDate, 0.0, 0.0, 10.0, loanId);
         } finally {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
-                    new PutGlobalConfigurationsRequest().stringValue("due-date"));
+            resetChargeAccrualConfig();
         }
     }
 
     @Test
     public void loanAccrualTransaction_ChargeSubmittedDate_AdjustRepaymentScheduleSnoozeFeeDueDateNewFeeAddTest() {
         try {
-
-            // Accounts oof periodic accrual
-            final Account assetAccount = this.accountHelper.createAssetAccount();
-            final Account incomeAccount = this.accountHelper.createIncomeAccount();
-            final Account expenseAccount = this.accountHelper.createExpenseAccount();
-            final Account overpaymentAccount = this.accountHelper.createLiabilityAccount();
-
-            // Set business date
-            LocalDate currentDate = LocalDate.of(2023, 05, 19);
-
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, currentDate);
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
-                    new PutGlobalConfigurationsRequest().stringValue("submitted-date"));
-
-            // Loan ExternalId
+            enableSubmittedDateChargeAccrual(LocalDate.of(2023, 5, 19));
             String loanExternalIdStr = UUID.randomUUID().toString();
-
-            // Client and Loan account creation
-
-            final Integer clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId().intValue();
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProductMultipleRepayments(
-                    loanTransactionHelper, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
-            assertNotNull(getLoanProductsProductResponse);
-
-            final Integer loanId = createLoanAccountAndDisburse(clientId, getLoanProductsProductResponse.getId(), loanExternalIdStr);
+            final Long clientId = createClient();
+            final Long loanProductId = createLoanProduct(multipleRepaymentsAccrualProduct());
+            final Long loanId = createLoanAccountAndDisburse(clientId, loanProductId, loanExternalIdStr);
 
             // set business date as date when fee charge is added/submitted
+            LocalDate chargeSubmittedDate = LocalDate.of(2023, 6, 12);
+            updateBusinessDate("12 June 2023");
 
-            LocalDate chargeSubmittedDate = LocalDate.of(2023, 06, 12);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, chargeSubmittedDate);
-
-            LocalDate chargeDueDate = LocalDate.of(2023, 07, 18);
-            final String feeChargeDueDate = dateFormatter.format(chargeDueDate);
-
-            // Add Fee
-            Integer feeCharge = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", false));
-
-            Integer feeLoanChargeId = this.loanTransactionHelper.addChargesForLoan(loanId,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(feeCharge), feeChargeDueDate, "10"));
-
-            assertNotNull(feeLoanChargeId);
+            addFeeCharge(loanId, "18 July 2023", 10.0);
 
             // adjust loan schedule
-            final PostCreateRescheduleLoansRequest createRequest = new LoanRescheduleRequestTestBuilder()
-                    .updateRescheduleFromDate("18 June 2023").updateAdjustedDueDate("18 July 2023").updateSubmittedOnDate("19 May 2023")
-                    .updateGraceOnPrincipal(null).updateGraceOnInterest(null).updateExtraTerms(null).buildRequest(loanId.longValue());
-            final PostCreateRescheduleLoansResponse loanRescheduleRequestResponse = LoanRescheduleRequestHelper
-                    .createLoanRescheduleRequest(createRequest);
-            final Long loanRescheduleRequestId = loanRescheduleRequestResponse.getResourceId();
-            LoanRescheduleRequestHelper.approveLoanRescheduleRequest(loanRescheduleRequestId,
-                    new LoanRescheduleRequestTestBuilder().updateRescheduleFromDate("18 June 2023").updateAdjustedDueDate("18 July 2023")
-                            .updateSubmittedOnDate("19 May 2023").updateGraceOnPrincipal(null).updateGraceOnInterest(null)
-                            .updateExtraTerms(null).getApproveRequest());
-
-            // run cob
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, chargeSubmittedDate.plusDays(1));
+            Long loanRescheduleRequestId = createRescheduleRequest(
+                    LoanRequestBuilders.rescheduleRequest(loanId, "19 May 2023", "18 June 2023", "18 July 2023"));
+            approveRescheduleRequest(loanRescheduleRequestId, LoanRequestBuilders.approveReschedule("19 May 2023"));
 
             // run inline cob for loan
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.longValue()));
+            updateBusinessDate(Utils.dateFormatter.format(chargeSubmittedDate.plusDays(1)));
+            executeInlineCOB(loanId);
+            checkAccrualTransaction(chargeSubmittedDate, 0.0, 10.0, 0.0, loanId);
 
-            // verify accrual transaction created for charges create date
-            checkAccrualTransaction(chargeSubmittedDate, 0.0f, 10.0f, 0.0f, loanId);
+            updateBusinessDate("18 July 2023");
+            final PostLoansLoanIdTransactionsResponse repaymentTransaction = makeLoanRepayment(loanExternalIdStr,
+                    repaymentRequest("18 July 2023", 1010.0));
 
-            // update business date
-            currentDate = LocalDate.of(2023, 07, 18);
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, currentDate);
+            LocalDate currentDate = LocalDate.of(2023, 7, 19);
+            updateBusinessDate("19 July 2023");
+            reverseLoanTransaction(loanId, repaymentTransaction.getResourceId(), "19 July 2023");
 
-            // make repayment
-            final PostLoansLoanIdTransactionsResponse repaymentTransaction_1 = loanTransactionHelper.makeLoanRepayment(loanExternalIdStr,
-                    new PostLoansLoanIdTransactionsRequest().dateFormat("dd MMMM yyyy").transactionDate("18 July 2023").locale("en")
-                            .transactionAmount(1010.0));
+            addPenaltyCharge(loanId, "19 July 2023", 10.0);
 
-            // update business date
-            currentDate = LocalDate.of(2023, 07, 19);
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, currentDate);
+            updateBusinessDate(Utils.dateFormatter.format(currentDate.plusDays(1)));
+            executeInlineCOB(loanId);
+            checkAccrualTransaction(currentDate, 0.0, 0.0, 10.0, loanId);
 
-            // reverse repayment
-            loanTransactionHelper.reverseRepayment(loanId, repaymentTransaction_1.getResourceId().intValue(), "19 July 2023");
-
-            // Add Charge Penalty
-            Integer penalty = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "10", true));
-
-            LocalDate targetDate = LocalDate.of(2023, 07, 19);
-            final String penaltyCharge1AddedDate = dateFormatter.format(targetDate);
-
-            Integer penalty1LoanChargeId = this.loanTransactionHelper.addChargesForLoan(loanId,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), penaltyCharge1AddedDate, "10"));
-
-            assertNotNull(penalty1LoanChargeId);
-
-            // update business date
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, currentDate.plusDays(1));
-
-            // run inline cob for loan
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.longValue()));
-
-            // verify accrual transaction created for charges create date
-            checkAccrualTransaction(currentDate, 0.0f, 0.0f, 10.0f, loanId);
-
-            // verify loan repayment schedules
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails((long) loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             assertTrue(loanDetails.getStatus().getActive());
 
             List<GetLoansLoanIdRepaymentPeriod> periods = loanDetails.getRepaymentSchedule().getPeriods();
             assertNotNull(periods);
-
             verifyPeriodDates(periods);
-
         } finally {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
-                    new PutGlobalConfigurationsRequest().stringValue("due-date"));
+            resetChargeAccrualConfig();
         }
+    }
+
+    private void enableSubmittedDateChargeAccrual(LocalDate businessDate) {
+        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+                new PutGlobalConfigurationsRequest().enabled(true));
+        updateBusinessDate(Utils.dateFormatter.format(businessDate));
+        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
+                new PutGlobalConfigurationsRequest().stringValue(CHARGE_ACCRUAL_DATE_SUBMITTED));
+    }
+
+    private void resetChargeAccrualConfig() {
+        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+                new PutGlobalConfigurationsRequest().enabled(false));
+        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
+                new PutGlobalConfigurationsRequest().stringValue(CHARGE_ACCRUAL_DATE_DUE));
+    }
+
+    private void addPenaltyCharge(Long loanId, String dueDate, double amount) {
+        Long chargeId = chargesHelper.createLoanSpecifiedDueDatePenalty(amount).getResourceId();
+        assertNotNull(addChargesForLoan(loanId, loanCharge(chargeId, dueDate, amount)).getResourceId());
+    }
+
+    private void addFeeCharge(Long loanId, String dueDate, double amount) {
+        Long chargeId = chargesHelper.createLoanSpecifiedDueDateCharge(amount).getResourceId();
+        assertNotNull(addChargesForLoan(loanId, loanCharge(chargeId, dueDate, amount)).getResourceId());
+    }
+
+    private PostLoansLoanIdChargesRequest loanCharge(Long chargeId, String dueDate, double amount) {
+        return new PostLoansLoanIdChargesRequest().chargeId(chargeId).dateFormat(DATETIME_PATTERN).locale("en").amount(amount)
+                .dueDate(dueDate);
+    }
+
+    private PostLoansLoanIdTransactionsRequest repaymentRequest(String date, double amount) {
+        return new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate(date).locale("en")
+                .transactionAmount(amount);
+    }
+
+    private PostLoanProductsRequest singleRepaymentAccrualProduct() {
+        return create4Period1MonthLongWithoutInterestProduct(STRATEGY).numberOfRepayments(1).maxNumberOfRepayments(30);
+    }
+
+    private PostLoanProductsRequest multipleRepaymentsAccrualProduct() {
+        return create4Period1MonthLongWithoutInterestProduct(STRATEGY).numberOfRepayments(1).maxNumberOfRepayments(30).repaymentEvery(1)
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.DAYS_L);
+    }
+
+    private PostLoanProductsRequest multipleDisbursementsAccrualProduct() {
+        return createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct().repaymentEvery(1)
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS_L).numberOfRepayments(1).maxNumberOfRepayments(30)
+                .transactionProcessingStrategyCode(STRATEGY).loanScheduleType("CUMULATIVE").loanScheduleProcessingType(null)
+                .paymentAllocation(null);
+    }
+
+    private Long createSingleRepaymentLoan(Long clientId, Long loanProductId, String externalId) {
+        Long loanId = applyForLoan(loanRequest(clientId, loanProductId, externalId, 1, LoanTestData.RepaymentFrequencyType.MONTHS, 1, 1,
+                LoanTestData.RepaymentFrequencyType.MONTHS, LoanTestData.InterestType.FLAT, "03 March 2023"));
+        approveLoan(loanId, LoanRequestBuilders.approveLoan(1000.0, "03 March 2023"));
+        disburseLoanWithNetDisbursalAmount(loanId, "03 March 2023", "1000");
+        return loanId;
+    }
+
+    private Long createMultipleRepaymentsLoan(Long clientId, Long loanProductId, String externalId, Integer interestType) {
+        return createMultipleRepaymentsLoan(clientId, loanProductId, externalId, interestType, true);
+    }
+
+    private Long createMultipleRepaymentsLoan(Long clientId, Long loanProductId, String externalId, Integer interestType,
+            boolean disburse) {
+        Long loanId = applyForLoan(loanRequest(clientId, loanProductId, externalId, 30, LoanTestData.RepaymentFrequencyType.DAYS, 10, 3,
+                LoanTestData.RepaymentFrequencyType.DAYS, interestType, "03 March 2023"));
+        approveLoan(loanId, LoanRequestBuilders.approveLoan(1000.0, "03 March 2023"));
+        if (disburse) {
+            disburseLoanWithNetDisbursalAmount(loanId, "03 March 2023", "1000");
+        }
+        return loanId;
+    }
+
+    private Long createLoanAccountAndDisburse(Long clientId, Long loanProductId, String externalId) {
+        Long loanId = applyForLoan(loanRequest(clientId, loanProductId, externalId, 30, LoanTestData.RepaymentFrequencyType.DAYS, 1, 30,
+                LoanTestData.RepaymentFrequencyType.DAYS, LoanTestData.InterestType.FLAT, "19 May 2023"));
+        approveLoan(loanId, LoanRequestBuilders.approveLoan(1000.0, "19 May 2023"));
+        disburseLoanWithNetDisbursalAmount(loanId, "19 May 2023", "1000");
+        return loanId;
+    }
+
+    private PostLoansRequest loanRequest(Long clientId, Long loanProductId, String externalId, int loanTermFrequency,
+            Integer loanTermFrequencyType, int numberOfRepayments, int repaymentEvery, Integer repaymentFrequencyType, Integer interestType,
+            String date) {
+        return new PostLoansRequest().clientId(clientId).productId(loanProductId).externalId(externalId).principal(new BigDecimal("1000"))
+                .loanTermFrequency(loanTermFrequency).loanTermFrequencyType(loanTermFrequencyType).numberOfRepayments(numberOfRepayments)
+                .repaymentEvery(repaymentEvery).repaymentFrequencyType(repaymentFrequencyType).interestRatePerPeriod(BigDecimal.ZERO)
+                .interestType(interestType)
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_PRINCIPAL).expectedDisbursementDate(date).submittedOnDate(date)
+                .transactionProcessingStrategyCode(STRATEGY).loanType("individual").dateFormat(DATETIME_PATTERN).locale("en");
+    }
+
+    private void checkAccrualTransaction(final LocalDate transactionDate, final double interestPortion, final double feePortion,
+            final double penaltyPortion, final Long loanId) {
+        boolean isTransactionFound = false;
+        for (GetLoansLoanIdTransactions transaction : getLoanDetails(loanId).getTransactions()) {
+            if (Boolean.TRUE.equals(transaction.getType().getAccrual()) && transactionDate.equals(transaction.getDate())) {
+                isTransactionFound = true;
+                assertEquals(interestPortion, Utils.getDoubleValue(transaction.getInterestPortion()), "Mismatch in transaction amounts");
+                assertEquals(feePortion, Utils.getDoubleValue(transaction.getFeeChargesPortion()), "Mismatch in transaction amounts");
+                assertEquals(penaltyPortion, Utils.getDoubleValue(transaction.getPenaltyChargesPortion()),
+                        "Mismatch in transaction amounts");
+                break;
+            }
+        }
+        assertTrue(isTransactionFound, "No Accrual entries are posted");
+    }
+
+    private void checkAccrualTransactionsForMultipleRepaymentSchedulesChargeDueDate(LocalDate transactionDate, Long loanId) {
+        boolean isTransactionFound = false;
+        for (GetLoansLoanIdTransactions transaction : getLoanDetails(loanId).getTransactions()) {
+            if (Boolean.TRUE.equals(transaction.getType().getAccrual()) && transactionDate.equals(transaction.getDate())) {
+                isTransactionFound = true;
+                assertEquals(0.0, Utils.getDoubleValue(transaction.getInterestPortion()), "Mismatch in transaction amounts");
+                assertEquals(0.0, Utils.getDoubleValue(transaction.getFeeChargesPortion()), "Mismatch in transaction amounts");
+                assertEquals(10.0, Utils.getDoubleValue(transaction.getPenaltyChargesPortion()), "Mismatch in transaction amounts");
+            }
+        }
+        assertTrue(isTransactionFound, "No Accrual entries are posted");
     }
 
     private void verifyPeriodDates(List<GetLoansLoanIdRepaymentPeriod> periods) {
         assertEquals(3, periods.size());
-        assertEquals(LocalDate.of(2023, 05, 19), periods.get(1).getFromDate());
-        assertEquals(LocalDate.of(2023, 07, 18), periods.get(1).getDueDate());
-        assertEquals(LocalDate.of(2023, 07, 18), periods.get(2).getFromDate());
-        assertEquals(LocalDate.of(2023, 07, 19), periods.get(2).getDueDate());
+        assertEquals(LocalDate.of(2023, 5, 19), periods.get(1).getFromDate());
+        assertEquals(LocalDate.of(2023, 7, 18), periods.get(1).getDueDate());
+        assertEquals(LocalDate.of(2023, 7, 18), periods.get(2).getFromDate());
+        assertEquals(LocalDate.of(2023, 7, 19), periods.get(2).getDueDate());
     }
-
-    private void checkAccrualTransactionsForMultipleRepaymentSchedulesChargeDueDate(LocalDate transactionDate, Integer loanId) {
-        ArrayList<HashMap> transactions = (ArrayList<HashMap>) loanTransactionHelper.getLoanTransactions(this.requestSpec,
-                this.responseSpec, loanId);
-        boolean isTransactionFound = false;
-        for (int i = 0; i < transactions.size(); i++) {
-            HashMap transactionType = (HashMap) transactions.get(i).get("type");
-            boolean isAccrualTransaction = (Boolean) transactionType.get("accrual");
-
-            if (isAccrualTransaction) {
-                ArrayList<Integer> accrualEntryDateAsArray = (ArrayList<Integer>) transactions.get(i).get("date");
-                LocalDate accrualEntryDate = LocalDate.of(accrualEntryDateAsArray.get(0), accrualEntryDateAsArray.get(1),
-                        accrualEntryDateAsArray.get(2));
-
-                if (DateUtils.isEqual(transactionDate, accrualEntryDate)) {
-                    isTransactionFound = true;
-                    verifyAmounts(0.0f, 0.0f, 10.0f, Float.valueOf(String.valueOf(transactions.get(i).get("interestPortion"))),
-                            Float.valueOf(String.valueOf(transactions.get(i).get("feeChargesPortion"))),
-                            Float.valueOf(String.valueOf(transactions.get(i).get("penaltyChargesPortion"))));
-                }
-            }
-        }
-        assertTrue(isTransactionFound, "No Accrual entries are posted");
-    }
-
-    private void verifyAmounts(final Float expectedInterestPortion, final Float expectedFeePortion, final Float expectedPenaltyPortion,
-            final Float actualInterestPortion, final Float actualFeePortion, final Float actualPenaltyPortion) {
-        assertEquals(expectedInterestPortion, actualInterestPortion, "Mismatch in transaction amounts");
-        assertEquals(expectedFeePortion, actualFeePortion, "Mismatch in transaction amounts");
-        assertEquals(expectedPenaltyPortion, actualPenaltyPortion, "Mismatch in transaction amounts");
-    }
-
-    private GetLoanProductsProductIdResponse createLoanProduct(final LoanTransactionHelper loanTransactionHelper,
-            final Account... accounts) {
-
-        final String loanProductJSON = new LoanProductTestBuilder().withPrincipal("1000").withRepaymentAfterEvery("1")
-                .withNumberOfRepayments("1").withRepaymentTypeAsMonth().withinterestRatePerPeriod("0")
-                .withInterestRateFrequencyTypeAsMonths().withAmortizationTypeAsEqualPrincipalPayment().withInterestTypeAsFlat()
-                .withAccountingRulePeriodicAccrual(accounts).withDaysInMonth("30").withDaysInYear("365").withMoratorium("0", "0")
-                .build(null);
-        final Integer loanProductId = loanTransactionHelper.getLoanProductId(loanProductJSON);
-        return loanTransactionHelper.getLoanProduct(loanProductId);
-    }
-
-    private Integer createLoanAccount(final Integer clientID, final Long loanProductID, final String externalId) {
-
-        String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal("1000").withLoanTermFrequency("1")
-                .withLoanTermFrequencyAsMonths().withNumberOfRepayments("1").withRepaymentEveryAfter("1")
-                .withRepaymentFrequencyTypeAsMonths().withInterestRatePerPeriod("0").withInterestTypeAsFlatBalance()
-                .withAmortizationTypeAsEqualPrincipalPayments().withInterestCalculationPeriodTypeSameAsRepaymentPeriod()
-                .withExpectedDisbursementDate("03 March 2023").withSubmittedOnDate("03 March 2023").withLoanType("individual")
-                .withExternalId(externalId).build(clientID.toString(), loanProductID.toString(), null);
-
-        final Integer loanId = loanTransactionHelper.getLoanId(loanApplicationJSON);
-        loanTransactionHelper.approveLoan("03 March 2023", "1000", loanId, null);
-        loanTransactionHelper.disburseLoanWithNetDisbursalAmount("03 March 2023", loanId, "1000");
-        return loanId;
-    }
-
-    private GetLoanProductsProductIdResponse createLoanProductMultipleRepayments(final LoanTransactionHelper loanTransactionHelper,
-            final Account... accounts) {
-
-        final String loanProductJSON = new LoanProductTestBuilder().withPrincipal("1000").withRepaymentAfterEvery("1")
-                .withNumberOfRepayments("1").withRepaymentTypeAsDays().withinterestRatePerPeriod("0")
-                .withInterestRateFrequencyTypeAsMonths().withAmortizationTypeAsEqualPrincipalPayment().withInterestTypeAsFlat()
-                .withAccountingRulePeriodicAccrual(accounts).withDaysInMonth("30").withDaysInYear("365").withMoratorium("0", "0")
-                .build(null);
-        final Integer loanProductId = loanTransactionHelper.getLoanProductId(loanProductJSON);
-        return loanTransactionHelper.getLoanProduct(loanProductId);
-    }
-
-    private GetLoanProductsProductIdResponse createLoanProductMultipleDisbursements(final LoanTransactionHelper loanTransactionHelper,
-            final Account... accounts) {
-
-        final String loanProductJSON = new LoanProductTestBuilder().withPrincipal("1000").withRepaymentTypeAsMonth()
-                .withRepaymentAfterEvery("1").withNumberOfRepayments("1").withRepaymentTypeAsMonth().withinterestRatePerPeriod("0")
-                .withInterestRateFrequencyTypeAsMonths().withAmortizationTypeAsEqualPrincipalPayment().withInterestTypeAsDecliningBalance()
-                .withAccountingRulePeriodicAccrual(accounts).withInterestCalculationPeriodTypeAsRepaymentPeriod(true).withDaysInMonth("30")
-                .withDaysInYear("365").withMoratorium("0", "0").withMultiDisburse().withDisallowExpectedDisbursements(true).build(null);
-        final Integer loanProductId = loanTransactionHelper.getLoanProductId(loanProductJSON);
-        return loanTransactionHelper.getLoanProduct(loanProductId);
-    }
-
-    private Integer createLoanAccountMultipleRepaymentsDisbursement(final Integer clientID, final Long loanProductID,
-            final String externalId) {
-
-        String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal("1000").withLoanTermFrequency("30")
-                .withLoanTermFrequencyAsDays().withNumberOfRepayments("10").withRepaymentEveryAfter("3").withRepaymentFrequencyTypeAsDays()
-                .withInterestRatePerPeriod("0").withInterestTypeAsDecliningBalance().withAmortizationTypeAsEqualPrincipalPayments()
-                .withInterestCalculationPeriodTypeSameAsRepaymentPeriod().withExpectedDisbursementDate("03 March 2023")
-                .withSubmittedOnDate("03 March 2023").withLoanType("individual").withExternalId(externalId)
-                .build(clientID.toString(), loanProductID.toString(), null);
-
-        final Integer loanId = loanTransactionHelper.getLoanId(loanApplicationJSON);
-        loanTransactionHelper.approveLoan("03 March 2023", "1000", loanId, null);
-        return loanId;
-    }
-
-    private Integer createLoanAccountMultipleRepayments(final Integer clientID, final Long loanProductID, final String externalId) {
-
-        String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal("1000").withLoanTermFrequency("30")
-                .withLoanTermFrequencyAsDays().withNumberOfRepayments("10").withRepaymentEveryAfter("3").withRepaymentFrequencyTypeAsDays()
-                .withInterestRatePerPeriod("0").withInterestTypeAsFlatBalance().withAmortizationTypeAsEqualPrincipalPayments()
-                .withInterestCalculationPeriodTypeSameAsRepaymentPeriod().withExpectedDisbursementDate("03 March 2023")
-                .withSubmittedOnDate("03 March 2023").withLoanType("individual").withExternalId(externalId)
-                .build(clientID.toString(), loanProductID.toString(), null);
-
-        final Integer loanId = loanTransactionHelper.getLoanId(loanApplicationJSON);
-        loanTransactionHelper.approveLoan("03 March 2023", "1000", loanId, null);
-        loanTransactionHelper.disburseLoanWithNetDisbursalAmount("03 March 2023", loanId, "1000");
-        return loanId;
-    }
-
-    private Integer createLoanAccountAndDisburse(final Integer clientID, final Long loanProductID, final String externalId) {
-
-        String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal("1000").withLoanTermFrequency("30")
-                .withLoanTermFrequencyAsDays().withNumberOfRepayments("1").withRepaymentEveryAfter("30").withRepaymentFrequencyTypeAsDays()
-                .withInterestRatePerPeriod("0").withInterestTypeAsFlatBalance().withAmortizationTypeAsEqualPrincipalPayments()
-                .withInterestCalculationPeriodTypeSameAsRepaymentPeriod().withExpectedDisbursementDate("19 May 2023")
-                .withSubmittedOnDate("19 May 2023").withLoanType("individual").withExternalId(externalId)
-                .build(clientID.toString(), loanProductID.toString(), null);
-
-        final Integer loanId = loanTransactionHelper.getLoanId(loanApplicationJSON);
-        loanTransactionHelper.approveLoan("19 May 2023", "1000", loanId, null);
-        loanTransactionHelper.disburseLoanWithNetDisbursalAmount("19 May 2023", loanId, "1000");
-        return loanId;
-    }
-
-    private void checkAccrualTransaction(final LocalDate transactionDate, final Float interestPortion, final Float feePortion,
-            final Float penaltyPortion, final Integer loanID) {
-
-        ArrayList<HashMap> transactions = (ArrayList<HashMap>) loanTransactionHelper.getLoanTransactions(this.requestSpec,
-                this.responseSpec, loanID);
-        boolean isTransactionFound = false;
-        for (int i = 0; i < transactions.size(); i++) {
-            HashMap transactionType = (HashMap) transactions.get(i).get("type");
-            boolean isAccrualTransaction = (Boolean) transactionType.get("accrual");
-
-            if (isAccrualTransaction) {
-                ArrayList<Integer> accrualEntryDateAsArray = (ArrayList<Integer>) transactions.get(i).get("date");
-                LocalDate accrualEntryDate = LocalDate.of(accrualEntryDateAsArray.get(0), accrualEntryDateAsArray.get(1),
-                        accrualEntryDateAsArray.get(2));
-
-                if (DateUtils.isEqual(transactionDate, accrualEntryDate)) {
-                    isTransactionFound = true;
-                    assertEquals(interestPortion, Float.valueOf(String.valueOf(transactions.get(i).get("interestPortion"))),
-                            "Mismatch in transaction amounts");
-                    assertEquals(feePortion, Float.valueOf(String.valueOf(transactions.get(i).get("feeChargesPortion"))),
-                            "Mismatch in transaction amounts");
-                    assertEquals(penaltyPortion, Float.valueOf(String.valueOf(transactions.get(i).get("penaltyChargesPortion"))),
-                            "Mismatch in transaction amounts");
-                    break;
-                }
-            }
-        }
-        assertTrue(isTransactionFound, "No Accrual entries are posted");
-    }
-
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanAccrualTransactionWithInterestAndChargeAccrualDateAsSubmittedOnDateTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanAccrualTransactionWithInterestAndChargeAccrualDateAsSubmittedOnDateTest.java
@@ -22,38 +22,33 @@ import static org.apache.fineract.integrationtests.common.loans.LoanApplicationT
 
 import java.math.BigDecimal;
 import org.apache.fineract.client.models.PostLoanProductsRequest;
-import org.apache.fineract.client.models.PostLoanProductsResponse;
-import org.apache.fineract.client.models.PostLoansLoanIdResponse;
 import org.apache.fineract.client.models.PostLoansRequest;
-import org.apache.fineract.client.models.PostLoansResponse;
 import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.SchedulerJobHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 
 @Order(1)
-public class LoanAccrualTransactionWithInterestAndChargeAccrualDateAsSubmittedOnDateTest extends BaseLoanIntegrationTest {
+public class LoanAccrualTransactionWithInterestAndChargeAccrualDateAsSubmittedOnDateTest extends FeignLoanTestBase {
 
     @Test
     public void accrualTransactionForInterestBearingLoan_WithoutCharges_SubmittedOnDateAsChargeAccrualDateWorksTest() {
         runAt("15 April 2024", () -> {
-
             try {
                 // Configure Charge accrual date as submitted on date
                 globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
                         new PutGlobalConfigurationsRequest().stringValue("submitted-date"));
 
                 // Create Client
-                Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+                Long clientId = createClient();
 
                 // Create Loan Product
-                PostLoanProductsRequest loanProductsRequest = createLoanProductWithInterestCalculation();
-                PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+                Long loanProductId = createLoanProduct(createLoanProductWithInterestCalculation());
 
                 // Apply and Approve Loan
-                Long loanId = applyAndApproveLoanApplication(clientId, loanProductResponse.getResourceId(), "15 April 2024", 1000.0, 4);
+                Long loanId = applyAndApproveLoanApplication(clientId, loanProductId, "15 April 2024", 1000.0, 4);
 
                 // Disburse Loan
                 disburseLoan(loanId, BigDecimal.valueOf(500), "15 April 2024");
@@ -75,7 +70,7 @@ public class LoanAccrualTransactionWithInterestAndChargeAccrualDateAsSubmittedOn
                 updateBusinessDate("25 April 2024");
 
                 // run cob
-                SchedulerJobHelper.executeAndAwaitJob("Loan COB");
+                schedulerHelper.executeAndAwaitJob("Loan COB");
 
                 verifyTransactions(loanId, //
                         transaction(500.0, "Disbursement", "15 April 2024", 500.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0), //
@@ -107,29 +102,25 @@ public class LoanAccrualTransactionWithInterestAndChargeAccrualDateAsSubmittedOn
                 globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
                         new PutGlobalConfigurationsRequest().stringValue("due-date"));
             }
-
         });
-
     }
 
     @Test
     public void accrualTransactionForInterestBearingLoan_WithCharges_SubmittedOnDateAsChargeAccrualDateWorksTest() {
         runAt("15 April 2024", () -> {
-
             try {
                 // Configure Charge accrual date as submitted on date
                 globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
                         new PutGlobalConfigurationsRequest().stringValue("submitted-date"));
 
                 // Create Client
-                Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+                Long clientId = createClient();
 
                 // Create Loan Product
-                PostLoanProductsRequest loanProductsRequest = createLoanProductWithInterestCalculation();
-                PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+                Long loanProductId = createLoanProduct(createLoanProductWithInterestCalculation());
 
                 // Apply and Approve Loan
-                Long loanId = applyAndApproveLoanApplication(clientId, loanProductResponse.getResourceId(), "15 April 2024", 1000.0, 4);
+                Long loanId = applyAndApproveLoanApplication(clientId, loanProductId, "15 April 2024", 1000.0, 4);
 
                 // Disburse Loan
                 disburseLoan(loanId, BigDecimal.valueOf(500), "15 April 2024");
@@ -166,7 +157,7 @@ public class LoanAccrualTransactionWithInterestAndChargeAccrualDateAsSubmittedOn
                 updateBusinessDate("25 April 2024");
 
                 // run cob
-                SchedulerJobHelper.executeAndAwaitJob("Loan COB");
+                schedulerHelper.executeAndAwaitJob("Loan COB");
 
                 verifyTransactions(loanId, //
                         transaction(500.0, "Disbursement", "15 April 2024", 500.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0), //
@@ -195,7 +186,7 @@ public class LoanAccrualTransactionWithInterestAndChargeAccrualDateAsSubmittedOn
                         transaction(500.0, "Disbursement", "26 April 2024", 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
 
                 // run cob
-                SchedulerJobHelper.executeAndAwaitJob("Loan COB");
+                schedulerHelper.executeAndAwaitJob("Loan COB");
 
                 verifyTransactions(loanId, //
                         transaction(500.0, "Disbursement", "15 April 2024", 500.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0), //
@@ -207,9 +198,7 @@ public class LoanAccrualTransactionWithInterestAndChargeAccrualDateAsSubmittedOn
                 globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
                         new PutGlobalConfigurationsRequest().stringValue("due-date"));
             }
-
         });
-
     }
 
     private Long applyAndApproveLoanApplication(Long clientId, Long productId, String disbursementDate, double amount,
@@ -217,16 +206,15 @@ public class LoanAccrualTransactionWithInterestAndChargeAccrualDateAsSubmittedOn
         PostLoansRequest postLoansRequest = new PostLoansRequest().clientId(clientId).productId(productId)
                 .expectedDisbursementDate(disbursementDate).dateFormat(DATETIME_PATTERN)
                 .transactionProcessingStrategyCode(DUE_PENALTY_INTEREST_PRINCIPAL_FEE_IN_ADVANCE_PENALTY_INTEREST_PRINCIPAL_FEE_STRATEGY)
-                .locale("en").submittedOnDate(disbursementDate).amortizationType(AmortizationType.EQUAL_INSTALLMENTS)
+                .locale("en").submittedOnDate(disbursementDate).amortizationType(LoanTestData.AmortizationType.EQUAL_INSTALLMENTS)
                 .interestRatePerPeriod(new BigDecimal(12.0))
-                .interestCalculationPeriodType(InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)
-                .interestType(InterestType.DECLINING_BALANCE).repaymentEvery(15).repaymentFrequencyType(RepaymentFrequencyType.DAYS)
-                .numberOfRepayments(numberOfRepayments).loanTermFrequency(numberOfRepayments * 15).loanTermFrequencyType(0)
-                .maxOutstandingLoanBalance(BigDecimal.valueOf(amount)).principal(BigDecimal.valueOf(amount)).loanType("individual");
-        PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(postLoansRequest);
-        PostLoansLoanIdResponse approvedLoanResult = loanTransactionHelper.approveLoan(postLoansResponse.getResourceId(),
-                approveLoanRequest(amount, disbursementDate));
-        return approvedLoanResult.getLoanId();
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE).repaymentEvery(15)
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.DAYS).numberOfRepayments(numberOfRepayments)
+                .loanTermFrequency(numberOfRepayments * 15).loanTermFrequencyType(0).maxOutstandingLoanBalance(BigDecimal.valueOf(amount))
+                .principal(BigDecimal.valueOf(amount)).loanType("individual");
+        Long loanId = applyForLoan(postLoansRequest);
+        return approveLoan(loanId, approveLoanRequest(amount, disbursementDate)).getLoanId();
     }
 
     private PostLoanProductsRequest createLoanProductWithInterestCalculation() {
@@ -238,12 +226,12 @@ public class LoanAccrualTransactionWithInterestAndChargeAccrualDateAsSubmittedOn
                 .principal(1000.0)//
                 .numberOfRepayments(4)//
                 .repaymentEvery(15)//
-                .repaymentFrequencyType(RepaymentFrequencyType.DAYS.longValue())//
-                .interestType(InterestType.DECLINING_BALANCE)//
-                .amortizationType(AmortizationType.EQUAL_INSTALLMENTS)//
-                .interestCalculationPeriodType(InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.DAYS_L)//
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE)//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_INSTALLMENTS)//
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)//
                 .interestRatePerPeriod(12.0) //
-                .interestRateFrequencyType(InterestRateFrequencyType.MONTHS)//
+                .interestRateFrequencyType(LoanTestData.InterestRateFrequencyType.MONTHS)//
                 .isInterestRecalculationEnabled(true) //
                 .interestRecalculationCompoundingMethod(0).rescheduleStrategyMethod(3).recalculationRestFrequencyType(1)
                 .recalculationRestFrequencyInterval(1);

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanAccrualTransactionWithInterestAndChargeAccrualDateAsSubmittedOnDateTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanAccrualTransactionWithInterestAndChargeAccrualDateAsSubmittedOnDateTest.java
@@ -22,43 +22,31 @@ import static org.apache.fineract.integrationtests.common.loans.LoanApplicationT
 
 import java.math.BigDecimal;
 import org.apache.fineract.client.models.PostLoanProductsRequest;
-import org.apache.fineract.client.models.PostLoanProductsResponse;
-import org.apache.fineract.client.models.PostLoansLoanIdResponse;
 import org.apache.fineract.client.models.PostLoansRequest;
-import org.apache.fineract.client.models.PostLoansResponse;
 import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.SchedulerJobHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
 import org.junit.jupiter.api.Test;
 
-public class LoanAccrualTransactionWithInterestAndChargeAccrualDateAsSubmittedOnDateTest extends BaseLoanIntegrationTest {
-
-    private SchedulerJobHelper schedulerJobHelper = new SchedulerJobHelper(this.requestSpec);
+public class LoanAccrualTransactionWithInterestAndChargeAccrualDateAsSubmittedOnDateTest extends FeignLoanTestBase {
 
     @Test
     public void accrualTransactionForInterestBearingLoan_WithoutCharges_SubmittedOnDateAsChargeAccrualDateWorksTest() {
         runAt("15 April 2024", () -> {
-
             try {
                 // Configure Charge accrual date as submitted on date
                 globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
                         new PutGlobalConfigurationsRequest().stringValue("submitted-date"));
 
-                // Create Client
-                Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+                Long clientId = createClient();
 
-                // Create Loan Product
-                PostLoanProductsRequest loanProductsRequest = createLoanProductWithInterestCalculation();
-                PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+                Long loanProductId = createLoanProduct(createLoanProductWithInterestCalculation());
 
-                // Apply and Approve Loan
-                Long loanId = applyAndApproveLoanApplication(clientId, loanProductResponse.getResourceId(), "15 April 2024", 1000.0, 4);
+                Long loanId = applyAndApproveLoanApplication(clientId, loanProductId, "15 April 2024", 1000.0, 4);
 
-                // Disburse Loan
                 disburseLoan(loanId, BigDecimal.valueOf(500), "15 April 2024");
 
-                // Verify Repayment Schedule and Due Dates
                 verifyRepaymentSchedule(loanId, //
                         installment(500.0, null, "15 April 2024"), //
                         installment(114.41, 29.59, 0.0, 0.0, 144.0, false, "30 April 2024"), //
@@ -71,24 +59,19 @@ public class LoanAccrualTransactionWithInterestAndChargeAccrualDateAsSubmittedOn
                         transaction(500.0, "Disbursement", "15 April 2024", 500.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0) //
                 );
 
-                // update business date
                 updateBusinessDate("25 April 2024");
 
-                // run cob
-                schedulerJobHelper.executeAndAwaitJob("Loan COB");
+                schedulerHelper.executeAndAwaitJob("Loan COB");
 
                 verifyTransactions(loanId, //
                         transaction(500.0, "Disbursement", "15 April 2024", 500.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0), //
                         transaction(17.75, "Accrual", "24 April 2024", 0.0, 0.0, 17.75, 0.0, 0.0, 0.0, 0.0) //
                 );
 
-                // update business date
                 updateBusinessDate("26 April 2024");
 
-                // disburse amount
                 disburseLoan(loanId, BigDecimal.valueOf(500), "26 April 2024");
 
-                // Verify Repayment Schedule and Due Dates
                 verifyRepaymentSchedule(loanId, //
                         installment(500.0, null, "15 April 2024"), //
                         installment(500.0, null, "26 April 2024"), //
@@ -107,34 +90,25 @@ public class LoanAccrualTransactionWithInterestAndChargeAccrualDateAsSubmittedOn
                 globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
                         new PutGlobalConfigurationsRequest().stringValue("due-date"));
             }
-
         });
-
     }
 
     @Test
     public void accrualTransactionForInterestBearingLoan_WithCharges_SubmittedOnDateAsChargeAccrualDateWorksTest() {
         runAt("15 April 2024", () -> {
-
             try {
                 // Configure Charge accrual date as submitted on date
                 globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
                         new PutGlobalConfigurationsRequest().stringValue("submitted-date"));
 
-                // Create Client
-                Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+                Long clientId = createClient();
 
-                // Create Loan Product
-                PostLoanProductsRequest loanProductsRequest = createLoanProductWithInterestCalculation();
-                PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductsRequest);
+                Long loanProductId = createLoanProduct(createLoanProductWithInterestCalculation());
 
-                // Apply and Approve Loan
-                Long loanId = applyAndApproveLoanApplication(clientId, loanProductResponse.getResourceId(), "15 April 2024", 1000.0, 4);
+                Long loanId = applyAndApproveLoanApplication(clientId, loanProductId, "15 April 2024", 1000.0, 4);
 
-                // Disburse Loan
                 disburseLoan(loanId, BigDecimal.valueOf(500), "15 April 2024");
 
-                // Verify Repayment Schedule and Due Dates
                 verifyRepaymentSchedule(loanId, //
                         installment(500.0, null, "15 April 2024"), //
                         installment(114.41, 29.59, 0.0, 0.0, 144.0, false, "30 April 2024"), //
@@ -147,13 +121,10 @@ public class LoanAccrualTransactionWithInterestAndChargeAccrualDateAsSubmittedOn
                         transaction(500.0, "Disbursement", "15 April 2024", 500.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0) //
                 );
 
-                // update business date
                 updateBusinessDate("24 April 2024");
 
-                // add charge
                 addCharge(loanId, false, 10.0, "29 April 2024");
 
-                // Verify Repayment Schedule and Due Dates
                 verifyRepaymentSchedule(loanId, //
                         installment(500.0, null, "15 April 2024"), //
                         installment(114.41, 29.59, 10.0, 0.0, 154.0, false, "30 April 2024"), //
@@ -162,24 +133,19 @@ public class LoanAccrualTransactionWithInterestAndChargeAccrualDateAsSubmittedOn
                         installment(136.06, 8.05, 0.0, 0.0, 144.11, false, "14 June 2024") //
                 );
 
-                // update business date
                 updateBusinessDate("25 April 2024");
 
-                // run cob
-                schedulerJobHelper.executeAndAwaitJob("Loan COB");
+                schedulerHelper.executeAndAwaitJob("Loan COB");
 
                 verifyTransactions(loanId, //
                         transaction(500.0, "Disbursement", "15 April 2024", 500.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0), //
                         transaction(27.75, "Accrual", "24 April 2024", 0.0, 0.0, 17.75, 10.0, 0.0, 0.0, 0.0) //
                 );
 
-                // update business date
                 updateBusinessDate("26 April 2024");
 
-                // disburse amount
                 disburseLoan(loanId, BigDecimal.valueOf(500), "26 April 2024");
 
-                // Verify Repayment Schedule and Due Dates
                 verifyRepaymentSchedule(loanId, //
                         installment(500.0, null, "15 April 2024"), //
                         installment(500.0, null, "26 April 2024"), //
@@ -194,8 +160,7 @@ public class LoanAccrualTransactionWithInterestAndChargeAccrualDateAsSubmittedOn
                         transaction(32.49, "Accrual", "24 April 2024", 0.0, 0.0, 22.49, 10.0, 0.0, 0.0, 0.0), //
                         transaction(500.0, "Disbursement", "26 April 2024", 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
 
-                // run cob
-                schedulerJobHelper.executeAndAwaitJob("Loan COB");
+                schedulerHelper.executeAndAwaitJob("Loan COB");
 
                 verifyTransactions(loanId, //
                         transaction(500.0, "Disbursement", "15 April 2024", 500.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0), //
@@ -207,9 +172,7 @@ public class LoanAccrualTransactionWithInterestAndChargeAccrualDateAsSubmittedOn
                 globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.CHARGE_ACCRUAL_DATE,
                         new PutGlobalConfigurationsRequest().stringValue("due-date"));
             }
-
         });
-
     }
 
     private Long applyAndApproveLoanApplication(Long clientId, Long productId, String disbursementDate, double amount,
@@ -217,16 +180,15 @@ public class LoanAccrualTransactionWithInterestAndChargeAccrualDateAsSubmittedOn
         PostLoansRequest postLoansRequest = new PostLoansRequest().clientId(clientId).productId(productId)
                 .expectedDisbursementDate(disbursementDate).dateFormat(DATETIME_PATTERN)
                 .transactionProcessingStrategyCode(DUE_PENALTY_INTEREST_PRINCIPAL_FEE_IN_ADVANCE_PENALTY_INTEREST_PRINCIPAL_FEE_STRATEGY)
-                .locale("en").submittedOnDate(disbursementDate).amortizationType(AmortizationType.EQUAL_INSTALLMENTS)
+                .locale("en").submittedOnDate(disbursementDate).amortizationType(LoanTestData.AmortizationType.EQUAL_INSTALLMENTS)
                 .interestRatePerPeriod(new BigDecimal(12.0))
-                .interestCalculationPeriodType(InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)
-                .interestType(InterestType.DECLINING_BALANCE).repaymentEvery(15).repaymentFrequencyType(RepaymentFrequencyType.DAYS)
-                .numberOfRepayments(numberOfRepayments).loanTermFrequency(numberOfRepayments * 15).loanTermFrequencyType(0)
-                .maxOutstandingLoanBalance(BigDecimal.valueOf(amount)).principal(BigDecimal.valueOf(amount)).loanType("individual");
-        PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(postLoansRequest);
-        PostLoansLoanIdResponse approvedLoanResult = loanTransactionHelper.approveLoan(postLoansResponse.getResourceId(),
-                approveLoanRequest(amount, disbursementDate));
-        return approvedLoanResult.getLoanId();
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE).repaymentEvery(15)
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.DAYS).numberOfRepayments(numberOfRepayments)
+                .loanTermFrequency(numberOfRepayments * 15).loanTermFrequencyType(0).maxOutstandingLoanBalance(BigDecimal.valueOf(amount))
+                .principal(BigDecimal.valueOf(amount)).loanType("individual");
+        Long loanId = applyForLoan(postLoansRequest);
+        return approveLoan(loanId, approveLoanRequest(amount, disbursementDate)).getLoanId();
     }
 
     private PostLoanProductsRequest createLoanProductWithInterestCalculation() {
@@ -238,12 +200,12 @@ public class LoanAccrualTransactionWithInterestAndChargeAccrualDateAsSubmittedOn
                 .principal(1000.0)//
                 .numberOfRepayments(4)//
                 .repaymentEvery(15)//
-                .repaymentFrequencyType(RepaymentFrequencyType.DAYS.longValue())//
-                .interestType(InterestType.DECLINING_BALANCE)//
-                .amortizationType(AmortizationType.EQUAL_INSTALLMENTS)//
-                .interestCalculationPeriodType(InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.DAYS_L)//
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE)//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_INSTALLMENTS)//
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)//
                 .interestRatePerPeriod(12.0) //
-                .interestRateFrequencyType(InterestRateFrequencyType.MONTHS)//
+                .interestRateFrequencyType(LoanTestData.InterestRateFrequencyType.MONTHS)//
                 .isInterestRecalculationEnabled(true) //
                 .interestRecalculationCompoundingMethod(0).rescheduleStrategyMethod(3).recalculationRestFrequencyType(1)
                 .recalculationRestFrequencyInterval(1);

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanBuyDownFeeTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanBuyDownFeeTest.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
 import org.apache.fineract.client.models.BuyDownFeeAmortizationDetails;
 import org.apache.fineract.client.models.ExternalAssetOwnerRequest;
 import org.apache.fineract.client.models.GetCodesResponse;
@@ -40,26 +41,25 @@ import org.apache.fineract.client.models.GetLoanProductsProductIdResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdTransactions;
 import org.apache.fineract.client.models.PostClassificationToIncomeAccountMappings;
-import org.apache.fineract.client.models.PostClientsResponse;
 import org.apache.fineract.client.models.PostCodeValueDataResponse;
 import org.apache.fineract.client.models.PostCodeValuesDataRequest;
 import org.apache.fineract.client.models.PostLoanProductsRequest;
-import org.apache.fineract.client.models.PostLoanProductsResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsTransactionIdRequest;
-import org.apache.fineract.client.models.PostLoansResponse;
 import org.apache.fineract.client.models.PutLoanProductsProductIdRequest;
-import org.apache.fineract.client.util.CallFailedRuntimeException;
-import org.apache.fineract.integrationtests.common.BusinessStepHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.ExternalAssetOwnerHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignBusinessStepHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignExternalAssetOwnerHelper;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.AmortizationType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestCalculationPeriodType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestRateFrequencyType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.RepaymentFrequencyType;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.common.accounting.Account;
-import org.apache.fineract.integrationtests.common.accounting.AccountHelper;
-import org.apache.fineract.integrationtests.common.accounting.FinancialActivityAccountHelper;
 import org.apache.fineract.integrationtests.common.externalevents.BusinessEvent;
-import org.apache.fineract.integrationtests.common.externalevents.ExternalEventHelper;
 import org.apache.fineract.integrationtests.common.externalevents.LoanAdjustTransactionBusinessEvent;
 import org.apache.fineract.integrationtests.common.externalevents.LoanTransactionMinimalBusinessEvent;
 import org.apache.fineract.portfolio.loanaccount.api.LoanTransactionApiConstants;
@@ -72,14 +72,13 @@ import org.junit.jupiter.api.Test;
  * Integration tests for Buy Down Fee functionality in Progressive Loans
  */
 @Slf4j
-public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
+public class LoanBuyDownFeeTest extends FeignLoanTestBase {
 
     private Long clientId;
     private Long loanId;
 
     @AfterAll
     public static void teardown() {
-        ExternalEventHelper externalEventHelper = new ExternalEventHelper();
         externalEventHelper.disableBusinessEvent("LoanAdjustTransactionBusinessEvent");
         externalEventHelper.disableBusinessEvent("LoanBuyDownFeeTransactionCreatedBusinessEvent");
         externalEventHelper.disableBusinessEvent("LoanBuyDownFeeAdjustmentTransactionCreatedBusinessEvent");
@@ -89,25 +88,25 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
 
     @BeforeEach
     public void beforeEach() {
-        new BusinessStepHelper().updateSteps("LOAN_CLOSE_OF_BUSINESS", "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION",
-                "CHECK_LOAN_REPAYMENT_DUE", "CHECK_LOAN_REPAYMENT_OVERDUE", "CHECK_DUE_INSTALLMENTS", "UPDATE_LOAN_ARREARS_AGING",
-                "ADD_PERIODIC_ACCRUAL_ENTRIES", "ACCRUAL_ACTIVITY_POSTING", "CAPITALIZED_INCOME_AMORTIZATION", "BUY_DOWN_FEE_AMORTIZATION",
-                "LOAN_INTEREST_RECALCULATION", "EXTERNAL_ASSET_OWNER_TRANSFER");
+        new FeignBusinessStepHelper(FineractFeignClientHelper.getFineractFeignClient()).updateSteps("LOAN_CLOSE_OF_BUSINESS",
+                "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION", "CHECK_LOAN_REPAYMENT_DUE",
+                "CHECK_LOAN_REPAYMENT_OVERDUE", "CHECK_DUE_INSTALLMENTS", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
+                "ACCRUAL_ACTIVITY_POSTING", "CAPITALIZED_INCOME_AMORTIZATION", "BUY_DOWN_FEE_AMORTIZATION", "LOAN_INTEREST_RECALCULATION",
+                "EXTERNAL_ASSET_OWNER_TRANSFER");
         externalEventHelper.enableBusinessEvent("LoanAdjustTransactionBusinessEvent");
         externalEventHelper.enableBusinessEvent("LoanBuyDownFeeTransactionCreatedBusinessEvent");
         externalEventHelper.enableBusinessEvent("LoanBuyDownFeeAdjustmentTransactionCreatedBusinessEvent");
         externalEventHelper.enableBusinessEvent("LoanBuyDownFeeAmortizationTransactionCreatedBusinessEvent");
         externalEventHelper.enableBusinessEvent("LoanBuyDownFeeAmortizationAdjustmentTransactionCreatedBusinessEvent");
         runAt("01 September 2024", () -> {
-            clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
-            final PostLoanProductsResponse loanProductsResponse = loanProductHelper
-                    .createLoanProduct(createProgressiveLoanProductWithBuyDownFee(null));
+            clientId = createClient();
+            final Long loanProductsResponse = createLoanProduct(createProgressiveLoanProductWithBuyDownFee(null));
 
             // Apply for the loan with proper progressive loan settings
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applyLP2ProgressiveLoanRequest(clientId,
-                    loanProductsResponse.getResourceId(), "01 September 2024", 1000.0, 10.0, 12, null));
-            loanId = postLoansResponse.getLoanId();
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(1000.0, "01 September 2024"));
+            Long appliedLoanId = applyForLoan(
+                    applyLP2ProgressiveLoanRequest(clientId, loanProductsResponse, "01 September 2024", 1000.0, 10.0, 12, null));
+            loanId = appliedLoanId;
+            approveLoan(loanId, approveLoanRequest(1000.0, "01 September 2024"));
             disburseLoan(loanId, BigDecimal.valueOf(1000.0), "01 September 2024");
         });
     }
@@ -116,7 +115,7 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
     public void testBuyDownFeeOnProgressiveLoan() {
         runAt("02 September 2024", () -> {
             // Verify loan product has buy down fee enabled
-            final GetLoansLoanIdResponse loanDetailsBeforeTransaction = loanTransactionHelper.getLoanDetails(loanId);
+            final GetLoansLoanIdResponse loanDetailsBeforeTransaction = getLoanDetails(loanId);
             assertNotNull(loanDetailsBeforeTransaction);
             log.info("Loan Product: {}", loanDetailsBeforeTransaction.getLoanProductName());
 
@@ -128,7 +127,7 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
             assertNotNull(buyDownFeeTransactionId);
 
             // Verify transaction was created in loan details
-            final GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            final GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             assertNotNull(loanDetails);
 
             // Find the buy down fee transaction
@@ -154,7 +153,7 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
 
             deleteAllExternalEvents();
 
-            PostLoansLoanIdTransactionsResponse response = loanTransactionHelper.makeLoanBuyDownFee(loanId,
+            PostLoansLoanIdTransactionsResponse response = makeLoanBuyDownFee(loanId,
                     new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate("03 September 2024").locale("en")
                             .transactionAmount(250.0).externalId(externalId).note(noteText));
 
@@ -162,7 +161,7 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
             verifyBusinessEvents(new BusinessEvent("LoanBuyDownFeeTransactionCreatedBusinessEvent", "03 September 2024"));
 
             // Verify transaction details
-            final GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            final GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             GetLoansLoanIdTransactions buyDownFeeTransaction = loanDetails.getTransactions().stream()
                     .filter(t -> t.getType() != null && t.getType().getId() != null && t.getType().getId().equals(40L))
                     .filter(t -> externalId.equals(t.getExternalId())).findFirst().orElse(null);
@@ -192,7 +191,7 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
             assertNotNull(secondBuyDownFeeId);
 
             // Verify both transactions exist
-            final GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            final GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             long buyDownFeeCount = loanDetails.getTransactions().stream()
                     .filter(t -> t.getType() != null && t.getType().getId() != null && t.getType().getId().equals(40L)).count();
 
@@ -207,7 +206,7 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
             Long buyDownFeeTransactionId = addBuyDownFeeForLoan(loanId, 250.0, "04 September 2024");
             assertNotNull(buyDownFeeTransactionId);
 
-            final GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            final GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             GetLoansLoanIdTransactions buyDownFeeTransaction = loanDetails.getTransactions().stream()
                     .filter(t -> t.getType() != null && t.getType().getId() != null && t.getType().getId().equals(40L))
                     .filter(t -> buyDownFeeTransactionId.equals(t.getId())).findFirst().orElse(null);
@@ -215,8 +214,11 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
             assertNotNull(buyDownFeeTransaction, "Buy down fee transaction should exist");
             assertEquals(0, BigDecimal.valueOf(250.0).compareTo(buyDownFeeTransaction.getAmount()));
 
-            verifyTRJournalEntries(buyDownFeeTransactionId, debit(buyDownExpenseAccount, 250.0), // DR: Buy Down Expense
-                    credit(deferredIncomeLiabilityAccount, 250.0) // CR: Deferred Income Liability
+            verifyTRJournalEntries(buyDownFeeTransactionId, debit(getAccounts().getBuyDownExpenseAccount(), 250.0), // DR:
+                                                                                                                    // Buy
+                                                                                                                    // Down
+                                                                                                                    // Expense
+                    credit(getAccounts().getDeferredIncomeLiabilityAccount(), 250.0) // CR: Deferred Income Liability
             );
 
             log.info("Buy Down Fee transaction created successfully (accounting validation pending client model regeneration)");
@@ -228,7 +230,7 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
         runAt("05 September 2024", () -> {
             // Test with negative amount (should fail)
             try {
-                PostLoansLoanIdTransactionsResponse response = loanTransactionHelper.makeLoanBuyDownFee(loanId,
+                PostLoansLoanIdTransactionsResponse response = makeLoanBuyDownFee(loanId,
                         new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate("05 September 2024")
                                 .locale("en").transactionAmount(-100.0).note("Invalid negative amount"));
                 assertTrue(false, "Buy down fee with negative amount should have failed");
@@ -239,7 +241,7 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
 
             // Test with zero amount (should fail)
             try {
-                PostLoansLoanIdTransactionsResponse response = loanTransactionHelper.makeLoanBuyDownFee(loanId,
+                PostLoansLoanIdTransactionsResponse response = makeLoanBuyDownFee(loanId,
                         new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate("05 September 2024")
                                 .locale("en").transactionAmount(0.0).note("Invalid zero amount"));
                 assertTrue(false, "Buy down fee with zero amount should have failed");
@@ -270,23 +272,23 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
                 .daysInMonthType(30).daysInYearType(360).isInterestRecalculationEnabled(false).accountingRule(3) // Accrual-based
                                                                                                                  // accounting
                 // GL Account Mappings for Accrual-Based Accounting
-                .fundSourceAccountId(fundSource.getAccountID().longValue())
-                .loanPortfolioAccountId(loansReceivableAccount.getAccountID().longValue())
-                .transfersInSuspenseAccountId(suspenseAccount.getAccountID().longValue())
-                .interestOnLoanAccountId(interestIncomeAccount.getAccountID().longValue())
-                .incomeFromFeeAccountId(feeIncomeAccount.getAccountID().longValue())
-                .incomeFromPenaltyAccountId(penaltyIncomeAccount.getAccountID().longValue())
-                .incomeFromRecoveryAccountId(recoveriesAccount.getAccountID().longValue())
-                .writeOffAccountId(writtenOffAccount.getAccountID().longValue())
-                .overpaymentLiabilityAccountId(overpaymentAccount.getAccountID().longValue())
+                .fundSourceAccountId(getAccounts().getFundSource().getAccountID().longValue())
+                .loanPortfolioAccountId(getAccounts().getLoansReceivableAccount().getAccountID().longValue())
+                .transfersInSuspenseAccountId(getAccounts().getSuspenseAccount().getAccountID().longValue())
+                .interestOnLoanAccountId(getAccounts().getInterestIncomeAccount().getAccountID().longValue())
+                .incomeFromFeeAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())
+                .incomeFromPenaltyAccountId(getAccounts().getPenaltyIncomeAccount().getAccountID().longValue())
+                .incomeFromRecoveryAccountId(getAccounts().getRecoveriesAccount().getAccountID().longValue())
+                .writeOffAccountId(getAccounts().getWrittenOffAccount().getAccountID().longValue())
+                .overpaymentLiabilityAccountId(getAccounts().getOverpaymentAccount().getAccountID().longValue())
                 // Receivable accounts required for accrual-based accounting
-                .receivableInterestAccountId(interestReceivableAccount.getAccountID().longValue())
-                .receivableFeeAccountId(feeReceivableAccount.getAccountID().longValue())
-                .receivablePenaltyAccountId(penaltyReceivableAccount.getAccountID().longValue())
-                .buyDownExpenseAccountId(buyDownExpenseAccount.getAccountID().longValue())
-                .incomeFromBuyDownAccountId(feeIncomeAccount.getAccountID().longValue())
-                .deferredIncomeLiabilityAccountId(deferredIncomeLiabilityAccount.getAccountID().longValue()).loanScheduleType("PROGRESSIVE")
-                .loanScheduleProcessingType("HORIZONTAL").enableBuyDownFee(true).merchantBuyDownFee(true)
+                .receivableInterestAccountId(getAccounts().getInterestReceivableAccount().getAccountID().longValue())
+                .receivableFeeAccountId(getAccounts().getFeeReceivableAccount().getAccountID().longValue())
+                .receivablePenaltyAccountId(getAccounts().getPenaltyReceivableAccount().getAccountID().longValue())
+                .buyDownExpenseAccountId(getAccounts().getBuyDownExpenseAccount().getAccountID().longValue())
+                .incomeFromBuyDownAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())
+                .deferredIncomeLiabilityAccountId(getAccounts().getDeferredIncomeLiabilityAccount().getAccountID().longValue())
+                .loanScheduleType("PROGRESSIVE").loanScheduleProcessingType("HORIZONTAL").enableBuyDownFee(true).merchantBuyDownFee(true)
                 .buyDownFeeCalculationType(PostLoanProductsRequest.BuyDownFeeCalculationTypeEnum.FLAT)
                 .buyDownFeeStrategy(PostLoanProductsRequest.BuyDownFeeStrategyEnum.EQUAL_AMORTIZATION)
                 .buyDownFeeIncomeType(PostLoanProductsRequest.BuyDownFeeIncomeTypeEnum.FEE).locale("en").dateFormat("dd MMMM yyyy");
@@ -309,8 +311,8 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
             deleteAllExternalEvents();
 
             // Create buy down fee adjustment (use same date as business date)
-            PostLoansLoanIdTransactionsResponse adjustmentResponse = loanTransactionHelper.buyDownFeeAdjustment(loanId,
-                    buyDownFeeTransactionId, "06 September 2024", 100.0);
+            PostLoansLoanIdTransactionsResponse adjustmentResponse = buyDownFeeAdjustment(loanId, buyDownFeeTransactionId,
+                    "06 September 2024", 100.0);
 
             verifyBusinessEvents(new LoanTransactionMinimalBusinessEvent("LoanBuyDownFeeAdjustmentTransactionCreatedBusinessEvent",
                     "06 September 2024", 100.0, false));
@@ -322,7 +324,7 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
             assertEquals(loanId, adjustmentResponse.getLoanId());
 
             // Verify loan details show both transactions
-            final GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            final GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             assertNotNull(loanDetails);
 
             List<GetLoansLoanIdTransactions> transactions = loanDetails.getTransactions();
@@ -337,7 +339,7 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
             assertEquals("06 September 2024", adjustmentTransaction.getDate().format(DateTimeFormatter.ofPattern("dd MMMM yyyy")));
 
             deleteAllExternalEvents();
-            loanTransactionHelper.reverseLoanTransaction(loanId, adjustmentResponse.getResourceId(), "06 September 2024");
+            reverseLoanTransaction(loanId, adjustmentResponse.getResourceId(), "06 September 2024");
             verifyBusinessEvents(new LoanAdjustTransactionBusinessEvent("LoanAdjustTransactionBusinessEvent", "06 September 2024",
                     "loanTransactionType.buyDownFeeAdjustment", "2024-09-06"));
 
@@ -353,7 +355,7 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
 
             // Test 1: Adjustment amount more than original amount (should fail)
             try {
-                loanTransactionHelper.buyDownFeeAdjustment(loanId, buyDownFeeTransactionId, "08 September 2024", 400.0);
+                buyDownFeeAdjustment(loanId, buyDownFeeTransactionId, "08 September 2024", 400.0);
                 assertTrue(false, "Expected validation error for adjustment amount exceeding original amount");
             } catch (Exception e) {
                 log.info("Expected validation error for excessive adjustment amount: {}", e.getMessage());
@@ -362,7 +364,7 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
 
             // Test 2: Adjustment date before original transaction date (should fail)
             try {
-                loanTransactionHelper.buyDownFeeAdjustment(loanId, buyDownFeeTransactionId, "07 September 2024", 100.0);
+                buyDownFeeAdjustment(loanId, buyDownFeeTransactionId, "07 September 2024", 100.0);
                 assertTrue(false, "Expected validation error for adjustment date before original transaction date");
             } catch (Exception e) {
                 log.info("Expected validation error for early adjustment date: {}", e.getMessage());
@@ -370,13 +372,13 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
             }
 
             // Test 3: Valid adjustment should succeed
-            PostLoansLoanIdTransactionsResponse validAdjustment = loanTransactionHelper.buyDownFeeAdjustment(loanId,
-                    buyDownFeeTransactionId, "08 September 2024", 150.0);
+            PostLoansLoanIdTransactionsResponse validAdjustment = buyDownFeeAdjustment(loanId, buyDownFeeTransactionId, "08 September 2024",
+                    150.0);
             assertNotNull(validAdjustment);
 
             // Test 4: Second adjustment that would exceed total should fail
             try {
-                loanTransactionHelper.buyDownFeeAdjustment(loanId, buyDownFeeTransactionId, "08 September 2024", 200.0);
+                buyDownFeeAdjustment(loanId, buyDownFeeTransactionId, "08 September 2024", 200.0);
                 assertTrue(false, "Expected validation error for total adjustments exceeding original amount");
             } catch (Exception e) {
                 log.info("Expected validation error for cumulative adjustment excess: {}", e.getMessage());
@@ -393,12 +395,12 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
             assertNotNull(buyDownFeeTransactionId);
 
             // Verify initial buy down fee accounting entries
-            verifyTRJournalEntries(buyDownFeeTransactionId, debit(buyDownExpenseAccount, 400.0),
-                    credit(deferredIncomeLiabilityAccount, 400.0));
+            verifyTRJournalEntries(buyDownFeeTransactionId, debit(getAccounts().getBuyDownExpenseAccount(), 400.0),
+                    credit(getAccounts().getDeferredIncomeLiabilityAccount(), 400.0));
 
             // Create buy down fee adjustment
-            PostLoansLoanIdTransactionsResponse adjustmentResponse = loanTransactionHelper.buyDownFeeAdjustment(loanId,
-                    buyDownFeeTransactionId, "10 September 2024", 120.0);
+            PostLoansLoanIdTransactionsResponse adjustmentResponse = buyDownFeeAdjustment(loanId, buyDownFeeTransactionId,
+                    "10 September 2024", 120.0);
             assertNotNull(adjustmentResponse);
         });
     }
@@ -416,22 +418,22 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
             deleteAllExternalEvents();
 
             // First adjustment
-            PostLoansLoanIdTransactionsResponse adjustment1 = loanTransactionHelper.buyDownFeeAdjustment(loanId, buyDownFeeTransactionId,
-                    "12 September 2024", 100.0);
+            PostLoansLoanIdTransactionsResponse adjustment1 = buyDownFeeAdjustment(loanId, buyDownFeeTransactionId, "12 September 2024",
+                    100.0);
             assertNotNull(adjustment1);
 
             verifyBusinessEvents(new BusinessEvent("LoanBuyDownFeeAdjustmentTransactionCreatedBusinessEvent", "12 September 2024"));
             deleteAllExternalEvents();
 
             // Second adjustment
-            PostLoansLoanIdTransactionsResponse adjustment2 = loanTransactionHelper.buyDownFeeAdjustment(loanId, buyDownFeeTransactionId,
-                    "12 September 2024", 150.0);
+            PostLoansLoanIdTransactionsResponse adjustment2 = buyDownFeeAdjustment(loanId, buyDownFeeTransactionId, "12 September 2024",
+                    150.0);
             assertNotNull(adjustment2);
 
             verifyBusinessEvents(new BusinessEvent("LoanBuyDownFeeAdjustmentTransactionCreatedBusinessEvent", "12 September 2024"));
 
             // Verify both adjustments are recorded
-            final GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            final GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             assertNotNull(loanDetails);
 
             List<GetLoansLoanIdTransactions> adjustmentTransactions = loanDetails.getTransactions().stream()
@@ -446,7 +448,7 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
 
             // Third adjustment that would exceed limit should fail
             try {
-                loanTransactionHelper.buyDownFeeAdjustment(loanId, buyDownFeeTransactionId, "12 September 2024", 400.0);
+                buyDownFeeAdjustment(loanId, buyDownFeeTransactionId, "12 September 2024", 400.0);
                 assertTrue(false, "Expected validation error for total adjustments exceeding original amount");
             } catch (Exception e) {
                 log.info("Expected validation error for cumulative adjustments exceeding limit: {}", e.getMessage());
@@ -465,8 +467,7 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
             deleteAllExternalEvents();
             // Create adjustment with external ID
             String adjustmentExternalId = UUID.randomUUID().toString();
-            PostLoansLoanIdTransactionsResponse adjustmentResponse = loanTransactionHelper.buyDownFeeAdjustment(loanId,
-                    buyDownFeeTransactionId,
+            PostLoansLoanIdTransactionsResponse adjustmentResponse = buyDownFeeAdjustment(loanId, buyDownFeeTransactionId,
                     new PostLoansLoanIdTransactionsTransactionIdRequest().transactionDate("16 September 2024").transactionAmount(80.0)
                             .externalId(adjustmentExternalId).note("Buy Down Fee Adjustment with external ID").dateFormat("dd MMMM yyyy")
                             .locale("en"));
@@ -477,7 +478,7 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
             verifyBusinessEvents(new BusinessEvent("LoanBuyDownFeeAdjustmentTransactionCreatedBusinessEvent", "16 September 2024"));
 
             // Verify adjustment transaction details
-            final GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            final GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             GetLoansLoanIdTransactions adjustmentTransaction = loanDetails.getTransactions().stream()
                     .filter(txn -> adjustmentExternalId.equals(txn.getExternalId())).findFirst().orElse(null);
 
@@ -499,7 +500,7 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
      */
     private Long addBuyDownFeeForLoan(Long loanId, Double amount, String date) {
         String buyDownFeeExternalId = UUID.randomUUID().toString();
-        PostLoansLoanIdTransactionsResponse response = loanTransactionHelper.makeLoanBuyDownFee(loanId,
+        PostLoansLoanIdTransactionsResponse response = makeLoanBuyDownFee(loanId,
                 new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate(date).locale("en")
                         .transactionAmount(amount).externalId(buyDownFeeExternalId).note("Buy Down Fee Transaction"));
         return response.getResourceId();
@@ -507,7 +508,7 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
 
     private Long addBuyDownFeeForLoan(Long loanId, Double amount, String date, Long classificationId) {
         String buyDownFeeExternalId = UUID.randomUUID().toString();
-        PostLoansLoanIdTransactionsResponse response = loanTransactionHelper.makeLoanBuyDownFee(loanId,
+        PostLoansLoanIdTransactionsResponse response = makeLoanBuyDownFee(loanId,
                 new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate(date).locale("en")
                         .transactionAmount(amount).externalId(buyDownFeeExternalId).note("Buy Down Fee Transaction")
                         .classificationId(classificationId));
@@ -519,25 +520,23 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
         final AtomicReference<Long> loanIdRef = new AtomicReference<>();
         final AtomicReference<Long> buyDownFeeTransactionIdIdRef = new AtomicReference<>();
 
-        final PostClientsResponse client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+        final Long localClientId = createClient();
 
-        final PostLoanProductsResponse loanProductsResponse = loanProductHelper.createLoanProduct(create4IProgressive()
-                .enableBuyDownFee(true).buyDownFeeCalculationType(PostLoanProductsRequest.BuyDownFeeCalculationTypeEnum.FLAT)
+        final Long loanProductsResponse = createLoanProduct(create4IProgressive().enableBuyDownFee(true)
+                .buyDownFeeCalculationType(PostLoanProductsRequest.BuyDownFeeCalculationTypeEnum.FLAT)
                 .buyDownFeeStrategy(PostLoanProductsRequest.BuyDownFeeStrategyEnum.EQUAL_AMORTIZATION)
                 .buyDownFeeIncomeType(PostLoanProductsRequest.BuyDownFeeIncomeTypeEnum.FEE)
-                .buyDownExpenseAccountId(buyDownExpenseAccount.getAccountID().longValue()).merchantBuyDownFee(true)
-                .deferredIncomeLiabilityAccountId(deferredIncomeLiabilityAccount.getAccountID().longValue())
-                .incomeFromBuyDownAccountId(feeIncomeAccount.getAccountID().longValue()));
+                .buyDownExpenseAccountId(getAccounts().getBuyDownExpenseAccount().getAccountID().longValue()).merchantBuyDownFee(true)
+                .deferredIncomeLiabilityAccountId(getAccounts().getDeferredIncomeLiabilityAccount().getAccountID().longValue())
+                .incomeFromBuyDownAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue()));
 
         runAt("1 January 2024", () -> {
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProductsResponse.getResourceId(), "1 January 2024",
-                    500.0, 7.0, 3, null);
+            Long loanId = applyAndApproveProgressiveLoan(localClientId, loanProductsResponse, "1 January 2024", 500.0, 7.0, 3, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(100), "1 January 2024");
             deleteAllExternalEvents();
-            PostLoansLoanIdTransactionsResponse transactionsResponse = loanTransactionHelper.makeLoanBuyDownFee(loanId, "1 January 2024",
-                    50.0);
+            PostLoansLoanIdTransactionsResponse transactionsResponse = makeLoanBuyDownFee(loanId, "1 January 2024", 50.0);
             buyDownFeeTransactionIdIdRef.set(transactionsResponse.getResourceId());
             verifyBusinessEvents(new BusinessEvent("LoanBuyDownFeeTransactionCreatedBusinessEvent", "01 January 2024"));
         });
@@ -570,7 +569,7 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
                     transaction(0.55, "Buy Down Fee Amortization", "31 January 2024"));
 
             deleteAllExternalEvents();
-            loanTransactionHelper.buyDownFeeAdjustment(loanId, buyDownFeeTransactionIdIdRef.get(), "1 February 2024", 10.0);
+            buyDownFeeAdjustment(loanId, buyDownFeeTransactionIdIdRef.get(), "1 February 2024", 10.0);
             verifyBusinessEvents(new BusinessEvent("LoanBuyDownFeeAdjustmentTransactionCreatedBusinessEvent", "01 February 2024"));
         });
         runAt("2 February 2024", () -> {
@@ -592,7 +591,7 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
                     transaction(0.39, "Buy Down Fee Amortization", "01 February 2024"));
 
             deleteAllExternalEvents();
-            loanTransactionHelper.buyDownFeeAdjustment(loanId, buyDownFeeTransactionIdIdRef.get(), "10 January 2024", 10.0);
+            buyDownFeeAdjustment(loanId, buyDownFeeTransactionIdIdRef.get(), "10 January 2024", 10.0);
             verifyBusinessEvents(new BusinessEvent("LoanBuyDownFeeAdjustmentTransactionCreatedBusinessEvent", "02 February 2024"));
         });
         runAt("3 February 2024", () -> {
@@ -618,7 +617,7 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
                     transaction(2.55, "Buy Down Fee Amortization Adjustment", "02 February 2024"));
 
             deleteAllExternalEvents();
-            loanTransactionHelper.buyDownFeeAdjustment(loanId, buyDownFeeTransactionIdIdRef.get(), "03 February 2024", 20.0);
+            buyDownFeeAdjustment(loanId, buyDownFeeTransactionIdIdRef.get(), "03 February 2024", 20.0);
             verifyBusinessEvents(new BusinessEvent("LoanBuyDownFeeAdjustmentTransactionCreatedBusinessEvent", "03 February 2024"));
         });
         runAt("4 February 2024", () -> {
@@ -647,7 +646,7 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
                     transaction(4.87, "Buy Down Fee Amortization Adjustment", "03 February 2024"));
 
             // Check journal entries of amortization and amortization adjustment
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
 
             Optional<GetLoansLoanIdTransactions> amortizationTransactionOpt = loanDetails.getTransactions().stream()
                     .filter(transaction -> LocalDate.of(2024, 2, 1).equals(transaction.getDate())
@@ -656,8 +655,8 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
             Assertions.assertTrue(amortizationTransactionOpt.isPresent());
 
             verifyTRJournalEntries(amortizationTransactionOpt.get().getId(), //
-                    journalEntry(0.39, feeIncomeAccount, "CREDIT"), //
-                    journalEntry(0.39, deferredIncomeLiabilityAccount, "DEBIT"));
+                    journalEntry(0.39, getAccounts().getFeeIncomeAccount(), "CREDIT"), //
+                    journalEntry(0.39, getAccounts().getDeferredIncomeLiabilityAccount(), "DEBIT"));
 
             Optional<GetLoansLoanIdTransactions> amortizationAdjustmentTransactionOpt = loanDetails.getTransactions().stream()
                     .filter(transaction -> LocalDate.of(2024, 2, 3).equals(transaction.getDate())
@@ -666,24 +665,23 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
             Assertions.assertTrue(amortizationAdjustmentTransactionOpt.isPresent());
 
             verifyTRJournalEntries(amortizationAdjustmentTransactionOpt.get().getId(), //
-                    journalEntry(4.87, deferredIncomeLiabilityAccount, "CREDIT"), //
-                    journalEntry(4.87, feeIncomeAccount, "DEBIT"));
+                    journalEntry(4.87, getAccounts().getDeferredIncomeLiabilityAccount(), "CREDIT"), //
+                    journalEntry(4.87, getAccounts().getFeeIncomeAccount(), "DEBIT"));
         });
     }
 
     @Test
     public void testRetrieveBuyDownFeeAmortizationDetails() {
-        final PostClientsResponse client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
-        final PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(createProgressiveLoanProductWithBuyDownFee(null));
+        final Long localClientId = createClient();
+        final Long loanProduct = createLoanProduct(createProgressiveLoanProductWithBuyDownFee(null));
 
-        final long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 February 2024", 1000.0,
-                7.0, 6, null);
+        final long loanId = applyAndApproveProgressiveLoan(localClientId, loanProduct, "1 February 2024", 1000.0, 7.0, 6, null);
 
         disburseLoan(loanId, BigDecimal.valueOf(1000), "1 February 2024");
 
         addBuyDownFeeForLoan(loanId, 100.0, "1 February 2024");
 
-        final List<BuyDownFeeAmortizationDetails> amortizationDetails = loanTransactionHelper.fetchBuyDownFeeAmortizationDetails(loanId);
+        final List<BuyDownFeeAmortizationDetails> amortizationDetails = fetchBuyDownFeeAmortizationDetails(loanId);
 
         assertNotNull(amortizationDetails);
         assertFalse(amortizationDetails.isEmpty());
@@ -704,12 +702,10 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
 
     @Test
     public void testRetrieveBuyDownFeeAmortizationDetails_notEnabled() {
-        final PostClientsResponse client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
-        final PostLoanProductsResponse loanProduct = loanProductHelper
-                .createLoanProduct(createProgressiveLoanProductWithBuyDownFee(null).enableBuyDownFee(false));
+        final Long localClientId = createClient();
+        final Long loanProduct = createLoanProduct(createProgressiveLoanProductWithBuyDownFee(null).enableBuyDownFee(false));
 
-        final long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 February 2024", 1000.0,
-                7.0, 6, null);
+        final long loanId = applyAndApproveProgressiveLoan(localClientId, loanProduct, "1 February 2024", 1000.0, 7.0, 6, null);
 
         disburseLoan(loanId, BigDecimal.valueOf(1000), "1 February 2024");
 
@@ -717,7 +713,7 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
             addBuyDownFeeForLoan(loanId, 100.0, "1 February 2024");
         });
 
-        assertEquals(400, exception.getResponse().code());
+        assertEquals(400, exception.getStatus());
         assertTrue(exception.getMessage().contains("buy.down.fee.not.enabled"));
         assertTrue(exception.getMessage().contains("Buy down fee is not enabled for this loan product"));
     }
@@ -736,7 +732,7 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
         });
         runAt("10 September 2024", () -> {
             deleteAllExternalEvents();
-            inlineLoanCOBHelper.executeInlineCOB(loanId);
+            executeInlineCOB(loanId);
 
             verifyBusinessEvents(new LoanTransactionMinimalBusinessEvent("LoanBuyDownFeeAmortizationTransactionCreatedBusinessEvent",
                     "09 September 2024", 8.79, false));
@@ -744,9 +740,9 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
             deleteAllExternalEvents();
             Long buyDownFeeTransactionId = buyDownFeeTransactionIdRef.get();
             // Reverse Buy Down Fee
-            PostLoansLoanIdTransactionsResponse transactionsResponse = loanTransactionHelper.reverseLoanTransaction(loanId,
-                    buyDownFeeTransactionId, new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN)
-                            .transactionDate("10 September 2024").note("Buy Down Fee reversed").transactionAmount(0.0).locale("en"));
+            PostLoansLoanIdTransactionsResponse transactionsResponse = reverseLoanTransaction(loanId, buyDownFeeTransactionId,
+                    new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("10 September 2024")
+                            .note("Buy Down Fee reversed").transactionAmount(0.0).locale("en"));
             Assertions.assertNotNull(transactionsResponse);
             Assertions.assertNotNull(transactionsResponse.getResourceId());
             Assertions.assertEquals(transactionsResponse.getResourceId(), buyDownFeeTransactionId);
@@ -780,17 +776,17 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
             buyDownFeeTransactionIdIdRef.set(buyDownFeeTransactionId);
 
             // Verify initial buy down fee accounting entries
-            verifyTRJournalEntries(buyDownFeeTransactionId, debit(buyDownExpenseAccount, 400.0),
-                    credit(deferredIncomeLiabilityAccount, 400.0));
+            verifyTRJournalEntries(buyDownFeeTransactionId, debit(getAccounts().getBuyDownExpenseAccount(), 400.0),
+                    credit(getAccounts().getDeferredIncomeLiabilityAccount(), 400.0));
 
             verifyTransactions(loanId, //
                     transaction(1000.0, "Disbursement", "01 September 2024"), //
                     transaction(400.0, "Buy Down Fee", "10 September 2024"));
 
             // Reverse Buy Down Fee
-            PostLoansLoanIdTransactionsResponse transactionsResponse = loanTransactionHelper.reverseLoanTransaction(loanId,
-                    buyDownFeeTransactionId, new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN)
-                            .transactionDate("10 September 2024").note("Buy Down Fee reversed").transactionAmount(0.0).locale("en"));
+            PostLoansLoanIdTransactionsResponse transactionsResponse = reverseLoanTransaction(loanId, buyDownFeeTransactionId,
+                    new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("10 September 2024")
+                            .note("Buy Down Fee reversed").transactionAmount(0.0).locale("en"));
             Assertions.assertNotNull(transactionsResponse);
             Assertions.assertNotNull(transactionsResponse.getResourceId());
             Assertions.assertEquals(transactionsResponse.getResourceId(), buyDownFeeTransactionId);
@@ -817,8 +813,8 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
                     "10 September 2024", 400.0, false));
 
             // Verify initial buy down fee accounting entries
-            verifyTRJournalEntries(buyDownFeeTransactionId, debit(buyDownExpenseAccount, 400.0),
-                    credit(deferredIncomeLiabilityAccount, 400.0));
+            verifyTRJournalEntries(buyDownFeeTransactionId, debit(getAccounts().getBuyDownExpenseAccount(), 400.0),
+                    credit(getAccounts().getDeferredIncomeLiabilityAccount(), 400.0));
 
             verifyTransactions(loanId, //
                     transaction(1000.0, "Disbursement", "01 September 2024"), //
@@ -834,9 +830,9 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
 
             deleteAllExternalEvents();
             // Reverse Buy Down Fee
-            PostLoansLoanIdTransactionsResponse transactionsResponse = loanTransactionHelper.reverseLoanTransaction(loanId,
-                    buyDownFeeTransactionId, new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN)
-                            .transactionDate("10 September 2024").note("Buy Down Fee reversed").transactionAmount(0.0).locale("en"));
+            PostLoansLoanIdTransactionsResponse transactionsResponse = reverseLoanTransaction(loanId, buyDownFeeTransactionId,
+                    new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("10 September 2024")
+                            .note("Buy Down Fee reversed").transactionAmount(0.0).locale("en"));
             Assertions.assertNotNull(transactionsResponse);
             Assertions.assertNotNull(transactionsResponse.getResourceId());
             Assertions.assertEquals(transactionsResponse.getResourceId(), buyDownFeeTransactionId);
@@ -845,9 +841,10 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
                     "loanTransactionType.buyDownFee", "2024-09-10"));
 
             // Verify initial buy down fee reversed accounting entries
-            verifyTRJournalEntries(buyDownFeeTransactionId, debit(buyDownExpenseAccount, 400.0),
-                    credit(deferredIncomeLiabilityAccount, 400.0), credit(buyDownExpenseAccount, 400.0),
-                    debit(deferredIncomeLiabilityAccount, 400.0));
+            verifyTRJournalEntries(buyDownFeeTransactionId, debit(getAccounts().getBuyDownExpenseAccount(), 400.0),
+                    credit(getAccounts().getDeferredIncomeLiabilityAccount(), 400.0),
+                    credit(getAccounts().getBuyDownExpenseAccount(), 400.0),
+                    debit(getAccounts().getDeferredIncomeLiabilityAccount(), 400.0));
 
             verifyTransactions(loanId, //
                     transaction(1000.000000, "Disbursement", "01 September 2024", 1000.000000, 0, 0, 0, 0, 0, 0, false), //
@@ -869,8 +866,8 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
             buyDownFeeTransactionIdIdRef.set(buyDownFeeTransactionId);
 
             // Verify initial buy down fee accounting entries
-            verifyTRJournalEntries(buyDownFeeTransactionId, debit(buyDownExpenseAccount, 400.0),
-                    credit(deferredIncomeLiabilityAccount, 400.0));
+            verifyTRJournalEntries(buyDownFeeTransactionId, debit(getAccounts().getBuyDownExpenseAccount(), 400.0),
+                    credit(getAccounts().getDeferredIncomeLiabilityAccount(), 400.0));
 
             verifyTransactions(loanId, //
                     transaction(1000.0, "Disbursement", "01 September 2024"), //
@@ -881,15 +878,15 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
             final Long buyDownFeeTransactionId = buyDownFeeTransactionIdIdRef.get();
             executeInlineCOB(loanId);
 
-            loanTransactionHelper.buyDownFeeAdjustment(loanId, buyDownFeeTransactionId, "23 September 2024", 200.0);
+            buyDownFeeAdjustment(loanId, buyDownFeeTransactionId, "23 September 2024", 200.0);
 
             // Try to Reverse Buy Down Fee that has linked a Buy Down Fee Adjustment
             CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.reverseLoanTransaction(loanId, buyDownFeeTransactionId,
+                    () -> reverseLoanTransaction(loanId, buyDownFeeTransactionId,
                             new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN)
                                     .transactionDate("10 September 2024").note("Buy Down Fee reversed").transactionAmount(0.0)
                                     .locale("en")));
-            assertEquals(403, exception.getResponse().code());
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("buy.down.fee.cannot.be.reversed.when.adjusted"));
         });
     }
@@ -900,14 +897,13 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
             deleteAllExternalEvents();
             // Add initial buy down fee
 
-            final PostLoanProductsResponse loanProductsResponse = loanProductHelper
-                    .createLoanProduct(createProgressiveLoanProductWithBuyDownFee(null).merchantBuyDownFee(false));
+            final Long loanProductsResponse = createLoanProduct(createProgressiveLoanProductWithBuyDownFee(null).merchantBuyDownFee(false));
 
             // Apply for the loan with proper progressive loan settings
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applyLP2ProgressiveLoanRequest(clientId,
-                    loanProductsResponse.getResourceId(), "01 September 2024", 1000.0, 10.0, 12, null));
-            loanId = postLoansResponse.getLoanId();
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(1000.0, "01 September 2024"));
+            Long appliedLoanId = applyForLoan(
+                    applyLP2ProgressiveLoanRequest(clientId, loanProductsResponse, "01 September 2024", 1000.0, 10.0, 12, null));
+            loanId = appliedLoanId;
+            approveLoan(loanId, approveLoanRequest(1000.0, "01 September 2024"));
             disburseLoan(loanId, BigDecimal.valueOf(1000.0), "01 September 2024");
 
             Long buyDownFeeTransactionId = addBuyDownFeeForLoan(loanId, 400.0, "10 September 2024");
@@ -918,31 +914,33 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
                     transaction(400.0, "Buy Down Fee", "10 September 2024"));
 
             // Verify initial buy down fee (non merchant) accounting entries
-            verifyTRJournalEntries(buyDownFeeTransactionId, debit(fundSource, 400.0), credit(deferredIncomeLiabilityAccount, 400.0));
+            verifyTRJournalEntries(buyDownFeeTransactionId, debit(getAccounts().getFundSource(), 400.0),
+                    credit(getAccounts().getDeferredIncomeLiabilityAccount(), 400.0));
 
             // Reverse Buy Down Fee (non merchant)
-            PostLoansLoanIdTransactionsResponse transactionsResponse = loanTransactionHelper.reverseLoanTransaction(loanId,
-                    buyDownFeeTransactionId, new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN)
-                            .transactionDate("10 September 2024").note("Buy Down Fee reversed").transactionAmount(0.0).locale("en"));
+            PostLoansLoanIdTransactionsResponse transactionsResponse = reverseLoanTransaction(loanId, buyDownFeeTransactionId,
+                    new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("10 September 2024")
+                            .note("Buy Down Fee reversed").transactionAmount(0.0).locale("en"));
             Assertions.assertNotNull(transactionsResponse);
             Assertions.assertNotNull(transactionsResponse.getResourceId());
             Assertions.assertEquals(transactionsResponse.getResourceId(), buyDownFeeTransactionId);
 
             // Verify initial buy down fee (non merchant) reversed accounting entries
-            verifyTRJournalEntries(buyDownFeeTransactionId, debit(fundSource, 400.0), credit(deferredIncomeLiabilityAccount, 400.0),
-                    credit(fundSource, 400.0), debit(deferredIncomeLiabilityAccount, 400.0));
+            verifyTRJournalEntries(buyDownFeeTransactionId, debit(getAccounts().getFundSource(), 400.0),
+                    credit(getAccounts().getDeferredIncomeLiabilityAccount(), 400.0), credit(getAccounts().getFundSource(), 400.0),
+                    debit(getAccounts().getDeferredIncomeLiabilityAccount(), 400.0));
 
             buyDownFeeTransactionId = addBuyDownFeeForLoan(loanId, 400.0, "10 September 2024");
             assertNotNull(buyDownFeeTransactionId);
 
             // Buy Down Fee Adjustment (non merchant)
-            final PostLoansLoanIdTransactionsResponse buyDownFeeAdjustmentTransaction = loanTransactionHelper.buyDownFeeAdjustment(loanId,
+            final PostLoansLoanIdTransactionsResponse buyDownFeeAdjustmentTransaction = buyDownFeeAdjustment(loanId,
                     buyDownFeeTransactionId, "10 September 2024", 200.0);
             assertNotNull(buyDownFeeAdjustmentTransaction);
 
             // Verify buy down fee adjustment (non merchant)
-            verifyTRJournalEntries(buyDownFeeAdjustmentTransaction.getResourceId(), debit(deferredIncomeLiabilityAccount, 200.0),
-                    credit(fundSource, 200.0));
+            verifyTRJournalEntries(buyDownFeeAdjustmentTransaction.getResourceId(),
+                    debit(getAccounts().getDeferredIncomeLiabilityAccount(), 200.0), credit(getAccounts().getFundSource(), 200.0));
         });
     }
 
@@ -954,7 +952,6 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
         runAt("10 September 2024", () -> {
             deleteAllExternalEvents();
 
-            final AccountHelper accountHelper = new AccountHelper(this.requestSpec, this.responseSpec);
             final Account classificationIncomeAccount = accountHelper
                     .createIncomeAccount(Utils.uniqueRandomStringGenerator("buydownfee_class_income_", 6));
             classificationIncomeAccountRef.set(classificationIncomeAccount);
@@ -968,11 +965,9 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
             final PostClassificationToIncomeAccountMappings classificationToIncomeMapping = new PostClassificationToIncomeAccountMappings()
                     .classificationCodeValueId(classificationIdRef.get())
                     .incomeAccountId(classificationIncomeAccount.getAccountID().longValue());
-            final PostLoanProductsResponse loanProductsResponse = loanProductHelper
-                    .createLoanProduct(createProgressiveLoanProductWithBuyDownFee(classificationToIncomeMapping));
+            final Long loanProductsResponse = createLoanProduct(createProgressiveLoanProductWithBuyDownFee(classificationToIncomeMapping));
 
-            GetLoanProductsProductIdResponse getLoanProductResponse = loanProductHelper
-                    .retrieveLoanProductById(loanProductsResponse.getResourceId());
+            GetLoanProductsProductIdResponse getLoanProductResponse = retrieveLoanProduct(loanProductsResponse);
             assertNotNull(getLoanProductResponse);
             assertNotNull(getLoanProductResponse.getBuydownFeeClassificationToIncomeAccountMappings());
             Assertions.assertEquals(1, getLoanProductResponse.getBuydownFeeClassificationToIncomeAccountMappings().size());
@@ -989,19 +984,19 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
                     new PostClassificationToIncomeAccountMappings().classificationCodeValueId(classificationIdRef.get())
                             .incomeAccountId(classificationIncomeAccount.getAccountID().longValue()));
 
-            loanProductHelper.updateLoanProductById(loanProductsResponse.getResourceId(), putLoanProductRequest);
-            getLoanProductResponse = loanProductHelper.retrieveLoanProductById(loanProductsResponse.getResourceId());
+            updateLoanProduct(loanProductsResponse, putLoanProductRequest);
+            getLoanProductResponse = retrieveLoanProduct(loanProductsResponse);
             assertNotNull(getLoanProductResponse);
             assertNotNull(getLoanProductResponse.getBuydownFeeClassificationToIncomeAccountMappings());
             Assertions.assertEquals(1, getLoanProductResponse.getBuydownFeeClassificationToIncomeAccountMappings().size());
             Assertions.assertEquals(classificationIdRef.get(), getLoanProductResponse.getBuydownFeeClassificationToIncomeAccountMappings()
                     .get(0).getClassificationCodeValue().getId());
 
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applyLP2ProgressiveLoanRequest(clientId,
-                    loanProductsResponse.getResourceId(), "10 September 2024", 1000.0, 10.0, 12, null));
-            loanId = postLoansResponse.getLoanId();
+            Long appliedLoanId = applyForLoan(
+                    applyLP2ProgressiveLoanRequest(clientId, loanProductsResponse, "10 September 2024", 1000.0, 10.0, 12, null));
+            loanId = appliedLoanId;
             loanIdRef.set(loanId);
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(1000.0, "10 September 2024"));
+            approveLoan(loanId, approveLoanRequest(1000.0, "10 September 2024"));
             disburseLoan(loanId, BigDecimal.valueOf(1000.0), "10 September 2024");
 
             Long buyDownFeeTransactionId = addBuyDownFeeForLoan(loanId, 400.0, "10 September 2024", classificationIdRef.get());
@@ -1022,14 +1017,14 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
             deleteAllExternalEvents();
             executeInlineCOB(loanId);
 
-            final GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            final GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             final Optional<GetLoansLoanIdTransactions> optTx = loanDetails.getTransactions().stream()
                     .filter(item -> Objects.equals(Utils.getDoubleValue(item.getAmount()), 1.23)
                             && Objects.equals(item.getType().getValue(), "Buy Down Fee Amortization"))
                     .findFirst();
-            verifyTRJournalEntries(optTx.get().getId(), debit(deferredIncomeLiabilityAccount, 1.23),
+            verifyTRJournalEntries(optTx.get().getId(), debit(getAccounts().getDeferredIncomeLiabilityAccount(), 1.23),
                     credit(classificationIncomeAccountRef.get(), 1.09), // First BuyDown Fee With classification
-                    credit(feeIncomeAccount, 0.14)); // Second BuyDown Fee Without classification
+                    credit(getAccounts().getFeeIncomeAccount(), 0.14)); // Second BuyDown Fee Without classification
         });
     }
 
@@ -1039,22 +1034,20 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
         final AtomicReference<Long> buyDownFeeTransactionIdRef = new AtomicReference<>();
 
         final Account transferAccount = accountHelper.createAssetAccount("transferInSuspense");
-        final FinancialActivityAccountHelper financialActivityAccountHelper = new FinancialActivityAccountHelper(requestSpec);
-        final ExternalAssetOwnerHelper externalAssetOwnerHelper = new ExternalAssetOwnerHelper();
-        externalAssetOwnerHelper.setProperFinancialActivity(financialActivityAccountHelper, transferAccount);
+        final FeignExternalAssetOwnerHelper externalAssetOwnerHelper = new FeignExternalAssetOwnerHelper(
+                FineractFeignClientHelper.getFineractFeignClient());
+        externalAssetOwnerHelper.setProperFinancialActivity(transferAccount);
 
-        final PostClientsResponse client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
-        final PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(createProgressiveLoanProductWithBuyDownFee(null));
+        final Long localClientId = createClient();
+        final Long loanProduct = createLoanProduct(createProgressiveLoanProductWithBuyDownFee(null));
 
         // Step 1: Create and disburse loan on July 1, 2026, add buydown fee, sell to investor
         runAt("01 July 2026", () -> {
-            final Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "01 July 2026", 1000.0,
-                    10.0, 6, null);
+            final Long loanId = applyAndApproveProgressiveLoan(localClientId, loanProduct, "01 July 2026", 1000.0, 10.0, 6, null);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(1000.0), "01 July 2026");
 
-            final PostLoansLoanIdTransactionsResponse buyDownFeeResponse = loanTransactionHelper.makeLoanBuyDownFee(loanId, "01 July 2026",
-                    50.0);
+            final PostLoansLoanIdTransactionsResponse buyDownFeeResponse = makeLoanBuyDownFee(loanId, "01 July 2026", 50.0);
             buyDownFeeTransactionIdRef.set(buyDownFeeResponse.getResourceId());
 
             externalAssetOwnerHelper.initiateTransferByLoanId(loanId, "sale",
@@ -1068,7 +1061,7 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
             final Long loanId = loanIdRef.get();
             executeInlineCOB(loanId);
 
-            final GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            final GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             assertNotNull(loanDetails.getTransactions());
 
             final BigDecimal totalAmortized = loanDetails.getTransactions().stream()
@@ -1078,7 +1071,7 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
             assertEquals(0, BigDecimal.valueOf(50.0).compareTo(totalAmortized),
                     "Buydown fee should be fully amortized after investor sale");
 
-            loanTransactionHelper.buyDownFeeAdjustment(loanId, buyDownFeeTransactionIdRef.get(), "02 July 2026", 20.0);
+            buyDownFeeAdjustment(loanId, buyDownFeeTransactionIdRef.get(), "02 July 2026", 20.0);
         });
 
         // Step 4: COB on July 3 — expect amortization adjustment equal to the $20 partial adjustment
@@ -1086,7 +1079,7 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
             final Long loanId = loanIdRef.get();
             executeInlineCOB(loanId);
 
-            final GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            final GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             assertNotNull(loanDetails.getTransactions());
 
             final BigDecimal amortizationAdjustmentAmount = loanDetails.getTransactions().stream()
@@ -1103,7 +1096,7 @@ public class LoanBuyDownFeeTest extends BaseLoanIntegrationTest {
             final Long loanId = loanIdRef.get();
             executeInlineCOB(loanId);
 
-            final GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            final GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             assertNotNull(loanDetails.getTransactions());
 
             final BigDecimal amortizationAdjustmentAmount = loanDetails.getTransactions().stream()

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanCOBAccountLockCatchupInlineCOBTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanCOBAccountLockCatchupInlineCOBTest.java
@@ -18,470 +18,204 @@
  */
 package org.apache.fineract.integrationtests;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.path.json.JsonPath;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import org.apache.fineract.client.models.GetLoansLoanIdResponse;
+import org.apache.fineract.client.models.ChargeRequest;
+import org.apache.fineract.client.models.LoanProductChargeData;
+import org.apache.fineract.client.models.PostLoanProductsRequest;
+import org.apache.fineract.client.models.PostLoansRequest;
 import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
 import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
-import org.apache.fineract.integrationtests.common.BusinessDateHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.CollateralManagementHelper;
-import org.apache.fineract.integrationtests.common.SchedulerJobHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignLoanCOBCatchUpHelper;
+import org.apache.fineract.integrationtests.client.feign.modules.ChargeRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
 import org.apache.fineract.integrationtests.common.loans.LoanAccountLockHelper;
-import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanCOBCatchUpHelper;
-import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanStatusChecker;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.apache.fineract.integrationtests.inlinecob.InlineLoanCOBHelper;
+import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanStatus;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 
 @Order(1)
-public class LoanCOBAccountLockCatchupInlineCOBTest extends BaseLoanIntegrationTest {
+public class LoanCOBAccountLockCatchupInlineCOBTest extends FeignLoanTestBase {
 
-    private ResponseSpecification responseSpec;
-    private RequestSpecification requestSpec;
-    private LoanCOBCatchUpHelper loanCOBCatchUpHelper;
-    private LoanTransactionHelper loanTransactionHelper;
-    private InlineLoanCOBHelper inlineLoanCOBHelper;
+    private static final String CUMULATIVE_STRATEGY = "mifos-standard-strategy";
+    private static final String INLINE_COB_LOCK_OWNER = "LOAN_INLINE_COB_PROCESSING";
+    private static final String COB_CHUNK_LOCK_OWNER = "LOAN_COB_CHUNK_PROCESSING";
+    private static final String LOAN_COB_JOB = "Loan COB";
 
-    @BeforeEach
-    public void setup() {
-        Utils.initializeRESTAssured();
-        requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        requestSpec.header("Fineract-Platform-TenantId", "default");
-        responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        this.requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        loanCOBCatchUpHelper = new LoanCOBCatchUpHelper();
-        inlineLoanCOBHelper = new InlineLoanCOBHelper(requestSpec, responseSpec);
+    private FeignLoanCOBCatchUpHelper loanCOBCatchUpHelper() {
+        return new FeignLoanCOBCatchUpHelper(FineractFeignClientHelper.getFineractFeignClient());
     }
 
     @Test
     public void testCatchUpInLockedInstanceLastCOBDateIsNull() {
+        FeignLoanCOBCatchUpHelper loanCOBCatchUpHelper = loanCOBCatchUpHelper();
         try {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 2));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
-                    new PutGlobalConfigurationsRequest().value(0L));
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
+            enableBusinessDate();
+            Long loanId = createOverdueLoan();
 
-            final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec);
-            Assertions.assertNotNull(clientID);
+            updateBusinessDate(BusinessDateType.COB_DATE.name(), "02 March 2020");
+            LoanAccountLockHelper.placeSoftLockOnLoanAccount(loanId, INLINE_COB_LOCK_OWNER, "Sample error");
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), "05 March 2020");
 
-            Integer overdueFeeChargeId = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
-            Assertions.assertNotNull(overdueFeeChargeId);
-
-            final Integer loanProductID = createLoanProduct(overdueFeeChargeId.toString());
-            Assertions.assertNotNull(loanProductID);
-            HashMap loanStatusHashMap;
-            final Integer loanID = applyForLoanApplication(clientID.toString(), loanProductID.toString(), null, "1 March 2020");
-
-            Assertions.assertNotNull(loanID);
-
-            loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
-
-            loanStatusHashMap = loanTransactionHelper.approveLoan("01 March 2020", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-
-            String loanDetails = loanTransactionHelper.getLoanDetails(requestSpec, responseSpec, loanID);
-            loanStatusHashMap = loanTransactionHelper.disburseLoanWithNetDisbursalAmount("02 March 2020", loanID,
-                    JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.COB_DATE, LocalDate.of(2020, 3, 2));
-            LoanAccountLockHelper.placeSoftLockOnLoanAccount(loanID.longValue(), "LOAN_INLINE_COB_PROCESSING", "Sample error");
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 5));
-
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
             loanCOBCatchUpHelper.executeLoanCOBCatchUp();
+            Utils.conditionalSleepWithMaxWait(30, 5, loanCOBCatchUpHelper::isLoanCOBCatchUpRunning);
 
-            Utils.conditionalSleepWithMaxWait(30, 5, () -> loanCOBCatchUpHelper.isLoanCOBCatchUpRunning());
-
-            GetLoansLoanIdResponse loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 4), loan.getLastClosedBusinessDate());
+            verifyLastClosedBusinessDate(loanId, "04 March 2020");
         } finally {
-            requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-            requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-            requestSpec.header("Fineract-Platform-TenantId", "default");
-            responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
-                    new PutGlobalConfigurationsRequest().value(2L));
+            disableBusinessDate();
         }
     }
 
     @Test
     public void testInlineCOBInLockedInstanceLastCOBDateIsNull() {
         try {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 2));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
-                    new PutGlobalConfigurationsRequest().value(0L));
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
+            enableBusinessDate();
+            Long loanId = createOverdueLoan();
 
-            final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec);
-            Assertions.assertNotNull(clientID);
+            updateBusinessDate(BusinessDateType.COB_DATE.name(), "02 March 2020");
+            LoanAccountLockHelper.placeSoftLockOnLoanAccount(loanId, COB_CHUNK_LOCK_OWNER, "Sample error");
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), "05 March 2020");
 
-            Integer overdueFeeChargeId = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
-            Assertions.assertNotNull(overdueFeeChargeId);
-
-            final Integer loanProductID = createLoanProduct(overdueFeeChargeId.toString());
-            Assertions.assertNotNull(loanProductID);
-            HashMap loanStatusHashMap;
-            final Integer loanID = applyForLoanApplication(clientID.toString(), loanProductID.toString(), null, "1 March 2020");
-
-            Assertions.assertNotNull(loanID);
-
-            loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
-
-            loanStatusHashMap = loanTransactionHelper.approveLoan("01 March 2020", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-
-            String loanDetails = loanTransactionHelper.getLoanDetails(requestSpec, responseSpec, loanID);
-            loanStatusHashMap = loanTransactionHelper.disburseLoanWithNetDisbursalAmount("02 March 2020", loanID,
-                    JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.COB_DATE, LocalDate.of(2020, 3, 2));
-            LoanAccountLockHelper.placeSoftLockOnLoanAccount(loanID.longValue(), "LOAN_COB_CHUNK_PROCESSING", "Sample error");
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 5));
-
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanID.longValue()));
-            GetLoansLoanIdResponse loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 4), loan.getLastClosedBusinessDate());
-
+            executeInlineCOB(List.of(loanId));
+            verifyLastClosedBusinessDate(loanId, "04 March 2020");
         } finally {
-            requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-            requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-            requestSpec.header("Fineract-Platform-TenantId", "default");
-            responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
-                    new PutGlobalConfigurationsRequest().value(2L));
+            disableBusinessDate();
         }
     }
 
     @Test
     public void testCatchUpInLockedInstanceLastCOBDateIsNotNull() {
+        FeignLoanCOBCatchUpHelper loanCOBCatchUpHelper = loanCOBCatchUpHelper();
         try {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 2));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
-                    new PutGlobalConfigurationsRequest().value(0L));
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-
-            // create client
-            final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec);
-            Assertions.assertNotNull(clientID);
-
-            Integer overdueFeeChargeId = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
-            Assertions.assertNotNull(overdueFeeChargeId);
-
-            // create loan product
-            final Integer loanProductID = createLoanProduct(overdueFeeChargeId.toString());
-            Assertions.assertNotNull(loanProductID);
-            HashMap loanStatusHashMap;
-            final Integer loanID = applyForLoanApplication(clientID.toString(), loanProductID.toString(), null, "1 March 2020");
-
-            Assertions.assertNotNull(loanID);
-
-            loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
-
-            // approve loan
-            loanStatusHashMap = loanTransactionHelper.approveLoan("01 March 2020", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-
-            String loanDetails = loanTransactionHelper.getLoanDetails(requestSpec, responseSpec, loanID);
-
-            // disburse loan
-            loanStatusHashMap = loanTransactionHelper.disburseLoanWithNetDisbursalAmount("02 March 2020", loanID,
-                    JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+            enableBusinessDate();
+            Long loanId = createOverdueLoan();
 
             // update business date 2020-03-02
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.COB_DATE, LocalDate.of(2020, 3, 2));
-
+            updateBusinessDate(BusinessDateType.COB_DATE.name(), "02 March 2020");
             // execute inline cob for the loan
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanID.longValue()));
-            GetLoansLoanIdResponse loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 2), loan.getLastClosedBusinessDate());
+            executeInlineCOB(List.of(loanId));
+            verifyLastClosedBusinessDate(loanId, "02 March 2020");
 
             // update business date to 2020-03-05
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 5));
-
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), "05 March 2020");
             // apply lock on the loan
-            LoanAccountLockHelper.placeSoftLockOnLoanAccount(loanID.longValue(), "LOAN_INLINE_COB_PROCESSING", "Sample error");
-
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
+            LoanAccountLockHelper.placeSoftLockOnLoanAccount(loanId, INLINE_COB_LOCK_OWNER, "Sample error");
 
             // execute catchup which sets the last cob date first 2020-03-04 and then 2020-03-05, as this loan is two
             // days behind
             loanCOBCatchUpHelper.executeLoanCOBCatchUp();
+            Awaitility.await().atMost(Duration.ofMinutes(2)).with().pollInterval(Duration.ofSeconds(5)).pollDelay(Duration.ofSeconds(5))
+                    .until(() -> loanCOBCatchUpHelper.isLoanCOBCatchUpFinishedFor(LocalDate.of(2020, 3, 4)));
 
-            Awaitility.await().atMost(Duration.ofMinutes(2)).with().pollInterval(Duration.ofSeconds(5)) //
-                    .pollDelay(Duration.ofSeconds(5)) //
-                    .until(() -> loanCOBCatchUpHelper.isLoanCOBCatchUpFinishedFor(LocalDate.of(2020, 3, 4))); //
-
-            loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 4), loan.getLastClosedBusinessDate());
+            verifyLastClosedBusinessDate(loanId, "04 March 2020");
         } finally {
-            requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-            requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-            requestSpec.header("Fineract-Platform-TenantId", "default");
-            responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
-                    new PutGlobalConfigurationsRequest().value(2L));
+            disableBusinessDate();
         }
     }
 
     @Test
     public void testInlineCOBInLockedInstanceLastCOBDateIsNotNull() {
         try {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 2));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
-                    new PutGlobalConfigurationsRequest().value(0L));
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
+            enableBusinessDate();
+            Long loanId = createOverdueLoan();
 
-            final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec);
-            Assertions.assertNotNull(clientID);
+            updateBusinessDate(BusinessDateType.COB_DATE.name(), "02 March 2020");
+            executeInlineCOB(List.of(loanId));
+            verifyLastClosedBusinessDate(loanId, "02 March 2020");
 
-            Integer overdueFeeChargeId = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
-            Assertions.assertNotNull(overdueFeeChargeId);
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), "05 March 2020");
+            LoanAccountLockHelper.placeSoftLockOnLoanAccount(loanId, COB_CHUNK_LOCK_OWNER, "Sample error");
 
-            final Integer loanProductID = createLoanProduct(overdueFeeChargeId.toString());
-            Assertions.assertNotNull(loanProductID);
-            HashMap loanStatusHashMap;
-            final Integer loanID = applyForLoanApplication(clientID.toString(), loanProductID.toString(), null, "1 March 2020");
-
-            Assertions.assertNotNull(loanID);
-
-            loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
-
-            loanStatusHashMap = loanTransactionHelper.approveLoan("01 March 2020", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-
-            String loanDetails = loanTransactionHelper.getLoanDetails(requestSpec, responseSpec, loanID);
-            loanStatusHashMap = loanTransactionHelper.disburseLoanWithNetDisbursalAmount("02 March 2020", loanID,
-                    JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.COB_DATE, LocalDate.of(2020, 3, 2));
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanID.longValue()));
-            GetLoansLoanIdResponse loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 2), loan.getLastClosedBusinessDate());
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 5));
-            LoanAccountLockHelper.placeSoftLockOnLoanAccount(loanID.longValue(), "LOAN_COB_CHUNK_PROCESSING", "Sample error");
-
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanID.longValue()));
-            loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 4), loan.getLastClosedBusinessDate());
-
+            executeInlineCOB(List.of(loanId));
+            verifyLastClosedBusinessDate(loanId, "04 March 2020");
         } finally {
-            requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-            requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-            requestSpec.header("Fineract-Platform-TenantId", "default");
-            responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
-                    new PutGlobalConfigurationsRequest().value(2L));
+            disableBusinessDate();
         }
     }
 
     @Test
     public void testLoanCOBNoLock() {
         try {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 2));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
-                    new PutGlobalConfigurationsRequest().value(0L));
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
+            enableBusinessDate();
+            Long loanId = createOverdueLoan();
 
-            final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec);
-            Assertions.assertNotNull(clientID);
+            updateBusinessDate(BusinessDateType.COB_DATE.name(), "02 March 2020");
+            schedulerHelper.executeAndAwaitJob(LOAN_COB_JOB);
 
-            Integer overdueFeeChargeId = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
-            Assertions.assertNotNull(overdueFeeChargeId);
-
-            final Integer loanProductID = createLoanProduct(overdueFeeChargeId.toString());
-            Assertions.assertNotNull(loanProductID);
-            HashMap loanStatusHashMap;
-            final Integer loanID = applyForLoanApplication(clientID.toString(), loanProductID.toString(), null, "1 March 2020");
-
-            Assertions.assertNotNull(loanID);
-
-            loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
-
-            loanStatusHashMap = loanTransactionHelper.approveLoan("01 March 2020", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-
-            String loanDetails = loanTransactionHelper.getLoanDetails(requestSpec, responseSpec, loanID);
-            loanStatusHashMap = loanTransactionHelper.disburseLoanWithNetDisbursalAmount("02 March 2020", loanID,
-                    JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.COB_DATE, LocalDate.of(2020, 3, 2));
-
-            final String jobName = "Loan COB";
-            SchedulerJobHelper.executeAndAwaitJob(jobName);
-
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-
-            GetLoansLoanIdResponse loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 2), loan.getLastClosedBusinessDate());
-
+            verifyLastClosedBusinessDate(loanId, "02 March 2020");
         } finally {
-            requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-            requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-            requestSpec.header("Fineract-Platform-TenantId", "default");
-            responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
-                    new PutGlobalConfigurationsRequest().value(2L));
+            disableBusinessDate();
         }
     }
 
     @Test
     public void testLoanCOBWithLoanAccountLockedWithInlineCOB() {
         try {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 2));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
-                    new PutGlobalConfigurationsRequest().value(0L));
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
+            enableBusinessDate();
+            Long loanId = createOverdueLoan();
 
-            final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec);
-            Assertions.assertNotNull(clientID);
+            updateBusinessDate(BusinessDateType.COB_DATE.name(), "02 March 2020");
+            LoanAccountLockHelper.placeSoftLockOnLoanAccount(loanId, INLINE_COB_LOCK_OWNER);
 
-            Integer overdueFeeChargeId = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
-            Assertions.assertNotNull(overdueFeeChargeId);
+            schedulerHelper.executeAndAwaitJob(LOAN_COB_JOB);
 
-            final Integer loanProductID = createLoanProduct(overdueFeeChargeId.toString());
-            Assertions.assertNotNull(loanProductID);
-            HashMap loanStatusHashMap;
-            final Integer loanID = applyForLoanApplication(clientID.toString(), loanProductID.toString(), null, "1 March 2020");
-
-            Assertions.assertNotNull(loanID);
-
-            loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
-
-            loanStatusHashMap = loanTransactionHelper.approveLoan("01 March 2020", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-
-            String loanDetails = loanTransactionHelper.getLoanDetails(requestSpec, responseSpec, loanID);
-            loanStatusHashMap = loanTransactionHelper.disburseLoanWithNetDisbursalAmount("02 March 2020", loanID,
-                    JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.COB_DATE, LocalDate.of(2020, 3, 2));
-            LoanAccountLockHelper.placeSoftLockOnLoanAccount(loanID.longValue(), "LOAN_INLINE_COB_PROCESSING");
-
-            final String jobName = "Loan COB";
-            SchedulerJobHelper.executeAndAwaitJob(jobName);
-
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-
-            GetLoansLoanIdResponse loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-
-            Assertions.assertNull(loan.getLastClosedBusinessDate());
-
+            assertNull(getLoanDetails(loanId).getLastClosedBusinessDate());
         } finally {
-            requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-            requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-            requestSpec.header("Fineract-Platform-TenantId", "default");
-            responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
-                    new PutGlobalConfigurationsRequest().value(2L));
+            disableBusinessDate();
         }
     }
 
-    private Integer createLoanProduct(final String chargeId) {
-        final String loanProductJSON = new LoanProductTestBuilder().withPrincipal("15,000.00").withNumberOfRepayments("4")
-                .withRepaymentAfterEvery("1").withRepaymentTypeAsMonth().withinterestRatePerPeriod("1")
-                .withInterestRateFrequencyTypeAsMonths().withAmortizationTypeAsEqualInstallments().withInterestTypeAsDecliningBalance()
-                .build(chargeId);
-        return this.loanTransactionHelper.getLoanProductId(loanProductJSON);
+    private void enableBusinessDate() {
+        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+                new PutGlobalConfigurationsRequest().enabled(true));
+        updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), "02 March 2020");
+        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
+                new PutGlobalConfigurationsRequest().value(0L));
     }
 
-    private Integer applyForLoanApplication(final String clientID, final String loanProductID, final String savingsID, final String date) {
-
-        List<HashMap> collaterals = new ArrayList<>();
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(this.requestSpec, this.responseSpec);
-        Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(this.requestSpec, this.responseSpec, clientID,
-                collateralId);
-        Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
-
-        final String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal("15,000.00").withLoanTermFrequency("4")
-                .withLoanTermFrequencyAsMonths().withNumberOfRepayments("4").withRepaymentEveryAfter("1")
-                .withRepaymentFrequencyTypeAsMonths().withInterestRatePerPeriod("2").withAmortizationTypeAsEqualInstallments()
-                .withInterestTypeAsDecliningBalance().withInterestCalculationPeriodTypeSameAsRepaymentPeriod()
-                .withExpectedDisbursementDate(date).withSubmittedOnDate(date).withCollaterals(collaterals)
-                .build(clientID, loanProductID, savingsID);
-        return this.loanTransactionHelper.getLoanId(loanApplicationJSON);
+    private void disableBusinessDate() {
+        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+                new PutGlobalConfigurationsRequest().enabled(false));
+        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
+                new PutGlobalConfigurationsRequest().value(2L));
     }
 
-    private void addCollaterals(List<HashMap> collaterals, Integer collateralId, BigDecimal quantity) {
-        collaterals.add(collaterals(collateralId, quantity));
-    }
+    private Long createOverdueLoan() {
+        // create client
+        Long clientId = createClient();
 
-    private HashMap<String, String> collaterals(Integer collateralId, BigDecimal quantity) {
-        HashMap<String, String> collateral = new HashMap<>(2);
-        collateral.put("clientCollateralId", collateralId.toString());
-        collateral.put("quantity", quantity.toString());
-        return collateral;
-    }
+        ChargeRequest overdueFeeCharge = ChargeRequestBuilders.loanOverdueFee(1.0)
+                .chargeCalculationType(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST.getValue());
+        Long overdueFeeChargeId = chargesHelper.createCharge(overdueFeeCharge).getResourceId();
 
+        PostLoanProductsRequest product = create4Period1MonthLongWithoutInterestProduct(CUMULATIVE_STRATEGY).principal(15000.0)
+                .charges(List.of(new LoanProductChargeData().id(overdueFeeChargeId)));
+        // create loan product
+        Long loanProductId = createLoanProduct(product);
+
+        PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "01 March 2020", 15000.0, 4)//
+                .repaymentEvery(1)//
+                .loanTermFrequency(4)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS);
+        Long loanId = applyForLoan(applicationRequest);
+        verifyLoanStatus(loanId, LoanStatus.SUBMITTED_AND_PENDING_APPROVAL);
+        // approve loan
+        approveLoan(loanId, approveLoanRequest(15000.0, "01 March 2020"));
+        verifyLoanStatus(loanId, LoanStatus.APPROVED);
+        // disburse loan
+        disburseLoan(loanId, BigDecimal.valueOf(15000.0), "02 March 2020");
+        verifyLoanStatus(loanId, LoanStatus.ACTIVE);
+        return loanId;
+    }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanCOBAccountLockCatchupInlineCOBTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanCOBAccountLockCatchupInlineCOBTest.java
@@ -18,470 +18,190 @@
  */
 package org.apache.fineract.integrationtests;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.path.json.JsonPath;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import org.apache.fineract.client.models.GetLoansLoanIdResponse;
+import org.apache.fineract.client.models.ChargeRequest;
+import org.apache.fineract.client.models.LoanProductChargeData;
+import org.apache.fineract.client.models.PostLoanProductsRequest;
+import org.apache.fineract.client.models.PostLoansRequest;
 import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
 import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
-import org.apache.fineract.integrationtests.common.BusinessDateHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.CollateralManagementHelper;
-import org.apache.fineract.integrationtests.common.SchedulerJobHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignLoanCOBCatchUpHelper;
+import org.apache.fineract.integrationtests.client.feign.modules.ChargeRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
 import org.apache.fineract.integrationtests.common.loans.LoanAccountLockHelper;
-import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanCOBCatchUpHelper;
-import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanStatusChecker;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.apache.fineract.integrationtests.inlinecob.InlineLoanCOBHelper;
+import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class LoanCOBAccountLockCatchupInlineCOBTest extends BaseLoanIntegrationTest {
+public class LoanCOBAccountLockCatchupInlineCOBTest extends FeignLoanTestBase {
 
-    private ResponseSpecification responseSpec;
-    private RequestSpecification requestSpec;
-    private LoanCOBCatchUpHelper loanCOBCatchUpHelper;
-    private LoanTransactionHelper loanTransactionHelper;
-    private InlineLoanCOBHelper inlineLoanCOBHelper;
+    private static final String CUMULATIVE_STRATEGY = "mifos-standard-strategy";
+    private static final String INLINE_COB_LOCK_OWNER = "LOAN_INLINE_COB_PROCESSING";
+    private static final String COB_CHUNK_LOCK_OWNER = "LOAN_COB_CHUNK_PROCESSING";
+    private static final String LOAN_COB_JOB = "Loan COB";
 
-    @BeforeEach
-    public void setup() {
-        Utils.initializeRESTAssured();
-        requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        requestSpec.header("Fineract-Platform-TenantId", "default");
-        responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        this.requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        loanCOBCatchUpHelper = new LoanCOBCatchUpHelper();
-        inlineLoanCOBHelper = new InlineLoanCOBHelper(requestSpec, responseSpec);
+    private FeignLoanCOBCatchUpHelper loanCOBCatchUpHelper() {
+        return new FeignLoanCOBCatchUpHelper(FineractFeignClientHelper.getFineractFeignClient());
     }
 
     @Test
     public void testCatchUpInLockedInstanceLastCOBDateIsNull() {
+        FeignLoanCOBCatchUpHelper loanCOBCatchUpHelper = loanCOBCatchUpHelper();
         try {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 2));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
-                    new PutGlobalConfigurationsRequest().value(0L));
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
+            enableBusinessDate();
+            Long loanId = createOverdueLoan();
 
-            final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec);
-            Assertions.assertNotNull(clientID);
+            updateBusinessDate(BusinessDateType.COB_DATE.name(), "02 March 2020");
+            LoanAccountLockHelper.placeSoftLockOnLoanAccount(loanId, INLINE_COB_LOCK_OWNER, "Sample error");
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), "05 March 2020");
 
-            Integer overdueFeeChargeId = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
-            Assertions.assertNotNull(overdueFeeChargeId);
-
-            final Integer loanProductID = createLoanProduct(overdueFeeChargeId.toString());
-            Assertions.assertNotNull(loanProductID);
-            HashMap loanStatusHashMap;
-            final Integer loanID = applyForLoanApplication(clientID.toString(), loanProductID.toString(), null, "1 March 2020");
-
-            Assertions.assertNotNull(loanID);
-
-            loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
-
-            loanStatusHashMap = loanTransactionHelper.approveLoan("01 March 2020", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-
-            String loanDetails = loanTransactionHelper.getLoanDetails(requestSpec, responseSpec, loanID);
-            loanStatusHashMap = loanTransactionHelper.disburseLoanWithNetDisbursalAmount("02 March 2020", loanID,
-                    JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.COB_DATE, LocalDate.of(2020, 3, 2));
-            LoanAccountLockHelper.placeSoftLockOnLoanAccount(loanID.longValue(), "LOAN_INLINE_COB_PROCESSING", "Sample error");
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 5));
-
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
             loanCOBCatchUpHelper.executeLoanCOBCatchUp();
+            Utils.conditionalSleepWithMaxWait(30, 5, loanCOBCatchUpHelper::isLoanCOBCatchUpRunning);
 
-            Utils.conditionalSleepWithMaxWait(30, 5, () -> loanCOBCatchUpHelper.isLoanCOBCatchUpRunning());
-
-            GetLoansLoanIdResponse loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 4), loan.getLastClosedBusinessDate());
+            verifyLastClosedBusinessDate(loanId, "04 March 2020");
         } finally {
-            requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-            requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-            requestSpec.header("Fineract-Platform-TenantId", "default");
-            responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
-                    new PutGlobalConfigurationsRequest().value(2L));
+            disableBusinessDate();
         }
     }
 
     @Test
     public void testInlineCOBInLockedInstanceLastCOBDateIsNull() {
         try {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 2));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
-                    new PutGlobalConfigurationsRequest().value(0L));
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
+            enableBusinessDate();
+            Long loanId = createOverdueLoan();
 
-            final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec);
-            Assertions.assertNotNull(clientID);
+            updateBusinessDate(BusinessDateType.COB_DATE.name(), "02 March 2020");
+            LoanAccountLockHelper.placeSoftLockOnLoanAccount(loanId, COB_CHUNK_LOCK_OWNER, "Sample error");
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), "05 March 2020");
 
-            Integer overdueFeeChargeId = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
-            Assertions.assertNotNull(overdueFeeChargeId);
-
-            final Integer loanProductID = createLoanProduct(overdueFeeChargeId.toString());
-            Assertions.assertNotNull(loanProductID);
-            HashMap loanStatusHashMap;
-            final Integer loanID = applyForLoanApplication(clientID.toString(), loanProductID.toString(), null, "1 March 2020");
-
-            Assertions.assertNotNull(loanID);
-
-            loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
-
-            loanStatusHashMap = loanTransactionHelper.approveLoan("01 March 2020", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-
-            String loanDetails = loanTransactionHelper.getLoanDetails(requestSpec, responseSpec, loanID);
-            loanStatusHashMap = loanTransactionHelper.disburseLoanWithNetDisbursalAmount("02 March 2020", loanID,
-                    JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.COB_DATE, LocalDate.of(2020, 3, 2));
-            LoanAccountLockHelper.placeSoftLockOnLoanAccount(loanID.longValue(), "LOAN_COB_CHUNK_PROCESSING", "Sample error");
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 5));
-
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanID.longValue()));
-            GetLoansLoanIdResponse loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 4), loan.getLastClosedBusinessDate());
-
+            executeInlineCOB(List.of(loanId));
+            verifyLastClosedBusinessDate(loanId, "04 March 2020");
         } finally {
-            requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-            requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-            requestSpec.header("Fineract-Platform-TenantId", "default");
-            responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
-                    new PutGlobalConfigurationsRequest().value(2L));
+            disableBusinessDate();
         }
     }
 
     @Test
     public void testCatchUpInLockedInstanceLastCOBDateIsNotNull() {
+        FeignLoanCOBCatchUpHelper loanCOBCatchUpHelper = loanCOBCatchUpHelper();
         try {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 2));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
-                    new PutGlobalConfigurationsRequest().value(0L));
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
+            enableBusinessDate();
+            Long loanId = createOverdueLoan();
 
-            // create client
-            final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec);
-            Assertions.assertNotNull(clientID);
+            updateBusinessDate(BusinessDateType.COB_DATE.name(), "02 March 2020");
+            executeInlineCOB(List.of(loanId));
+            verifyLastClosedBusinessDate(loanId, "02 March 2020");
 
-            Integer overdueFeeChargeId = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
-            Assertions.assertNotNull(overdueFeeChargeId);
-
-            // create loan product
-            final Integer loanProductID = createLoanProduct(overdueFeeChargeId.toString());
-            Assertions.assertNotNull(loanProductID);
-            HashMap loanStatusHashMap;
-            final Integer loanID = applyForLoanApplication(clientID.toString(), loanProductID.toString(), null, "1 March 2020");
-
-            Assertions.assertNotNull(loanID);
-
-            loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
-
-            // approve loan
-            loanStatusHashMap = loanTransactionHelper.approveLoan("01 March 2020", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-
-            String loanDetails = loanTransactionHelper.getLoanDetails(requestSpec, responseSpec, loanID);
-
-            // disburse loan
-            loanStatusHashMap = loanTransactionHelper.disburseLoanWithNetDisbursalAmount("02 March 2020", loanID,
-                    JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-
-            // update business date 2020-03-02
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.COB_DATE, LocalDate.of(2020, 3, 2));
-
-            // execute inline cob for the loan
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanID.longValue()));
-            GetLoansLoanIdResponse loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 2), loan.getLastClosedBusinessDate());
-
-            // update business date to 2020-03-05
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 5));
-
-            // apply lock on the loan
-            LoanAccountLockHelper.placeSoftLockOnLoanAccount(loanID.longValue(), "LOAN_INLINE_COB_PROCESSING", "Sample error");
-
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), "05 March 2020");
+            LoanAccountLockHelper.placeSoftLockOnLoanAccount(loanId, INLINE_COB_LOCK_OWNER, "Sample error");
 
             // execute catchup which sets the last cob date first 2020-03-04 and then 2020-03-05, as this loan is two
             // days behind
             loanCOBCatchUpHelper.executeLoanCOBCatchUp();
+            Awaitility.await().atMost(Duration.ofMinutes(2)).with().pollInterval(Duration.ofSeconds(5)).pollDelay(Duration.ofSeconds(5))
+                    .until(() -> loanCOBCatchUpHelper.isLoanCOBCatchUpFinishedFor(LocalDate.of(2020, 3, 4)));
 
-            Awaitility.await().atMost(Duration.ofMinutes(2)).with().pollInterval(Duration.ofSeconds(5)) //
-                    .pollDelay(Duration.ofSeconds(5)) //
-                    .until(() -> loanCOBCatchUpHelper.isLoanCOBCatchUpFinishedFor(LocalDate.of(2020, 3, 4))); //
-
-            loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 4), loan.getLastClosedBusinessDate());
+            verifyLastClosedBusinessDate(loanId, "04 March 2020");
         } finally {
-            requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-            requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-            requestSpec.header("Fineract-Platform-TenantId", "default");
-            responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
-                    new PutGlobalConfigurationsRequest().value(2L));
+            disableBusinessDate();
         }
     }
 
     @Test
     public void testInlineCOBInLockedInstanceLastCOBDateIsNotNull() {
         try {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 2));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
-                    new PutGlobalConfigurationsRequest().value(0L));
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
+            enableBusinessDate();
+            Long loanId = createOverdueLoan();
 
-            final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec);
-            Assertions.assertNotNull(clientID);
+            updateBusinessDate(BusinessDateType.COB_DATE.name(), "02 March 2020");
+            executeInlineCOB(List.of(loanId));
+            verifyLastClosedBusinessDate(loanId, "02 March 2020");
 
-            Integer overdueFeeChargeId = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
-            Assertions.assertNotNull(overdueFeeChargeId);
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), "05 March 2020");
+            LoanAccountLockHelper.placeSoftLockOnLoanAccount(loanId, COB_CHUNK_LOCK_OWNER, "Sample error");
 
-            final Integer loanProductID = createLoanProduct(overdueFeeChargeId.toString());
-            Assertions.assertNotNull(loanProductID);
-            HashMap loanStatusHashMap;
-            final Integer loanID = applyForLoanApplication(clientID.toString(), loanProductID.toString(), null, "1 March 2020");
-
-            Assertions.assertNotNull(loanID);
-
-            loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
-
-            loanStatusHashMap = loanTransactionHelper.approveLoan("01 March 2020", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-
-            String loanDetails = loanTransactionHelper.getLoanDetails(requestSpec, responseSpec, loanID);
-            loanStatusHashMap = loanTransactionHelper.disburseLoanWithNetDisbursalAmount("02 March 2020", loanID,
-                    JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.COB_DATE, LocalDate.of(2020, 3, 2));
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanID.longValue()));
-            GetLoansLoanIdResponse loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 2), loan.getLastClosedBusinessDate());
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 5));
-            LoanAccountLockHelper.placeSoftLockOnLoanAccount(loanID.longValue(), "LOAN_COB_CHUNK_PROCESSING", "Sample error");
-
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanID.longValue()));
-            loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 4), loan.getLastClosedBusinessDate());
-
+            executeInlineCOB(List.of(loanId));
+            verifyLastClosedBusinessDate(loanId, "04 March 2020");
         } finally {
-            requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-            requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-            requestSpec.header("Fineract-Platform-TenantId", "default");
-            responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
-                    new PutGlobalConfigurationsRequest().value(2L));
+            disableBusinessDate();
         }
     }
 
     @Test
     public void testLoanCOBNoLock() {
         try {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 2));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
-                    new PutGlobalConfigurationsRequest().value(0L));
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-            final SchedulerJobHelper schedulerJobHelper = new SchedulerJobHelper(requestSpec);
+            enableBusinessDate();
+            Long loanId = createOverdueLoan();
 
-            final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec);
-            Assertions.assertNotNull(clientID);
+            updateBusinessDate(BusinessDateType.COB_DATE.name(), "02 March 2020");
+            schedulerHelper.executeAndAwaitJob(LOAN_COB_JOB);
 
-            Integer overdueFeeChargeId = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
-            Assertions.assertNotNull(overdueFeeChargeId);
-
-            final Integer loanProductID = createLoanProduct(overdueFeeChargeId.toString());
-            Assertions.assertNotNull(loanProductID);
-            HashMap loanStatusHashMap;
-            final Integer loanID = applyForLoanApplication(clientID.toString(), loanProductID.toString(), null, "1 March 2020");
-
-            Assertions.assertNotNull(loanID);
-
-            loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
-
-            loanStatusHashMap = loanTransactionHelper.approveLoan("01 March 2020", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-
-            String loanDetails = loanTransactionHelper.getLoanDetails(requestSpec, responseSpec, loanID);
-            loanStatusHashMap = loanTransactionHelper.disburseLoanWithNetDisbursalAmount("02 March 2020", loanID,
-                    JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.COB_DATE, LocalDate.of(2020, 3, 2));
-
-            final String jobName = "Loan COB";
-            schedulerJobHelper.executeAndAwaitJob(jobName);
-
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-
-            GetLoansLoanIdResponse loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 2), loan.getLastClosedBusinessDate());
-
+            verifyLastClosedBusinessDate(loanId, "02 March 2020");
         } finally {
-            requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-            requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-            requestSpec.header("Fineract-Platform-TenantId", "default");
-            responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
-                    new PutGlobalConfigurationsRequest().value(2L));
+            disableBusinessDate();
         }
     }
 
     @Test
     public void testLoanCOBWithLoanAccountLockedWithInlineCOB() {
         try {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 2));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
-                    new PutGlobalConfigurationsRequest().value(0L));
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-            final SchedulerJobHelper schedulerJobHelper = new SchedulerJobHelper(requestSpec);
+            enableBusinessDate();
+            Long loanId = createOverdueLoan();
 
-            final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec);
-            Assertions.assertNotNull(clientID);
+            updateBusinessDate(BusinessDateType.COB_DATE.name(), "02 March 2020");
+            LoanAccountLockHelper.placeSoftLockOnLoanAccount(loanId, INLINE_COB_LOCK_OWNER);
 
-            Integer overdueFeeChargeId = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
-            Assertions.assertNotNull(overdueFeeChargeId);
+            schedulerHelper.executeAndAwaitJob(LOAN_COB_JOB);
 
-            final Integer loanProductID = createLoanProduct(overdueFeeChargeId.toString());
-            Assertions.assertNotNull(loanProductID);
-            HashMap loanStatusHashMap;
-            final Integer loanID = applyForLoanApplication(clientID.toString(), loanProductID.toString(), null, "1 March 2020");
-
-            Assertions.assertNotNull(loanID);
-
-            loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
-
-            loanStatusHashMap = loanTransactionHelper.approveLoan("01 March 2020", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-
-            String loanDetails = loanTransactionHelper.getLoanDetails(requestSpec, responseSpec, loanID);
-            loanStatusHashMap = loanTransactionHelper.disburseLoanWithNetDisbursalAmount("02 March 2020", loanID,
-                    JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.COB_DATE, LocalDate.of(2020, 3, 2));
-            LoanAccountLockHelper.placeSoftLockOnLoanAccount(loanID.longValue(), "LOAN_INLINE_COB_PROCESSING");
-
-            final String jobName = "Loan COB";
-            schedulerJobHelper.executeAndAwaitJob(jobName);
-
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-
-            GetLoansLoanIdResponse loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-
-            Assertions.assertNull(loan.getLastClosedBusinessDate());
-
+            assertNull(getLoanDetails(loanId).getLastClosedBusinessDate());
         } finally {
-            requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-            requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-            requestSpec.header("Fineract-Platform-TenantId", "default");
-            responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
-                    new PutGlobalConfigurationsRequest().value(2L));
+            disableBusinessDate();
         }
     }
 
-    private Integer createLoanProduct(final String chargeId) {
-        final String loanProductJSON = new LoanProductTestBuilder().withPrincipal("15,000.00").withNumberOfRepayments("4")
-                .withRepaymentAfterEvery("1").withRepaymentTypeAsMonth().withinterestRatePerPeriod("1")
-                .withInterestRateFrequencyTypeAsMonths().withAmortizationTypeAsEqualInstallments().withInterestTypeAsDecliningBalance()
-                .build(chargeId);
-        return this.loanTransactionHelper.getLoanProductId(loanProductJSON);
+    private void enableBusinessDate() {
+        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+                new PutGlobalConfigurationsRequest().enabled(true));
+        updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), "02 March 2020");
+        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
+                new PutGlobalConfigurationsRequest().value(0L));
     }
 
-    private Integer applyForLoanApplication(final String clientID, final String loanProductID, final String savingsID, final String date) {
-
-        List<HashMap> collaterals = new ArrayList<>();
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(this.requestSpec, this.responseSpec);
-        Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(this.requestSpec, this.responseSpec, clientID,
-                collateralId);
-        Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
-
-        final String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal("15,000.00").withLoanTermFrequency("4")
-                .withLoanTermFrequencyAsMonths().withNumberOfRepayments("4").withRepaymentEveryAfter("1")
-                .withRepaymentFrequencyTypeAsMonths().withInterestRatePerPeriod("2").withAmortizationTypeAsEqualInstallments()
-                .withInterestTypeAsDecliningBalance().withInterestCalculationPeriodTypeSameAsRepaymentPeriod()
-                .withExpectedDisbursementDate(date).withSubmittedOnDate(date).withCollaterals(collaterals)
-                .build(clientID, loanProductID, savingsID);
-        return this.loanTransactionHelper.getLoanId(loanApplicationJSON);
+    private void disableBusinessDate() {
+        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+                new PutGlobalConfigurationsRequest().enabled(false));
+        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
+                new PutGlobalConfigurationsRequest().value(2L));
     }
 
-    private void addCollaterals(List<HashMap> collaterals, Integer collateralId, BigDecimal quantity) {
-        collaterals.add(collaterals(collateralId, quantity));
-    }
+    private Long createOverdueLoan() {
+        Long clientId = createClient();
 
-    private HashMap<String, String> collaterals(Integer collateralId, BigDecimal quantity) {
-        HashMap<String, String> collateral = new HashMap<>(2);
-        collateral.put("clientCollateralId", collateralId.toString());
-        collateral.put("quantity", quantity.toString());
-        return collateral;
-    }
+        ChargeRequest overdueFeeCharge = ChargeRequestBuilders.loanOverdueFee(1.0)
+                .chargeCalculationType(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST.getValue());
+        Long overdueFeeChargeId = chargesHelper.createCharge(overdueFeeCharge).getResourceId();
 
+        PostLoanProductsRequest product = create4Period1MonthLongWithoutInterestProduct(CUMULATIVE_STRATEGY).principal(15000.0)
+                .charges(List.of(new LoanProductChargeData().id(overdueFeeChargeId)));
+        Long loanProductId = createLoanProduct(product);
+
+        PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "01 March 2020", 15000.0, 4)//
+                .repaymentEvery(1)//
+                .loanTermFrequency(4)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS);
+        Long loanId = applyForLoan(applicationRequest);
+        approveLoan(loanId, approveLoanRequest(15000.0, "01 March 2020"));
+        disburseLoan(loanId, BigDecimal.valueOf(15000.0), "02 March 2020");
+        return loanId;
+    }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanCOBCatchUpInstanceModeIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanCOBCatchUpInstanceModeIntegrationTest.java
@@ -21,20 +21,16 @@ package org.apache.fineract.integrationtests;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
 import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
-import org.apache.fineract.client.util.CallFailedRuntimeException;
-import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
-import org.apache.fineract.integrationtests.common.BusinessDateHelper;
-import org.apache.fineract.integrationtests.common.SchedulerJobHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignLoanCOBCatchUpHelper;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.loans.LoanCOBCatchUpHelper;
 import org.apache.fineract.integrationtests.support.instancemode.ConfigureInstanceMode;
 import org.apache.fineract.integrationtests.support.instancemode.InstanceModeSupportExtension;
 import org.junit.jupiter.api.AfterEach;
@@ -45,25 +41,21 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 @Order(1)
 @ExtendWith(InstanceModeSupportExtension.class)
-public class LoanCOBCatchUpInstanceModeIntegrationTest extends BaseLoanIntegrationTest {
+public class LoanCOBCatchUpInstanceModeIntegrationTest extends FeignLoanTestBase {
 
-    private LoanCOBCatchUpHelper loanCOBCatchUpHelper;
-    private ResponseSpecification responseSpec;
-    private RequestSpecification requestSpec;
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("dd MMMM yyyy", Locale.US);
+
+    private FeignLoanCOBCatchUpHelper loanCOBCatchUpHelper;
     private Boolean originalSchedulerStatus;
 
     @BeforeEach
-    public void setup() throws InterruptedException {
-        Utils.initializeRESTAssured();
-        loanCOBCatchUpHelper = new LoanCOBCatchUpHelper();
-        this.responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        this.requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        this.requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        originalSchedulerStatus = SchedulerJobHelper.getSchedulerStatus();
+    public void setup() {
+        loanCOBCatchUpHelper = new FeignLoanCOBCatchUpHelper(FineractFeignClientHelper.getFineractFeignClient());
+        originalSchedulerStatus = schedulerHelper.getSchedulerStatus();
         final LocalDate todaysDate = Utils.getLocalDateOfTenant();
         globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                 new PutGlobalConfigurationsRequest().enabled(true));
-        BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, todaysDate);
+        updateBusinessDate(todaysDate.format(DATE_FORMATTER));
     }
 
     @ConfigureInstanceMode(readEnabled = false, writeEnabled = false, batchWorkerEnabled = false, batchManagerEnabled = true)
@@ -77,7 +69,7 @@ public class LoanCOBCatchUpInstanceModeIntegrationTest extends BaseLoanIntegrati
     public void testLoanCOBCatchUpDoesNotWorksWhenNotInBatchManagerMode() {
         CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
                 () -> loanCOBCatchUpHelper.executeLoanCOBCatchUp());
-        assertEquals(405, exception.getResponse().code());
+        assertEquals(405, exception.getStatus());
     }
 
     @ConfigureInstanceMode(readEnabled = false, writeEnabled = false, batchWorkerEnabled = false, batchManagerEnabled = true)
@@ -91,7 +83,7 @@ public class LoanCOBCatchUpInstanceModeIntegrationTest extends BaseLoanIntegrati
     public void testLoanCOBCatchUpGetStatusDoesNotWorksWhenNotInBatchManagerMode() {
         CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
                 () -> loanCOBCatchUpHelper.executeGetLoanCatchUpStatus());
-        assertEquals(405, exception.getResponse().code());
+        assertEquals(405, exception.getStatus());
     }
 
     @ConfigureInstanceMode(readEnabled = true, writeEnabled = false, batchWorkerEnabled = false, batchManagerEnabled = true)
@@ -109,23 +101,21 @@ public class LoanCOBCatchUpInstanceModeIntegrationTest extends BaseLoanIntegrati
     @ConfigureInstanceMode(readEnabled = false, writeEnabled = false, batchWorkerEnabled = false, batchManagerEnabled = true)
     @Test
     public void testSchedulerWorksWhenInBatchManagerMode() {
-        SchedulerJobHelper.updateSchedulerStatus(false);
+        schedulerHelper.updateSchedulerStatus(false);
     }
 
     @ConfigureInstanceMode(readEnabled = true, writeEnabled = true, batchWorkerEnabled = true, batchManagerEnabled = false)
     @Test
     public void testSchedulerDoesNotWorksWhenNotInBatchManagerMode() {
-        org.apache.fineract.client.feign.util.CallFailedRuntimeException exception = assertThrows(
-                org.apache.fineract.client.feign.util.CallFailedRuntimeException.class,
-                () -> SchedulerJobHelper.updateSchedulerStatus(false));
+        CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
+                () -> schedulerHelper.updateSchedulerStatus(false));
         assertEquals(405, exception.getStatus());
     }
 
     @AfterEach
-    public void tearDown() throws InterruptedException {
+    public void tearDown() {
         globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                 new PutGlobalConfigurationsRequest().enabled(false));
-        SchedulerJobHelper.updateSchedulerStatus(originalSchedulerStatus);
+        schedulerHelper.updateSchedulerStatus(originalSchedulerStatus);
     }
-
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanCOBCatchUpInstanceModeIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanCOBCatchUpInstanceModeIntegrationTest.java
@@ -21,20 +21,16 @@ package org.apache.fineract.integrationtests;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
 import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
-import org.apache.fineract.client.util.CallFailedRuntimeException;
-import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
-import org.apache.fineract.integrationtests.common.BusinessDateHelper;
-import org.apache.fineract.integrationtests.common.SchedulerJobHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignLoanCOBCatchUpHelper;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.loans.LoanCOBCatchUpHelper;
 import org.apache.fineract.integrationtests.support.instancemode.ConfigureInstanceMode;
 import org.apache.fineract.integrationtests.support.instancemode.InstanceModeSupportExtension;
 import org.junit.jupiter.api.AfterEach;
@@ -45,27 +41,21 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 @Order(1)
 @ExtendWith(InstanceModeSupportExtension.class)
-public class LoanCOBCatchUpInstanceModeIntegrationTest extends BaseLoanIntegrationTest {
+public class LoanCOBCatchUpInstanceModeIntegrationTest extends FeignLoanTestBase {
 
-    private LoanCOBCatchUpHelper loanCOBCatchUpHelper;
-    private ResponseSpecification responseSpec;
-    private RequestSpecification requestSpec;
-    private SchedulerJobHelper schedulerJobHelper;
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("dd MMMM yyyy", Locale.US);
+
+    private FeignLoanCOBCatchUpHelper loanCOBCatchUpHelper;
     private Boolean originalSchedulerStatus;
 
     @BeforeEach
-    public void setup() throws InterruptedException {
-        Utils.initializeRESTAssured();
-        loanCOBCatchUpHelper = new LoanCOBCatchUpHelper();
-        this.responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        this.requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        this.requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        schedulerJobHelper = new SchedulerJobHelper(requestSpec);
-        originalSchedulerStatus = schedulerJobHelper.getSchedulerStatus();
+    public void setup() {
+        loanCOBCatchUpHelper = new FeignLoanCOBCatchUpHelper(FineractFeignClientHelper.getFineractFeignClient());
+        originalSchedulerStatus = schedulerHelper.getSchedulerStatus();
         final LocalDate todaysDate = Utils.getLocalDateOfTenant();
         globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                 new PutGlobalConfigurationsRequest().enabled(true));
-        BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, todaysDate);
+        updateBusinessDate(todaysDate.format(DATE_FORMATTER));
     }
 
     @ConfigureInstanceMode(readEnabled = false, writeEnabled = false, batchWorkerEnabled = false, batchManagerEnabled = true)
@@ -79,7 +69,7 @@ public class LoanCOBCatchUpInstanceModeIntegrationTest extends BaseLoanIntegrati
     public void testLoanCOBCatchUpDoesNotWorksWhenNotInBatchManagerMode() {
         CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
                 () -> loanCOBCatchUpHelper.executeLoanCOBCatchUp());
-        assertEquals(405, exception.getResponse().code());
+        assertEquals(405, exception.getStatus());
     }
 
     @ConfigureInstanceMode(readEnabled = false, writeEnabled = false, batchWorkerEnabled = false, batchManagerEnabled = true)
@@ -93,7 +83,7 @@ public class LoanCOBCatchUpInstanceModeIntegrationTest extends BaseLoanIntegrati
     public void testLoanCOBCatchUpGetStatusDoesNotWorksWhenNotInBatchManagerMode() {
         CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
                 () -> loanCOBCatchUpHelper.executeGetLoanCatchUpStatus());
-        assertEquals(405, exception.getResponse().code());
+        assertEquals(405, exception.getStatus());
     }
 
     @ConfigureInstanceMode(readEnabled = true, writeEnabled = false, batchWorkerEnabled = false, batchManagerEnabled = true)
@@ -111,23 +101,21 @@ public class LoanCOBCatchUpInstanceModeIntegrationTest extends BaseLoanIntegrati
     @ConfigureInstanceMode(readEnabled = false, writeEnabled = false, batchWorkerEnabled = false, batchManagerEnabled = true)
     @Test
     public void testSchedulerWorksWhenInBatchManagerMode() {
-        schedulerJobHelper.updateSchedulerStatus(false);
+        schedulerHelper.updateSchedulerStatus(false);
     }
 
     @ConfigureInstanceMode(readEnabled = true, writeEnabled = true, batchWorkerEnabled = true, batchManagerEnabled = false)
     @Test
     public void testSchedulerDoesNotWorksWhenNotInBatchManagerMode() {
-        org.apache.fineract.client.feign.util.CallFailedRuntimeException exception = assertThrows(
-                org.apache.fineract.client.feign.util.CallFailedRuntimeException.class,
-                () -> schedulerJobHelper.updateSchedulerStatus(false));
+        CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
+                () -> schedulerHelper.updateSchedulerStatus(false));
         assertEquals(405, exception.getStatus());
     }
 
     @AfterEach
-    public void tearDown() throws InterruptedException {
+    public void tearDown() {
         globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                 new PutGlobalConfigurationsRequest().enabled(false));
-        schedulerJobHelper.updateSchedulerStatus(originalSchedulerStatus);
+        schedulerHelper.updateSchedulerStatus(originalSchedulerStatus);
     }
-
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanCOBCreateAccrualsTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanCOBCreateAccrualsTest.java
@@ -28,38 +28,34 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.client.models.CreditAllocationData;
 import org.apache.fineract.client.models.CreditAllocationOrder;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
-import org.apache.fineract.client.models.PostClientsResponse;
-import org.apache.fineract.client.models.PostLoanProductsResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsRequest;
-import org.apache.fineract.integrationtests.common.ClientHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-@Slf4j
-public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
+public class LoanCOBCreateAccrualsTest extends FeignLoanTestBase {
 
-    private PostClientsResponse client;
-    private PostLoanProductsResponse loanProduct;
+    private Long clientId;
+    private Long loanProductId;
 
     private void setup() {
-        if (loanProduct == null) {
-            loanProduct = loanProductHelper.createLoanProduct(create4IProgressive() //
-                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+        if (loanProductId == null) {
+            loanProductId = createLoanProduct(create4IProgressive() //
+                    .recalculationRestFrequencyType(LoanTestData.RecalculationRestFrequencyType.DAILY) //
                     .isInterestRecalculationEnabled(false).minPrincipal(1.0d).maxPrincipal(100000.0d).minInterestRatePerPeriod(0.0d)
                     .maxInterestRatePerPeriod(108.0d)
-                    .paymentAllocation(List.of(createDefaultPaymentAllocation(FuturePaymentAllocationRule.LAST_INSTALLMENT)))
-                    .repaymentFrequencyType(RepaymentFrequencyType.DAYS_L).repaymentEvery(30).minNumberOfRepayments(1)
+                    .paymentAllocation(List.of(createDefaultPaymentAllocation(LoanTestData.FuturePaymentAllocationRule.LAST_INSTALLMENT)))
+                    .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.DAYS_L).repaymentEvery(30).minNumberOfRepayments(1)
                     .maxNumberOfRepayments(12).numberOfRepayments(1).currencyCode("USD"));
         }
 
-        if (client == null) {
-            ClientHelper clientHelper = new ClientHelper(requestSpec, responseSpec);
-            client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+        if (clientId == null) {
+            clientId = createClient();
         }
     }
 
@@ -76,14 +72,13 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         setup();
         runAt("20 October 2024", () -> {
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "20 October 2024", 100.0, 0.0,
-                    1, null);
+            Long loanId = applyAndApproveProgressiveLoan(clientId, loanProductId, "20 October 2024", 100.0, 0.0, 1, null);
 
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(100), "20 October 2024");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "20 November 2024", 100, 0, 0, 0);
 
             verifyTransactions(loanId, transaction(100.0d, "Disbursement", "20 October 2024"));
@@ -93,7 +88,7 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
 
             executeInlineCOB(loanIdRef.get());
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "20 November 2024", 100, 0, 0, 0);
 
             verifyTransactions(loanId, transaction(100.0d, "Disbursement", "20 October 2024"));
@@ -103,14 +98,14 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
 
             executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "20 November 2024", 100, 0, 0, 0);
 
             verifyTransactions(loanId, transaction(100.0d, "Disbursement", "20 October 2024"));
 
-            loanTransactionHelper.makeLoanRepayment("22 October 2024", 102.0F, loanId.intValue());
+            addRepaymentForLoan(loanId, 102.0, "22 October 2024");
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "20 November 2024", 100, 0, 0, 0, 0, 100);
 
             verifyTransactions(loanId, //
@@ -123,7 +118,7 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
 
             executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "20 November 2024", 100, 0, 0, 0, 0, 100);
 
             verifyTransactions(loanId, //
@@ -132,7 +127,7 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
 
             addCharge(loanId, true, 1.5d, "23 October 2024");
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 11, 20), 100.0, 100.0, 0, 0, 0, 0, 1.5, 1.5, 0, 0, 0, 0, 101.5, 0);
 
             verifyTransactions(loanId, //
@@ -146,7 +141,7 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
 
             executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 11, 20), 100.0, 100.0, 0, 0, 0, 0, 1.5, 1.5, 0, 0, 0, 0, 101.5, 0);
 
             verifyTransactions(loanId, //
@@ -169,14 +164,13 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         setup();
         runAt("20 October 2024", () -> {
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "20 October 2024", 100.0, 0.0,
-                    1, null);
+            Long loanId = applyAndApproveProgressiveLoan(clientId, loanProductId, "20 October 2024", 100.0, 0.0, 1, null);
 
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(100), "20 October 2024");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "20 November 2024", 100, 0, 0, 0);
 
             verifyTransactions(loanId, transaction(100.0d, "Disbursement", "20 October 2024"));
@@ -186,7 +180,7 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
 
             executeInlineCOB(loanIdRef.get());
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "20 November 2024", 100, 0, 0, 0);
 
             verifyTransactions(loanId, transaction(100.0d, "Disbursement", "20 October 2024"));
@@ -196,14 +190,14 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
 
             executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "20 November 2024", 100, 0, 0, 0);
 
             verifyTransactions(loanId, transaction(100.0d, "Disbursement", "20 October 2024"));
 
-            loanTransactionHelper.makeLoanRepayment("22 October 2024", 102.0F, loanId.intValue());
+            addRepaymentForLoan(loanId, 102.0, "22 October 2024");
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "20 November 2024", 100, 0, 0, 0, 0, 100);
 
             verifyTransactions(loanId, //
@@ -216,7 +210,7 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
 
             executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "20 November 2024", 100, 0, 0, 0, 0, 100);
 
             verifyTransactions(loanId, //
@@ -225,7 +219,7 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
 
             addCharge(loanId, true, 2.0d, "23 October 2024");
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 11, 20), 100.0, 100.0, 0, 0, 0, 0, 2, 2, 0, 0, 0, 0, 102, 0);
 
             verifyTransactions(loanId, //
@@ -239,7 +233,7 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
 
             executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 11, 20), 100.0, 100.0, 0, 0, 0, 0, 2, 2, 0, 0, 0, 0, 102, 0);
 
             verifyTransactions(loanId, //
@@ -262,14 +256,13 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         setup();
         runAt("20 October 2024", () -> {
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "20 October 2024", 100.0, 0.0,
-                    1, null);
+            Long loanId = applyAndApproveProgressiveLoan(clientId, loanProductId, "20 October 2024", 100.0, 0.0, 1, null);
 
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(100), "20 October 2024");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "20 November 2024", 100, 0, 0, 0);
 
             verifyTransactions(loanId, transaction(100.0d, "Disbursement", "20 October 2024"));
@@ -279,7 +272,7 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
 
             executeInlineCOB(loanIdRef.get());
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "20 November 2024", 100, 0, 0, 0);
 
             verifyTransactions(loanId, transaction(100.0d, "Disbursement", "20 October 2024"));
@@ -289,14 +282,14 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
 
             executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "20 November 2024", 100, 0, 0, 0);
 
             verifyTransactions(loanId, transaction(100.0d, "Disbursement", "20 October 2024"));
 
-            loanTransactionHelper.makeLoanRepayment("22 October 2024", 102.0F, loanId.intValue());
+            addRepaymentForLoan(loanId, 102.0, "22 October 2024");
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "20 November 2024", 100, 0, 0, 0, 0, 100);
 
             verifyTransactions(loanId, //
@@ -309,7 +302,7 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
 
             executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "20 November 2024", 100, 0, 0, 0, 0, 100);
 
             verifyTransactions(loanId, //
@@ -318,7 +311,7 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
 
             addCharge(loanId, true, 5.0d, "23 October 2024");
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 11, 20), 100.0, 100.0, 0, 0, 0, 0, 5, 2, 3, 0, 0, 0, 102, 0);
 
             verifyTransactions(loanId, //
@@ -331,7 +324,7 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
 
             executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 11, 20), 100.0, 100.0, 0, 0, 0, 0, 5, 2, 3, 0, 0, 0, 102, 0);
 
             verifyTransactions(loanId, //
@@ -355,14 +348,13 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         setup();
         runAt("20 October 2024", () -> {
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "20 October 2024", 100.0, 0.0,
-                    1, null);
+            Long loanId = applyAndApproveProgressiveLoan(clientId, loanProductId, "20 October 2024", 100.0, 0.0, 1, null);
 
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(100), "20 October 2024");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "20 November 2024", 100, 0, 0, 0);
 
             verifyTransactions(loanId, transaction(100.0d, "Disbursement", "20 October 2024"));
@@ -372,7 +364,7 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
 
             executeInlineCOB(loanIdRef.get());
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "20 November 2024", 100, 0, 0, 0);
 
             verifyTransactions(loanId, transaction(100.0d, "Disbursement", "20 October 2024"));
@@ -382,14 +374,14 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
 
             executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "20 November 2024", 100, 0, 0, 0);
 
             verifyTransactions(loanId, transaction(100.0d, "Disbursement", "20 October 2024"));
 
-            loanTransactionHelper.makeLoanRepayment("22 October 2024", 100.0F, loanId.intValue());
+            addRepaymentForLoan(loanId, 100.0, "22 October 2024");
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "20 November 2024", 100, 0, 0, 0, 0, 100);
 
             verifyTransactions(loanId, //
@@ -402,7 +394,7 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
 
             executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "20 November 2024", 100, 0, 0, 0, 0, 100);
 
             verifyTransactions(loanId, //
@@ -411,7 +403,7 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
 
             addCharge(loanId, true, 5.0d, "23 October 2024");
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 11, 20), 100.0, 100.0, 0, 0, 0, 0, 5, 0, 5, 0, 0, 0, 100, 0);
 
             verifyTransactions(loanId, //
@@ -424,7 +416,7 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
 
             executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 11, 20), 100.0, 100.0, 0, 0, 0, 0, 5, 0, 5, 0, 0, 0, 100, 0);
 
             verifyTransactions(loanId, //
@@ -439,17 +431,16 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
     public void testEarlyRepaymentAccruals() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         setup();
-        final PostLoanProductsResponse loanProductsResponse = loanProductHelper.createLoanProduct(create4IProgressive());
+        final Long testProductId = createLoanProduct(create4IProgressive());
 
         runAt("20 December 2024", () -> {
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProductsResponse.getResourceId(), "20 December 2024",
-                    430.0, 26.0, 6, null);
+            Long loanId = applyAndApproveProgressiveLoan(clientId, testProductId, "20 December 2024", 430.0, 26.0, 6, null);
 
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(430), "20 December 2024");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "20 January 2025", 67.88, 0, 0, 9.32);
             validateFullyUnpaidRepaymentPeriod(loanDetails, 2, "20 February 2025", 69.35, 0, 0, 7.85);
             validateFullyUnpaidRepaymentPeriod(loanDetails, 3, "20 March 2025", 70.86, 0, 0, 6.34);
@@ -463,10 +454,10 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
         runAt("30 December 2024", () -> {
             executeInlineCOB(loanIdRef.get());
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+            makeLoanRepayment(loanId, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
                     .transactionDate("30 December 2024").locale("en").transactionAmount(200.0));
             // Accruals around installment due dates are as expected
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             // Accruals around installment due dates are as expected
             validateTransactionsExist(loanDetails, //
                     transaction(0.3, "Accrual", "21 December 2024", 0.0, 0.0, 0.3, 0.0, 0.0, 0.0, 0.0) //
@@ -476,7 +467,7 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
             Long loanId = loanIdRef.get();
             executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             // Accruals around installment due dates are as expected
             validateTransactionsExist(loanDetails, //
                     transaction(0.16, "Accrual", "31 December 2024", 0.0, 0.0, 0.16, 0.0, 0.0, 0.0, 0.0) //
@@ -489,18 +480,16 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
     public void testInterestRecognitionOnDisbursementDateTrue() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         setup();
-        final PostLoanProductsResponse loanProductsResponse = loanProductHelper
-                .createLoanProduct(create4IProgressive().interestRecognitionOnDisbursementDate(true));
+        final Long testProductId = createLoanProduct(create4IProgressive().interestRecognitionOnDisbursementDate(true));
 
         runAt("20 December 2024", () -> {
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProductsResponse.getResourceId(), "20 December 2024",
-                    430.0, 26.0, 1, null);
+            Long loanId = applyAndApproveProgressiveLoan(clientId, testProductId, "20 December 2024", 430.0, 26.0, 1, null);
 
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(430), "20 December 2024");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "20 January 2025", 430.0, 0, 0, 9.32);
 
             verifyTransactions(loanId, transaction(430.0d, "Disbursement", "20 December 2024"));
@@ -519,7 +508,7 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
         runAt("21 January 2025", () -> {
             Long loanId = loanIdRef.get();
             executeInlineCOB(loanId);
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
 
             Assertions.assertTrue(loanDetails.getTransactions().stream()
                     .noneMatch(t -> t.getDate().equals(LocalDate.of(2025, 1, 20)) && t.getType().getAccrual()));
@@ -530,18 +519,16 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
     public void testInterestRecognitionOnDisbursementDateFalse() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         setup();
-        final PostLoanProductsResponse loanProductsResponse = loanProductHelper
-                .createLoanProduct(create4IProgressive().interestRecognitionOnDisbursementDate(false));
+        final Long testProductId = createLoanProduct(create4IProgressive().interestRecognitionOnDisbursementDate(false));
 
         runAt("20 December 2024", () -> {
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProductsResponse.getResourceId(), "20 December 2024",
-                    430.0, 26.0, 6, null);
+            Long loanId = applyAndApproveProgressiveLoan(clientId, testProductId, "20 December 2024", 430.0, 26.0, 6, null);
 
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(430), "20 December 2024");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "20 January 2025", 67.88, 0, 0, 9.32);
             validateFullyUnpaidRepaymentPeriod(loanDetails, 2, "20 February 2025", 69.35, 0, 0, 7.85);
             validateFullyUnpaidRepaymentPeriod(loanDetails, 3, "20 March 2025", 70.86, 0, 0, 6.34);
@@ -567,14 +554,12 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
         AtomicReference<Long> repaymentIdRef = new AtomicReference<>();
 
         setup();
-        final PostLoanProductsResponse loanProductsResponse = loanProductHelper
-                .createLoanProduct(create4IProgressive().isInterestRecalculationEnabled(false)
-                        .creditAllocation(chargebackCreditAllocationOrders(List.of("PRINCIPAL", "PENALTY", "FEE", "INTEREST")))
-                        .currencyCode("USD"));
+        final Long testProductId = createLoanProduct(create4IProgressive().isInterestRecalculationEnabled(false)
+                .creditAllocation(chargebackCreditAllocationOrders(List.of("PRINCIPAL", "PENALTY", "FEE", "INTEREST")))
+                .currencyCode("USD"));
 
         runAt("20 December 2024", () -> {
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProductsResponse.getResourceId(), "20 December 2024",
-                    430.0, 26.0, 6, null);
+            Long loanId = applyAndApproveProgressiveLoan(clientId, testProductId, "20 December 2024", 430.0, 26.0, 6, null);
 
             loanIdRef.set(loanId);
 
@@ -586,7 +571,7 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
             executeInlineCOB(loanId);
 
             addCharge(loanId, true, 5.0d, "20 January 2025");
-            Long repaymentId = loanTransactionHelper.makeLoanRepayment(loanId, "Repayment", "20 January 2025", 82.20).getResourceId();
+            Long repaymentId = addRepaymentForLoan(loanId, 82.20, "20 January 2025");
             repaymentIdRef.set(repaymentId);
         });
         runAt("2 February 2025", () -> {
@@ -599,7 +584,7 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
             Long loanId = loanIdRef.get();
             executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateTransactionsExist(loanDetails, //
                     transaction(0.26, "Accrual", "01 February 2025", 0.0, 0.0, 0.26, 0.0, 0.0, 0.0, 0.0), //
                     transaction(0.25, "Accrual", "02 February 2025", 0.0, 0.0, 0.25, 0.0, 0.0, 0.0, 0.0), //
@@ -609,7 +594,7 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
             Long loanId = loanIdRef.get();
             executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateTransactionsExist(loanDetails, //
                     transaction(0.25, "Accrual", "19 February 2025", 0.0, 0.0, 0.25, 0.0, 0.0, 0.0, 0.0), //
                     transaction(0.26, "Accrual", "20 February 2025", 0.0, 0.0, 0.26, 0.0, 0.0, 0.0, 0.0), //
@@ -624,14 +609,12 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
         AtomicReference<Long> repaymentIdRef = new AtomicReference<>();
 
         setup();
-        final PostLoanProductsResponse loanProductsResponse = loanProductHelper
-                .createLoanProduct(create4IProgressive().isInterestRecalculationEnabled(true)
-                        .creditAllocation(chargebackCreditAllocationOrders(List.of("PRINCIPAL", "PENALTY", "FEE", "INTEREST")))
-                        .currencyCode("USD"));
+        final Long testProductId = createLoanProduct(create4IProgressive().isInterestRecalculationEnabled(true)
+                .creditAllocation(chargebackCreditAllocationOrders(List.of("PRINCIPAL", "PENALTY", "FEE", "INTEREST")))
+                .currencyCode("USD"));
 
         runAt("20 December 2024", () -> {
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProductsResponse.getResourceId(), "20 December 2024",
-                    430.0, 26.0, 6, null);
+            Long loanId = applyAndApproveProgressiveLoan(clientId, testProductId, "20 December 2024", 430.0, 26.0, 6, null);
 
             loanIdRef.set(loanId);
 
@@ -643,7 +626,7 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
             executeInlineCOB(loanId);
 
             addCharge(loanId, true, 5.0d, "20 January 2025");
-            Long repaymentId = loanTransactionHelper.makeLoanRepayment(loanId, "Repayment", "20 January 2025", 82.20).getResourceId();
+            Long repaymentId = addRepaymentForLoan(loanId, 82.20, "20 January 2025");
             repaymentIdRef.set(repaymentId);
         });
         runAt("2 February 2025", () -> {
@@ -656,7 +639,7 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
             Long loanId = loanIdRef.get();
             executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateTransactionsExist(loanDetails, //
                     transaction(0.26, "Accrual", "01 February 2025", 0.0, 0.0, 0.26, 0.0, 0.0, 0.0, 0.0), //
                     transaction(0.25, "Accrual", "02 February 2025", 0.0, 0.0, 0.25, 0.0, 0.0, 0.0, 0.0), //
@@ -667,7 +650,7 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
             Long loanId = loanIdRef.get();
             executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateTransactionsExist(loanDetails, //
                     transaction(0.30, "Accrual", "19 February 2025", 0.0, 0.0, 0.30, 0.0, 0.0, 0.0, 0.0), //
                     transaction(0.30, "Accrual", "20 February 2025", 0.0, 0.0, 0.30, 0.0, 0.0, 0.0, 0.0), //
@@ -680,12 +663,10 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
     public void testRunCOBJobAfterUndoDisbursement() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         setup();
-        final PostLoanProductsResponse loanProductsResponse = loanProductHelper
-                .createLoanProduct(create4IProgressive().enableAccrualActivityPosting(true));
+        final Long testProductId = createLoanProduct(create4IProgressive().enableAccrualActivityPosting(true));
 
         runAt("1 April 2025", () -> {
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProductsResponse.getResourceId(), "1 March 2025", 430.0,
-                    26.0, 6, null);
+            Long loanId = applyAndApproveProgressiveLoan(clientId, testProductId, "1 March 2025", 430.0, 26.0, 6, null);
 
             loanIdRef.set(loanId);
 
@@ -693,23 +674,23 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
 
             executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateTransactionsExist(loanDetails, //
                     transaction(9.02, "Accrual", "31 March 2025", 0.0, 0.0, 9.02, 0.0, 0.0, 0.0, 0.0));
             assertEquals(LocalDate.of(2025, 3, 31), loanDetails.getLastClosedBusinessDate());
 
-            undoDisbursement(loanId.intValue());
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            undoDisbursement(loanId);
+            loanDetails = getLoanDetails(loanId);
             assertNull(loanDetails.getLastClosedBusinessDate());
 
             disburseLoan(loanIdRef.get(), BigDecimal.valueOf(430), "2 March 2025");
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             assertNull(loanDetails.getLastClosedBusinessDate());
         });
 
         runAt("2 April 2025", () -> {
             executeInlineCOB(loanIdRef.get());
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanIdRef.get());
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanIdRef.get());
             validateTransactionsExist(loanDetails, //
                     transaction(9.02, "Accrual", "01 April 2025", 0.0, 0.0, 9.02, 0.0, 0.0, 0.0, 0.0));
             assertEquals(LocalDate.of(2025, 4, 1), loanDetails.getLastClosedBusinessDate());
@@ -725,7 +706,7 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
         return List.of(new CreditAllocationData().transactionType("CHARGEBACK").creditAllocationOrder(creditAllocationOrders));
     }
 
-    private void validateTransactionsExist(GetLoansLoanIdResponse loanDetails, TransactionExt... transactions) {
+    private void validateTransactionsExist(GetLoansLoanIdResponse loanDetails, LoanTestData.TransactionExt... transactions) {
         Arrays.stream(transactions).forEach(tr -> {
             boolean found = loanDetails.getTransactions().stream()
                     .anyMatch(item -> Objects.equals(Utils.getDoubleValue(item.getAmount()), tr.amount) //
@@ -749,8 +730,7 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("01 April 2025", () -> {
             // Create and disburse a loan with a single installment due in the future
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "01 April 2025", 100.0, 0.0, 1,
-                    null);
+            Long loanId = applyAndApproveProgressiveLoan(clientId, loanProductId, "01 April 2025", 100.0, 0.0, 1, null);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(100), "01 April 2025");
         });
@@ -758,7 +738,7 @@ public class LoanCOBCreateAccrualsTest extends BaseLoanIntegrationTest {
             Long loanId = loanIdRef.get();
             // No overdue installments: installment due in the future
             executeInlineCOB(loanId);
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             // There should be only the disbursement transaction, no accrual/interest recalculation
             Assertions.assertEquals(1, loanDetails.getTransactions().size(),
                     "No interest recalculation/accrual should occur if there are no overdue installments");

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanCOBPerformanceRestTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanCOBPerformanceRestTest.java
@@ -18,11 +18,6 @@
  */
 package org.apache.fineract.integrationtests;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -32,12 +27,10 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import org.apache.fineract.client.models.PostClientsResponse;
-import org.apache.fineract.client.models.PostLoanProductsResponse;
-import org.apache.fineract.integrationtests.common.BusinessStepHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.inlinecob.InlineLoanCOBHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignBusinessStepHelper;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.RecalculationRestFrequencyType;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
@@ -56,15 +49,11 @@ import org.slf4j.LoggerFactory;
  ***/
 @Disabled("This test is disabled by default. To run it, please remove the @Disabled annotation.")
 @TestInstance(Lifecycle.PER_CLASS)
-public class LoanCOBPerformanceRestTest extends BaseLoanIntegrationTest {
+public class LoanCOBPerformanceRestTest extends FeignLoanTestBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(LoanCOBPerformanceRestTest.class);
 
-    private static ResponseSpecification responseSpec;
-    private static RequestSpecification requestSpec;
-    private static PostClientsResponse client;
-    private static InlineLoanCOBHelper inlineLoanCOBHelper;
-    private static BusinessStepHelper businessStepHelper;
+    private static Long clientId;
     private Random random = new Random();
 
     // Store metrics for all test runs
@@ -72,18 +61,11 @@ public class LoanCOBPerformanceRestTest extends BaseLoanIntegrationTest {
 
     @BeforeAll
     public static void setup() {
-        Utils.initializeRESTAssured();
-        requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        requestSpec.header("Fineract-Platform-TenantId", Utils.DEFAULT_TENANT);
-        responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        ClientHelper clientHelper = new ClientHelper(requestSpec, responseSpec);
-        client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
-        inlineLoanCOBHelper = new InlineLoanCOBHelper(requestSpec, responseSpec);
-        businessStepHelper = new BusinessStepHelper();
+        clientId = clientHelper.createClient();
         // setup COB Business Steps to prevent test failing due other integration test configurations
-        businessStepHelper.updateSteps("LOAN_CLOSE_OF_BUSINESS", "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION",
-                "CHECK_LOAN_REPAYMENT_DUE", "CHECK_LOAN_REPAYMENT_OVERDUE", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
+        new FeignBusinessStepHelper(FineractFeignClientHelper.getFineractFeignClient()).updateSteps("LOAN_CLOSE_OF_BUSINESS",
+                "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION", "CHECK_LOAN_REPAYMENT_DUE",
+                "CHECK_LOAN_REPAYMENT_OVERDUE", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
                 "EXTERNAL_ASSET_OWNER_TRANSFER", "CHECK_DUE_INSTALLMENTS", "ACCRUAL_ACTIVITY_POSTING", "LOAN_INTEREST_RECALCULATION");
     }
 
@@ -171,12 +153,11 @@ public class LoanCOBPerformanceRestTest extends BaseLoanIntegrationTest {
         }
     }
 
-    private Long createLoanProduct(String disbursementDate, Double amount, Double interestRate, Integer numberOfInstallments) {
-        PostLoanProductsResponse loanProduct = loanProductHelper
-                .createLoanProduct(create4IProgressive().recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY));
+    private Long createLoan(String disbursementDate, Double amount, Double interestRate, Integer numberOfInstallments) {
+        Long loanProductId = createLoanProduct(create4IProgressive().recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY));
 
-        Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), disbursementDate, amount,
-                interestRate, numberOfInstallments, null);
+        Long loanId = applyAndApproveProgressiveLoan(clientId, loanProductId, disbursementDate, amount, interestRate, numberOfInstallments,
+                null);
         disburseLoan(loanId, BigDecimal.valueOf(amount), disbursementDate);
         return loanId;
     }
@@ -188,7 +169,7 @@ public class LoanCOBPerformanceRestTest extends BaseLoanIntegrationTest {
 
         List<Long> loanIds = new ArrayList<>();
         for (int i = 0; i < numberOfLoans; i++) {
-            Long loanId = createLoanProduct(disbursementDate, amount != null ? amount : getRandomAmount(),
+            Long loanId = createLoan(disbursementDate, amount != null ? amount : getRandomAmount(),
                     interestRate != null ? interestRate : getRandomInterestRate(),
                     numberOfInstallments != null ? numberOfInstallments : getRandomNumberOfInstallments());
             loanIds.add(loanId);
@@ -243,7 +224,7 @@ public class LoanCOBPerformanceRestTest extends BaseLoanIntegrationTest {
         runAt("1 February 2023", () -> {
             LOG.info("Running first COB for {} loans...", loanCount);
             long startTime = System.nanoTime();
-            inlineLoanCOBHelper.executeInlineCOB(loanIds.get());
+            executeInlineCOB(loanIds.get());
             long endTime = System.nanoTime();
             long duration = TimeUnit.NANOSECONDS.toMillis(endTime - startTime);
             metrics.put("firstCOBTimeMs", duration);
@@ -254,7 +235,7 @@ public class LoanCOBPerformanceRestTest extends BaseLoanIntegrationTest {
         runAt("1 March 2023", () -> {
             LOG.info("Running second COB for {} loans...", loanCount);
             long startTime = System.nanoTime();
-            inlineLoanCOBHelper.executeInlineCOB(loanIds.get());
+            executeInlineCOB(loanIds.get());
             long endTime = System.nanoTime();
             long duration = TimeUnit.NANOSECONDS.toMillis(endTime - startTime);
             metrics.put("secondCOBTimeMs", duration);

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanCapitalizedIncomeTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanCapitalizedIncomeTest.java
@@ -30,6 +30,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
 import org.apache.fineract.client.models.CapitalizedIncomeDetails;
 import org.apache.fineract.client.models.ExternalAssetOwnerRequest;
 import org.apache.fineract.client.models.GetCodesResponse;
@@ -39,23 +40,18 @@ import org.apache.fineract.client.models.GetLoansLoanIdTransactions;
 import org.apache.fineract.client.models.GetLoansLoanIdTransactionsTransactionIdResponse;
 import org.apache.fineract.client.models.LoanCapitalizedIncomeData;
 import org.apache.fineract.client.models.PostClassificationToIncomeAccountMappings;
-import org.apache.fineract.client.models.PostClientsResponse;
 import org.apache.fineract.client.models.PostCodeValueDataResponse;
 import org.apache.fineract.client.models.PostCodeValuesDataRequest;
 import org.apache.fineract.client.models.PostLoanProductsRequest;
-import org.apache.fineract.client.models.PostLoanProductsResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsResponse;
-import org.apache.fineract.client.models.PostLoansResponse;
 import org.apache.fineract.client.models.PutLoanProductsProductIdRequest;
-import org.apache.fineract.client.util.CallFailedRuntimeException;
-import org.apache.fineract.integrationtests.common.BusinessStepHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.ExternalAssetOwnerHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignBusinessStepHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignExternalAssetOwnerHelper;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.common.accounting.Account;
-import org.apache.fineract.integrationtests.common.accounting.AccountHelper;
-import org.apache.fineract.integrationtests.common.accounting.FinancialActivityAccountHelper;
 import org.apache.fineract.integrationtests.common.externalevents.LoanAdjustTransactionBusinessEvent;
 import org.apache.fineract.integrationtests.common.externalevents.LoanBusinessEvent;
 import org.apache.fineract.integrationtests.common.externalevents.LoanTransactionBusinessEvent;
@@ -64,37 +60,36 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
+public class LoanCapitalizedIncomeTest extends FeignLoanTestBase {
 
     @BeforeAll
     public void setup() {
-        new BusinessStepHelper().updateSteps("LOAN_CLOSE_OF_BUSINESS", "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION",
-                "CHECK_LOAN_REPAYMENT_DUE", "CHECK_LOAN_REPAYMENT_OVERDUE", "CHECK_DUE_INSTALLMENTS", "UPDATE_LOAN_ARREARS_AGING",
-                "ADD_PERIODIC_ACCRUAL_ENTRIES", "ACCRUAL_ACTIVITY_POSTING", "CAPITALIZED_INCOME_AMORTIZATION",
-                "LOAN_INTEREST_RECALCULATION", "EXTERNAL_ASSET_OWNER_TRANSFER");
+        new FeignBusinessStepHelper(FineractFeignClientHelper.getFineractFeignClient()).updateSteps("LOAN_CLOSE_OF_BUSINESS",
+                "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION", "CHECK_LOAN_REPAYMENT_DUE",
+                "CHECK_LOAN_REPAYMENT_OVERDUE", "CHECK_DUE_INSTALLMENTS", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
+                "ACCRUAL_ACTIVITY_POSTING", "CAPITALIZED_INCOME_AMORTIZATION", "LOAN_INTEREST_RECALCULATION",
+                "EXTERNAL_ASSET_OWNER_TRANSFER");
     }
 
     @Test
     public void testLoanCapitalizedIncomeAmortization() {
         final AtomicReference<Long> loanIdRef = new AtomicReference<>();
 
-        final PostClientsResponse client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+        final Long clientId = createClient();
 
-        final PostLoanProductsResponse loanProductsResponse = loanProductHelper
-                .createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
-                        .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
-                        .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
-                        .deferredIncomeLiabilityAccountId(deferredIncomeLiabilityAccount.getAccountID().longValue())
-                        .incomeFromCapitalizationAccountId(feeIncomeAccount.getAccountID().longValue())
-                        .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
+        final Long loanProductsResponse = createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
+                .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
+                .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
+                .deferredIncomeLiabilityAccountId(getAccounts().getDeferredIncomeLiabilityAccount().getAccountID().longValue())
+                .incomeFromCapitalizationAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())
+                .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
 
         runAt("1 January 2024", () -> {
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProductsResponse.getResourceId(), "1 January 2024",
-                    500.0, 7.0, 3, null);
+            Long loanId = applyAndApproveProgressiveLoan(clientId, loanProductsResponse, "1 January 2024", 500.0, 7.0, 3, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(100), "1 January 2024");
-            loanTransactionHelper.addCapitalizedIncome(loanId, "1 January 2024", 50.0);
+            addCapitalizedIncomeTransaction(loanId, "1 January 2024", 50.0);
         });
         runAt("2 January 2024", () -> {
             Long loanId = loanIdRef.get();
@@ -105,13 +100,13 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
                     transaction(50.0, "Capitalized Income", "01 January 2024"), //
                     transaction(0.55, "Capitalized Income Amortization", "01 January 2024") //
             );
-            final LoanCapitalizedIncomeData loanCapitalizedIncomeData = loanTransactionHelper.fetchLoanCapitalizedIncomeData(loanId);
+            final LoanCapitalizedIncomeData loanCapitalizedIncomeData = fetchLoanCapitalizedIncomeData(loanId);
             assertTrue(loanCapitalizedIncomeData.getCapitalizedIncomeData().size() > 0);
             CapitalizedIncomeDetails capitalizedIncomeData = loanCapitalizedIncomeData.getCapitalizedIncomeData().get(0);
             assertNotNull(capitalizedIncomeData);
             assertEquals(50.0, Utils.getDoubleValue(capitalizedIncomeData.getAmount()));
             assertEquals(0.55, Utils.getDoubleValue(capitalizedIncomeData.getAmortizedAmount()));
-            final List<CapitalizedIncomeDetails> capitalizedIncomeDetails = loanTransactionHelper.fetchCapitalizedIncomeDetails(loanId);
+            final List<CapitalizedIncomeDetails> capitalizedIncomeDetails = fetchCapitalizedIncomeDetails(loanId);
             assertNotNull(capitalizedIncomeDetails);
             assertTrue(loanCapitalizedIncomeData.getCapitalizedIncomeData().size() == capitalizedIncomeDetails.size());
             capitalizedIncomeData = capitalizedIncomeDetails.get(0);
@@ -130,7 +125,7 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
                     transaction(0.03, "Accrual", "02 January 2024"), //
                     transaction(0.55, "Capitalized Income Amortization", "02 January 2024") //
             );
-            final List<CapitalizedIncomeDetails> capitalizedIncomeDetails = loanTransactionHelper.fetchCapitalizedIncomeDetails(loanId);
+            final List<CapitalizedIncomeDetails> capitalizedIncomeDetails = fetchCapitalizedIncomeDetails(loanId);
             assertTrue(capitalizedIncomeDetails.size() > 0);
             final CapitalizedIncomeDetails capitalizedIncomeData = capitalizedIncomeDetails.get(0);
             assertNotNull(capitalizedIncomeData);
@@ -139,16 +134,16 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
             assertEquals(48.90, Utils.getDoubleValue(capitalizedIncomeData.getUnrecognizedAmount()));
 
             verifyJournalEntries(loanId, //
-                    journalEntry(100, loansReceivableAccount, "DEBIT"), //
-                    journalEntry(100, fundSource, "CREDIT"), //
-                    journalEntry(50, loansReceivableAccount, "DEBIT"), //
-                    journalEntry(50, deferredIncomeLiabilityAccount, "CREDIT"), //
-                    journalEntry(0.55, deferredIncomeLiabilityAccount, "DEBIT"), //
-                    journalEntry(0.55, feeIncomeAccount, "CREDIT"), //
-                    journalEntry(0.03, interestReceivableAccount, "DEBIT"), //
-                    journalEntry(0.03, interestIncomeAccount, "CREDIT"), //
-                    journalEntry(0.55, deferredIncomeLiabilityAccount, "DEBIT"), //
-                    journalEntry(0.55, feeIncomeAccount, "CREDIT") //
+                    journalEntry(100, getAccounts().getLoansReceivableAccount(), "DEBIT"), //
+                    journalEntry(100, getAccounts().getFundSource(), "CREDIT"), //
+                    journalEntry(50, getAccounts().getLoansReceivableAccount(), "DEBIT"), //
+                    journalEntry(50, getAccounts().getDeferredIncomeLiabilityAccount(), "CREDIT"), //
+                    journalEntry(0.55, getAccounts().getDeferredIncomeLiabilityAccount(), "DEBIT"), //
+                    journalEntry(0.55, getAccounts().getFeeIncomeAccount(), "CREDIT"), //
+                    journalEntry(0.03, getAccounts().getInterestReceivableAccount(), "DEBIT"), //
+                    journalEntry(0.03, getAccounts().getInterestIncomeAccount(), "CREDIT"), //
+                    journalEntry(0.55, getAccounts().getDeferredIncomeLiabilityAccount(), "DEBIT"), //
+                    journalEntry(0.55, getAccounts().getFeeIncomeAccount(), "CREDIT") //
             );
         });
     }
@@ -158,24 +153,21 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
         final AtomicReference<Long> loanIdRef = new AtomicReference<>();
         final AtomicReference<Long> capitalizedIncomeIdRef = new AtomicReference<>();
 
-        final PostClientsResponse client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+        final Long clientId = createClient();
 
-        final PostLoanProductsResponse loanProductsResponse = loanProductHelper
-                .createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
-                        .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
-                        .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
-                        .deferredIncomeLiabilityAccountId(deferredIncomeLiabilityAccount.getAccountID().longValue())
-                        .incomeFromCapitalizationAccountId(feeIncomeAccount.getAccountID().longValue())
-                        .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE).overAppliedNumber(3));
+        final Long loanProductsResponse = createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
+                .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
+                .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
+                .deferredIncomeLiabilityAccountId(getAccounts().getDeferredIncomeLiabilityAccount().getAccountID().longValue())
+                .incomeFromCapitalizationAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())
+                .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE).overAppliedNumber(3));
 
         runAt("1 April 2024", () -> {
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProductsResponse.getResourceId(), "1 January 2024",
-                    500.0, 7.0, 3, null);
+            Long loanId = applyAndApproveProgressiveLoan(clientId, loanProductsResponse, "1 January 2024", 500.0, 7.0, 3, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(300), "1 January 2024");
-            PostLoansLoanIdTransactionsResponse capitalizedIncomeResponse = loanTransactionHelper.addCapitalizedIncome(loanId,
-                    "1 January 2024", 50.0);
+            PostLoansLoanIdTransactionsResponse capitalizedIncomeResponse = addCapitalizedIncomeTransaction(loanId, "1 January 2024", 50.0);
 
             CallFailedRuntimeException callFailedRuntimeException = Assertions.assertThrows(CallFailedRuntimeException.class,
                     () -> disburseLoan(loanId, BigDecimal.valueOf(200), "1 February 2024"));
@@ -190,15 +182,14 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
         final AtomicReference<Long> loanIdRef = new AtomicReference<>();
         final AtomicReference<Long> capitalizedIncomeIdRef = new AtomicReference<>();
 
-        final PostClientsResponse client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+        final Long clientId = createClient();
 
-        final PostLoanProductsResponse loanProductsResponse = loanProductHelper
-                .createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
-                        .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
-                        .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
-                        .deferredIncomeLiabilityAccountId(deferredIncomeLiabilityAccount.getAccountID().longValue())
-                        .incomeFromCapitalizationAccountId(feeIncomeAccount.getAccountID().longValue())
-                        .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
+        final Long loanProductsResponse = createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
+                .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
+                .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
+                .deferredIncomeLiabilityAccountId(getAccounts().getDeferredIncomeLiabilityAccount().getAccountID().longValue())
+                .incomeFromCapitalizationAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())
+                .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
 
         final GetCodesResponse code = codeHelper.retrieveCodeByName(LoanTransactionApiConstants.CAPITALIZED_INCOME_CLASSIFICATION_CODE);
         final PostCodeValueDataResponse classificationCode = codeHelper.createCodeValue(code.getId(),
@@ -206,23 +197,22 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
         final Long classificationId = classificationCode.getSubResourceId();
 
         runAt("1 April 2024", () -> {
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProductsResponse.getResourceId(), "1 January 2024",
-                    500.0, 7.0, 3, null);
+            Long loanId = applyAndApproveProgressiveLoan(clientId, loanProductsResponse, "1 January 2024", 500.0, 7.0, 3, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(100), "1 January 2024");
-            PostLoansLoanIdTransactionsResponse capitalizedIncomeResponse = loanTransactionHelper.addCapitalizedIncome(loanId,
-                    "1 January 2024", 50.0, classificationId);
+            PostLoansLoanIdTransactionsResponse capitalizedIncomeResponse = addCapitalizedIncomeTransaction(loanId, "1 January 2024", 50.0,
+                    classificationId);
             capitalizedIncomeIdRef.set(capitalizedIncomeResponse.getResourceId());
 
             // Validate Loan Transaction classification set value
-            GetLoansLoanIdTransactionsTransactionIdResponse transactionDetails = loanTransactionHelper.getLoanTransactionDetails(loanId,
+            GetLoansLoanIdTransactionsTransactionIdResponse transactionDetails = getLoanTransactionDetails(loanId,
                     capitalizedIncomeIdRef.get());
             assertNotNull(transactionDetails.getClassification());
             assertEquals(classificationId, transactionDetails.getClassification().getId());
 
-            PostLoansLoanIdTransactionsResponse capitalizedIncomeAdjustmentResponse = loanTransactionHelper
-                    .capitalizedIncomeAdjustment(loanId, capitalizedIncomeIdRef.get(), "1 April 2024", 50.0);
+            PostLoansLoanIdTransactionsResponse capitalizedIncomeAdjustmentResponse = capitalizedIncomeAdjustment(loanId,
+                    capitalizedIncomeIdRef.get(), "1 April 2024", 50.0);
             assertNotNull(capitalizedIncomeAdjustmentResponse.getLoanId());
             assertNotNull(capitalizedIncomeAdjustmentResponse.getClientId());
             assertNotNull(capitalizedIncomeAdjustmentResponse.getOfficeId());
@@ -232,7 +222,7 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
                     transaction(50.0, "Capitalized Income", "01 January 2024"), //
                     transaction(50.0, "Capitalized Income Adjustment", "01 April 2024") //
             );
-            final List<CapitalizedIncomeDetails> capitalizedIncomeDetails = loanTransactionHelper.fetchCapitalizedIncomeDetails(loanId);
+            final List<CapitalizedIncomeDetails> capitalizedIncomeDetails = fetchCapitalizedIncomeDetails(loanId);
             assertTrue(capitalizedIncomeDetails.size() > 0);
             final CapitalizedIncomeDetails capitalizedIncomeData = capitalizedIncomeDetails.get(0);
             assertNotNull(capitalizedIncomeData);
@@ -240,18 +230,17 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
             assertEquals(50.0, Utils.getDoubleValue(capitalizedIncomeData.getAmountAdjustment()));
 
             verifyJournalEntries(loanId, //
-                    journalEntry(100, loansReceivableAccount, "DEBIT"), //
-                    journalEntry(100, fundSource, "CREDIT"), //
-                    journalEntry(50, loansReceivableAccount, "DEBIT"), //
-                    journalEntry(50, deferredIncomeLiabilityAccount, "CREDIT"), //
-                    journalEntry(50.0, deferredIncomeLiabilityAccount, "DEBIT"), //
-                    journalEntry(49.71, loansReceivableAccount, "CREDIT"), //
-                    journalEntry(0.29, interestReceivableAccount, "CREDIT") //
+                    journalEntry(100, getAccounts().getLoansReceivableAccount(), "DEBIT"), //
+                    journalEntry(100, getAccounts().getFundSource(), "CREDIT"), //
+                    journalEntry(50, getAccounts().getLoansReceivableAccount(), "DEBIT"), //
+                    journalEntry(50, getAccounts().getDeferredIncomeLiabilityAccount(), "CREDIT"), //
+                    journalEntry(50.0, getAccounts().getDeferredIncomeLiabilityAccount(), "DEBIT"), //
+                    journalEntry(49.71, getAccounts().getLoansReceivableAccount(), "CREDIT"), //
+                    journalEntry(0.29, getAccounts().getInterestReceivableAccount(), "CREDIT") //
             );
 
             // Validate Loan Transaction classification Inherit
-            transactionDetails = loanTransactionHelper.getLoanTransactionDetails(loanId,
-                    capitalizedIncomeAdjustmentResponse.getResourceId());
+            transactionDetails = getLoanTransactionDetails(loanId, capitalizedIncomeAdjustmentResponse.getResourceId());
             assertNotNull(transactionDetails.getClassification());
             assertEquals(classificationId, transactionDetails.getClassification().getId());
         });
@@ -262,41 +251,37 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
         final AtomicReference<Long> loanIdRef = new AtomicReference<>();
         final AtomicReference<Long> capitalizedIncomeIdRef = new AtomicReference<>();
 
-        final PostClientsResponse client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+        final Long clientId = createClient();
 
-        final PostLoanProductsResponse loanProductsResponse = loanProductHelper
-                .createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
-                        .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
-                        .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
-                        .deferredIncomeLiabilityAccountId(deferredIncomeLiabilityAccount.getAccountID().longValue())
-                        .incomeFromCapitalizationAccountId(feeIncomeAccount.getAccountID().longValue())
-                        .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
+        final Long loanProductsResponse = createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
+                .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
+                .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
+                .deferredIncomeLiabilityAccountId(getAccounts().getDeferredIncomeLiabilityAccount().getAccountID().longValue())
+                .incomeFromCapitalizationAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())
+                .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
 
         runAt("3 January 2024", () -> {
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProductsResponse.getResourceId(), "1 January 2024",
-                    500.0, 7.0, 3, null);
+            Long loanId = applyAndApproveProgressiveLoan(clientId, loanProductsResponse, "1 January 2024", 500.0, 7.0, 3, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(100), "1 January 2024");
-            PostLoansLoanIdTransactionsResponse capitalizedIncomeResponse = loanTransactionHelper.addCapitalizedIncome(loanId,
-                    "3 January 2024", 50.0);
+            PostLoansLoanIdTransactionsResponse capitalizedIncomeResponse = addCapitalizedIncomeTransaction(loanId, "3 January 2024", 50.0);
             capitalizedIncomeIdRef.set(capitalizedIncomeResponse.getResourceId());
 
             // Amount more than remaining
             Assertions.assertThrows(RuntimeException.class,
-                    () -> loanTransactionHelper.capitalizedIncomeAdjustment(loanId, capitalizedIncomeIdRef.get(), "3 January 2024", 60.0));
+                    () -> capitalizedIncomeAdjustment(loanId, capitalizedIncomeIdRef.get(), "3 January 2024", 60.0));
 
-            loanTransactionHelper.capitalizedIncomeAdjustment(loanId, capitalizedIncomeIdRef.get(), "3 January 2024", 30.0);
+            capitalizedIncomeAdjustment(loanId, capitalizedIncomeIdRef.get(), "3 January 2024", 30.0);
             Assertions.assertThrows(RuntimeException.class,
-                    () -> loanTransactionHelper.capitalizedIncomeAdjustment(loanId, capitalizedIncomeIdRef.get(), "3 January 2024", 30.0));
+                    () -> capitalizedIncomeAdjustment(loanId, capitalizedIncomeIdRef.get(), "3 January 2024", 30.0));
 
             // Capitalized income transaction with given id doesn't exist for this loan
-            Assertions.assertThrows(RuntimeException.class,
-                    () -> loanTransactionHelper.capitalizedIncomeAdjustment(loanId, 1L, "3 January 2024", 30.0));
+            Assertions.assertThrows(RuntimeException.class, () -> capitalizedIncomeAdjustment(loanId, 1L, "3 January 2024", 30.0));
 
             // Cannot be earlier than capitalized income transaction
             Assertions.assertThrows(RuntimeException.class,
-                    () -> loanTransactionHelper.capitalizedIncomeAdjustment(loanId, capitalizedIncomeIdRef.get(), "2 January 2024", 30.0));
+                    () -> capitalizedIncomeAdjustment(loanId, capitalizedIncomeIdRef.get(), "2 January 2024", 30.0));
         });
     }
 
@@ -306,24 +291,22 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
         final AtomicReference<Long> capitalizedIncomeIdRef = new AtomicReference<>();
         final AtomicReference<Long> capitalizedIncomeAdjustmentTransactionIdRef = new AtomicReference<>();
 
-        final PostClientsResponse client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+        final Long clientId = createClient();
 
-        final PostLoanProductsResponse loanProductsResponse = loanProductHelper
-                .createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
-                        .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
-                        .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
-                        .deferredIncomeLiabilityAccountId(deferredIncomeLiabilityAccount.getAccountID().longValue())
-                        .incomeFromCapitalizationAccountId(feeIncomeAccount.getAccountID().longValue())
-                        .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
+        final Long loanProductsResponse = createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
+                .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
+                .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
+                .deferredIncomeLiabilityAccountId(getAccounts().getDeferredIncomeLiabilityAccount().getAccountID().longValue())
+                .incomeFromCapitalizationAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())
+                .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
 
         runAt("1 January 2024", () -> {
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProductsResponse.getResourceId(), "1 January 2024",
-                    500.0, 7.0, 3, null);
+            Long loanId = applyAndApproveProgressiveLoan(clientId, loanProductsResponse, "1 January 2024", 500.0, 7.0, 3, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(100), "1 January 2024");
-            PostLoansLoanIdTransactionsResponse capitalizedIncomeResponse = loanTransactionHelper.addCapitalizedIncome(loanId,
-                    "1 January 2024", 100.0);
+            PostLoansLoanIdTransactionsResponse capitalizedIncomeResponse = addCapitalizedIncomeTransaction(loanId, "1 January 2024",
+                    100.0);
             capitalizedIncomeIdRef.set(capitalizedIncomeResponse.getResourceId());
         });
         runAt("2 January 2024", () -> {
@@ -349,20 +332,20 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
             );
 
             verifyJournalEntries(loanId, //
-                    journalEntry(100, loansReceivableAccount, "DEBIT"), //
-                    journalEntry(100, fundSource, "CREDIT"), //
-                    journalEntry(100, loansReceivableAccount, "DEBIT"), //
-                    journalEntry(100, deferredIncomeLiabilityAccount, "CREDIT"), //
-                    journalEntry(1.10, deferredIncomeLiabilityAccount, "DEBIT"), //
-                    journalEntry(1.10, feeIncomeAccount, "CREDIT"), //
-                    journalEntry(0.04, interestReceivableAccount, "DEBIT"), //
-                    journalEntry(0.04, interestIncomeAccount, "CREDIT"), //
-                    journalEntry(1.10, deferredIncomeLiabilityAccount, "DEBIT"), //
-                    journalEntry(1.10, feeIncomeAccount, "CREDIT") //
+                    journalEntry(100, getAccounts().getLoansReceivableAccount(), "DEBIT"), //
+                    journalEntry(100, getAccounts().getFundSource(), "CREDIT"), //
+                    journalEntry(100, getAccounts().getLoansReceivableAccount(), "DEBIT"), //
+                    journalEntry(100, getAccounts().getDeferredIncomeLiabilityAccount(), "CREDIT"), //
+                    journalEntry(1.10, getAccounts().getDeferredIncomeLiabilityAccount(), "DEBIT"), //
+                    journalEntry(1.10, getAccounts().getFeeIncomeAccount(), "CREDIT"), //
+                    journalEntry(0.04, getAccounts().getInterestReceivableAccount(), "DEBIT"), //
+                    journalEntry(0.04, getAccounts().getInterestIncomeAccount(), "CREDIT"), //
+                    journalEntry(1.10, getAccounts().getDeferredIncomeLiabilityAccount(), "DEBIT"), //
+                    journalEntry(1.10, getAccounts().getFeeIncomeAccount(), "CREDIT") //
             );
 
-            Long capitalizedIncomeAdjustmentTransactionId = loanTransactionHelper
-                    .capitalizedIncomeAdjustment(loanId, capitalizedIncomeIdRef.get(), "3 January 2024", 100.0).getResourceId();
+            Long capitalizedIncomeAdjustmentTransactionId = capitalizedIncomeAdjustment(loanId, capitalizedIncomeIdRef.get(),
+                    "3 January 2024", 100.0).getResourceId();
             capitalizedIncomeAdjustmentTransactionIdRef.set(capitalizedIncomeAdjustmentTransactionId);
         });
         runAt("4 January 2024", () -> {
@@ -381,29 +364,29 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
             );
 
             verifyJournalEntries(loanId, //
-                    journalEntry(100, loansReceivableAccount, "DEBIT"), //
-                    journalEntry(100, fundSource, "CREDIT"), //
-                    journalEntry(100, loansReceivableAccount, "DEBIT"), //
-                    journalEntry(100, deferredIncomeLiabilityAccount, "CREDIT"), //
-                    journalEntry(1.10, deferredIncomeLiabilityAccount, "DEBIT"), //
-                    journalEntry(1.10, feeIncomeAccount, "CREDIT"), //
-                    journalEntry(0.04, interestReceivableAccount, "DEBIT"), //
-                    journalEntry(0.04, interestIncomeAccount, "CREDIT"), //
-                    journalEntry(1.10, deferredIncomeLiabilityAccount, "DEBIT"), //
-                    journalEntry(1.10, feeIncomeAccount, "CREDIT"), //
-                    journalEntry(99.92, loansReceivableAccount, "CREDIT"), //
-                    journalEntry(0.08, interestReceivableAccount, "CREDIT"), //
-                    journalEntry(100.0, deferredIncomeLiabilityAccount, "DEBIT"), //
-                    journalEntry(0.04, interestReceivableAccount, "DEBIT"), //
-                    journalEntry(0.04, interestIncomeAccount, "CREDIT"), //
-                    journalEntry(2.20, feeIncomeAccount, "DEBIT"), //
-                    journalEntry(2.20, deferredIncomeLiabilityAccount, "CREDIT") //
+                    journalEntry(100, getAccounts().getLoansReceivableAccount(), "DEBIT"), //
+                    journalEntry(100, getAccounts().getFundSource(), "CREDIT"), //
+                    journalEntry(100, getAccounts().getLoansReceivableAccount(), "DEBIT"), //
+                    journalEntry(100, getAccounts().getDeferredIncomeLiabilityAccount(), "CREDIT"), //
+                    journalEntry(1.10, getAccounts().getDeferredIncomeLiabilityAccount(), "DEBIT"), //
+                    journalEntry(1.10, getAccounts().getFeeIncomeAccount(), "CREDIT"), //
+                    journalEntry(0.04, getAccounts().getInterestReceivableAccount(), "DEBIT"), //
+                    journalEntry(0.04, getAccounts().getInterestIncomeAccount(), "CREDIT"), //
+                    journalEntry(1.10, getAccounts().getDeferredIncomeLiabilityAccount(), "DEBIT"), //
+                    journalEntry(1.10, getAccounts().getFeeIncomeAccount(), "CREDIT"), //
+                    journalEntry(99.92, getAccounts().getLoansReceivableAccount(), "CREDIT"), //
+                    journalEntry(0.08, getAccounts().getInterestReceivableAccount(), "CREDIT"), //
+                    journalEntry(100.0, getAccounts().getDeferredIncomeLiabilityAccount(), "DEBIT"), //
+                    journalEntry(0.04, getAccounts().getInterestReceivableAccount(), "DEBIT"), //
+                    journalEntry(0.04, getAccounts().getInterestIncomeAccount(), "CREDIT"), //
+                    journalEntry(2.20, getAccounts().getFeeIncomeAccount(), "DEBIT"), //
+                    journalEntry(2.20, getAccounts().getDeferredIncomeLiabilityAccount(), "CREDIT") //
             );
 
             // Reverse-replay
             addRepaymentForLoan(loanId, 67.45, "2 January 2024");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             assertNotNull(loanDetails.getSummary().getTotalCapitalizedIncomeAdjustment());
             assertEquals(BigDecimal.valueOf(100.0).stripTrailingZeros(),
                     loanDetails.getSummary().getTotalCapitalizedIncomeAdjustment().stripTrailingZeros());
@@ -413,18 +396,18 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
             Assertions.assertTrue(replayedCapitalizedIncomeAdjustmentOpt.isPresent(), "Capitalized income adjustment not found");
 
             verifyTRJournalEntries(replayedCapitalizedIncomeAdjustmentOpt.get().getId(), //
-                    journalEntry(99.98, loansReceivableAccount, "CREDIT"), //
-                    journalEntry(0.02, interestReceivableAccount, "CREDIT"), //
-                    journalEntry(100.0, deferredIncomeLiabilityAccount, "DEBIT") //
+                    journalEntry(99.98, getAccounts().getLoansReceivableAccount(), "CREDIT"), //
+                    journalEntry(0.02, getAccounts().getInterestReceivableAccount(), "CREDIT"), //
+                    journalEntry(100.0, getAccounts().getDeferredIncomeLiabilityAccount(), "DEBIT") //
             );
 
             verifyTRJournalEntries(capitalizedIncomeAdjustmentTransactionIdRef.get(), //
-                    journalEntry(99.92, loansReceivableAccount, "CREDIT"), //
-                    journalEntry(0.08, interestReceivableAccount, "CREDIT"), //
-                    journalEntry(100.0, deferredIncomeLiabilityAccount, "DEBIT"), //
-                    journalEntry(99.92, loansReceivableAccount, "DEBIT"), //
-                    journalEntry(0.08, interestReceivableAccount, "DEBIT"), //
-                    journalEntry(100.0, deferredIncomeLiabilityAccount, "CREDIT") //
+                    journalEntry(99.92, getAccounts().getLoansReceivableAccount(), "CREDIT"), //
+                    journalEntry(0.08, getAccounts().getInterestReceivableAccount(), "CREDIT"), //
+                    journalEntry(100.0, getAccounts().getDeferredIncomeLiabilityAccount(), "DEBIT"), //
+                    journalEntry(99.92, getAccounts().getLoansReceivableAccount(), "DEBIT"), //
+                    journalEntry(0.08, getAccounts().getInterestReceivableAccount(), "DEBIT"), //
+                    journalEntry(100.0, getAccounts().getDeferredIncomeLiabilityAccount(), "CREDIT") //
             );
         });
     }
@@ -433,32 +416,29 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
     public void testCapitalizedIncomeTransactionsNotInFuture() {
         final AtomicReference<Long> loanIdRef = new AtomicReference<>();
 
-        final PostClientsResponse client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+        final Long clientId = createClient();
 
-        final PostLoanProductsResponse loanProductsResponse = loanProductHelper
-                .createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
-                        .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
-                        .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
-                        .deferredIncomeLiabilityAccountId(deferredIncomeLiabilityAccount.getAccountID().longValue())
-                        .incomeFromCapitalizationAccountId(feeIncomeAccount.getAccountID().longValue())
-                        .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
+        final Long loanProductsResponse = createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
+                .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
+                .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
+                .deferredIncomeLiabilityAccountId(getAccounts().getDeferredIncomeLiabilityAccount().getAccountID().longValue())
+                .incomeFromCapitalizationAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())
+                .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
 
         runAt("1 January 2024", () -> {
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProductsResponse.getResourceId(), "1 January 2024",
-                    500.0, 7.0, 3, null);
+            Long loanId = applyAndApproveProgressiveLoan(clientId, loanProductsResponse, "1 January 2024", 500.0, 7.0, 3, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(100), "1 January 2024");
 
             // Capitalized income cannot be in the future
-            Assertions.assertThrows(RuntimeException.class,
-                    () -> loanTransactionHelper.addCapitalizedIncome(loanId, "1 February 2024", 100.0));
+            Assertions.assertThrows(RuntimeException.class, () -> addCapitalizedIncomeTransaction(loanId, "1 February 2024", 100.0));
 
-            Long capitalizedIncomeId = loanTransactionHelper.addCapitalizedIncome(loanId, "1 January 2024", 100.0).getResourceId();
+            Long capitalizedIncomeId = addCapitalizedIncomeTransaction(loanId, "1 January 2024", 100.0).getResourceId();
 
             // Capitalized income adjustment cannot be in the future
             Assertions.assertThrows(RuntimeException.class,
-                    () -> loanTransactionHelper.capitalizedIncomeAdjustment(loanId, capitalizedIncomeId, "1 February 2024", 10.0));
+                    () -> capitalizedIncomeAdjustment(loanId, capitalizedIncomeId, "1 February 2024", 10.0));
         });
     }
 
@@ -467,24 +447,22 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
         final AtomicReference<Long> loanIdRef = new AtomicReference<>();
         final AtomicReference<Long> capitalizedIncomeIdRef = new AtomicReference<>();
 
-        final PostClientsResponse client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+        final Long clientId = createClient();
 
-        final PostLoanProductsResponse loanProductsResponse = loanProductHelper
-                .createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
-                        .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
-                        .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
-                        .deferredIncomeLiabilityAccountId(deferredIncomeLiabilityAccount.getAccountID().longValue())
-                        .incomeFromCapitalizationAccountId(feeIncomeAccount.getAccountID().longValue())
-                        .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
+        final Long loanProductsResponse = createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
+                .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
+                .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
+                .deferredIncomeLiabilityAccountId(getAccounts().getDeferredIncomeLiabilityAccount().getAccountID().longValue())
+                .incomeFromCapitalizationAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())
+                .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
 
         runAt("1 January 2024", () -> {
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProductsResponse.getResourceId(), "1 January 2024",
-                    500.0, 7.0, 3, null);
+            Long loanId = applyAndApproveProgressiveLoan(clientId, loanProductsResponse, "1 January 2024", 500.0, 7.0, 3, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(100), "1 January 2024");
-            PostLoansLoanIdTransactionsResponse capitalizedIncomeResponse = loanTransactionHelper.addCapitalizedIncome(loanId,
-                    "1 January 2024", 100.0);
+            PostLoansLoanIdTransactionsResponse capitalizedIncomeResponse = addCapitalizedIncomeTransaction(loanId, "1 January 2024",
+                    100.0);
             assertNotNull(capitalizedIncomeResponse.getLoanId());
             assertNotNull(capitalizedIncomeResponse.getClientId());
             assertNotNull(capitalizedIncomeResponse.getOfficeId());
@@ -516,24 +494,21 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
         final AtomicReference<Long> loanIdRef = new AtomicReference<>();
         final AtomicReference<Long> capitalizedIncomeTransactionIdRef = new AtomicReference<>();
 
-        final PostClientsResponse client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+        final Long clientId = createClient();
 
-        final PostLoanProductsResponse loanProductsResponse = loanProductHelper
-                .createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
-                        .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
-                        .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
-                        .deferredIncomeLiabilityAccountId(deferredIncomeLiabilityAccount.getAccountID().longValue())
-                        .incomeFromCapitalizationAccountId(feeIncomeAccount.getAccountID().longValue())
-                        .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
+        final Long loanProductsResponse = createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
+                .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
+                .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
+                .deferredIncomeLiabilityAccountId(getAccounts().getDeferredIncomeLiabilityAccount().getAccountID().longValue())
+                .incomeFromCapitalizationAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())
+                .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
 
         runAt("1 January 2024", () -> {
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProductsResponse.getResourceId(), "1 January 2024",
-                    500.0, 7.0, 3, null);
+            Long loanId = applyAndApproveProgressiveLoan(clientId, loanProductsResponse, "1 January 2024", 500.0, 7.0, 3, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(100), "1 January 2024");
-            Long capitalizedIncomeTransactionId = loanTransactionHelper.addCapitalizedIncome(loanId, "1 January 2024", 50.0)
-                    .getResourceId();
+            Long capitalizedIncomeTransactionId = addCapitalizedIncomeTransaction(loanId, "1 January 2024", 50.0).getResourceId();
             capitalizedIncomeTransactionIdRef.set(capitalizedIncomeTransactionId);
         });
         runAt("2 January 2024", () -> {
@@ -559,19 +534,19 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
             );
 
             verifyJournalEntries(loanId, //
-                    journalEntry(100, loansReceivableAccount, "DEBIT"), //
-                    journalEntry(100, fundSource, "CREDIT"), //
-                    journalEntry(50, loansReceivableAccount, "DEBIT"), //
-                    journalEntry(50, deferredIncomeLiabilityAccount, "CREDIT"), //
-                    journalEntry(0.55, deferredIncomeLiabilityAccount, "DEBIT"), //
-                    journalEntry(0.55, feeIncomeAccount, "CREDIT"), //
-                    journalEntry(0.03, interestReceivableAccount, "DEBIT"), //
-                    journalEntry(0.03, interestIncomeAccount, "CREDIT"), //
-                    journalEntry(0.55, deferredIncomeLiabilityAccount, "DEBIT"), //
-                    journalEntry(0.55, feeIncomeAccount, "CREDIT") //
+                    journalEntry(100, getAccounts().getLoansReceivableAccount(), "DEBIT"), //
+                    journalEntry(100, getAccounts().getFundSource(), "CREDIT"), //
+                    journalEntry(50, getAccounts().getLoansReceivableAccount(), "DEBIT"), //
+                    journalEntry(50, getAccounts().getDeferredIncomeLiabilityAccount(), "CREDIT"), //
+                    journalEntry(0.55, getAccounts().getDeferredIncomeLiabilityAccount(), "DEBIT"), //
+                    journalEntry(0.55, getAccounts().getFeeIncomeAccount(), "CREDIT"), //
+                    journalEntry(0.03, getAccounts().getInterestReceivableAccount(), "DEBIT"), //
+                    journalEntry(0.03, getAccounts().getInterestIncomeAccount(), "CREDIT"), //
+                    journalEntry(0.55, getAccounts().getDeferredIncomeLiabilityAccount(), "DEBIT"), //
+                    journalEntry(0.55, getAccounts().getFeeIncomeAccount(), "CREDIT") //
             );
 
-            loanTransactionHelper.reverseLoanTransaction(loanId, capitalizedIncomeTransactionIdRef.get(), "3 January 2024");
+            reverseLoanTransaction(loanId, capitalizedIncomeTransactionIdRef.get(), "3 January 2024");
 
         });
         runAt("4 January 2024", () -> {
@@ -589,22 +564,22 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
             );
 
             verifyJournalEntries(loanId, //
-                    journalEntry(100, loansReceivableAccount, "DEBIT"), //
-                    journalEntry(100, fundSource, "CREDIT"), //
-                    journalEntry(50, loansReceivableAccount, "DEBIT"), //
-                    journalEntry(50, deferredIncomeLiabilityAccount, "CREDIT"), //
-                    journalEntry(0.55, deferredIncomeLiabilityAccount, "DEBIT"), //
-                    journalEntry(0.55, feeIncomeAccount, "CREDIT"), //
-                    journalEntry(0.03, interestReceivableAccount, "DEBIT"), //
-                    journalEntry(0.03, interestIncomeAccount, "CREDIT"), //
-                    journalEntry(0.55, deferredIncomeLiabilityAccount, "DEBIT"), //
-                    journalEntry(0.55, feeIncomeAccount, "CREDIT"), //
-                    journalEntry(50, deferredIncomeLiabilityAccount, "DEBIT"), //
-                    journalEntry(50, loansReceivableAccount, "CREDIT"), //
-                    journalEntry(0.01, interestReceivableAccount, "DEBIT"), //
-                    journalEntry(0.01, interestIncomeAccount, "CREDIT"), //
-                    journalEntry(1.10, feeIncomeAccount, "DEBIT"), //
-                    journalEntry(1.10, deferredIncomeLiabilityAccount, "CREDIT") //
+                    journalEntry(100, getAccounts().getLoansReceivableAccount(), "DEBIT"), //
+                    journalEntry(100, getAccounts().getFundSource(), "CREDIT"), //
+                    journalEntry(50, getAccounts().getLoansReceivableAccount(), "DEBIT"), //
+                    journalEntry(50, getAccounts().getDeferredIncomeLiabilityAccount(), "CREDIT"), //
+                    journalEntry(0.55, getAccounts().getDeferredIncomeLiabilityAccount(), "DEBIT"), //
+                    journalEntry(0.55, getAccounts().getFeeIncomeAccount(), "CREDIT"), //
+                    journalEntry(0.03, getAccounts().getInterestReceivableAccount(), "DEBIT"), //
+                    journalEntry(0.03, getAccounts().getInterestIncomeAccount(), "CREDIT"), //
+                    journalEntry(0.55, getAccounts().getDeferredIncomeLiabilityAccount(), "DEBIT"), //
+                    journalEntry(0.55, getAccounts().getFeeIncomeAccount(), "CREDIT"), //
+                    journalEntry(50, getAccounts().getDeferredIncomeLiabilityAccount(), "DEBIT"), //
+                    journalEntry(50, getAccounts().getLoansReceivableAccount(), "CREDIT"), //
+                    journalEntry(0.01, getAccounts().getInterestReceivableAccount(), "DEBIT"), //
+                    journalEntry(0.01, getAccounts().getInterestIncomeAccount(), "CREDIT"), //
+                    journalEntry(1.10, getAccounts().getFeeIncomeAccount(), "DEBIT"), //
+                    journalEntry(1.10, getAccounts().getDeferredIncomeLiabilityAccount(), "CREDIT") //
             );
         });
     }
@@ -614,28 +589,25 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
         final AtomicReference<Long> loanIdRef = new AtomicReference<>();
         final AtomicReference<Long> capitalizedIncomeIdRef = new AtomicReference<>();
 
-        final PostClientsResponse client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+        final Long clientId = createClient();
 
-        final PostLoanProductsResponse loanProductsResponse = loanProductHelper
-                .createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
-                        .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
-                        .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
-                        .deferredIncomeLiabilityAccountId(deferredIncomeLiabilityAccount.getAccountID().longValue())
-                        .incomeFromCapitalizationAccountId(feeIncomeAccount.getAccountID().longValue())
-                        .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
+        final Long loanProductsResponse = createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
+                .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
+                .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
+                .deferredIncomeLiabilityAccountId(getAccounts().getDeferredIncomeLiabilityAccount().getAccountID().longValue())
+                .incomeFromCapitalizationAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())
+                .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
 
         runAt("1 April 2024", () -> {
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProductsResponse.getResourceId(), "1 January 2024",
-                    500.0, 7.0, 3, null);
+            Long loanId = applyAndApproveProgressiveLoan(clientId, loanProductsResponse, "1 January 2024", 500.0, 7.0, 3, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(100), "1 January 2024");
-            PostLoansLoanIdTransactionsResponse capitalizedIncomeResponse = loanTransactionHelper.addCapitalizedIncome(loanId,
-                    "1 January 2024", 50.0);
+            PostLoansLoanIdTransactionsResponse capitalizedIncomeResponse = addCapitalizedIncomeTransaction(loanId, "1 January 2024", 50.0);
             capitalizedIncomeIdRef.set(capitalizedIncomeResponse.getResourceId());
 
-            final PostLoansLoanIdTransactionsResponse capitalizedIncomeAdjustmentResponse = loanTransactionHelper
-                    .capitalizedIncomeAdjustment(loanId, capitalizedIncomeIdRef.get(), "1 April 2024", 50.0);
+            final PostLoansLoanIdTransactionsResponse capitalizedIncomeAdjustmentResponse = capitalizedIncomeAdjustment(loanId,
+                    capitalizedIncomeIdRef.get(), "1 April 2024", 50.0);
             final Long capitalizedIncomeAdjustmentTransactionId = capitalizedIncomeAdjustmentResponse.getResourceId();
 
             verifyTransactions(loanId, //
@@ -645,28 +617,28 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
             );
 
             verifyJournalEntries(loanId, //
-                    journalEntry(100, loansReceivableAccount, "DEBIT"), //
-                    journalEntry(100, fundSource, "CREDIT"), //
-                    journalEntry(50, loansReceivableAccount, "DEBIT"), //
-                    journalEntry(50, deferredIncomeLiabilityAccount, "CREDIT"), //
-                    journalEntry(50.0, deferredIncomeLiabilityAccount, "DEBIT"), //
-                    journalEntry(49.71, loansReceivableAccount, "CREDIT"), //
-                    journalEntry(0.29, interestReceivableAccount, "CREDIT") //
+                    journalEntry(100, getAccounts().getLoansReceivableAccount(), "DEBIT"), //
+                    journalEntry(100, getAccounts().getFundSource(), "CREDIT"), //
+                    journalEntry(50, getAccounts().getLoansReceivableAccount(), "DEBIT"), //
+                    journalEntry(50, getAccounts().getDeferredIncomeLiabilityAccount(), "CREDIT"), //
+                    journalEntry(50.0, getAccounts().getDeferredIncomeLiabilityAccount(), "DEBIT"), //
+                    journalEntry(49.71, getAccounts().getLoansReceivableAccount(), "CREDIT"), //
+                    journalEntry(0.29, getAccounts().getInterestReceivableAccount(), "CREDIT") //
             );
 
-            loanTransactionHelper.reverseLoanTransaction(loanId, capitalizedIncomeAdjustmentTransactionId, "1 April 2024");
+            reverseLoanTransaction(loanId, capitalizedIncomeAdjustmentTransactionId, "1 April 2024");
 
             verifyJournalEntries(loanId, //
-                    journalEntry(100, loansReceivableAccount, "DEBIT"), //
-                    journalEntry(100, fundSource, "CREDIT"), //
-                    journalEntry(50, loansReceivableAccount, "DEBIT"), //
-                    journalEntry(50, deferredIncomeLiabilityAccount, "CREDIT"), //
-                    journalEntry(50.0, deferredIncomeLiabilityAccount, "DEBIT"), //
-                    journalEntry(49.71, loansReceivableAccount, "CREDIT"), //
-                    journalEntry(0.29, interestReceivableAccount, "CREDIT"), //
-                    journalEntry(50.0, deferredIncomeLiabilityAccount, "CREDIT"), //
-                    journalEntry(49.71, loansReceivableAccount, "DEBIT"), //
-                    journalEntry(0.29, interestReceivableAccount, "DEBIT") //
+                    journalEntry(100, getAccounts().getLoansReceivableAccount(), "DEBIT"), //
+                    journalEntry(100, getAccounts().getFundSource(), "CREDIT"), //
+                    journalEntry(50, getAccounts().getLoansReceivableAccount(), "DEBIT"), //
+                    journalEntry(50, getAccounts().getDeferredIncomeLiabilityAccount(), "CREDIT"), //
+                    journalEntry(50.0, getAccounts().getDeferredIncomeLiabilityAccount(), "DEBIT"), //
+                    journalEntry(49.71, getAccounts().getLoansReceivableAccount(), "CREDIT"), //
+                    journalEntry(0.29, getAccounts().getInterestReceivableAccount(), "CREDIT"), //
+                    journalEntry(50.0, getAccounts().getDeferredIncomeLiabilityAccount(), "CREDIT"), //
+                    journalEntry(49.71, getAccounts().getLoansReceivableAccount(), "DEBIT"), //
+                    journalEntry(0.29, getAccounts().getInterestReceivableAccount(), "DEBIT") //
             );
         });
     }
@@ -676,24 +648,21 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
         final AtomicReference<Long> loanIdRef = new AtomicReference<>();
         final AtomicReference<Long> capitalizedIncomeTransactionIdRef = new AtomicReference<>();
 
-        final PostClientsResponse client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+        final Long clientId = createClient();
 
-        final PostLoanProductsResponse loanProductsResponse = loanProductHelper
-                .createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
-                        .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
-                        .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
-                        .deferredIncomeLiabilityAccountId(deferredIncomeLiabilityAccount.getAccountID().longValue())
-                        .incomeFromCapitalizationAccountId(feeIncomeAccount.getAccountID().longValue())
-                        .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
+        final Long loanProductsResponse = createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
+                .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
+                .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
+                .deferredIncomeLiabilityAccountId(getAccounts().getDeferredIncomeLiabilityAccount().getAccountID().longValue())
+                .incomeFromCapitalizationAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())
+                .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
 
         runAt("1 January 2024", () -> {
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProductsResponse.getResourceId(), "1 January 2024",
-                    500.0, 7.0, 3, null);
+            Long loanId = applyAndApproveProgressiveLoan(clientId, loanProductsResponse, "1 January 2024", 500.0, 7.0, 3, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(100), "1 January 2024");
-            Long capitalizedIncomeTransactionId = loanTransactionHelper.addCapitalizedIncome(loanId, "1 January 2024", 50.0)
-                    .getResourceId();
+            Long capitalizedIncomeTransactionId = addCapitalizedIncomeTransaction(loanId, "1 January 2024", 50.0).getResourceId();
             capitalizedIncomeTransactionIdRef.set(capitalizedIncomeTransactionId);
         });
         runAt("2 January 2024", () -> {
@@ -710,10 +679,10 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
             Long loanId = loanIdRef.get();
             executeInlineCOB(loanId);
 
-            loanTransactionHelper.capitalizedIncomeAdjustment(loanId, capitalizedIncomeTransactionIdRef.get(), "3 January 2024", 40.0);
+            capitalizedIncomeAdjustment(loanId, capitalizedIncomeTransactionIdRef.get(), "3 January 2024", 40.0);
 
             Assertions.assertThrows(RuntimeException.class, () -> {
-                loanTransactionHelper.reverseLoanTransaction(loanId, capitalizedIncomeTransactionIdRef.get(), "3 January 2024");
+                reverseLoanTransaction(loanId, capitalizedIncomeTransactionIdRef.get(), "3 January 2024");
             });
         });
     }
@@ -723,24 +692,21 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
         final AtomicReference<Long> loanIdRef = new AtomicReference<>();
         final AtomicReference<Long> capitalizedIncomeTransactionIdRef = new AtomicReference<>();
 
-        final PostClientsResponse client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+        final Long clientId = createClient();
 
-        final PostLoanProductsResponse loanProductsResponse = loanProductHelper
-                .createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
-                        .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
-                        .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
-                        .deferredIncomeLiabilityAccountId(deferredIncomeLiabilityAccount.getAccountID().longValue())
-                        .incomeFromCapitalizationAccountId(feeIncomeAccount.getAccountID().longValue())
-                        .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
+        final Long loanProductsResponse = createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
+                .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
+                .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
+                .deferredIncomeLiabilityAccountId(getAccounts().getDeferredIncomeLiabilityAccount().getAccountID().longValue())
+                .incomeFromCapitalizationAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())
+                .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
 
         runAt("1 January 2024", () -> {
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProductsResponse.getResourceId(), "1 January 2024",
-                    500.0, 7.0, 3, null);
+            Long loanId = applyAndApproveProgressiveLoan(clientId, loanProductsResponse, "1 January 2024", 500.0, 7.0, 3, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(100), "1 January 2024");
-            Long capitalizedIncomeTransactionId = loanTransactionHelper.addCapitalizedIncome(loanId, "1 January 2024", 50.0)
-                    .getResourceId();
+            Long capitalizedIncomeTransactionId = addCapitalizedIncomeTransaction(loanId, "1 January 2024", 50.0).getResourceId();
             capitalizedIncomeTransactionIdRef.set(capitalizedIncomeTransactionId);
         });
         runAt("1 February 2024", () -> {
@@ -761,14 +727,14 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
 
             addRepaymentForLoan(loanId, 50.58, "15 March 2024");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 0.0, 151.59, 0.0, 150.0, 0.15);
 
-            loanTransactionHelper.makeCreditBalanceRefund(loanId, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+            makeCreditBalanceRefund(loanId, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
                     .transactionDate("15 March 2024").locale("en").transactionAmount(0.15));
 
             // Validate Loan is Closed
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 0.0, 151.59, 0.0, 150.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 1), 49.71, 49.71, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2024, 3, 1), 49.99, 49.99, 0.0, 0.0, 0.0);
@@ -780,13 +746,13 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
             Long loanId = loanIdRef.get();
             executeInlineCOB(loanId);
 
-            Long capitalizedIncomeTransactionId = loanTransactionHelper.addCapitalizedIncome(loanId, "16 March 2024", 50.0).getResourceId();
+            Long capitalizedIncomeTransactionId = addCapitalizedIncomeTransaction(loanId, "16 March 2024", 50.0).getResourceId();
 
-            verifyTRJournalEntries(capitalizedIncomeTransactionId, journalEntry(50, loansReceivableAccount, "DEBIT"), //
-                    journalEntry(50, deferredIncomeLiabilityAccount, "CREDIT") //
+            verifyTRJournalEntries(capitalizedIncomeTransactionId, journalEntry(50, getAccounts().getLoansReceivableAccount(), "DEBIT"), //
+                    journalEntry(50, getAccounts().getDeferredIncomeLiabilityAccount(), "CREDIT") //
             );
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 50.15, 151.59, 50.00, 150.00, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 1), 49.71, 49.71, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2024, 3, 1), 49.99, 49.99, 0.0, 0.0, 0.0);
@@ -801,24 +767,21 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
         final AtomicReference<Long> loanIdRef = new AtomicReference<>();
         final AtomicReference<Long> capitalizedIncomeTransactionIdRef = new AtomicReference<>();
 
-        final PostClientsResponse client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+        final Long clientId = createClient();
 
-        final PostLoanProductsResponse loanProductsResponse = loanProductHelper
-                .createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
-                        .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
-                        .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
-                        .deferredIncomeLiabilityAccountId(deferredIncomeLiabilityAccount.getAccountID().longValue())
-                        .incomeFromCapitalizationAccountId(feeIncomeAccount.getAccountID().longValue())
-                        .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
+        final Long loanProductsResponse = createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
+                .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
+                .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
+                .deferredIncomeLiabilityAccountId(getAccounts().getDeferredIncomeLiabilityAccount().getAccountID().longValue())
+                .incomeFromCapitalizationAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())
+                .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
 
         runAt("1 January 2024", () -> {
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProductsResponse.getResourceId(), "1 January 2024",
-                    500.0, 7.0, 3, null);
+            Long loanId = applyAndApproveProgressiveLoan(clientId, loanProductsResponse, "1 January 2024", 500.0, 7.0, 3, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(100), "1 January 2024");
-            Long capitalizedIncomeTransactionId = loanTransactionHelper.addCapitalizedIncome(loanId, "1 January 2024", 50.0)
-                    .getResourceId();
+            Long capitalizedIncomeTransactionId = addCapitalizedIncomeTransaction(loanId, "1 January 2024", 50.0).getResourceId();
             capitalizedIncomeTransactionIdRef.set(capitalizedIncomeTransactionId);
         });
         runAt("1 February 2024", () -> {
@@ -839,7 +802,7 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
 
             addRepaymentForLoan(loanId, 50.58, "15 March 2024");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 0.0, 151.59, 0.0, 150.0, 0.15);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 1), 49.71, 49.71, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2024, 3, 1), 49.99, 49.99, 0.0, 0.0, 0.0);
@@ -851,13 +814,13 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
             Long loanId = loanIdRef.get();
             executeInlineCOB(loanId);
 
-            Long capitalizedIncomeTransactionId = loanTransactionHelper.addCapitalizedIncome(loanId, "16 March 2024", 50.0).getResourceId();
+            Long capitalizedIncomeTransactionId = addCapitalizedIncomeTransaction(loanId, "16 March 2024", 50.0).getResourceId();
 
-            verifyTRJournalEntries(capitalizedIncomeTransactionId, journalEntry(50, loansReceivableAccount, "DEBIT"), //
-                    journalEntry(50, deferredIncomeLiabilityAccount, "CREDIT") //
+            verifyTRJournalEntries(capitalizedIncomeTransactionId, journalEntry(50, getAccounts().getLoansReceivableAccount(), "DEBIT"), //
+                    journalEntry(50, getAccounts().getDeferredIncomeLiabilityAccount(), "CREDIT") //
             );
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 50.0, 151.74, 49.85, 150.15, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 1), 49.71, 49.71, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2024, 3, 1), 49.99, 49.99, 0.0, 0.0, 0.0);
@@ -872,24 +835,21 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
         final AtomicReference<Long> loanIdRef = new AtomicReference<>();
         final AtomicReference<Long> capitalizedIncomeTransactionIdRef = new AtomicReference<>();
 
-        final PostClientsResponse client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+        final Long clientId = createClient();
 
-        final PostLoanProductsResponse loanProductsResponse = loanProductHelper
-                .createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
-                        .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
-                        .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
-                        .deferredIncomeLiabilityAccountId(deferredIncomeLiabilityAccount.getAccountID().longValue())
-                        .incomeFromCapitalizationAccountId(feeIncomeAccount.getAccountID().longValue())
-                        .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
+        final Long loanProductsResponse = createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
+                .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
+                .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
+                .deferredIncomeLiabilityAccountId(getAccounts().getDeferredIncomeLiabilityAccount().getAccountID().longValue())
+                .incomeFromCapitalizationAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())
+                .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
 
         runAt("1 January 2024", () -> {
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProductsResponse.getResourceId(), "1 January 2024",
-                    500.0, 7.0, 3, null);
+            Long loanId = applyAndApproveProgressiveLoan(clientId, loanProductsResponse, "1 January 2024", 500.0, 7.0, 3, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(100), "1 January 2024");
-            Long capitalizedIncomeTransactionId = loanTransactionHelper.addCapitalizedIncome(loanId, "1 January 2024", 50.0)
-                    .getResourceId();
+            Long capitalizedIncomeTransactionId = addCapitalizedIncomeTransaction(loanId, "1 January 2024", 50.0).getResourceId();
             capitalizedIncomeTransactionIdRef.set(capitalizedIncomeTransactionId);
         });
         runAt("1 February 2024", () -> {
@@ -910,7 +870,7 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
 
             addRepaymentForLoan(loanId, 60.6, "1 April 2024");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             // Validate Loan is Overpaid
             assertTrue(loanDetails.getStatus().getOverpaid());
         });
@@ -918,10 +878,10 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
             Long loanId = loanIdRef.get();
             executeInlineCOB(loanId);
 
-            loanTransactionHelper.makeCreditBalanceRefund(loanId, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+            makeCreditBalanceRefund(loanId, new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
                     .transactionDate("5 April 2024").locale("en").transactionAmount(10.00));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             // Validate Loan remains Overpaid
             assertTrue(loanDetails.getStatus().getOverpaid());
         });
@@ -929,13 +889,14 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
             Long loanId = loanIdRef.get();
             executeInlineCOB(loanId);
 
-            Long capitalizedIncomeAdjustmentTransactionId = loanTransactionHelper
-                    .capitalizedIncomeAdjustment(loanId, capitalizedIncomeTransactionIdRef.get(), "15 April 2024", 15.0).getResourceId();
-            verifyTRJournalEntries(capitalizedIncomeAdjustmentTransactionId, journalEntry(15, deferredIncomeLiabilityAccount, "DEBIT"), //
-                    journalEntry(15, overpaymentAccount, "CREDIT") //
+            Long capitalizedIncomeAdjustmentTransactionId = capitalizedIncomeAdjustment(loanId, capitalizedIncomeTransactionIdRef.get(),
+                    "15 April 2024", 15.0).getResourceId();
+            verifyTRJournalEntries(capitalizedIncomeAdjustmentTransactionId,
+                    journalEntry(15, getAccounts().getDeferredIncomeLiabilityAccount(), "DEBIT"), //
+                    journalEntry(15, getAccounts().getOverpaymentAccount(), "CREDIT") //
             );
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             // Validate Loan remains Overpaid
             assertTrue(loanDetails.getStatus().getOverpaid());
             validateLoanSummaryBalances(loanDetails, 0.0, 151.75, 0.0, 150.00, 15.01);
@@ -947,24 +908,21 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
         final AtomicReference<Long> loanIdRef = new AtomicReference<>();
         final AtomicReference<Long> capitalizedIncomeTransactionIdRef = new AtomicReference<>();
 
-        final PostClientsResponse client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+        final Long clientId = createClient();
 
-        final PostLoanProductsResponse loanProductsResponse = loanProductHelper
-                .createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
-                        .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
-                        .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
-                        .deferredIncomeLiabilityAccountId(deferredIncomeLiabilityAccount.getAccountID().longValue())
-                        .incomeFromCapitalizationAccountId(feeIncomeAccount.getAccountID().longValue())
-                        .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
+        final Long loanProductsResponse = createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
+                .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
+                .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
+                .deferredIncomeLiabilityAccountId(getAccounts().getDeferredIncomeLiabilityAccount().getAccountID().longValue())
+                .incomeFromCapitalizationAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())
+                .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
 
         runAt("1 January 2024", () -> {
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProductsResponse.getResourceId(), "1 January 2024",
-                    500.0, 7.0, 3, null);
+            Long loanId = applyAndApproveProgressiveLoan(clientId, loanProductsResponse, "1 January 2024", 500.0, 7.0, 3, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(100), "1 January 2024");
-            Long capitalizedIncomeTransactionId = loanTransactionHelper.addCapitalizedIncome(loanId, "1 January 2024", 50.0)
-                    .getResourceId();
+            Long capitalizedIncomeTransactionId = addCapitalizedIncomeTransaction(loanId, "1 January 2024", 50.0).getResourceId();
             capitalizedIncomeTransactionIdRef.set(capitalizedIncomeTransactionId);
         });
         runAt("1 February 2024", () -> {
@@ -985,20 +943,21 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
 
             addRepaymentForLoan(loanId, 50.59, "1 April 2024");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 0.0, 151.75, 0.0, 150.00, null);
             // Validate Loan goes to Closed
             assertTrue(loanDetails.getStatus().getClosedObligationsMet());
         });
         runAt("15 April 2024", () -> {
             Long loanId = loanIdRef.get();
-            Long capitalizedIncomeAdjustmentTransactionId = loanTransactionHelper
-                    .capitalizedIncomeAdjustment(loanId, capitalizedIncomeTransactionIdRef.get(), "15 April 2024", 15.0).getResourceId();
-            verifyTRJournalEntries(capitalizedIncomeAdjustmentTransactionId, journalEntry(15, deferredIncomeLiabilityAccount, "DEBIT"), //
-                    journalEntry(15.00, overpaymentAccount, "CREDIT") //
+            Long capitalizedIncomeAdjustmentTransactionId = capitalizedIncomeAdjustment(loanId, capitalizedIncomeTransactionIdRef.get(),
+                    "15 April 2024", 15.0).getResourceId();
+            verifyTRJournalEntries(capitalizedIncomeAdjustmentTransactionId,
+                    journalEntry(15, getAccounts().getDeferredIncomeLiabilityAccount(), "DEBIT"), //
+                    journalEntry(15.00, getAccounts().getOverpaymentAccount(), "CREDIT") //
             );
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 0.0, 151.75, 0.0, 150.00, 15.0);
             assertNotNull(loanDetails.getSummary().getTotalCapitalizedIncomeAdjustment());
             assertEquals(BigDecimal.valueOf(15.0).stripTrailingZeros(),
@@ -1011,24 +970,21 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
     @Test
     public void testOverpaymentAmountWhenCapitalizedIncomeTransactionsAreReversed() {
         final AtomicReference<Long> loanIdRef = new AtomicReference<>();
-        final PostClientsResponse client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+        final Long clientId = createClient();
         runAt("01 March 2023", () -> {
-            final PostLoanProductsResponse loanProductsResponse = loanProductHelper
-                    .createLoanProduct(create4IProgressiveWithCapitalizedIncome());
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applyLP2ProgressiveLoanRequest(client.getClientId(),
-                    loanProductsResponse.getResourceId(), "01 March 2023", 10000.00, 12.00, 4, null));
-            Long loanId = postLoansResponse.getLoanId();
+            final Long loanProductsResponse = createLoanProduct(create4IProgressiveWithCapitalizedIncome());
+            Long loanId = applyForLoan(
+                    applyLP2ProgressiveLoanRequest(clientId, loanProductsResponse, "01 March 2023", 10000.00, 12.00, 4, null));
             loanIdRef.set(loanId);
 
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(10000.00, "01 March 2023"));
+            approveLoan(loanId, approveLoanRequest(10000.00, "01 March 2023"));
             disburseLoan(loanId, BigDecimal.valueOf(1000.00), "01 March 2023");
 
-            loanTransactionHelper.addCapitalizedIncome(loanId, "01 March 2023", 500.00);
-            PostLoansLoanIdTransactionsResponse transactionsResponse = loanTransactionHelper.addCapitalizedIncome(loanId, "01 March 2023",
-                    500.00);
+            addCapitalizedIncomeTransaction(loanId, "01 March 2023", 500.00);
+            PostLoansLoanIdTransactionsResponse transactionsResponse = addCapitalizedIncomeTransaction(loanId, "01 March 2023", 500.00);
 
-            loanTransactionHelper.makeLoanRepayment(loanId, "Repayment", "1 March 2023", 2000.00);
-            loanTransactionHelper.reverseLoanTransaction(loanId, transactionsResponse.getResourceId(), "1 March 2023");
+            makeLoanRepayment(loanId, "Repayment", "1 March 2023", 2000.00);
+            reverseLoanTransaction(loanId, transactionsResponse.getResourceId(), "1 March 2023");
         });
 
         BigDecimal zero = BigDecimal.ZERO;
@@ -1036,7 +992,7 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
         BigDecimal fiveHundred = BigDecimal.valueOf(500.0);
         BigDecimal thousandFiveHundred = BigDecimal.valueOf(1500.0);
 
-        GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanIdRef.get());
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanIdRef.get());
         Assertions.assertEquals(thousand, loanDetails.getPrincipal().setScale(1, RoundingMode.HALF_UP));
         Assertions.assertEquals(thousand, loanDetails.getSummary().getPrincipalDisbursed().setScale(1, RoundingMode.HALF_UP));
         Assertions.assertEquals(fiveHundred, loanDetails.getSummary().getTotalCapitalizedIncome().setScale(1, RoundingMode.HALF_UP));
@@ -1049,22 +1005,20 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
     @Test
     public void testOverpaymentAmountCorrectlyCalculatedWhenBackdatedRepaymentIsMade() {
         final AtomicReference<Long> loanIdRef = new AtomicReference<>();
-        final PostClientsResponse client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+        final Long clientId = createClient();
         runAt("01 March 2023", () -> {
-            final PostLoanProductsResponse loanProductsResponse = loanProductHelper
-                    .createLoanProduct(create4IProgressiveWithCapitalizedIncome());
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applyLP2ProgressiveLoanRequest(client.getClientId(),
-                    loanProductsResponse.getResourceId(), "01 March 2023", 10000.00, 12.00, 4, null));
-            Long loanId = postLoansResponse.getLoanId();
+            final Long loanProductsResponse = createLoanProduct(create4IProgressiveWithCapitalizedIncome());
+            Long loanId = applyForLoan(
+                    applyLP2ProgressiveLoanRequest(clientId, loanProductsResponse, "01 March 2023", 10000.00, 12.00, 4, null));
             loanIdRef.set(loanId);
 
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(10000.00, "01 March 2023"));
+            approveLoan(loanId, approveLoanRequest(10000.00, "01 March 2023"));
             disburseLoan(loanId, BigDecimal.valueOf(1000.00), "01 March 2023");
         });
 
         runAt("15 March 2023", () -> {
-            loanTransactionHelper.addCapitalizedIncome(loanIdRef.get(), "15 March 2023", 500.00);
-            loanTransactionHelper.makeLoanRepayment(loanIdRef.get(), "Repayment", "1 March 2023", 1500.00);
+            addCapitalizedIncomeTransaction(loanIdRef.get(), "15 March 2023", 500.00);
+            makeLoanRepayment(loanIdRef.get(), "Repayment", "1 March 2023", 1500.00);
         });
 
         BigDecimal zero = BigDecimal.ZERO;
@@ -1072,7 +1026,7 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
         BigDecimal fiveHundred = BigDecimal.valueOf(500.0);
         BigDecimal thousandFiveHundred = BigDecimal.valueOf(1500.0);
 
-        GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanIdRef.get());
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanIdRef.get());
         Assertions.assertEquals(thousand, loanDetails.getPrincipal().setScale(1, RoundingMode.HALF_UP));
         Assertions.assertEquals(thousand, loanDetails.getSummary().getPrincipalDisbursed().setScale(1, RoundingMode.HALF_UP));
         Assertions.assertEquals(fiveHundred, loanDetails.getSummary().getTotalCapitalizedIncome().setScale(1, RoundingMode.HALF_UP));
@@ -1092,27 +1046,24 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
         final AtomicReference<Long> loanIdRef = new AtomicReference<>();
         final AtomicReference<Long> capitalizedIncomeTransactionIdRef = new AtomicReference<>();
 
-        final PostClientsResponse client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+        final Long clientId = createClient();
 
-        final PostLoanProductsResponse loanProductsResponse = loanProductHelper
-                .createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
-                        .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
-                        .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
-                        .deferredIncomeLiabilityAccountId(deferredIncomeLiabilityAccount.getAccountID().longValue())
-                        .incomeFromCapitalizationAccountId(feeIncomeAccount.getAccountID().longValue())
-                        .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
+        final Long loanProductsResponse = createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
+                .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
+                .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
+                .deferredIncomeLiabilityAccountId(getAccounts().getDeferredIncomeLiabilityAccount().getAccountID().longValue())
+                .incomeFromCapitalizationAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())
+                .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
 
         runAt("1 January 2024", () -> {
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProductsResponse.getResourceId(), "1 January 2024",
-                    500.0, 7.0, 3, null);
+            Long loanId = applyAndApproveProgressiveLoan(clientId, loanProductsResponse, "1 January 2024", 500.0, 7.0, 3, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(100), "1 January 2024");
 
             deleteAllExternalEvents();
 
-            Long capitalizedIncomeTransactionId = loanTransactionHelper.addCapitalizedIncome(loanId, "1 January 2024", 100.0)
-                    .getResourceId();
+            Long capitalizedIncomeTransactionId = addCapitalizedIncomeTransaction(loanId, "1 January 2024", 100.0).getResourceId();
             capitalizedIncomeTransactionIdRef.set(capitalizedIncomeTransactionId);
 
             verifyBusinessEvents(
@@ -1141,8 +1092,8 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
 
             deleteAllExternalEvents();
 
-            Long capitalizedIncomeAdjustmentTransactionId = loanTransactionHelper
-                    .capitalizedIncomeAdjustment(loanId, capitalizedIncomeTransactionIdRef.get(), "3 January 2024", 50.0).getResourceId();
+            Long capitalizedIncomeAdjustmentTransactionId = capitalizedIncomeAdjustment(loanId, capitalizedIncomeTransactionIdRef.get(),
+                    "3 January 2024", 50.0).getResourceId();
 
             verifyTransactions(loanId, //
                     transaction(100.0, "Disbursement", "01 January 2024"), //
@@ -1160,7 +1111,7 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
 
             deleteAllExternalEvents();
 
-            loanTransactionHelper.reverseLoanTransaction(loanId, capitalizedIncomeAdjustmentTransactionId, "3 January 2024");
+            reverseLoanTransaction(loanId, capitalizedIncomeAdjustmentTransactionId, "3 January 2024");
 
             verifyBusinessEvents(new LoanAdjustTransactionBusinessEvent("LoanAdjustTransactionBusinessEvent", "03 January 2024",
                     "loanTransactionType.capitalizedIncomeAdjustment", "2024-01-03"));
@@ -1171,7 +1122,7 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
 
             deleteAllExternalEvents();
 
-            loanTransactionHelper.reverseLoanTransaction(loanId, capitalizedIncomeTransactionIdRef.get(), "3 January 2024");
+            reverseLoanTransaction(loanId, capitalizedIncomeTransactionIdRef.get(), "3 January 2024");
 
             verifyTransactions(loanId, //
                     transaction(100.0, "Disbursement", "01 January 2024"), //
@@ -1195,27 +1146,25 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
         final AtomicReference<Long> loanIdRef = new AtomicReference<>();
         final AtomicReference<Long> capitalizedIncomeTransactionIdRef = new AtomicReference<>();
         final Account transferAccount = accountHelper.createAssetAccount("transferInSuspense");
-        final FinancialActivityAccountHelper financialActivityAccountHelper = new FinancialActivityAccountHelper(requestSpec);
-        final ExternalAssetOwnerHelper externalAssetOwnerHelper = new ExternalAssetOwnerHelper();
-        externalAssetOwnerHelper.setProperFinancialActivity(financialActivityAccountHelper, transferAccount);
+        final FeignExternalAssetOwnerHelper externalAssetOwnerHelper = new FeignExternalAssetOwnerHelper(
+                FineractFeignClientHelper.getFineractFeignClient());
+        externalAssetOwnerHelper.setProperFinancialActivity(transferAccount);
 
-        final PostClientsResponse client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
-        final PostLoanProductsResponse loanProductsResponse = loanProductHelper
-                .createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
-                        .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
-                        .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
-                        .deferredIncomeLiabilityAccountId(deferredIncomeLiabilityAccount.getAccountID().longValue())
-                        .incomeFromCapitalizationAccountId(feeIncomeAccount.getAccountID().longValue())
-                        .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
+        final Long clientId = createClient();
+        final Long loanProductsResponse = createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
+                .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
+                .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
+                .deferredIncomeLiabilityAccountId(getAccounts().getDeferredIncomeLiabilityAccount().getAccountID().longValue())
+                .incomeFromCapitalizationAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())
+                .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
 
         runAt("01 July 2026", () -> {
-            final Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProductsResponse.getResourceId(), "01 July 2026",
-                    1000.0, 10.0, 6, null);
+            final Long loanId = applyAndApproveProgressiveLoan(clientId, loanProductsResponse, "01 July 2026", 1000.0, 10.0, 6, null);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(1000.0), "01 July 2026");
 
-            final PostLoansLoanIdTransactionsResponse capitalizedIncomeResponse = loanTransactionHelper.addCapitalizedIncome(loanId,
-                    "01 July 2026", 50.0);
+            final PostLoansLoanIdTransactionsResponse capitalizedIncomeResponse = addCapitalizedIncomeTransaction(loanId, "01 July 2026",
+                    50.0);
             capitalizedIncomeTransactionIdRef.set(capitalizedIncomeResponse.getResourceId());
 
             externalAssetOwnerHelper.initiateTransferByLoanId(loanId, "sale",
@@ -1228,7 +1177,7 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
             final Long loanId = loanIdRef.get();
             executeInlineCOB(loanId);
 
-            final GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            final GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             assertNotNull(loanDetails.getTransactions());
 
             final BigDecimal totalAmortized = loanDetails.getTransactions().stream()
@@ -1238,14 +1187,14 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
             assertEquals(0, BigDecimal.valueOf(50.0).compareTo(totalAmortized),
                     "Capitalized income should be fully amortized after investor sale COB");
 
-            loanTransactionHelper.capitalizedIncomeAdjustment(loanId, capitalizedIncomeTransactionIdRef.get(), "02 July 2026", 20.0);
+            capitalizedIncomeAdjustment(loanId, capitalizedIncomeTransactionIdRef.get(), "02 July 2026", 20.0);
         });
 
         runAt("03 July 2026", () -> {
             final Long loanId = loanIdRef.get();
             executeInlineCOB(loanId);
 
-            final GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            final GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             assertNotNull(loanDetails.getTransactions());
 
             final BigDecimal amortizationAdjustmentAmount = loanDetails.getTransactions().stream()
@@ -1260,7 +1209,7 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
             final Long loanId = loanIdRef.get();
             executeInlineCOB(loanId);
 
-            final GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            final GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             assertNotNull(loanDetails.getTransactions());
 
             final BigDecimal amortizationAdjustmentAmount = loanDetails.getTransactions().stream()
@@ -1279,9 +1228,8 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
         final AtomicReference<Account> classificationIncomeAccountRef = new AtomicReference<>();
         runAt("10 September 2024", () -> {
             deleteAllExternalEvents();
-            final PostClientsResponse client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+            final Long clientId = createClient();
 
-            final AccountHelper accountHelper = new AccountHelper(this.requestSpec, this.responseSpec);
             final Account classificationIncomeAccount = accountHelper
                     .createIncomeAccount(Utils.uniqueRandomStringGenerator("capitalizedincome_class_income_", 6));
             classificationIncomeAccountRef.set(classificationIncomeAccount);
@@ -1296,17 +1244,15 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
                     .classificationCodeValueId(classificationIdRef.get())
                     .incomeAccountId(classificationIncomeAccount.getAccountID().longValue());
 
-            final PostLoanProductsResponse loanProductsResponse = loanProductHelper
-                    .createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
-                            .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
-                            .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
-                            .deferredIncomeLiabilityAccountId(deferredIncomeLiabilityAccount.getAccountID().longValue())
-                            .incomeFromCapitalizationAccountId(feeIncomeAccount.getAccountID().longValue())
-                            .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE)
-                            .addCapitalizedIncomeClassificationToIncomeAccountMappingsItem(classificationToIncomeMapping));
+            final Long loanProductsResponse = createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
+                    .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
+                    .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
+                    .deferredIncomeLiabilityAccountId(getAccounts().getDeferredIncomeLiabilityAccount().getAccountID().longValue())
+                    .incomeFromCapitalizationAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())
+                    .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE)
+                    .addCapitalizedIncomeClassificationToIncomeAccountMappingsItem(classificationToIncomeMapping));
 
-            GetLoanProductsProductIdResponse getLoanProductResponse = loanProductHelper
-                    .retrieveLoanProductById(loanProductsResponse.getResourceId());
+            GetLoanProductsProductIdResponse getLoanProductResponse = retrieveLoanProduct(loanProductsResponse);
             assertNotNull(getLoanProductResponse);
             assertNotNull(getLoanProductResponse.getCapitalizedIncomeClassificationToIncomeAccountMappings());
             Assertions.assertEquals(1, getLoanProductResponse.getCapitalizedIncomeClassificationToIncomeAccountMappings().size());
@@ -1323,23 +1269,22 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
                     new PostClassificationToIncomeAccountMappings().classificationCodeValueId(classificationIdRef.get())
                             .incomeAccountId(classificationIncomeAccount.getAccountID().longValue()));
 
-            loanProductHelper.updateLoanProductById(loanProductsResponse.getResourceId(), putLoanProductRequest);
-            getLoanProductResponse = loanProductHelper.retrieveLoanProductById(loanProductsResponse.getResourceId());
+            updateLoanProduct(loanProductsResponse, putLoanProductRequest);
+            getLoanProductResponse = retrieveLoanProduct(loanProductsResponse);
             assertNotNull(getLoanProductResponse);
             assertNotNull(getLoanProductResponse.getCapitalizedIncomeClassificationToIncomeAccountMappings());
             Assertions.assertEquals(1, getLoanProductResponse.getCapitalizedIncomeClassificationToIncomeAccountMappings().size());
             Assertions.assertEquals(classificationIdRef.get(), getLoanProductResponse
                     .getCapitalizedIncomeClassificationToIncomeAccountMappings().get(0).getClassificationCodeValue().getId());
 
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applyLP2ProgressiveLoanRequest(client.getClientId(),
-                    loanProductsResponse.getResourceId(), "10 September 2024", 1000.0, 10.0, 12, null));
-            Long loanId = postLoansResponse.getLoanId();
+            Long loanId = applyForLoan(
+                    applyLP2ProgressiveLoanRequest(clientId, loanProductsResponse, "10 September 2024", 1000.0, 10.0, 12, null));
             loanIdRef.set(loanId);
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(1000.0, "10 September 2024"));
+            approveLoan(loanId, approveLoanRequest(1000.0, "10 September 2024"));
             disburseLoan(loanId, BigDecimal.valueOf(1000.0), "10 September 2024");
 
-            Long capitalizedIncomeTransactionId = loanTransactionHelper
-                    .addCapitalizedIncome(loanId, "10 September 2024", 100.0, classificationIdRef.get()).getResourceId();
+            Long capitalizedIncomeTransactionId = addCapitalizedIncomeTransaction(loanId, "10 September 2024", 100.0,
+                    classificationIdRef.get()).getResourceId();
             assertNotNull(capitalizedIncomeTransactionId);
         });
 
@@ -1348,8 +1293,7 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
             deleteAllExternalEvents();
             executeInlineCOB(loanId);
 
-            Long capitalizedIncomeTransactionId = loanTransactionHelper.addCapitalizedIncome(loanId, "20 September 2024", 20.0)
-                    .getResourceId();
+            Long capitalizedIncomeTransactionId = addCapitalizedIncomeTransaction(loanId, "20 September 2024", 20.0).getResourceId();
             assertNotNull(capitalizedIncomeTransactionId);
         });
 
@@ -1358,14 +1302,15 @@ public class LoanCapitalizedIncomeTest extends BaseLoanIntegrationTest {
             deleteAllExternalEvents();
             executeInlineCOB(loanId);
 
-            final GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            final GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             final Optional<GetLoansLoanIdTransactions> optTx = loanDetails.getTransactions().stream()
                     .filter(item -> Objects.equals(Utils.getDoubleValue(item.getAmount()), 0.33)
                             && Objects.equals(item.getType().getValue(), "Capitalized Income Amortization"))
                     .findFirst();
-            verifyTRJournalEntries(optTx.get().getId(), debit(deferredIncomeLiabilityAccount, 0.33),
+            verifyTRJournalEntries(optTx.get().getId(), debit(getAccounts().getDeferredIncomeLiabilityAccount(), 0.33),
                     credit(classificationIncomeAccountRef.get(), 0.27), // First Capitalized Income With classification
-                    credit(feeIncomeAccount, 0.06)); // Second Capitalized Income Without classification
+                    credit(getAccounts().getFeeIncomeAccount(), 0.06)); // Second Capitalized Income Without
+                                                                        // classification
 
         });
     }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanCatchUpIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanCatchUpIntegrationTest.java
@@ -18,177 +18,92 @@
  */
 package org.apache.fineract.integrationtests;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.path.json.JsonPath;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import org.apache.fineract.batch.domain.BatchRequest;
-import org.apache.fineract.batch.domain.BatchResponse;
-import org.apache.fineract.client.models.GetLoansLoanIdResponse;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.fineract.client.models.BatchResponse;
+import org.apache.fineract.client.models.ChargeRequest;
+import org.apache.fineract.client.models.LoanProductChargeData;
+import org.apache.fineract.client.models.PostLoanProductsRequest;
+import org.apache.fineract.client.models.PostLoansRequest;
 import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
 import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
-import org.apache.fineract.integrationtests.common.BatchHelper;
-import org.apache.fineract.integrationtests.common.BusinessDateHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.CollateralManagementHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignLoanCOBCatchUpHelper;
+import org.apache.fineract.integrationtests.client.feign.modules.ChargeRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
 import org.apache.fineract.integrationtests.common.loans.LoanAccountLockHelper;
-import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanCOBCatchUpHelper;
-import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanStatusChecker;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.apache.fineract.integrationtests.useradministration.users.UserHelper;
-import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleType;
+import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanStatus;
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 
 @Order(1)
-public class LoanCatchUpIntegrationTest extends BaseLoanIntegrationTest {
+public class LoanCatchUpIntegrationTest extends FeignLoanTestBase {
 
-    private static final String REPAYMENT_LOAN_PERMISSION = "REPAYMENT_LOAN";
-    private static final String READ_LOAN_PERMISSION = "READ_LOAN";
-
-    private ResponseSpecification responseSpec;
-    private RequestSpecification requestSpec;
-    private LoanCOBCatchUpHelper loanCOBCatchUpHelper;
-    private LoanTransactionHelper loanTransactionHelper;
-
-    @BeforeEach
-    public void setup() {
-        Utils.initializeRESTAssured();
-        loanCOBCatchUpHelper = new LoanCOBCatchUpHelper();
-        requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        requestSpec.header("Fineract-Platform-TenantId", "default");
-        responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        this.requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-    }
+    private static final String CUMULATIVE_STRATEGY = "mifos-standard-strategy";
+    private static final String INLINE_COB_LOCK_OWNER = "LOAN_INLINE_COB_PROCESSING";
+    private static final Long REPAYMENT_BATCH_REQUEST_ID = 4730L;
 
     @Test
     public void testCatchUpInLockedInstance() {
+        FeignLoanCOBCatchUpHelper loanCOBCatchUpHelper = new FeignLoanCOBCatchUpHelper(FineractFeignClientHelper.getFineractFeignClient());
         try {
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 2));
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), "02 March 2020");
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
                     new PutGlobalConfigurationsRequest().value(0L));
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
 
-            final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec);
-            Assertions.assertNotNull(clientID);
+            Long clientId = createClient();
 
-            Integer overdueFeeChargeId = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
-            Assertions.assertNotNull(overdueFeeChargeId);
+            ChargeRequest overdueFeeCharge = ChargeRequestBuilders.loanOverdueFee(1.0)
+                    .chargeCalculationType(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST.getValue());
+            Long overdueFeeChargeId = chargesHelper.createCharge(overdueFeeCharge).getResourceId();
 
-            final Integer loanProductID = createLoanProduct(overdueFeeChargeId.toString());
-            Assertions.assertNotNull(loanProductID);
-            HashMap loanStatusHashMap;
-            final Integer loanID = applyForLoanApplication(clientID.toString(), loanProductID.toString(), null, "1 March 2020");
+            PostLoanProductsRequest product = create4Period1MonthLongWithoutInterestProduct(CUMULATIVE_STRATEGY).principal(15000.0)
+                    .charges(List.of(new LoanProductChargeData().id(overdueFeeChargeId)));
+            Long loanProductId = createLoanProduct(product);
 
-            Assertions.assertNotNull(loanID);
+            PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "01 March 2020", 15000.0, 4)//
+                    .repaymentEvery(1)//
+                    .loanTermFrequency(4)//
+                    .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                    .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS);
+            Long loanId = applyForLoan(applicationRequest);
+            verifyLoanStatus(loanId, LoanStatus.SUBMITTED_AND_PENDING_APPROVAL);
+            approveLoan(loanId, approveLoanRequest(15000.0, "01 March 2020"));
+            verifyLoanStatus(loanId, LoanStatus.APPROVED);
+            disburseLoan(loanId, BigDecimal.valueOf(15000.0), "02 March 2020");
+            verifyLoanStatus(loanId, LoanStatus.ACTIVE);
 
-            loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+            updateBusinessDate(BusinessDateType.COB_DATE.name(), "02 March 2020");
+            LoanAccountLockHelper.placeSoftLockOnLoanAccount(loanId, INLINE_COB_LOCK_OWNER, "Sample error");
 
-            loanStatusHashMap = loanTransactionHelper.approveLoan("01 March 2020", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), "05 March 2020");
 
-            String loanDetails = loanTransactionHelper.getLoanDetails(requestSpec, responseSpec, loanID);
-            loanStatusHashMap = loanTransactionHelper.disburseLoanWithNetDisbursalAmount("02 March 2020", loanID,
-                    JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.COB_DATE, LocalDate.of(2020, 3, 2));
-            LoanAccountLockHelper.placeSoftLockOnLoanAccount(loanID.longValue(), "LOAN_INLINE_COB_PROCESSING", "Sample error");
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 5));
-
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
             loanCOBCatchUpHelper.executeLoanCOBCatchUp();
+            Utils.conditionalSleepWithMaxWait(30, 5, loanCOBCatchUpHelper::isLoanCOBCatchUpRunning);
 
-            Utils.conditionalSleepWithMaxWait(30, 5, () -> loanCOBCatchUpHelper.isLoanCOBCatchUpRunning());
+            verifyLastClosedBusinessDate(loanId, "04 March 2020");
 
-            GetLoansLoanIdResponse loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 4), loan.getLastClosedBusinessDate());
+            AtomicReference<List<BatchResponse>> responseRef = new AtomicReference<>();
+            runAsNonByPass(() -> responseRef.set(batchRequest().repayLoan(REPAYMENT_BATCH_REQUEST_ID, loanId, "10", "05 March 2020")
+                    .executeWithoutEnclosingTransaction()));
+            assertEquals(HttpStatus.SC_OK, responseRef.get().get(0).getStatusCode().intValue(), "Verify Status Code 200 for Repayment");
 
-            requestSpec = UserHelper.getSimpleUserWithoutBypassPermission(requestSpec, responseSpec);
-
-            final BatchRequest br1 = BatchHelper.repayLoanRequestWithGivenLoanId(4730L, loanID, "10", LocalDate.of(2020, 3, 5));
-
-            final List<BatchRequest> batchRequests = new ArrayList<>();
-
-            batchRequests.add(br1);
-
-            final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-
-            final List<BatchResponse> response = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec,
-                    this.responseSpec, jsonifiedRequest);
-            Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(0).getStatusCode(), "Verify Status Code 200 for Repayment");
-
-            loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 4), loan.getLastClosedBusinessDate());
+            verifyLastClosedBusinessDate(loanId, "04 March 2020");
         } finally {
-            requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-            requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-            requestSpec.header("Fineract-Platform-TenantId", "default");
-            responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(false));
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
                     new PutGlobalConfigurationsRequest().value(2L));
         }
     }
-
-    private Integer createLoanProduct(final String chargeId) {
-        final String loanProductJSON = new LoanProductTestBuilder().withPrincipal("15,000.00").withNumberOfRepayments("4")
-                .withRepaymentAfterEvery("1").withRepaymentTypeAsMonth().withinterestRatePerPeriod("1")
-                .withInterestRateFrequencyTypeAsMonths().withAmortizationTypeAsEqualInstallments().withInterestTypeAsDecliningBalance()
-                .withLoanScheduleType(LoanScheduleType.CUMULATIVE).build(chargeId);
-        return this.loanTransactionHelper.getLoanProductId(loanProductJSON);
-    }
-
-    private Integer applyForLoanApplication(final String clientID, final String loanProductID, final String savingsID, final String date) {
-
-        List<HashMap> collaterals = new ArrayList<>();
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(this.requestSpec, this.responseSpec);
-        Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(this.requestSpec, this.responseSpec, clientID,
-                collateralId);
-        Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
-
-        final String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal("15,000.00").withLoanTermFrequency("4")
-                .withLoanTermFrequencyAsMonths().withNumberOfRepayments("4").withRepaymentEveryAfter("1")
-                .withRepaymentFrequencyTypeAsMonths().withInterestRatePerPeriod("2").withAmortizationTypeAsEqualInstallments()
-                .withInterestTypeAsDecliningBalance().withInterestCalculationPeriodTypeSameAsRepaymentPeriod()
-                .withExpectedDisbursementDate(date).withSubmittedOnDate(date).withCollaterals(collaterals)
-                .build(clientID, loanProductID, savingsID);
-        return this.loanTransactionHelper.getLoanId(loanApplicationJSON);
-    }
-
-    private void addCollaterals(List<HashMap> collaterals, Integer collateralId, BigDecimal quantity) {
-        collaterals.add(collaterals(collateralId, quantity));
-    }
-
-    private HashMap<String, String> collaterals(Integer collateralId, BigDecimal quantity) {
-        HashMap<String, String> collateral = new HashMap<>(2);
-        collateral.put("clientCollateralId", collateralId.toString());
-        collateral.put("quantity", quantity.toString());
-        return collateral;
-    }
-
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanCatchUpIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanCatchUpIntegrationTest.java
@@ -18,177 +18,88 @@
  */
 package org.apache.fineract.integrationtests;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.path.json.JsonPath;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import org.apache.fineract.batch.domain.BatchRequest;
-import org.apache.fineract.batch.domain.BatchResponse;
-import org.apache.fineract.client.models.GetLoansLoanIdResponse;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.fineract.client.models.BatchResponse;
+import org.apache.fineract.client.models.ChargeRequest;
+import org.apache.fineract.client.models.LoanProductChargeData;
+import org.apache.fineract.client.models.PostLoanProductsRequest;
+import org.apache.fineract.client.models.PostLoansRequest;
 import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
 import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
-import org.apache.fineract.integrationtests.common.BatchHelper;
-import org.apache.fineract.integrationtests.common.BusinessDateHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.CollateralManagementHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignLoanCOBCatchUpHelper;
+import org.apache.fineract.integrationtests.client.feign.modules.ChargeRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
 import org.apache.fineract.integrationtests.common.loans.LoanAccountLockHelper;
-import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanCOBCatchUpHelper;
-import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanStatusChecker;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.apache.fineract.integrationtests.useradministration.users.UserHelper;
-import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleType;
+import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 
 @Order(1)
-public class LoanCatchUpIntegrationTest extends BaseLoanIntegrationTest {
+public class LoanCatchUpIntegrationTest extends FeignLoanTestBase {
 
-    private static final String REPAYMENT_LOAN_PERMISSION = "REPAYMENT_LOAN";
-    private static final String READ_LOAN_PERMISSION = "READ_LOAN";
-
-    private ResponseSpecification responseSpec;
-    private RequestSpecification requestSpec;
-    private LoanCOBCatchUpHelper loanCOBCatchUpHelper;
-    private LoanTransactionHelper loanTransactionHelper;
-
-    @BeforeEach
-    public void setup() {
-        Utils.initializeRESTAssured();
-        loanCOBCatchUpHelper = new LoanCOBCatchUpHelper();
-        requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        requestSpec.header("Fineract-Platform-TenantId", "default");
-        responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        this.requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-    }
+    private static final String CUMULATIVE_STRATEGY = "mifos-standard-strategy";
+    private static final String INLINE_COB_LOCK_OWNER = "LOAN_INLINE_COB_PROCESSING";
+    private static final Long REPAYMENT_BATCH_REQUEST_ID = 4730L;
 
     @Test
     public void testCatchUpInLockedInstance() {
+        FeignLoanCOBCatchUpHelper loanCOBCatchUpHelper = new FeignLoanCOBCatchUpHelper(FineractFeignClientHelper.getFineractFeignClient());
         try {
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 2));
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), "02 March 2020");
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
                     new PutGlobalConfigurationsRequest().value(0L));
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
 
-            final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec);
-            Assertions.assertNotNull(clientID);
+            Long clientId = createClient();
 
-            Integer overdueFeeChargeId = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
-            Assertions.assertNotNull(overdueFeeChargeId);
+            ChargeRequest overdueFeeCharge = ChargeRequestBuilders.loanOverdueFee(1.0)
+                    .chargeCalculationType(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST.getValue());
+            Long overdueFeeChargeId = chargesHelper.createCharge(overdueFeeCharge).getResourceId();
 
-            final Integer loanProductID = createLoanProduct(overdueFeeChargeId.toString());
-            Assertions.assertNotNull(loanProductID);
-            HashMap loanStatusHashMap;
-            final Integer loanID = applyForLoanApplication(clientID.toString(), loanProductID.toString(), null, "1 March 2020");
+            PostLoanProductsRequest product = create4Period1MonthLongWithoutInterestProduct(CUMULATIVE_STRATEGY).principal(15000.0)
+                    .charges(List.of(new LoanProductChargeData().id(overdueFeeChargeId)));
+            Long loanProductId = createLoanProduct(product);
 
-            Assertions.assertNotNull(loanID);
+            PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "01 March 2020", 15000.0, 4)//
+                    .repaymentEvery(1)//
+                    .loanTermFrequency(4)//
+                    .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                    .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS);
+            Long loanId = applyForLoan(applicationRequest);
+            approveLoan(loanId, approveLoanRequest(15000.0, "01 March 2020"));
+            disburseLoan(loanId, BigDecimal.valueOf(15000.0), "02 March 2020");
 
-            loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+            updateBusinessDate(BusinessDateType.COB_DATE.name(), "02 March 2020");
+            LoanAccountLockHelper.placeSoftLockOnLoanAccount(loanId, INLINE_COB_LOCK_OWNER, "Sample error");
 
-            loanStatusHashMap = loanTransactionHelper.approveLoan("01 March 2020", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), "05 March 2020");
 
-            String loanDetails = loanTransactionHelper.getLoanDetails(requestSpec, responseSpec, loanID);
-            loanStatusHashMap = loanTransactionHelper.disburseLoanWithNetDisbursalAmount("02 March 2020", loanID,
-                    JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.COB_DATE, LocalDate.of(2020, 3, 2));
-            LoanAccountLockHelper.placeSoftLockOnLoanAccount(loanID.longValue(), "LOAN_INLINE_COB_PROCESSING", "Sample error");
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 5));
-
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
             loanCOBCatchUpHelper.executeLoanCOBCatchUp();
+            Utils.conditionalSleepWithMaxWait(30, 5, loanCOBCatchUpHelper::isLoanCOBCatchUpRunning);
 
-            Utils.conditionalSleepWithMaxWait(30, 5, () -> loanCOBCatchUpHelper.isLoanCOBCatchUpRunning());
+            verifyLastClosedBusinessDate(loanId, "04 March 2020");
 
-            GetLoansLoanIdResponse loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 4), loan.getLastClosedBusinessDate());
+            AtomicReference<List<BatchResponse>> responseRef = new AtomicReference<>();
+            runAsNonByPass(() -> responseRef.set(batchRequest().repayLoan(REPAYMENT_BATCH_REQUEST_ID, loanId, "10", "05 March 2020")
+                    .executeWithoutEnclosingTransaction()));
+            assertEquals(HttpStatus.SC_OK, responseRef.get().get(0).getStatusCode().intValue(), "Verify Status Code 200 for Repayment");
 
-            requestSpec = UserHelper.getSimpleUserWithoutBypassPermission(requestSpec, responseSpec);
-
-            final BatchRequest br1 = BatchHelper.repayLoanRequestWithGivenLoanId(4730L, loanID, "10", LocalDate.of(2020, 3, 5));
-
-            final List<BatchRequest> batchRequests = new ArrayList<>();
-
-            batchRequests.add(br1);
-
-            final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-
-            final List<BatchResponse> response = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec,
-                    this.responseSpec, jsonifiedRequest);
-            Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(0).getStatusCode(), "Verify Status Code 200 for Repayment");
-
-            loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 4), loan.getLastClosedBusinessDate());
+            verifyLastClosedBusinessDate(loanId, "04 March 2020");
         } finally {
-            requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-            requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-            requestSpec.header("Fineract-Platform-TenantId", "default");
-            responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(false));
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
                     new PutGlobalConfigurationsRequest().value(2L));
         }
     }
-
-    private Integer createLoanProduct(final String chargeId) {
-        final String loanProductJSON = new LoanProductTestBuilder().withPrincipal("15,000.00").withNumberOfRepayments("4")
-                .withRepaymentAfterEvery("1").withRepaymentTypeAsMonth().withinterestRatePerPeriod("1")
-                .withInterestRateFrequencyTypeAsMonths().withAmortizationTypeAsEqualInstallments().withInterestTypeAsDecliningBalance()
-                .withLoanScheduleType(LoanScheduleType.CUMULATIVE).build(chargeId);
-        return this.loanTransactionHelper.getLoanProductId(loanProductJSON);
-    }
-
-    private Integer applyForLoanApplication(final String clientID, final String loanProductID, final String savingsID, final String date) {
-
-        List<HashMap> collaterals = new ArrayList<>();
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(this.requestSpec, this.responseSpec);
-        Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(this.requestSpec, this.responseSpec, clientID,
-                collateralId);
-        Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
-
-        final String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal("15,000.00").withLoanTermFrequency("4")
-                .withLoanTermFrequencyAsMonths().withNumberOfRepayments("4").withRepaymentEveryAfter("1")
-                .withRepaymentFrequencyTypeAsMonths().withInterestRatePerPeriod("2").withAmortizationTypeAsEqualInstallments()
-                .withInterestTypeAsDecliningBalance().withInterestCalculationPeriodTypeSameAsRepaymentPeriod()
-                .withExpectedDisbursementDate(date).withSubmittedOnDate(date).withCollaterals(collaterals)
-                .build(clientID, loanProductID, savingsID);
-        return this.loanTransactionHelper.getLoanId(loanApplicationJSON);
-    }
-
-    private void addCollaterals(List<HashMap> collaterals, Integer collateralId, BigDecimal quantity) {
-        collaterals.add(collaterals(collateralId, quantity));
-    }
-
-    private HashMap<String, String> collaterals(Integer collateralId, BigDecimal quantity) {
-        HashMap<String, String> collateral = new HashMap<>(2);
-        collateral.put("clientCollateralId", collateralId.toString());
-        collateral.put("quantity", quantity.toString());
-        return collateral;
-    }
-
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanChargeRoundingTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanChargeRoundingTest.java
@@ -21,7 +21,6 @@ package org.apache.fineract.integrationtests;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
@@ -34,24 +33,22 @@ import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
 import org.apache.fineract.client.models.ChargeRequest;
 import org.apache.fineract.client.models.GetLoansLoanIdLoanChargeData;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
 import org.apache.fineract.client.models.PostChargesResponse;
 import org.apache.fineract.client.models.PostLoanProductsRequest;
-import org.apache.fineract.client.models.PostLoanProductsResponse;
 import org.apache.fineract.client.models.PostLoansDisbursementData;
 import org.apache.fineract.client.models.PostLoansLoanIdChargesRequest;
-import org.apache.fineract.client.models.PostLoansLoanIdChargesResponse;
 import org.apache.fineract.client.models.PostLoansRequest;
-import org.apache.fineract.client.models.PostLoansResponse;
-import org.apache.fineract.client.util.CallFailedRuntimeException;
-import org.apache.fineract.integrationtests.common.ClientHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanRequestBuilders;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 @Slf4j
-public class LoanChargeRoundingTest extends BaseLoanIntegrationTest {
+public class LoanChargeRoundingTest extends FeignLoanTestBase {
 
     private Long clientId;
 
@@ -60,7 +57,7 @@ public class LoanChargeRoundingTest extends BaseLoanIntegrationTest {
 
     @BeforeEach
     public void setup() {
-        clientId = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+        clientId = createClient();
     }
 
     /** FLAT CHARGE **/
@@ -120,11 +117,10 @@ public class LoanChargeRoundingTest extends BaseLoanIntegrationTest {
 
             PostLoansLoanIdChargesRequest request = buildLoanChargeRequest(chargeResponse.getResourceId(), DATE, 0.5);
 
-            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.addLoanCharge(loanId, request));
+            CallFailedRuntimeException exception = loanHelper.addLoanChargeExpectingError(loanId, request);
 
-            assertEquals(403, exception.getResponse().code());
-            assertTrue(exception.getMessage().contains("error.msg.loanCharge.cannot.be.added.as.amount.rounded.to.zero"));
+            assertEquals(403, exception.getStatus());
+            assertErrorGlobalisationCode(exception, "error.msg.loanCharge.cannot.be.added.as.amount.rounded.to.zero");
 
             assertNoChargesPersisted(loanId, chargeResponse.getResourceId());
         });
@@ -191,11 +187,10 @@ public class LoanChargeRoundingTest extends BaseLoanIntegrationTest {
 
             PostLoansLoanIdChargesRequest request = buildLoanChargeRequest(chargeResponse.getResourceId(), DATE, 0.005);
 
-            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.addLoanCharge(loanId, request));
+            CallFailedRuntimeException exception = loanHelper.addLoanChargeExpectingError(loanId, request);
 
-            assertEquals(403, exception.getResponse().code());
-            assertTrue(exception.getMessage().contains("error.msg.loanCharge.cannot.be.added.as.amount.rounded.to.zero"));
+            assertEquals(403, exception.getStatus());
+            assertErrorGlobalisationCode(exception, "error.msg.loanCharge.cannot.be.added.as.amount.rounded.to.zero");
 
             assertNoChargesPersisted(loanId, chargeResponse.getResourceId());
         });
@@ -303,11 +298,10 @@ public class LoanChargeRoundingTest extends BaseLoanIntegrationTest {
 
             PostLoansLoanIdChargesRequest request = buildLoanChargeRequest(chargeResponse.getResourceId(), DATE, 0.38);
 
-            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.addLoanCharge(loanId, request));
+            CallFailedRuntimeException exception = loanHelper.addLoanChargeExpectingError(loanId, request);
 
-            assertEquals(403, exception.getResponse().code());
-            assertTrue(exception.getMessage().contains("error.msg.loanCharge.cannot.be.added.as.amount.rounded.to.zero"));
+            assertEquals(403, exception.getStatus());
+            assertErrorGlobalisationCode(exception, "error.msg.loanCharge.cannot.be.added.as.amount.rounded.to.zero");
 
             assertNoChargesPersisted(loanId, chargeResponse.getResourceId());
         });
@@ -388,11 +382,10 @@ public class LoanChargeRoundingTest extends BaseLoanIntegrationTest {
 
             PostLoansLoanIdChargesRequest request = buildLoanChargeRequest(chargeResponse.getResourceId(), DATE, 1.68);
 
-            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.addLoanCharge(loanId, request));
+            CallFailedRuntimeException exception = loanHelper.addLoanChargeExpectingError(loanId, request);
 
-            assertEquals(403, exception.getResponse().code());
-            assertTrue(exception.getMessage().contains("error.msg.loanCharge.cannot.be.added.as.amount.rounded.to.zero"));
+            assertEquals(403, exception.getStatus());
+            assertErrorGlobalisationCode(exception, "error.msg.loanCharge.cannot.be.added.as.amount.rounded.to.zero");
 
             assertNoChargesPersisted(loanId, chargeResponse.getResourceId());
         });
@@ -416,7 +409,7 @@ public class LoanChargeRoundingTest extends BaseLoanIntegrationTest {
 
             addLoanCharge(loanId, chargeResponse.getResourceId(), DATE, 0.5);
 
-            List<GetLoansLoanIdLoanChargeData> charges = getLoanCharges(loanId);
+            List<GetLoansLoanIdLoanChargeData> charges = getLoanChargeData(loanId);
             assertNotNull(charges);
             assertEquals(2, charges.size());
 
@@ -448,13 +441,12 @@ public class LoanChargeRoundingTest extends BaseLoanIntegrationTest {
 
             PostLoansLoanIdChargesRequest request = buildLoanChargeRequest(chargeResponse.getResourceId(), DATE, 0.09);
 
-            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.addLoanCharge(loanId, request));
+            CallFailedRuntimeException exception = loanHelper.addLoanChargeExpectingError(loanId, request);
 
-            assertEquals(403, exception.getResponse().code());
-            assertTrue(exception.getMessage().contains("error.msg.loanCharge.cannot.be.added.as.amount.rounded.to.zero"));
+            assertEquals(403, exception.getStatus());
+            assertErrorGlobalisationCode(exception, "error.msg.loanCharge.cannot.be.added.as.amount.rounded.to.zero");
 
-            List<GetLoansLoanIdLoanChargeData> charges = getLoanCharges(loanId);
+            List<GetLoansLoanIdLoanChargeData> charges = getLoanChargeData(loanId);
             assertTrue(charges == null || charges.isEmpty(), "Expected no charges since rounded amount becomes 0");
 
             assertNoChargesPersisted(loanId, chargeResponse.getResourceId());
@@ -478,13 +470,12 @@ public class LoanChargeRoundingTest extends BaseLoanIntegrationTest {
 
             PostLoansLoanIdChargesRequest request = buildLoanChargeRequest(chargeResponse.getResourceId(), DATE, 0.04);
 
-            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.addLoanCharge(loanId, request));
+            CallFailedRuntimeException exception = loanHelper.addLoanChargeExpectingError(loanId, request);
 
-            assertEquals(403, exception.getResponse().code());
-            assertTrue(exception.getMessage().contains("error.msg.loanCharge.cannot.be.added.as.amount.rounded.to.zero"));
+            assertEquals(403, exception.getStatus());
+            assertErrorGlobalisationCode(exception, "error.msg.loanCharge.cannot.be.added.as.amount.rounded.to.zero");
 
-            List<GetLoansLoanIdLoanChargeData> charges = getLoanCharges(loanId);
+            List<GetLoansLoanIdLoanChargeData> charges = getLoanChargeData(loanId);
             assertTrue(charges == null || charges.isEmpty(), "Expected no charges since rounded amount becomes 0");
 
             assertNoChargesPersisted(loanId, chargeResponse.getResourceId());
@@ -509,7 +500,7 @@ public class LoanChargeRoundingTest extends BaseLoanIntegrationTest {
             assertNotNull(chargeResponse.getResourceId());
             addLoanCharge(loanId, chargeResponse.getResourceId(), DATE, 0.5);
 
-            List<GetLoansLoanIdLoanChargeData> charges = getLoanCharges(loanId);
+            List<GetLoansLoanIdLoanChargeData> charges = getLoanChargeData(loanId);
 
             assertNotNull(charges);
             assertEquals(1, charges.size());
@@ -539,7 +530,7 @@ public class LoanChargeRoundingTest extends BaseLoanIntegrationTest {
 
             addLoanCharge(loanId, chargeResponse.getResourceId(), DATE, 0.09);
 
-            List<GetLoansLoanIdLoanChargeData> charges = getLoanCharges(loanId);
+            List<GetLoansLoanIdLoanChargeData> charges = getLoanChargeData(loanId);
 
             assertNotNull(charges);
             assertEquals(1, charges.size());
@@ -570,11 +561,10 @@ public class LoanChargeRoundingTest extends BaseLoanIntegrationTest {
 
             PostLoansLoanIdChargesRequest request = buildLoanChargeRequest(chargeResponse.getResourceId(), DATE, 0.04);
 
-            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.addLoanCharge(loanId, request));
+            CallFailedRuntimeException exception = loanHelper.addLoanChargeExpectingError(loanId, request);
 
-            assertEquals(403, exception.getResponse().code());
-            assertTrue(exception.getMessage().contains("error.msg.loanCharge.cannot.be.added.as.amount.rounded.to.zero"));
+            assertEquals(403, exception.getStatus());
+            assertErrorGlobalisationCode(exception, "error.msg.loanCharge.cannot.be.added.as.amount.rounded.to.zero");
 
             assertNoChargesPersisted(loanId, chargeResponse.getResourceId());
         });
@@ -585,16 +575,12 @@ public class LoanChargeRoundingTest extends BaseLoanIntegrationTest {
     // -----------------------------
 
     private Long createLoanProduct(int digitsAfterDecimal, int inMultiplesOf) {
-        return loanProductHelper
-                .createLoanProduct(baseLoanProductRequest().digitsAfterDecimal(digitsAfterDecimal).inMultiplesOf(inMultiplesOf))
-                .getResourceId();
+        return createLoanProduct(baseLoanProductRequest().digitsAfterDecimal(digitsAfterDecimal).inMultiplesOf(inMultiplesOf));
     }
 
     private Long createMultiDisbursementLoanProduct(int digitsAfterDecimal, int inMultiplesOf) {
-        return loanProductHelper
-                .createLoanProduct(
-                        baseLoanProductRequestMultiRepayment().digitsAfterDecimal(digitsAfterDecimal).inMultiplesOf(inMultiplesOf))
-                .getResourceId();
+        return createLoanProduct(
+                baseLoanProductRequestMultiRepayment().digitsAfterDecimal(digitsAfterDecimal).inMultiplesOf(inMultiplesOf));
     }
 
     private PostLoanProductsRequest baseLoanProductRequest() {
@@ -619,84 +605,76 @@ public class LoanChargeRoundingTest extends BaseLoanIntegrationTest {
     }
 
     private Long applyAndApproveLoan(Long productId, double principal, int repayments) {
-        PostLoansResponse response = loanTransactionHelper.applyLoan(applyLoanRequest(clientId, productId, DATE, principal, repayments));
-        Long loanId = response.getLoanId();
+        Long loanId = applyForLoan(LoanRequestBuilders.applyLoanRequest(clientId, productId, DATE, principal, repayments));
         BigDecimal approvedPrincipal = getLoanPrincipal(loanId);
         assertNotNull(approvedPrincipal);
-        loanTransactionHelper.approveLoan(loanId, approveLoanRequest(approvedPrincipal.doubleValue(), DATE));
+        approveLoan(loanId, approveLoanRequest(approvedPrincipal.doubleValue(), DATE));
         return loanId;
     }
 
     private BigDecimal getLoanPrincipal(Long loanId) {
-        return loanTransactionHelper.getLoanDetails(loanId).getPrincipal();
+        return getLoanDetails(loanId).getPrincipal();
     }
 
     private Long applyAndApproveMultiTrancheLoan(Long productId, List<PostLoansDisbursementData> disbursements) {
         double totalPrincipal = disbursements.stream().map(PostLoansDisbursementData::getPrincipal).mapToDouble(BigDecimal::doubleValue)
                 .sum();
 
-        PostLoansRequest request = applyLoanRequest(clientId, productId, DATE, totalPrincipal, disbursements.size());
+        PostLoansRequest request = LoanRequestBuilders.applyLoanRequest(clientId, productId, DATE, totalPrincipal, disbursements.size());
         request.interestCalculationPeriodType(0).setDisbursementData(disbursements);
-        PostLoansResponse response = loanTransactionHelper.applyLoan(request);
-        Long loanId = response.getLoanId();
-        loanTransactionHelper.approveLoan(loanId, approveLoanRequest(totalPrincipal, DATE));
+        Long loanId = applyForLoan(request);
+        approveLoan(loanId, approveLoanRequest(totalPrincipal, DATE));
         return loanId;
     }
 
     private PostChargesResponse createFlatCharge(double amount) {
         String uniqueChargeName = "Loan Flat Charge" + UUID.randomUUID().toString().replace("-", "");
-        return chargesHelper.createCharges(new ChargeRequest().name(uniqueChargeName).chargeAppliesTo(1).chargeTimeType(2)
+        return chargesHelper.createCharge(new ChargeRequest().name(uniqueChargeName).chargeAppliesTo(1).chargeTimeType(2)
                 .chargeCalculationType(1).amount(amount).currencyCode("USD").locale("en").chargePaymentMode(0).active(true).penalty(false));
     }
 
     private PostChargesResponse createPercentageOfAmountCharge(double percentage) {
         String uniqueChargeName = "Loan Percentage of Amount Charge" + UUID.randomUUID().toString().replace("-", "");
         return chargesHelper
-                .createCharges(new ChargeRequest().name(uniqueChargeName).chargeAppliesTo(1).chargeTimeType(2).chargeCalculationType(2)
+                .createCharge(new ChargeRequest().name(uniqueChargeName).chargeAppliesTo(1).chargeTimeType(2).chargeCalculationType(2)
                         .amount(percentage).currencyCode("USD").locale("en").chargePaymentMode(0).active(true).penalty(false));
     }
 
     private PostChargesResponse createPercentageOfAmountPlusInterestCharge(double percentage) {
         String uniqueChargeName = "Loan Percentage of Amount Plus Interest Charge" + UUID.randomUUID().toString().replace("-", "");
         return chargesHelper
-                .createCharges(new ChargeRequest().name(uniqueChargeName).chargeAppliesTo(1).chargeTimeType(2).chargeCalculationType(3)
+                .createCharge(new ChargeRequest().name(uniqueChargeName).chargeAppliesTo(1).chargeTimeType(2).chargeCalculationType(3)
                         .amount(percentage).currencyCode("USD").locale("en").chargePaymentMode(0).active(true).penalty(false));
     }
 
     private PostChargesResponse createPercentageOfInterestCharge(double percentage) {
         String uniqueChargeName = "Loan Percentage of Interest Charge" + UUID.randomUUID().toString().replace("-", "");
         return chargesHelper
-                .createCharges(new ChargeRequest().name(uniqueChargeName).chargeAppliesTo(1).chargeTimeType(2).chargeCalculationType(4)
+                .createCharge(new ChargeRequest().name(uniqueChargeName).chargeAppliesTo(1).chargeTimeType(2).chargeCalculationType(4)
                         .amount(percentage).currencyCode("USD").locale("en").chargePaymentMode(0).active(true).penalty(false));
     }
 
     private PostChargesResponse createPercentageOfTrancheDisbursementCharge(double percentage) {
         String uniqueChargeName = "Loan Tranche Charge" + UUID.randomUUID().toString().replace("-", "");
         return chargesHelper
-                .createCharges(new ChargeRequest().name(uniqueChargeName).chargeAppliesTo(1).chargeTimeType(12).chargeCalculationType(5)
+                .createCharge(new ChargeRequest().name(uniqueChargeName).chargeAppliesTo(1).chargeTimeType(12).chargeCalculationType(5)
                         .amount(percentage).currencyCode("USD").locale("en").chargePaymentMode(0).active(true).penalty(false));
     }
 
     private PostChargesResponse createPercentageOfDisbursementCharge(double percentage) {
         String uniqueChargeName = "Loan Disbursement Charge" + UUID.randomUUID().toString().replace("-", "");
         return chargesHelper
-                .createCharges(new ChargeRequest().name(uniqueChargeName).chargeAppliesTo(1).chargeTimeType(1).chargeCalculationType(2)
+                .createCharge(new ChargeRequest().name(uniqueChargeName).chargeAppliesTo(1).chargeTimeType(1).chargeCalculationType(2)
                         .amount(percentage).currencyCode("USD").locale("en").chargePaymentMode(0).active(true).penalty(false));
     }
 
-    protected PostLoansLoanIdChargesRequest buildLoanChargeRequest(Long chargeId, String dueDate, Double amount) {
+    private PostLoansLoanIdChargesRequest buildLoanChargeRequest(Long chargeId, String dueDate, Double amount) {
         return new PostLoansLoanIdChargesRequest().chargeId(chargeId).amount(amount).dueDate(dueDate).dateFormat("dd MMMM yyyy")
                 .locale("en");
     }
 
-    @Override
-    protected PostLoansLoanIdChargesResponse addLoanCharge(Long loanId, Long chargeId, String dueDate, Double amount) {
-        PostLoansLoanIdChargesRequest request = buildLoanChargeRequest(chargeId, dueDate, amount);
-        return loanTransactionHelper.addLoanCharge(loanId, request);
-    }
-
     private BigDecimal getLoanChargeAmount(Long loanId, Long chargeId) {
-        List<GetLoansLoanIdLoanChargeData> charges = getLoanCharges(loanId);
+        List<GetLoansLoanIdLoanChargeData> charges = getLoanChargeData(loanId);
         assertNotNull(charges);
         GetLoansLoanIdLoanChargeData charge = charges.stream().filter(c -> Objects.equals(c.getChargeId(), chargeId)).findFirst()
                 .orElseThrow(() -> new AssertionError("Loan charge not found: " + chargeId));
@@ -714,8 +692,8 @@ public class LoanChargeRoundingTest extends BaseLoanIntegrationTest {
         return applyRoundingRules(rawCharge, digitsAfterDecimal, inMultiplesOf);
     }
 
-    private List<GetLoansLoanIdLoanChargeData> getLoanCharges(Long loanId) {
-        GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+    private List<GetLoansLoanIdLoanChargeData> getLoanChargeData(Long loanId) {
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
         return loanDetails.getCharges();
     }
 
@@ -776,29 +754,29 @@ public class LoanChargeRoundingTest extends BaseLoanIntegrationTest {
 
     /// AMOUNT + INTEREST
     private Long createAndDisburseProgressiveLoan(double principal, int digitsAfterDecimal, int inMultiplesOf) {
-        PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(
+        Long productId = createLoanProduct(
                 create4IProgressive().numberOfRepayments(12).interestRatePerPeriod(1.0).isInterestRecalculationEnabled(false)
                         .currencyCode("USD").digitsAfterDecimal(digitsAfterDecimal).inMultiplesOf(inMultiplesOf));
 
-        PostLoansRequest request = applyLoanRequest(clientId, loanProduct.getResourceId(), DATE, principal, 12);
+        PostLoansRequest request = LoanRequestBuilders.applyLoanRequest(clientId, productId, DATE, principal, 12);
 
         request.setInterestRatePerPeriod(new BigDecimal("1.0"));
         request.setInterestRateFrequencyType(1);
         request.setTransactionProcessingStrategyCode("advanced-payment-allocation-strategy");
 
-        Long loanId = loanTransactionHelper.applyLoan(request).getLoanId();
+        Long loanId = applyForLoan(request);
 
-        loanTransactionHelper.approveLoan(loanId, approveLoanRequest(principal, DATE));
+        approveLoan(loanId, approveLoanRequest(principal, DATE));
 
-        loanTransactionHelper.disburseLoan(loanId, DATE, principal);
+        disburseLoanWithAmount(loanId, DATE, principal);
 
         return loanId;
     }
 
     private BigDecimal executeCobAndGetTotalInterest(Long loanId) {
-        inlineLoanCOBHelper.executeInlineCOB(loanId);
+        executeInlineCOB(loanId);
 
-        GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
 
         BigDecimal totalInterest = loanDetails.getRepaymentSchedule().getPeriods().stream()
                 .map(p -> p.getInterestDue() == null ? BigDecimal.ZERO : p.getInterestDue()).reduce(BigDecimal.ZERO, BigDecimal::add);
@@ -809,7 +787,7 @@ public class LoanChargeRoundingTest extends BaseLoanIntegrationTest {
     }
 
     private void assertNoChargesPersisted(Long loanId, Long chargeId) {
-        List<GetLoansLoanIdLoanChargeData> charges = getLoanCharges(loanId);
+        List<GetLoansLoanIdLoanChargeData> charges = getLoanChargeData(loanId);
 
         boolean chargeExists = charges != null && charges.stream().anyMatch(c -> Objects.equals(c.getChargeId(), chargeId));
 

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanChargeSpecificDueDateTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanChargeSpecificDueDateTest.java
@@ -22,120 +22,73 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
-import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.client.models.ChargeRequest;
 import org.apache.fineract.client.models.GetJournalEntriesTransactionIdResponse;
-import org.apache.fineract.client.models.GetLoanProductsProductIdResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
+import org.apache.fineract.client.models.GetLoansLoanIdSummary;
 import org.apache.fineract.client.models.GetLoansLoanIdTransactions;
 import org.apache.fineract.client.models.JournalEntryTransactionItem;
-import org.apache.fineract.client.models.PostChargesResponse;
-import org.apache.fineract.client.models.PostLoansLoanIdChargesChargeIdResponse;
-import org.apache.fineract.client.models.PostLoansLoanIdChargesResponse;
+import org.apache.fineract.client.models.PostLoanProductsRequest;
+import org.apache.fineract.client.models.PostLoansLoanIdChargesChargeIdRequest;
+import org.apache.fineract.client.models.PostLoansLoanIdChargesRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsResponse;
+import org.apache.fineract.client.models.PostLoansRequest;
 import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
-import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
-import org.apache.fineract.integrationtests.common.BusinessDateHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.modules.ChargeRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
 import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.accounting.Account;
-import org.apache.fineract.integrationtests.common.accounting.AccountHelper;
-import org.apache.fineract.integrationtests.common.accounting.JournalEntryHelper;
-import org.apache.fineract.integrationtests.common.accounting.PeriodicAccrualAccountingHelper;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
-import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.junit.jupiter.api.BeforeEach;
+import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
 import org.junit.jupiter.api.Test;
 
-@Slf4j
-public class LoanChargeSpecificDueDateTest extends BaseLoanIntegrationTest {
-
-    private ResponseSpecification responseSpec;
-    private RequestSpecification requestSpec;
-    private LoanTransactionHelper loanTransactionHelper;
-    private AccountHelper accountHelper;
-    private JournalEntryHelper journalEntryHelper;
+public class LoanChargeSpecificDueDateTest extends FeignLoanTestBase {
 
     private static final String principalAmount = "1000.00";
 
-    @BeforeEach
-    public void setup() {
-        Utils.initializeRESTAssured();
-
-        requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-
-        loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-        accountHelper = new AccountHelper(this.requestSpec, this.responseSpec);
-        journalEntryHelper = new JournalEntryHelper(this.requestSpec, this.responseSpec);
-    }
-
     @Test
     public void testApplyLoanSpecificDueDateFeeWithDisbursementDate() {
-
         final LocalDate todaysDate = Utils.getLocalDateOfTenant();
 
+        final Long clientId = createClient("01 January 2012");
         // Client and Loan account creation
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-        final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProductWithPeriodicAccrual(loanTransactionHelper,
-                null);
-        assertNotNull(getLoanProductsProductResponse);
+        final Long loanProductId = createLoanProduct(testLoanProduct());
 
+        final LocalDate transactionDate = todaysDate;
         // Older date to have more than one overdue installment
-        LocalDate transactionDate = todaysDate;
-        String operationDate = Utils.dateFormatter.format(transactionDate);
-        log.info("Operation date {}", transactionDate);
+        final String operationDate = Utils.dateFormatter.format(transactionDate);
 
         // Create Loan Account
-        final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                getLoanProductsProductResponse.getId().toString(), operationDate, "12", "0");
+        final Long loanId = createLoanAccount(clientId, loanProductId, operationDate, 12);
 
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
         // Get loan details
-        GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("0.00"), false);
+        validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("0.00"), false);
+
+        final Long loanChargeId = chargesHelper.createLoanSpecifiedDueDateCharge(10.0).getResourceId();
+        assertNotNull(loanChargeId);
+        addChargesForLoan(loanId, LoanRequestBuilders.addLoanCharge(loanChargeId, 10.0, operationDate));
 
         // Apply Loan Charge with specific due date
+        loanDetails = getLoanDetails(loanId);
+        validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("10.00"), false);
 
-        final String feeAmount = "10.00";
-        String payloadJSON = ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, feeAmount, false);
-        final PostChargesResponse postChargesResponse = ChargesHelper.createLoanCharge(requestSpec, responseSpec, payloadJSON);
-        assertNotNull(postChargesResponse);
-        final Long loanChargeId = postChargesResponse.getResourceId();
-
-        payloadJSON = LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(loanChargeId.toString(), operationDate, feeAmount);
-        PostLoansLoanIdChargesResponse postLoansLoanIdChargesResponse = loanTransactionHelper.addChargeForLoan(loanId, payloadJSON,
-                responseSpec);
-        assertNotNull(postLoansLoanIdChargesResponse);
+        runPeriodicAccrualAccounting(operationDate);
+        loanDetails = getLoanDetails(loanId);
 
         // Get loan details expecting to have a delinquency classification
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("10.00"), false);
+        final Long transactionId = evaluateLastLoanTransactionData(loanDetails, "loanTransactionType.accrual", operationDate,
+                Double.valueOf("10.00"));
+        assertNotNull(transactionId);
 
         // Run Accruals
-        log.info("Running Periodic Accrual for date {}", transactionDate);
-        PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting(operationDate);
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-
-        final Long transactionId = loanTransactionHelper.evaluateLastLoanTransactionData(getLoansLoanIdResponse,
-                "loanTransactionType.accrual", operationDate, Double.valueOf("10.00"));
-        assertNotNull(transactionId);
-        log.info("transactionId {}", transactionId);
-
-        final GetJournalEntriesTransactionIdResponse journalEntriesResponse = journalEntryHelper.getJournalEntries("L" + transactionId);
+        final GetJournalEntriesTransactionIdResponse journalEntriesResponse = getJournalEntries("L" + transactionId);
         assertNotNull(journalEntriesResponse);
         final List<JournalEntryTransactionItem> journalEntries = journalEntriesResponse.getPageItems();
         assertEquals(2, journalEntries.size());
@@ -145,71 +98,50 @@ public class LoanChargeSpecificDueDateTest extends BaseLoanIntegrationTest {
         assertEquals(transactionDate, journalEntries.get(1).getTransactionDate());
 
         // Make a full repayment to close the Loan
-        Float amount = Float.valueOf("1010.00");
-        PostLoansLoanIdTransactionsResponse loanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(operationDate, amount,
-                loanId);
+        PostLoansLoanIdTransactionsResponse loanIdTransactionsResponse = makeRepayment(operationDate, 1010.00f, loanId);
         assertNotNull(loanIdTransactionsResponse);
-        log.info("Loan Transaction Id: {} {}", loanId, loanIdTransactionsResponse.getResourceId());
 
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        assertNotNull(getLoansLoanIdResponse);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf("0.00"), Double.valueOf("0.00"), false);
-
+        loanDetails = getLoanDetails(loanId);
+        validateLoanAccount(loanDetails, Double.valueOf("0.00"), Double.valueOf("0.00"), false);
     }
 
     @Test
     public void testApplyLoanSpecificDueDatePenaltyWithDisbursementDate() {
-
         final LocalDate todaysDate = Utils.getLocalDateOfTenant();
 
+        final Long clientId = createClient("01 January 2012");
         // Client and Loan account creation
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-        final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProductWithPeriodicAccrual(loanTransactionHelper,
-                null);
-        assertNotNull(getLoanProductsProductResponse);
+        final Long loanProductId = createLoanProduct(testLoanProduct());
 
+        final LocalDate transactionDate = todaysDate;
         // Older date to have more than one overdue installment
-        LocalDate transactionDate = todaysDate;
-        String operationDate = Utils.dateFormatter.format(transactionDate);
-        log.info("Operation date {}", transactionDate);
+        final String operationDate = Utils.dateFormatter.format(transactionDate);
 
         // Create Loan Account
-        final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                getLoanProductsProductResponse.getId().toString(), operationDate, "12", "0");
+        final Long loanId = createLoanAccount(clientId, loanProductId, operationDate, 12);
 
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
         // Get loan details
-        GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("0.00"), true);
+        validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("0.00"), true);
+
+        final Long loanChargeId = chargesHelper.createLoanSpecifiedDueDatePenalty(10.0).getResourceId();
+        assertNotNull(loanChargeId);
+        addChargesForLoan(loanId, LoanRequestBuilders.addLoanCharge(loanChargeId, 10.0, operationDate));
 
         // Apply Loan Charge with specific due date
+        loanDetails = getLoanDetails(loanId);
+        validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("10.00"), true);
 
-        final String feeAmount = "10.00";
-        String payloadJSON = ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, feeAmount, true);
-        final PostChargesResponse postChargesResponse = ChargesHelper.createLoanCharge(requestSpec, responseSpec, payloadJSON);
-        assertNotNull(postChargesResponse);
-        final Long loanChargeId = postChargesResponse.getResourceId();
-        assertNotNull(loanChargeId);
-
-        payloadJSON = LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(loanChargeId.toString(), operationDate, feeAmount);
-        PostLoansLoanIdChargesResponse postLoansLoanIdChargesResponse = loanTransactionHelper.addChargeForLoan(loanId, payloadJSON,
-                responseSpec);
-        assertNotNull(postLoansLoanIdChargesResponse);
+        runPeriodicAccrualAccounting(operationDate);
+        loanDetails = getLoanDetails(loanId);
 
         // Get loan details expecting to have a delinquency classification
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("10.00"), true);
+        final Long transactionId = evaluateLastLoanTransactionData(loanDetails, "loanTransactionType.accrual", operationDate,
+                Double.valueOf("10.00"));
+        assertNotNull(transactionId);
 
         // Run Accruals
-        log.info("Running Periodic Accrual for date {}", transactionDate);
-        PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting(operationDate);
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-
-        final Long transactionId = loanTransactionHelper.evaluateLastLoanTransactionData(getLoansLoanIdResponse,
-                "loanTransactionType.accrual", operationDate, Double.valueOf("10.00"));
-        assertNotNull(transactionId);
-        log.info("transactionId {}", transactionId);
-
-        final GetJournalEntriesTransactionIdResponse journalEntriesResponse = journalEntryHelper.getJournalEntries("L" + transactionId);
+        final GetJournalEntriesTransactionIdResponse journalEntriesResponse = getJournalEntries("L" + transactionId);
         assertNotNull(journalEntriesResponse);
         final List<JournalEntryTransactionItem> journalEntries = journalEntriesResponse.getPageItems();
         assertEquals(2, journalEntries.size());
@@ -219,17 +151,12 @@ public class LoanChargeSpecificDueDateTest extends BaseLoanIntegrationTest {
         assertEquals(transactionDate, journalEntries.get(1).getTransactionDate());
 
         // Make a full repayment to close the Loan
-        Float amount = Float.valueOf("1010.00");
-        PostLoansLoanIdTransactionsResponse loanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(operationDate, amount,
-                loanId);
+        PostLoansLoanIdTransactionsResponse loanIdTransactionsResponse = makeRepayment(operationDate, 1010.00f, loanId);
         assertNotNull(loanIdTransactionsResponse);
-        log.info("Loan Transaction Id: {} {}", loanId, loanIdTransactionsResponse.getResourceId());
 
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        assertNotNull(getLoansLoanIdResponse);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf("0.00"), Double.valueOf("0.00"), true);
-        loanTransactionHelper.validateLoanStatus(getLoansLoanIdResponse, "loanStatusType.closed.obligations.met");
-
+        loanDetails = getLoanDetails(loanId);
+        validateLoanAccount(loanDetails, Double.valueOf("0.00"), Double.valueOf("0.00"), true);
+        validateLoanStatus(loanDetails, "loanStatusType.closed.obligations.met");
     }
 
     @Test
@@ -237,73 +164,53 @@ public class LoanChargeSpecificDueDateTest extends BaseLoanIntegrationTest {
         globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                 new PutGlobalConfigurationsRequest().enabled(true));
         final LocalDate todaysDate = Utils.getLocalDateOfTenant();
-        BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, todaysDate);
+        updateBusinessDate(Utils.dateFormatter.format(todaysDate));
 
+        final Long clientId = createClient("01 January 2012");
         // Client and Loan account creation
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-        final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper, null);
-        assertNotNull(getLoanProductsProductResponse);
+        final Long loanProductId = createLoanProduct(testLoanProduct());
 
+        final LocalDate transactionDate = todaysDate;
         // Older date to have more than one overdue installment
-        LocalDate transactionDate = todaysDate;
-        String operationDate = Utils.dateFormatter.format(transactionDate);
-        log.info("Operation date {}", transactionDate);
+        final String operationDate = Utils.dateFormatter.format(transactionDate);
 
         // Create Loan Account
-        final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                getLoanProductsProductResponse.getId().toString(), operationDate, "1", "0");
+        final Long loanId = createLoanAccount(clientId, loanProductId, operationDate, 1);
 
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
         // Get loan details
-        GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("0.00"), false);
+        validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("0.00"), false);
 
         // Apply Loan Charge with specific due date
-        final String feeAmount = "1.500000";
-        String payloadJSON = ChargesHelper.getLoanSpecificInstallmentFeeJSON();
-        final PostChargesResponse postChargesResponse = ChargesHelper.createLoanCharge(requestSpec, responseSpec, payloadJSON);
-        assertNotNull(postChargesResponse);
-        final Long chargeId = postChargesResponse.getResourceId();
+        final Long chargeId = chargesHelper.createCharge(installmentFee()).getResourceId();
         assertNotNull(chargeId);
 
-        float amount = Float.parseFloat("5.00");
-        PostLoansLoanIdTransactionsResponse loanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(operationDate, amount,
-                loanId);
+        makeRepayment(operationDate, 5.00f, loanId);
 
-        payloadJSON = LoanTransactionHelper.getSpecifiedInstallmentChargesForLoanAsJSON(chargeId.toString(), feeAmount);
-        PostLoansLoanIdChargesResponse postLoansLoanIdChargesResponse = loanTransactionHelper.addChargeForLoan(loanId, payloadJSON,
-                responseSpec);
-        assertNotNull(postLoansLoanIdChargesResponse);
-        final Long loanChargeId = postLoansLoanIdChargesResponse.getResourceId();
+        final Long loanChargeId = addChargesForLoan(loanId, installmentCharge(chargeId, 1.5)).getResourceId();
         assertNotNull(loanChargeId);
 
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("10.00"), false);
+        loanDetails = getLoanDetails(loanId);
+        validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("10.00"), false);
 
         // Waive the Loan Charge
-        final PostLoansLoanIdChargesChargeIdResponse postWaiveLoanChargesResponse = loanTransactionHelper.applyLoanChargeCommand(loanId,
-                loanChargeId, "waive", Utils.emptyJson());
-        assertNotNull(postWaiveLoanChargesResponse);
+        waiveLoanCharge(loanId, loanChargeId, new PostLoansLoanIdChargesChargeIdRequest());
 
+        loanDetails = getLoanDetails(loanId);
         // evaluate the outstanding
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("0.00"), false);
+        validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("0.00"), false);
 
-        Optional<GetLoansLoanIdTransactions> waiveTransaction = getLoansLoanIdResponse.getTransactions().stream()
+        Optional<GetLoansLoanIdTransactions> waiveTransaction = loanDetails.getTransactions().stream()
                 .filter(transaction -> transaction.getType().getWaiveCharges() != null && transaction.getType().getWaiveCharges())
                 .findFirst();
         assertTrue(waiveTransaction.isPresent());
         assertEquals(transactionDate, waiveTransaction.get().getDate());
 
         // Make a full repayment to close the Loan
-        amount = Float.parseFloat("1000.00");
-        loanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(operationDate, amount, loanId);
-        assertNotNull(loanIdTransactionsResponse);
-        log.info("Loan Transaction Id: {} {}", loanId, loanIdTransactionsResponse.getResourceId());
+        makeRepayment(operationDate, 1000.00f, loanId);
 
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        assertNotNull(getLoansLoanIdResponse);
-        loanTransactionHelper.validateLoanStatus(getLoansLoanIdResponse, "loanStatusType.closed.obligations.met");
-
+        loanDetails = getLoanDetails(loanId);
+        validateLoanStatus(loanDetails, "loanStatusType.closed.obligations.met");
     }
 
     @Test
@@ -311,138 +218,101 @@ public class LoanChargeSpecificDueDateTest extends BaseLoanIntegrationTest {
         globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                 new PutGlobalConfigurationsRequest().enabled(true));
         final LocalDate todaysDate = Utils.getLocalDateOfTenant();
-        BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, todaysDate);
+        updateBusinessDate(Utils.dateFormatter.format(todaysDate));
 
+        final Long clientId = createClient("01 January 2012");
         // Client and Loan account creation
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-        final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper, null);
-        assertNotNull(getLoanProductsProductResponse);
+        final Long loanProductId = createLoanProduct(testLoanProduct());
 
         // Older date to have more than one overdue installment
         LocalDate transactionDate = todaysDate;
-        String operationDate = Utils.dateFormatter.format(transactionDate);
-        log.info("Operation date {}", transactionDate);
+        final String operationDate = Utils.dateFormatter.format(transactionDate);
 
         // Create Loan Account
-        final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                getLoanProductsProductResponse.getId().toString(), operationDate, "1", "0");
+        final Long loanId = createLoanAccount(clientId, loanProductId, operationDate, 1);
 
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
         // Get loan details
-        GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("0.00"), false);
+        validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("0.00"), false);
 
         // Apply Loan Charge with specific due date
-        final String feeAmount = "1.500000";
-        String payloadJSON = ChargesHelper.getLoanSpecificInstallmentFeeJSON();
-        final PostChargesResponse postChargesResponse = ChargesHelper.createLoanCharge(requestSpec, responseSpec, payloadJSON);
-        assertNotNull(postChargesResponse);
-        final Long chargeId = postChargesResponse.getResourceId();
+        final Long chargeId = chargesHelper.createCharge(installmentFee()).getResourceId();
         assertNotNull(chargeId);
 
-        float amount = Float.parseFloat("5.00");
-        PostLoansLoanIdTransactionsResponse loanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(operationDate, amount,
-                loanId);
+        makeRepayment(operationDate, 5.00f, loanId);
         transactionDate = todaysDate.plusDays(32);
-        BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, transactionDate);
+        updateBusinessDate(Utils.dateFormatter.format(transactionDate));
 
-        payloadJSON = LoanTransactionHelper.getSpecifiedInstallmentChargesForLoanAsJSON(chargeId.toString(), feeAmount);
-        PostLoansLoanIdChargesResponse postLoansLoanIdChargesResponse = loanTransactionHelper.addChargeForLoan(loanId, payloadJSON,
-                responseSpec);
-        assertNotNull(postLoansLoanIdChargesResponse);
-        final Long loanChargeId = postLoansLoanIdChargesResponse.getResourceId();
+        final Long loanChargeId = addChargesForLoan(loanId, installmentCharge(chargeId, 1.5)).getResourceId();
         assertNotNull(loanChargeId);
 
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("10.00"), false);
-        LocalDate repaymentDueDate = getLoansLoanIdResponse.getRepaymentSchedule().getPeriods().get(1).getDueDate();
+        loanDetails = getLoanDetails(loanId);
+        validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("10.00"), false);
         // Waive the Loan Charge
-        final PostLoansLoanIdChargesChargeIdResponse postWaiveLoanChargesResponse = loanTransactionHelper.applyLoanChargeCommand(loanId,
-                loanChargeId, "waive", Utils.emptyJson());
-        assertNotNull(postWaiveLoanChargesResponse);
+        LocalDate repaymentDueDate = loanDetails.getRepaymentSchedule().getPeriods().get(1).getDueDate();
 
         // evaluate the outstanding
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("0.00"), false);
+        waiveLoanCharge(loanId, loanChargeId, new PostLoansLoanIdChargesChargeIdRequest());
 
-        Optional<GetLoansLoanIdTransactions> waiveTransaction = getLoansLoanIdResponse.getTransactions().stream()
+        loanDetails = getLoanDetails(loanId);
+        validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("0.00"), false);
+
+        Optional<GetLoansLoanIdTransactions> waiveTransaction = loanDetails.getTransactions().stream()
                 .filter(transaction -> transaction.getType().getWaiveCharges() != null && transaction.getType().getWaiveCharges())
                 .findFirst();
         assertTrue(waiveTransaction.isPresent());
         assertEquals(repaymentDueDate, waiveTransaction.get().getDate());
 
         // Make a full repayment to close the Loan
-        amount = Float.parseFloat("1000.00");
-        loanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(operationDate, amount, loanId);
-        assertNotNull(loanIdTransactionsResponse);
-        log.info("Loan Transaction Id: {} {}", loanId, loanIdTransactionsResponse.getResourceId());
+        makeRepayment(operationDate, 1000.00f, loanId);
 
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        assertNotNull(getLoansLoanIdResponse);
-        loanTransactionHelper.validateLoanStatus(getLoansLoanIdResponse, "loanStatusType.closed.obligations.met");
-
+        loanDetails = getLoanDetails(loanId);
+        validateLoanStatus(loanDetails, "loanStatusType.closed.obligations.met");
     }
 
     @Test
     public void testApplyAndWaiveLoanSpecificDueDatePenaltyWithDisbursementDate() {
-
         final LocalDate todaysDate = Utils.getLocalDateOfTenant();
 
+        final Long clientId = createClient("01 January 2012");
         // Client and Loan account creation
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-        final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper, null);
-        assertNotNull(getLoanProductsProductResponse);
+        final Long loanProductId = createLoanProduct(testLoanProduct());
 
+        final LocalDate transactionDate = todaysDate;
         // Older date to have more than one overdue installment
-        LocalDate transactionDate = todaysDate;
-        String operationDate = Utils.dateFormatter.format(transactionDate);
-        log.info("Operation date {}", transactionDate);
+        final String operationDate = Utils.dateFormatter.format(transactionDate);
 
         // Create Loan Account
-        final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                getLoanProductsProductResponse.getId().toString(), operationDate, "12", "0");
+        final Long loanId = createLoanAccount(clientId, loanProductId, operationDate, 12);
 
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
         // Get loan details
-        GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("0.00"), true);
+        validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("0.00"), true);
 
         // Apply Loan Charge with specific due date
-        final String feeAmount = "10.00";
-        String payloadJSON = ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, feeAmount, true);
-        final PostChargesResponse postChargesResponse = ChargesHelper.createLoanCharge(requestSpec, responseSpec, payloadJSON);
-        assertNotNull(postChargesResponse);
-        final Long chargeId = postChargesResponse.getResourceId();
+        final Long chargeId = chargesHelper.createLoanSpecifiedDueDatePenalty(10.0).getResourceId();
         assertNotNull(chargeId);
 
-        payloadJSON = LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(chargeId.toString(), operationDate, feeAmount);
-        PostLoansLoanIdChargesResponse postLoansLoanIdChargesResponse = loanTransactionHelper.addChargeForLoan(loanId, payloadJSON,
-                responseSpec);
-        assertNotNull(postLoansLoanIdChargesResponse);
-        final Long loanChargeId = postLoansLoanIdChargesResponse.getResourceId();
+        final Long loanChargeId = addChargesForLoan(loanId, LoanRequestBuilders.addLoanCharge(chargeId, 10.0, operationDate))
+                .getResourceId();
         assertNotNull(loanChargeId);
 
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("10.00"), true);
+        loanDetails = getLoanDetails(loanId);
+        validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("10.00"), true);
 
         // Waive the Loan Charge
-        final PostLoansLoanIdChargesChargeIdResponse postWaiveLoanChargesResponse = loanTransactionHelper.applyLoanChargeCommand(loanId,
-                loanChargeId, "waive", Utils.emptyJson());
-        assertNotNull(postWaiveLoanChargesResponse);
+        waiveLoanCharge(loanId, loanChargeId, new PostLoansLoanIdChargesChargeIdRequest());
 
+        loanDetails = getLoanDetails(loanId);
         // evaluate the outstanding
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("0.00"), true);
+        validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("0.00"), true);
 
         // Make a full repayment to close the Loan
-        Float amount = Float.valueOf("1000.00");
-        PostLoansLoanIdTransactionsResponse loanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(operationDate, amount,
-                loanId);
+        PostLoansLoanIdTransactionsResponse loanIdTransactionsResponse = makeRepayment(operationDate, 1000.00f, loanId);
         assertNotNull(loanIdTransactionsResponse);
-        log.info("Loan Transaction Id: {} {}", loanId, loanIdTransactionsResponse.getResourceId());
 
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        assertNotNull(getLoansLoanIdResponse);
-        loanTransactionHelper.validateLoanStatus(getLoansLoanIdResponse, "loanStatusType.closed.obligations.met");
-
+        loanDetails = getLoanDetails(loanId);
+        validateLoanStatus(loanDetails, "loanStatusType.closed.obligations.met");
     }
 
     @Test
@@ -452,121 +322,87 @@ public class LoanChargeSpecificDueDateTest extends BaseLoanIntegrationTest {
                     new PutGlobalConfigurationsRequest().enabled(true));
 
             final LocalDate todaysDate = Utils.getLocalDateOfTenant();
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, todaysDate);
+            updateBusinessDate(Utils.dateFormatter.format(todaysDate));
 
+            final Long clientId = createClient("01 January 2012");
             // Client and Loan account creation
-            final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProductWithPeriodicAccrual(
-                    loanTransactionHelper, null);
-            assertNotNull(getLoanProductsProductResponse);
+            final Long loanProductId = createLoanProduct(testLoanProduct());
 
             LocalDate transactionDate = LocalDate.of(Utils.getLocalDateOfTenant().getYear(), 1, 1);
             String operationDate = Utils.dateFormatter.format(transactionDate);
-            log.info("Disbursement date {}", transactionDate);
 
             // Create Loan Account
-            final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                    getLoanProductsProductResponse.getId().toString(), operationDate, "1", "0");
+            final Long loanId = createLoanAccount(clientId, loanProductId, operationDate, 1);
 
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             // Get loan details
-            GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-            validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("0.00"), true);
+            validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("0.00"), true);
 
             // Apply Loan Charge with specific due date
             String feeAmount = "10.00";
-            String payloadJSON = ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, feeAmount, true);
-            final PostChargesResponse postChargesResponse = ChargesHelper.createLoanCharge(requestSpec, responseSpec, payloadJSON);
-            assertNotNull(postChargesResponse);
-            final Long chargeId = postChargesResponse.getResourceId();
+            final Long chargeId = chargesHelper.createLoanSpecifiedDueDatePenalty(Double.parseDouble(feeAmount)).getResourceId();
             assertNotNull(chargeId);
 
             // First Loan Charge
             transactionDate = transactionDate.plusDays(1);
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, transactionDate);
+            updateBusinessDate(Utils.dateFormatter.format(transactionDate));
             operationDate = Utils.dateFormatter.format(transactionDate);
-            log.info("Operation date {}", transactionDate);
-            payloadJSON = LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(chargeId.toString(), operationDate, feeAmount);
-            PostLoansLoanIdChargesResponse postLoansLoanIdChargesResponse = loanTransactionHelper.addChargeForLoan(loanId, payloadJSON,
-                    responseSpec);
-            assertNotNull(postLoansLoanIdChargesResponse);
-            final Long loanChargeId01 = postLoansLoanIdChargesResponse.getResourceId();
+            final Long loanChargeId01 = addChargesForLoan(loanId, LoanRequestBuilders.addLoanCharge(chargeId, 10.0, operationDate))
+                    .getResourceId();
             assertNotNull(loanChargeId01);
 
+            runPeriodicAccrualAccounting(operationDate);
             // Run Accruals
-            log.info("Running Periodic Accrual for date {}", transactionDate);
-            PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting(operationDate);
-            getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-            loanTransactionHelper.evaluateLoanTransactionData(getLoansLoanIdResponse, "loanTransactionType.accrual",
-                    Double.valueOf("10.00"));
+            loanDetails = getLoanDetails(loanId);
+            evaluateLoanTransactionData(loanDetails, "loanTransactionType.accrual", Double.valueOf("10.00"));
 
             // Repay the first charge fully, 10
-            Float amount = Float.valueOf("10.00");
             transactionDate = transactionDate.plusDays(40);
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, transactionDate);
+            updateBusinessDate(Utils.dateFormatter.format(transactionDate));
             operationDate = Utils.dateFormatter.format(transactionDate);
-            log.info("Operation date {}", transactionDate);
-            PostLoansLoanIdTransactionsResponse loanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(operationDate, amount,
-                    loanId);
+            PostLoansLoanIdTransactionsResponse loanIdTransactionsResponse = makeRepayment(operationDate, 10.00f, loanId);
             assertNotNull(loanIdTransactionsResponse);
-            log.info("Loan Transaction Id: {} {}", loanId, loanIdTransactionsResponse.getResourceId());
 
             // Second Loan Charge
-            feeAmount = "15.00";
             transactionDate = transactionDate.plusDays(1);
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, transactionDate);
+            updateBusinessDate(Utils.dateFormatter.format(transactionDate));
             operationDate = Utils.dateFormatter.format(transactionDate);
-            log.info("Operation date {}", transactionDate);
-            payloadJSON = LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(chargeId.toString(), operationDate, feeAmount);
-            postLoansLoanIdChargesResponse = loanTransactionHelper.addChargeForLoan(loanId, payloadJSON, responseSpec);
-            assertNotNull(postLoansLoanIdChargesResponse);
-            final Long loanChargeId02 = postLoansLoanIdChargesResponse.getResourceId();
+            final Long loanChargeId02 = addChargesForLoan(loanId, LoanRequestBuilders.addLoanCharge(chargeId, 15.0, operationDate))
+                    .getResourceId();
             assertNotNull(loanChargeId02);
 
-            getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-            validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("15.00"), true);
+            loanDetails = getLoanDetails(loanId);
+            validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("15.00"), true);
 
+            runPeriodicAccrualAccounting(operationDate);
             // Run Accruals
-            log.info("Running Periodic Accrual for date {}", transactionDate);
-            PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting(operationDate);
-            getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-            loanTransactionHelper.evaluateLoanTransactionData(getLoansLoanIdResponse, "loanTransactionType.accrual",
-                    Double.valueOf("25.00"));
+            loanDetails = getLoanDetails(loanId);
+            evaluateLoanTransactionData(loanDetails, "loanTransactionType.accrual", Double.valueOf("25.00"));
 
             // Third Loan Charge
-            feeAmount = "25.00";
             transactionDate = transactionDate.plusDays(1);
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, transactionDate);
+            updateBusinessDate(Utils.dateFormatter.format(transactionDate));
             operationDate = Utils.dateFormatter.format(transactionDate);
-            log.info("Operation date {}", transactionDate);
-            payloadJSON = LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(chargeId.toString(), operationDate, feeAmount);
-            postLoansLoanIdChargesResponse = loanTransactionHelper.addChargeForLoan(loanId, payloadJSON, responseSpec);
-            assertNotNull(postLoansLoanIdChargesResponse);
-            final Long loanChargeId03 = postLoansLoanIdChargesResponse.getResourceId();
+            final Long loanChargeId03 = addChargesForLoan(loanId, LoanRequestBuilders.addLoanCharge(chargeId, 25.0, operationDate))
+                    .getResourceId();
             assertNotNull(loanChargeId03);
 
-            getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-            validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("40.00"), true);
-            loanTransactionHelper.evaluateLoanTransactionData(getLoansLoanIdResponse, "loanTransactionType.accrual",
-                    Double.valueOf("25.00"));
+            loanDetails = getLoanDetails(loanId);
+            validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("40.00"), true);
+            evaluateLoanTransactionData(loanDetails, "loanTransactionType.accrual", Double.valueOf("25.00"));
 
-            amount = Float.valueOf("1040.00");
-            loanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(operationDate, amount, loanId);
+            loanIdTransactionsResponse = makeRepayment(operationDate, 1040.00f, loanId);
             assertNotNull(loanIdTransactionsResponse);
-            log.info("Loan Transaction Id: {} {}", loanId, loanIdTransactionsResponse.getResourceId());
 
-            getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-            assertNotNull(getLoansLoanIdResponse);
-            loanTransactionHelper.validateLoanStatus(getLoansLoanIdResponse, "loanStatusType.closed.obligations.met");
-            loanTransactionHelper.evaluateLoanTransactionData(getLoansLoanIdResponse, "loanTransactionType.accrual",
-                    Double.valueOf("50.00"));
+            loanDetails = getLoanDetails(loanId);
+            validateLoanStatus(loanDetails, "loanStatusType.closed.obligations.met");
+            evaluateLoanTransactionData(loanDetails, "loanTransactionType.accrual", Double.valueOf("50.00"));
 
-            final Long transactionId = loanTransactionHelper.evaluateLastLoanTransactionData(getLoansLoanIdResponse,
-                    "loanTransactionType.accrual", operationDate, Double.valueOf("25.00"));
+            final Long transactionId = evaluateLastLoanTransactionData(loanDetails, "loanTransactionType.accrual", operationDate,
+                    Double.valueOf("25.00"));
             assertNotNull(transactionId);
-            log.info("transactionId {}", transactionId);
 
-            final GetJournalEntriesTransactionIdResponse journalEntriesResponse = journalEntryHelper
-                    .getJournalEntries("L" + transactionId.toString());
+            final GetJournalEntriesTransactionIdResponse journalEntriesResponse = getJournalEntries("L" + transactionId);
             assertNotNull(journalEntriesResponse);
             final List<JournalEntryTransactionItem> journalEntries = journalEntriesResponse.getPageItems();
             assertEquals(2, journalEntries.size());
@@ -587,66 +423,49 @@ public class LoanChargeSpecificDueDateTest extends BaseLoanIntegrationTest {
                     new PutGlobalConfigurationsRequest().enabled(true));
 
             final LocalDate todaysDate = Utils.getLocalDateOfTenant();
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, todaysDate);
+            updateBusinessDate(Utils.dateFormatter.format(todaysDate));
 
+            final Long clientId = createClient("01 January 2012");
             // Client and Loan account creation
-            final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProductWithPeriodicAccrual(
-                    loanTransactionHelper, null);
-            assertNotNull(getLoanProductsProductResponse);
+            final Long loanProductId = createLoanProduct(testLoanProduct());
 
             LocalDate transactionDate = LocalDate.of(Utils.getLocalDateOfTenant().getYear(), 1, 1);
             String operationDate = Utils.dateFormatter.format(transactionDate);
-            log.info("Disbursement date {}", transactionDate);
 
             // Create Loan Account
-            final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                    getLoanProductsProductResponse.getId().toString(), operationDate, "1", "0");
+            final Long loanId = createLoanAccount(clientId, loanProductId, operationDate, 1);
 
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             // Get loan details
-            GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-            validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("0.00"), true);
+            validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("0.00"), true);
 
             // Apply Loan Charge with specific due date
             String feeAmount = "10.00";
-            String payloadJSON = ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, feeAmount, true);
-            final PostChargesResponse postChargesResponse = ChargesHelper.createLoanCharge(requestSpec, responseSpec, payloadJSON);
-            assertNotNull(postChargesResponse);
-            final Long chargeId = postChargesResponse.getResourceId();
+            final Long chargeId = chargesHelper.createLoanSpecifiedDueDatePenalty(Double.parseDouble(feeAmount)).getResourceId();
             assertNotNull(chargeId);
 
             // First Loan Charge
             transactionDate = transactionDate.plusDays(1);
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, transactionDate);
+            updateBusinessDate(Utils.dateFormatter.format(transactionDate));
             operationDate = Utils.dateFormatter.format(transactionDate);
-            log.info("Operation date {}", transactionDate);
-            payloadJSON = LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(chargeId.toString(), operationDate, feeAmount);
-            PostLoansLoanIdChargesResponse postLoansLoanIdChargesResponse = loanTransactionHelper.addChargeForLoan(loanId, payloadJSON,
-                    responseSpec);
-            assertNotNull(postLoansLoanIdChargesResponse);
-            final Long loanChargeId01 = postLoansLoanIdChargesResponse.getResourceId();
+            final Long loanChargeId01 = addChargesForLoan(loanId, LoanRequestBuilders.addLoanCharge(chargeId, 10.0, operationDate))
+                    .getResourceId();
             assertNotNull(loanChargeId01);
 
-            Float amount = Float.valueOf("1020.00");
             transactionDate = transactionDate.plusDays(2);
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, transactionDate);
+            updateBusinessDate(Utils.dateFormatter.format(transactionDate));
             operationDate = Utils.dateFormatter.format(transactionDate);
-            log.info("Operation date {}", transactionDate);
-            PostLoansLoanIdTransactionsResponse loanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(operationDate, amount,
-                    loanId);
+            PostLoansLoanIdTransactionsResponse loanIdTransactionsResponse = makeRepayment(operationDate, 1020.00f, loanId);
             assertNotNull(loanIdTransactionsResponse);
-            log.info("Loan Transaction Id: {} {}", loanId, loanIdTransactionsResponse.getResourceId());
 
-            getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-            assertNotNull(getLoansLoanIdResponse);
-            loanTransactionHelper.validateLoanStatus(getLoansLoanIdResponse, "loanStatusType.overpaid");
+            loanDetails = getLoanDetails(loanId);
+            validateLoanStatus(loanDetails, "loanStatusType.overpaid");
 
-            final Long transactionId = loanTransactionHelper.evaluateLastLoanTransactionData(getLoansLoanIdResponse,
-                    "loanTransactionType.accrual", operationDate, Double.valueOf("10.00"));
+            final Long transactionId = evaluateLastLoanTransactionData(loanDetails, "loanTransactionType.accrual", operationDate,
+                    Double.valueOf("10.00"));
             assertNotNull(transactionId);
-            log.info("transactionId {}", transactionId);
 
-            final GetJournalEntriesTransactionIdResponse journalEntriesResponse = journalEntryHelper.getJournalEntries("L" + transactionId);
+            final GetJournalEntriesTransactionIdResponse journalEntriesResponse = getJournalEntries("L" + transactionId);
             assertNotNull(journalEntriesResponse);
             final List<JournalEntryTransactionItem> journalEntries = journalEntriesResponse.getPageItems();
             assertEquals(2, journalEntries.size());
@@ -662,181 +481,175 @@ public class LoanChargeSpecificDueDateTest extends BaseLoanIntegrationTest {
 
     @Test
     public void testApplyLoanSpecificDueDatePenaltyWithDisbursementDateWithMultipleDisbursement() {
-
         final LocalDate todaysDate = Utils.getLocalDateOfTenant();
 
+        final Long clientId = createClient("01 January 2012");
         // Client and Loan account creation
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-        final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProductWithPeriodicAccrual(loanTransactionHelper,
-                null);
-        assertNotNull(getLoanProductsProductResponse);
+        final Long loanProductId = createLoanProduct(testLoanProduct());
 
         // Older date to have more than one overdue installment
-        LocalDate transactionDate = todaysDate;
+        final LocalDate transactionDate = todaysDate;
         String operationDate = Utils.dateFormatter.format(transactionDate);
-        log.info("Operation date {}", transactionDate);
 
         // Create Loan Account
-        final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                getLoanProductsProductResponse.getId().toString(), operationDate, "12", "0");
+        final Long loanId = createLoanAccount(clientId, loanProductId, operationDate, 12);
 
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
         // Get loan details
-        GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("0.00"), true);
+        validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("0.00"), true);
+
+        final Long loanChargeId = chargesHelper.createLoanSpecifiedDueDatePenalty(10.0).getResourceId();
+        assertNotNull(loanChargeId);
+        addChargesForLoan(loanId, LoanRequestBuilders.addLoanCharge(loanChargeId, 10.0, operationDate));
 
         // Apply Loan Charge with specific due date
+        runPeriodicAccrualAccounting(operationDate);
 
-        final String feeAmount = "10.00";
-        String payloadJSON = ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, feeAmount, true);
-        final PostChargesResponse postChargesResponse = ChargesHelper.createLoanCharge(requestSpec, responseSpec, payloadJSON);
-        assertNotNull(postChargesResponse);
-        final Long loanChargeId = postChargesResponse.getResourceId();
-        assertNotNull(loanChargeId);
+        loanDetails = getLoanDetails(loanId);
+        validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("10.00"), true);
 
-        payloadJSON = LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(loanChargeId.toString(), operationDate, feeAmount);
-        PostLoansLoanIdChargesResponse postLoansLoanIdChargesResponse = loanTransactionHelper.addChargeForLoan(loanId, payloadJSON,
-                responseSpec);
-        assertNotNull(postLoansLoanIdChargesResponse);
-
-        PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting(operationDate);
+        disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate(operationDate).transactionAmount(new BigDecimal("1000"))
+                .locale("en").dateFormat(DATETIME_PATTERN));
 
         // Get loan details expecting to have a delinquency classification
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("10.00"), true);
-
-        loanTransactionHelper.disburseLoan((long) loanId, new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
-                .transactionAmount(new BigDecimal("1000")).locale("en").dateFormat("dd MMMM yyyy"));
-
-        // Get loan details expecting to have a delinquency classification
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.parseDouble(principalAmount) * 2, Double.valueOf("10.00"), true);
+        loanDetails = getLoanDetails(loanId);
+        validateLoanAccount(loanDetails, Double.parseDouble(principalAmount) * 2, Double.valueOf("10.00"), true);
 
         operationDate = Utils.dateFormatter.format(transactionDate.plusMonths(1));
-        payloadJSON = LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(loanChargeId.toString(), operationDate, feeAmount);
-        postLoansLoanIdChargesResponse = loanTransactionHelper.addChargeForLoan(loanId, payloadJSON, responseSpec);
+        addChargesForLoan(loanId, LoanRequestBuilders.addLoanCharge(loanChargeId, 10.0, operationDate));
 
+        loanDetails = getLoanDetails(loanId);
         // Get loan details expecting to have a delinquency classification
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.parseDouble(principalAmount) * 2, Double.valueOf("20.00"), true);
+        validateLoanAccount(loanDetails, Double.parseDouble(principalAmount) * 2, Double.valueOf("20.00"), true);
     }
 
     @Test
     public void testApplyLoanSpecificDueDatePenaltyAccrualWithDisbursementDateWithMultipleDisbursement() {
-
         final LocalDate todaysDate = Utils.getLocalDateOfTenant();
 
+        final Long clientId = createClient("01 January 2012");
         // Client and Loan account creation
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-        final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProductWithPeriodicAccrual(loanTransactionHelper,
-                null);
-        assertNotNull(getLoanProductsProductResponse);
+        final Long loanProductId = createLoanProduct(testLoanProduct());
 
         // Older date to have more than one overdue installment
         LocalDate transactionDate = todaysDate.minusDays(2);
         String operationDate = Utils.dateFormatter.format(transactionDate);
-        log.info("Operation date {}", transactionDate);
 
         // Create Loan Account
-        final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                getLoanProductsProductResponse.getId().toString(), operationDate, "12", "0");
+        final Long loanId = createLoanAccount(clientId, loanProductId, operationDate, 12);
 
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
         // Get loan details
-        GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("0.00"), true);
+        validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("0.00"), true);
+
+        final Long loanChargeId = chargesHelper.createLoanSpecifiedDueDatePenalty(10.0).getResourceId();
+        assertNotNull(loanChargeId);
+        addChargesForLoan(loanId, LoanRequestBuilders.addLoanCharge(loanChargeId, 10.0, operationDate));
 
         // Apply Loan Charge with specific due date
+        runPeriodicAccrualAccounting(operationDate);
 
-        final String feeAmount = "10.00";
-        String payloadJSON = ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, feeAmount, true);
-        final PostChargesResponse postChargesResponse = ChargesHelper.createLoanCharge(requestSpec, responseSpec, payloadJSON);
-        assertNotNull(postChargesResponse);
-        final Long loanChargeId = postChargesResponse.getResourceId();
-        assertNotNull(loanChargeId);
-
-        payloadJSON = LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(loanChargeId.toString(), operationDate, feeAmount);
-        PostLoansLoanIdChargesResponse postLoansLoanIdChargesResponse = loanTransactionHelper.addChargeForLoan(loanId, payloadJSON,
-                responseSpec);
-        assertNotNull(postLoansLoanIdChargesResponse);
-
-        PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting(operationDate);
-
+        loanDetails = getLoanDetails(loanId);
         // Get loan details expecting to have a delinquency classification
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("10.00"), true);
+        validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("10.00"), true);
 
         transactionDate = transactionDate.plusDays(1);
         operationDate = Utils.dateFormatter.format(transactionDate);
 
-        loanTransactionHelper.disburseLoan((long) loanId, new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
-                .transactionAmount(new BigDecimal("1000")).locale("en").dateFormat("dd MMMM yyyy"));
+        disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate(operationDate).transactionAmount(new BigDecimal("1000"))
+                .locale("en").dateFormat(DATETIME_PATTERN));
 
+        loanDetails = getLoanDetails(loanId);
         // Get loan details expecting to have a delinquency classification
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.parseDouble(principalAmount) * 2, Double.valueOf("10.00"), true);
+        validateLoanAccount(loanDetails, Double.parseDouble(principalAmount) * 2, Double.valueOf("10.00"), true);
 
-        PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting(operationDate);
+        runPeriodicAccrualAccounting(operationDate);
 
         operationDate = Utils.dateFormatter.format(transactionDate.plusMonths(1));
-        payloadJSON = LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(loanChargeId.toString(), operationDate, feeAmount);
-        postLoansLoanIdChargesResponse = loanTransactionHelper.addChargeForLoan(loanId, payloadJSON, responseSpec);
+        addChargesForLoan(loanId, LoanRequestBuilders.addLoanCharge(loanChargeId, 10.0, operationDate));
 
         transactionDate = transactionDate.plusDays(1);
         operationDate = Utils.dateFormatter.format(transactionDate);
-        PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting(operationDate);
+        runPeriodicAccrualAccounting(operationDate);
+
         // Get loan details expecting to have a delinquency classification
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.parseDouble(principalAmount) * 2, Double.valueOf("20.00"), true);
+        loanDetails = getLoanDetails(loanId);
+        validateLoanAccount(loanDetails, Double.parseDouble(principalAmount) * 2, Double.valueOf("20.00"), true);
     }
 
-    private GetLoanProductsProductIdResponse createLoanProduct(final LoanTransactionHelper loanTransactionHelper,
-            final Long delinquencyBucketId) {
-        final HashMap<String, Object> loanProductMap = new LoanProductTestBuilder().build(null, delinquencyBucketId);
-        final Integer loanProductId = loanTransactionHelper.getLoanProductId(Utils.convertToJson(loanProductMap));
-        return loanTransactionHelper.getLoanProduct(loanProductId);
+    private PostLoanProductsRequest testLoanProduct() {
+        return createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct()//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS_L)//
+                .numberOfRepayments(1)//
+                .maxNumberOfRepayments(30)//
+                .allowApprovedDisbursedAmountsOverApplied(true)//
+                .overAppliedCalculationType("percentage")//
+                .overAppliedNumber(1000);
     }
 
-    private GetLoanProductsProductIdResponse createLoanProductWithPeriodicAccrual(final LoanTransactionHelper loanTransactionHelper,
-            final Long delinquencyBucketId) {
-        final Account assetAccount = this.accountHelper.createAssetAccount();
-        final Account incomeAccount = this.accountHelper.createIncomeAccount();
-        final Account expenseAccount = this.accountHelper.createExpenseAccount();
-        final Account overpaymentAccount = this.accountHelper.createLiabilityAccount();
-
-        final HashMap<String, Object> loanProductMap = new LoanProductTestBuilder().withMultiDisburse()
-                .withInterestCalculationPeriodTypeAsRepaymentPeriod(true).withInterestTypeAsDecliningBalance()
-                .withAccountingRulePeriodicAccrual(new Account[] { assetAccount, incomeAccount, expenseAccount, overpaymentAccount })
-                .withDisallowExpectedDisbursements(true) //
-                .build(null, delinquencyBucketId);
-        final Integer loanProductId = loanTransactionHelper.getLoanProductId(Utils.convertToJson(loanProductMap));
-        return loanTransactionHelper.getLoanProduct(loanProductId);
-    }
-
-    private Integer createLoanAccount(final LoanTransactionHelper loanTransactionHelper, final String clientId, final String loanProductId,
-            final String operationDate, final String repayments, final String interestRate) {
-        final String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal(principalAmount).withLoanTermFrequency(repayments)
-                .withLoanTermFrequencyAsMonths().withNumberOfRepayments(repayments).withRepaymentEveryAfter("1")
-                .withRepaymentFrequencyTypeAsMonths() //
-                .withInterestRatePerPeriod(interestRate) //
-                .withExpectedDisbursementDate(operationDate) //
-                .withInterestTypeAsDecliningBalance() //
-                .withSubmittedOnDate(operationDate) //
-                .build(clientId, loanProductId, null);
-        final Integer loanId = loanTransactionHelper.getLoanId(loanApplicationJSON);
-        loanTransactionHelper.approveLoan(operationDate, principalAmount, loanId, null);
-        loanTransactionHelper.disburseLoanWithTransactionAmount(operationDate, loanId, principalAmount);
+    private Long createLoanAccount(final Long clientId, final Long loanProductId, final String operationDate, final int repayments) {
+        final Long loanId = applyForLoan(
+                new PostLoansRequest().clientId(clientId).productId(loanProductId).principal(new BigDecimal(principalAmount))
+                        .loanTermFrequency(repayments).loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)
+                        .numberOfRepayments(repayments).repaymentEvery(1).repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)
+                        .interestRatePerPeriod(BigDecimal.ZERO).interestType(LoanTestData.InterestType.DECLINING_BALANCE)
+                        .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)
+                        .amortizationType(LoanTestData.AmortizationType.EQUAL_PRINCIPAL).expectedDisbursementDate(operationDate)
+                        .submittedOnDate(operationDate).transactionProcessingStrategyCode("mifos-standard-strategy").loanType("individual")
+                        .dateFormat(DATETIME_PATTERN).locale("en"));
+        approveLoan(loanId, LoanRequestBuilders.approveLoan(Double.valueOf(principalAmount), operationDate));
+        disburseLoan(loanId, LoanRequestBuilders.disburseLoan(Double.valueOf(principalAmount), operationDate));
         return loanId;
     }
 
-    private void validateLoanAccount(GetLoansLoanIdResponse getLoansLoanIdResponse, Double principal, Double fees, boolean isPenalty) {
-        assertNotNull(getLoansLoanIdResponse);
-        loanTransactionHelper.printRepaymentSchedule(getLoansLoanIdResponse);
-        loanTransactionHelper.validateLoanPrincipalOustandingBalance(getLoansLoanIdResponse, principal);
-        if (isPenalty) {
-            loanTransactionHelper.validateLoanPenaltiesOustandingBalance(getLoansLoanIdResponse, fees);
-        } else {
-            loanTransactionHelper.validateLoanFeesOustandingBalance(getLoansLoanIdResponse, fees);
-        }
-        loanTransactionHelper.validateLoanTotalOustandingBalance(getLoansLoanIdResponse, (principal + fees));
+    private static ChargeRequest installmentFee() {
+        return ChargeRequestBuilders.loanInstallmentFee(1.5)
+                .chargeCalculationType(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST.getValue()).penalty(false);
     }
 
+    private PostLoansLoanIdChargesRequest installmentCharge(Long chargeId, double amount) {
+        return new PostLoansLoanIdChargesRequest().chargeId(chargeId).locale("en").amount(amount);
+    }
+
+    private PostLoansLoanIdTransactionsResponse makeRepayment(String date, float amount, Long loanId) {
+        return makeLoanRepayment(loanId, "repayment", date, (double) amount);
+    }
+
+    private void validateLoanAccount(GetLoansLoanIdResponse loanDetails, Double principal, Double fees, boolean isPenalty) {
+        assertNotNull(loanDetails);
+        final GetLoansLoanIdSummary summary = loanDetails.getSummary();
+        assertNotNull(summary);
+        assertEquals(principal, Utils.getDoubleValue(summary.getPrincipalOutstanding()));
+        if (isPenalty) {
+            assertEquals(fees, Utils.getDoubleValue(summary.getPenaltyChargesOutstanding()));
+        } else {
+            assertEquals(fees, Utils.getDoubleValue(summary.getFeeChargesOutstanding()));
+        }
+        assertEquals(principal + fees, Utils.getDoubleValue(summary.getTotalOutstanding()));
+    }
+
+    private Long evaluateLastLoanTransactionData(GetLoansLoanIdResponse loanDetails, String transactionType, String transactionExpected,
+            Double amountExpected) {
+        GetLoansLoanIdTransactions lastTransaction = null;
+        for (GetLoansLoanIdTransactions transaction : loanDetails.getTransactions()) {
+            if (transactionType.equals(transaction.getType().getCode())) {
+                lastTransaction = transaction;
+            }
+        }
+        assertNotNull(lastTransaction);
+        assertEquals(transactionExpected, Utils.dateFormatter.format(lastTransaction.getDate()));
+        assertEquals(amountExpected, Utils.getDoubleValue(lastTransaction.getAmount()));
+        return lastTransaction.getId();
+    }
+
+    private void evaluateLoanTransactionData(GetLoansLoanIdResponse loanDetails, String transactionType, Double amountExpected) {
+        Double transactionsAmount = 0.0;
+        for (GetLoansLoanIdTransactions transaction : loanDetails.getTransactions()) {
+            if (transactionType.equals(transaction.getType().getCode())) {
+                transactionsAmount += Utils.getDoubleValue(transaction.getAmount());
+            }
+        }
+        assertEquals(amountExpected, transactionsAmount);
+    }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanChargeSpecificDueDateTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanChargeSpecificDueDateTest.java
@@ -22,120 +22,66 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
-import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.client.models.ChargeRequest;
 import org.apache.fineract.client.models.GetJournalEntriesTransactionIdResponse;
-import org.apache.fineract.client.models.GetLoanProductsProductIdResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
+import org.apache.fineract.client.models.GetLoansLoanIdSummary;
 import org.apache.fineract.client.models.GetLoansLoanIdTransactions;
 import org.apache.fineract.client.models.JournalEntryTransactionItem;
-import org.apache.fineract.client.models.PostChargesResponse;
-import org.apache.fineract.client.models.PostLoansLoanIdChargesChargeIdResponse;
-import org.apache.fineract.client.models.PostLoansLoanIdChargesResponse;
+import org.apache.fineract.client.models.PostLoanProductsRequest;
+import org.apache.fineract.client.models.PostLoansLoanIdChargesChargeIdRequest;
+import org.apache.fineract.client.models.PostLoansLoanIdChargesRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsResponse;
+import org.apache.fineract.client.models.PostLoansRequest;
 import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
-import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
-import org.apache.fineract.integrationtests.common.BusinessDateHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.modules.ChargeRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
 import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.accounting.Account;
-import org.apache.fineract.integrationtests.common.accounting.AccountHelper;
-import org.apache.fineract.integrationtests.common.accounting.JournalEntryHelper;
-import org.apache.fineract.integrationtests.common.accounting.PeriodicAccrualAccountingHelper;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
-import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.junit.jupiter.api.BeforeEach;
+import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
 import org.junit.jupiter.api.Test;
 
-@Slf4j
-public class LoanChargeSpecificDueDateTest extends BaseLoanIntegrationTest {
-
-    private ResponseSpecification responseSpec;
-    private RequestSpecification requestSpec;
-    private LoanTransactionHelper loanTransactionHelper;
-    private AccountHelper accountHelper;
-    private JournalEntryHelper journalEntryHelper;
+public class LoanChargeSpecificDueDateTest extends FeignLoanTestBase {
 
     private static final String principalAmount = "1000.00";
 
-    @BeforeEach
-    public void setup() {
-        Utils.initializeRESTAssured();
-
-        requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-
-        loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-        accountHelper = new AccountHelper(this.requestSpec, this.responseSpec);
-        journalEntryHelper = new JournalEntryHelper(this.requestSpec, this.responseSpec);
-    }
-
     @Test
     public void testApplyLoanSpecificDueDateFeeWithDisbursementDate() {
-
         final LocalDate todaysDate = Utils.getLocalDateOfTenant();
 
-        // Client and Loan account creation
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-        final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProductWithPeriodicAccrual(loanTransactionHelper,
-                null);
-        assertNotNull(getLoanProductsProductResponse);
+        final Long clientId = createClient("01 January 2012");
+        final Long loanProductId = createLoanProduct(testLoanProduct());
 
-        // Older date to have more than one overdue installment
-        LocalDate transactionDate = todaysDate;
-        String operationDate = Utils.dateFormatter.format(transactionDate);
-        log.info("Operation date {}", transactionDate);
+        final LocalDate transactionDate = todaysDate;
+        final String operationDate = Utils.dateFormatter.format(transactionDate);
 
-        // Create Loan Account
-        final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                getLoanProductsProductResponse.getId().toString(), operationDate, "12", "0");
+        final Long loanId = createLoanAccount(clientId, loanProductId, operationDate, 12);
 
-        // Get loan details
-        GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("0.00"), false);
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
+        validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("0.00"), false);
 
-        // Apply Loan Charge with specific due date
+        final Long loanChargeId = chargesHelper.createLoanSpecifiedDueDateCharge(10.0).getResourceId();
+        assertNotNull(loanChargeId);
+        addChargesForLoan(loanId, LoanRequestBuilders.addLoanCharge(loanChargeId, 10.0, operationDate));
 
-        final String feeAmount = "10.00";
-        String payloadJSON = ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, feeAmount, false);
-        final PostChargesResponse postChargesResponse = ChargesHelper.createLoanCharge(requestSpec, responseSpec, payloadJSON);
-        assertNotNull(postChargesResponse);
-        final Long loanChargeId = postChargesResponse.getResourceId();
+        loanDetails = getLoanDetails(loanId);
+        validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("10.00"), false);
 
-        payloadJSON = LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(loanChargeId.toString(), operationDate, feeAmount);
-        PostLoansLoanIdChargesResponse postLoansLoanIdChargesResponse = loanTransactionHelper.addChargeForLoan(loanId, payloadJSON,
-                responseSpec);
-        assertNotNull(postLoansLoanIdChargesResponse);
+        runPeriodicAccrualAccounting(operationDate);
+        loanDetails = getLoanDetails(loanId);
 
-        // Get loan details expecting to have a delinquency classification
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("10.00"), false);
-
-        // Run Accruals
-        log.info("Running Periodic Accrual for date {}", transactionDate);
-        PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting(operationDate);
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-
-        final Long transactionId = loanTransactionHelper.evaluateLastLoanTransactionData(getLoansLoanIdResponse,
-                "loanTransactionType.accrual", operationDate, Double.valueOf("10.00"));
+        final Long transactionId = evaluateLastLoanTransactionData(loanDetails, "loanTransactionType.accrual", operationDate,
+                Double.valueOf("10.00"));
         assertNotNull(transactionId);
-        log.info("transactionId {}", transactionId);
 
-        final GetJournalEntriesTransactionIdResponse journalEntriesResponse = journalEntryHelper.getJournalEntries("L" + transactionId);
+        final GetJournalEntriesTransactionIdResponse journalEntriesResponse = getJournalEntries("L" + transactionId);
         assertNotNull(journalEntriesResponse);
         final List<JournalEntryTransactionItem> journalEntries = journalEntriesResponse.getPageItems();
         assertEquals(2, journalEntries.size());
@@ -144,72 +90,43 @@ public class LoanChargeSpecificDueDateTest extends BaseLoanIntegrationTest {
         assertEquals(transactionDate, journalEntries.get(0).getTransactionDate());
         assertEquals(transactionDate, journalEntries.get(1).getTransactionDate());
 
-        // Make a full repayment to close the Loan
-        Float amount = Float.valueOf("1010.00");
-        PostLoansLoanIdTransactionsResponse loanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(operationDate, amount,
-                loanId);
+        PostLoansLoanIdTransactionsResponse loanIdTransactionsResponse = makeRepayment(operationDate, 1010.00f, loanId);
         assertNotNull(loanIdTransactionsResponse);
-        log.info("Loan Transaction Id: {} {}", loanId, loanIdTransactionsResponse.getResourceId());
 
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        assertNotNull(getLoansLoanIdResponse);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf("0.00"), Double.valueOf("0.00"), false);
-
+        loanDetails = getLoanDetails(loanId);
+        validateLoanAccount(loanDetails, Double.valueOf("0.00"), Double.valueOf("0.00"), false);
     }
 
     @Test
     public void testApplyLoanSpecificDueDatePenaltyWithDisbursementDate() {
-
         final LocalDate todaysDate = Utils.getLocalDateOfTenant();
 
-        // Client and Loan account creation
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-        final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProductWithPeriodicAccrual(loanTransactionHelper,
-                null);
-        assertNotNull(getLoanProductsProductResponse);
+        final Long clientId = createClient("01 January 2012");
+        final Long loanProductId = createLoanProduct(testLoanProduct());
 
-        // Older date to have more than one overdue installment
-        LocalDate transactionDate = todaysDate;
-        String operationDate = Utils.dateFormatter.format(transactionDate);
-        log.info("Operation date {}", transactionDate);
+        final LocalDate transactionDate = todaysDate;
+        final String operationDate = Utils.dateFormatter.format(transactionDate);
 
-        // Create Loan Account
-        final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                getLoanProductsProductResponse.getId().toString(), operationDate, "12", "0");
+        final Long loanId = createLoanAccount(clientId, loanProductId, operationDate, 12);
 
-        // Get loan details
-        GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("0.00"), true);
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
+        validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("0.00"), true);
 
-        // Apply Loan Charge with specific due date
-
-        final String feeAmount = "10.00";
-        String payloadJSON = ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, feeAmount, true);
-        final PostChargesResponse postChargesResponse = ChargesHelper.createLoanCharge(requestSpec, responseSpec, payloadJSON);
-        assertNotNull(postChargesResponse);
-        final Long loanChargeId = postChargesResponse.getResourceId();
+        final Long loanChargeId = chargesHelper.createLoanSpecifiedDueDatePenalty(10.0).getResourceId();
         assertNotNull(loanChargeId);
+        addChargesForLoan(loanId, LoanRequestBuilders.addLoanCharge(loanChargeId, 10.0, operationDate));
 
-        payloadJSON = LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(loanChargeId.toString(), operationDate, feeAmount);
-        PostLoansLoanIdChargesResponse postLoansLoanIdChargesResponse = loanTransactionHelper.addChargeForLoan(loanId, payloadJSON,
-                responseSpec);
-        assertNotNull(postLoansLoanIdChargesResponse);
+        loanDetails = getLoanDetails(loanId);
+        validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("10.00"), true);
 
-        // Get loan details expecting to have a delinquency classification
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("10.00"), true);
+        runPeriodicAccrualAccounting(operationDate);
+        loanDetails = getLoanDetails(loanId);
 
-        // Run Accruals
-        log.info("Running Periodic Accrual for date {}", transactionDate);
-        PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting(operationDate);
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-
-        final Long transactionId = loanTransactionHelper.evaluateLastLoanTransactionData(getLoansLoanIdResponse,
-                "loanTransactionType.accrual", operationDate, Double.valueOf("10.00"));
+        final Long transactionId = evaluateLastLoanTransactionData(loanDetails, "loanTransactionType.accrual", operationDate,
+                Double.valueOf("10.00"));
         assertNotNull(transactionId);
-        log.info("transactionId {}", transactionId);
 
-        final GetJournalEntriesTransactionIdResponse journalEntriesResponse = journalEntryHelper.getJournalEntries("L" + transactionId);
+        final GetJournalEntriesTransactionIdResponse journalEntriesResponse = getJournalEntries("L" + transactionId);
         assertNotNull(journalEntriesResponse);
         final List<JournalEntryTransactionItem> journalEntries = journalEntriesResponse.getPageItems();
         assertEquals(2, journalEntries.size());
@@ -218,18 +135,12 @@ public class LoanChargeSpecificDueDateTest extends BaseLoanIntegrationTest {
         assertEquals(transactionDate, journalEntries.get(0).getTransactionDate());
         assertEquals(transactionDate, journalEntries.get(1).getTransactionDate());
 
-        // Make a full repayment to close the Loan
-        Float amount = Float.valueOf("1010.00");
-        PostLoansLoanIdTransactionsResponse loanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(operationDate, amount,
-                loanId);
+        PostLoansLoanIdTransactionsResponse loanIdTransactionsResponse = makeRepayment(operationDate, 1010.00f, loanId);
         assertNotNull(loanIdTransactionsResponse);
-        log.info("Loan Transaction Id: {} {}", loanId, loanIdTransactionsResponse.getResourceId());
 
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        assertNotNull(getLoansLoanIdResponse);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf("0.00"), Double.valueOf("0.00"), true);
-        loanTransactionHelper.validateLoanStatus(getLoansLoanIdResponse, "loanStatusType.closed.obligations.met");
-
+        loanDetails = getLoanDetails(loanId);
+        validateLoanAccount(loanDetails, Double.valueOf("0.00"), Double.valueOf("0.00"), true);
+        validateLoanStatus(loanDetails, "loanStatusType.closed.obligations.met");
     }
 
     @Test
@@ -237,73 +148,45 @@ public class LoanChargeSpecificDueDateTest extends BaseLoanIntegrationTest {
         globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                 new PutGlobalConfigurationsRequest().enabled(true));
         final LocalDate todaysDate = Utils.getLocalDateOfTenant();
-        BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, todaysDate);
+        updateBusinessDate(Utils.dateFormatter.format(todaysDate));
 
-        // Client and Loan account creation
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-        final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper, null);
-        assertNotNull(getLoanProductsProductResponse);
+        final Long clientId = createClient("01 January 2012");
+        final Long loanProductId = createLoanProduct(testLoanProduct());
 
-        // Older date to have more than one overdue installment
-        LocalDate transactionDate = todaysDate;
-        String operationDate = Utils.dateFormatter.format(transactionDate);
-        log.info("Operation date {}", transactionDate);
+        final LocalDate transactionDate = todaysDate;
+        final String operationDate = Utils.dateFormatter.format(transactionDate);
 
-        // Create Loan Account
-        final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                getLoanProductsProductResponse.getId().toString(), operationDate, "1", "0");
+        final Long loanId = createLoanAccount(clientId, loanProductId, operationDate, 1);
 
-        // Get loan details
-        GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("0.00"), false);
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
+        validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("0.00"), false);
 
-        // Apply Loan Charge with specific due date
-        final String feeAmount = "1.500000";
-        String payloadJSON = ChargesHelper.getLoanSpecificInstallmentFeeJSON();
-        final PostChargesResponse postChargesResponse = ChargesHelper.createLoanCharge(requestSpec, responseSpec, payloadJSON);
-        assertNotNull(postChargesResponse);
-        final Long chargeId = postChargesResponse.getResourceId();
+        final Long chargeId = chargesHelper.createCharge(installmentFee()).getResourceId();
         assertNotNull(chargeId);
 
-        float amount = Float.parseFloat("5.00");
-        PostLoansLoanIdTransactionsResponse loanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(operationDate, amount,
-                loanId);
+        makeRepayment(operationDate, 5.00f, loanId);
 
-        payloadJSON = LoanTransactionHelper.getSpecifiedInstallmentChargesForLoanAsJSON(chargeId.toString(), feeAmount);
-        PostLoansLoanIdChargesResponse postLoansLoanIdChargesResponse = loanTransactionHelper.addChargeForLoan(loanId, payloadJSON,
-                responseSpec);
-        assertNotNull(postLoansLoanIdChargesResponse);
-        final Long loanChargeId = postLoansLoanIdChargesResponse.getResourceId();
+        final Long loanChargeId = addChargesForLoan(loanId, installmentCharge(chargeId, 1.5)).getResourceId();
         assertNotNull(loanChargeId);
 
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("10.00"), false);
+        loanDetails = getLoanDetails(loanId);
+        validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("10.00"), false);
 
-        // Waive the Loan Charge
-        final PostLoansLoanIdChargesChargeIdResponse postWaiveLoanChargesResponse = loanTransactionHelper.applyLoanChargeCommand(loanId,
-                loanChargeId, "waive", Utils.emptyJson());
-        assertNotNull(postWaiveLoanChargesResponse);
+        waiveLoanCharge(loanId, loanChargeId, new PostLoansLoanIdChargesChargeIdRequest());
 
-        // evaluate the outstanding
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("0.00"), false);
+        loanDetails = getLoanDetails(loanId);
+        validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("0.00"), false);
 
-        Optional<GetLoansLoanIdTransactions> waiveTransaction = getLoansLoanIdResponse.getTransactions().stream()
+        Optional<GetLoansLoanIdTransactions> waiveTransaction = loanDetails.getTransactions().stream()
                 .filter(transaction -> transaction.getType().getWaiveCharges() != null && transaction.getType().getWaiveCharges())
                 .findFirst();
         assertTrue(waiveTransaction.isPresent());
         assertEquals(transactionDate, waiveTransaction.get().getDate());
 
-        // Make a full repayment to close the Loan
-        amount = Float.parseFloat("1000.00");
-        loanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(operationDate, amount, loanId);
-        assertNotNull(loanIdTransactionsResponse);
-        log.info("Loan Transaction Id: {} {}", loanId, loanIdTransactionsResponse.getResourceId());
+        makeRepayment(operationDate, 1000.00f, loanId);
 
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        assertNotNull(getLoansLoanIdResponse);
-        loanTransactionHelper.validateLoanStatus(getLoansLoanIdResponse, "loanStatusType.closed.obligations.met");
-
+        loanDetails = getLoanDetails(loanId);
+        validateLoanStatus(loanDetails, "loanStatusType.closed.obligations.met");
     }
 
     @Test
@@ -311,138 +194,85 @@ public class LoanChargeSpecificDueDateTest extends BaseLoanIntegrationTest {
         globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                 new PutGlobalConfigurationsRequest().enabled(true));
         final LocalDate todaysDate = Utils.getLocalDateOfTenant();
-        BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, todaysDate);
+        updateBusinessDate(Utils.dateFormatter.format(todaysDate));
 
-        // Client and Loan account creation
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-        final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper, null);
-        assertNotNull(getLoanProductsProductResponse);
+        final Long clientId = createClient("01 January 2012");
+        final Long loanProductId = createLoanProduct(testLoanProduct());
 
-        // Older date to have more than one overdue installment
         LocalDate transactionDate = todaysDate;
-        String operationDate = Utils.dateFormatter.format(transactionDate);
-        log.info("Operation date {}", transactionDate);
+        final String operationDate = Utils.dateFormatter.format(transactionDate);
 
-        // Create Loan Account
-        final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                getLoanProductsProductResponse.getId().toString(), operationDate, "1", "0");
+        final Long loanId = createLoanAccount(clientId, loanProductId, operationDate, 1);
 
-        // Get loan details
-        GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("0.00"), false);
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
+        validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("0.00"), false);
 
-        // Apply Loan Charge with specific due date
-        final String feeAmount = "1.500000";
-        String payloadJSON = ChargesHelper.getLoanSpecificInstallmentFeeJSON();
-        final PostChargesResponse postChargesResponse = ChargesHelper.createLoanCharge(requestSpec, responseSpec, payloadJSON);
-        assertNotNull(postChargesResponse);
-        final Long chargeId = postChargesResponse.getResourceId();
+        final Long chargeId = chargesHelper.createCharge(installmentFee()).getResourceId();
         assertNotNull(chargeId);
 
-        float amount = Float.parseFloat("5.00");
-        PostLoansLoanIdTransactionsResponse loanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(operationDate, amount,
-                loanId);
+        makeRepayment(operationDate, 5.00f, loanId);
         transactionDate = todaysDate.plusDays(32);
-        BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, transactionDate);
+        updateBusinessDate(Utils.dateFormatter.format(transactionDate));
 
-        payloadJSON = LoanTransactionHelper.getSpecifiedInstallmentChargesForLoanAsJSON(chargeId.toString(), feeAmount);
-        PostLoansLoanIdChargesResponse postLoansLoanIdChargesResponse = loanTransactionHelper.addChargeForLoan(loanId, payloadJSON,
-                responseSpec);
-        assertNotNull(postLoansLoanIdChargesResponse);
-        final Long loanChargeId = postLoansLoanIdChargesResponse.getResourceId();
+        final Long loanChargeId = addChargesForLoan(loanId, installmentCharge(chargeId, 1.5)).getResourceId();
         assertNotNull(loanChargeId);
 
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("10.00"), false);
-        LocalDate repaymentDueDate = getLoansLoanIdResponse.getRepaymentSchedule().getPeriods().get(1).getDueDate();
-        // Waive the Loan Charge
-        final PostLoansLoanIdChargesChargeIdResponse postWaiveLoanChargesResponse = loanTransactionHelper.applyLoanChargeCommand(loanId,
-                loanChargeId, "waive", Utils.emptyJson());
-        assertNotNull(postWaiveLoanChargesResponse);
+        loanDetails = getLoanDetails(loanId);
+        validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("10.00"), false);
+        LocalDate repaymentDueDate = loanDetails.getRepaymentSchedule().getPeriods().get(1).getDueDate();
 
-        // evaluate the outstanding
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("0.00"), false);
+        waiveLoanCharge(loanId, loanChargeId, new PostLoansLoanIdChargesChargeIdRequest());
 
-        Optional<GetLoansLoanIdTransactions> waiveTransaction = getLoansLoanIdResponse.getTransactions().stream()
+        loanDetails = getLoanDetails(loanId);
+        validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("0.00"), false);
+
+        Optional<GetLoansLoanIdTransactions> waiveTransaction = loanDetails.getTransactions().stream()
                 .filter(transaction -> transaction.getType().getWaiveCharges() != null && transaction.getType().getWaiveCharges())
                 .findFirst();
         assertTrue(waiveTransaction.isPresent());
         assertEquals(repaymentDueDate, waiveTransaction.get().getDate());
 
-        // Make a full repayment to close the Loan
-        amount = Float.parseFloat("1000.00");
-        loanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(operationDate, amount, loanId);
-        assertNotNull(loanIdTransactionsResponse);
-        log.info("Loan Transaction Id: {} {}", loanId, loanIdTransactionsResponse.getResourceId());
+        makeRepayment(operationDate, 1000.00f, loanId);
 
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        assertNotNull(getLoansLoanIdResponse);
-        loanTransactionHelper.validateLoanStatus(getLoansLoanIdResponse, "loanStatusType.closed.obligations.met");
-
+        loanDetails = getLoanDetails(loanId);
+        validateLoanStatus(loanDetails, "loanStatusType.closed.obligations.met");
     }
 
     @Test
     public void testApplyAndWaiveLoanSpecificDueDatePenaltyWithDisbursementDate() {
-
         final LocalDate todaysDate = Utils.getLocalDateOfTenant();
 
-        // Client and Loan account creation
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-        final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProduct(loanTransactionHelper, null);
-        assertNotNull(getLoanProductsProductResponse);
+        final Long clientId = createClient("01 January 2012");
+        final Long loanProductId = createLoanProduct(testLoanProduct());
 
-        // Older date to have more than one overdue installment
-        LocalDate transactionDate = todaysDate;
-        String operationDate = Utils.dateFormatter.format(transactionDate);
-        log.info("Operation date {}", transactionDate);
+        final LocalDate transactionDate = todaysDate;
+        final String operationDate = Utils.dateFormatter.format(transactionDate);
 
-        // Create Loan Account
-        final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                getLoanProductsProductResponse.getId().toString(), operationDate, "12", "0");
+        final Long loanId = createLoanAccount(clientId, loanProductId, operationDate, 12);
 
-        // Get loan details
-        GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("0.00"), true);
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
+        validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("0.00"), true);
 
-        // Apply Loan Charge with specific due date
-        final String feeAmount = "10.00";
-        String payloadJSON = ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, feeAmount, true);
-        final PostChargesResponse postChargesResponse = ChargesHelper.createLoanCharge(requestSpec, responseSpec, payloadJSON);
-        assertNotNull(postChargesResponse);
-        final Long chargeId = postChargesResponse.getResourceId();
+        final Long chargeId = chargesHelper.createLoanSpecifiedDueDatePenalty(10.0).getResourceId();
         assertNotNull(chargeId);
 
-        payloadJSON = LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(chargeId.toString(), operationDate, feeAmount);
-        PostLoansLoanIdChargesResponse postLoansLoanIdChargesResponse = loanTransactionHelper.addChargeForLoan(loanId, payloadJSON,
-                responseSpec);
-        assertNotNull(postLoansLoanIdChargesResponse);
-        final Long loanChargeId = postLoansLoanIdChargesResponse.getResourceId();
+        final Long loanChargeId = addChargesForLoan(loanId, LoanRequestBuilders.addLoanCharge(chargeId, 10.0, operationDate))
+                .getResourceId();
         assertNotNull(loanChargeId);
 
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("10.00"), true);
+        loanDetails = getLoanDetails(loanId);
+        validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("10.00"), true);
 
-        // Waive the Loan Charge
-        final PostLoansLoanIdChargesChargeIdResponse postWaiveLoanChargesResponse = loanTransactionHelper.applyLoanChargeCommand(loanId,
-                loanChargeId, "waive", Utils.emptyJson());
-        assertNotNull(postWaiveLoanChargesResponse);
+        waiveLoanCharge(loanId, loanChargeId, new PostLoansLoanIdChargesChargeIdRequest());
 
-        // evaluate the outstanding
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("0.00"), true);
+        loanDetails = getLoanDetails(loanId);
+        validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("0.00"), true);
 
-        // Make a full repayment to close the Loan
-        Float amount = Float.valueOf("1000.00");
-        PostLoansLoanIdTransactionsResponse loanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(operationDate, amount,
-                loanId);
+        PostLoansLoanIdTransactionsResponse loanIdTransactionsResponse = makeRepayment(operationDate, 1000.00f, loanId);
         assertNotNull(loanIdTransactionsResponse);
-        log.info("Loan Transaction Id: {} {}", loanId, loanIdTransactionsResponse.getResourceId());
 
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        assertNotNull(getLoansLoanIdResponse);
-        loanTransactionHelper.validateLoanStatus(getLoansLoanIdResponse, "loanStatusType.closed.obligations.met");
-
+        loanDetails = getLoanDetails(loanId);
+        validateLoanStatus(loanDetails, "loanStatusType.closed.obligations.met");
     }
 
     @Test
@@ -452,121 +282,81 @@ public class LoanChargeSpecificDueDateTest extends BaseLoanIntegrationTest {
                     new PutGlobalConfigurationsRequest().enabled(true));
 
             final LocalDate todaysDate = Utils.getLocalDateOfTenant();
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, todaysDate);
+            updateBusinessDate(Utils.dateFormatter.format(todaysDate));
 
-            // Client and Loan account creation
-            final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProductWithPeriodicAccrual(
-                    loanTransactionHelper, null);
-            assertNotNull(getLoanProductsProductResponse);
+            final Long clientId = createClient("01 January 2012");
+            final Long loanProductId = createLoanProduct(testLoanProduct());
 
             LocalDate transactionDate = LocalDate.of(Utils.getLocalDateOfTenant().getYear(), 1, 1);
             String operationDate = Utils.dateFormatter.format(transactionDate);
-            log.info("Disbursement date {}", transactionDate);
 
-            // Create Loan Account
-            final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                    getLoanProductsProductResponse.getId().toString(), operationDate, "1", "0");
+            final Long loanId = createLoanAccount(clientId, loanProductId, operationDate, 1);
 
-            // Get loan details
-            GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-            validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("0.00"), true);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
+            validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("0.00"), true);
 
-            // Apply Loan Charge with specific due date
             String feeAmount = "10.00";
-            String payloadJSON = ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, feeAmount, true);
-            final PostChargesResponse postChargesResponse = ChargesHelper.createLoanCharge(requestSpec, responseSpec, payloadJSON);
-            assertNotNull(postChargesResponse);
-            final Long chargeId = postChargesResponse.getResourceId();
+            final Long chargeId = chargesHelper.createLoanSpecifiedDueDatePenalty(Double.parseDouble(feeAmount)).getResourceId();
             assertNotNull(chargeId);
 
             // First Loan Charge
             transactionDate = transactionDate.plusDays(1);
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, transactionDate);
+            updateBusinessDate(Utils.dateFormatter.format(transactionDate));
             operationDate = Utils.dateFormatter.format(transactionDate);
-            log.info("Operation date {}", transactionDate);
-            payloadJSON = LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(chargeId.toString(), operationDate, feeAmount);
-            PostLoansLoanIdChargesResponse postLoansLoanIdChargesResponse = loanTransactionHelper.addChargeForLoan(loanId, payloadJSON,
-                    responseSpec);
-            assertNotNull(postLoansLoanIdChargesResponse);
-            final Long loanChargeId01 = postLoansLoanIdChargesResponse.getResourceId();
+            final Long loanChargeId01 = addChargesForLoan(loanId, LoanRequestBuilders.addLoanCharge(chargeId, 10.0, operationDate))
+                    .getResourceId();
             assertNotNull(loanChargeId01);
 
-            // Run Accruals
-            log.info("Running Periodic Accrual for date {}", transactionDate);
-            PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting(operationDate);
-            getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-            loanTransactionHelper.evaluateLoanTransactionData(getLoansLoanIdResponse, "loanTransactionType.accrual",
-                    Double.valueOf("10.00"));
+            runPeriodicAccrualAccounting(operationDate);
+            loanDetails = getLoanDetails(loanId);
+            evaluateLoanTransactionData(loanDetails, "loanTransactionType.accrual", Double.valueOf("10.00"));
 
             // Repay the first charge fully, 10
-            Float amount = Float.valueOf("10.00");
             transactionDate = transactionDate.plusDays(40);
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, transactionDate);
+            updateBusinessDate(Utils.dateFormatter.format(transactionDate));
             operationDate = Utils.dateFormatter.format(transactionDate);
-            log.info("Operation date {}", transactionDate);
-            PostLoansLoanIdTransactionsResponse loanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(operationDate, amount,
-                    loanId);
+            PostLoansLoanIdTransactionsResponse loanIdTransactionsResponse = makeRepayment(operationDate, 10.00f, loanId);
             assertNotNull(loanIdTransactionsResponse);
-            log.info("Loan Transaction Id: {} {}", loanId, loanIdTransactionsResponse.getResourceId());
 
             // Second Loan Charge
-            feeAmount = "15.00";
             transactionDate = transactionDate.plusDays(1);
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, transactionDate);
+            updateBusinessDate(Utils.dateFormatter.format(transactionDate));
             operationDate = Utils.dateFormatter.format(transactionDate);
-            log.info("Operation date {}", transactionDate);
-            payloadJSON = LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(chargeId.toString(), operationDate, feeAmount);
-            postLoansLoanIdChargesResponse = loanTransactionHelper.addChargeForLoan(loanId, payloadJSON, responseSpec);
-            assertNotNull(postLoansLoanIdChargesResponse);
-            final Long loanChargeId02 = postLoansLoanIdChargesResponse.getResourceId();
+            final Long loanChargeId02 = addChargesForLoan(loanId, LoanRequestBuilders.addLoanCharge(chargeId, 15.0, operationDate))
+                    .getResourceId();
             assertNotNull(loanChargeId02);
 
-            getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-            validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("15.00"), true);
+            loanDetails = getLoanDetails(loanId);
+            validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("15.00"), true);
 
-            // Run Accruals
-            log.info("Running Periodic Accrual for date {}", transactionDate);
-            PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting(operationDate);
-            getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-            loanTransactionHelper.evaluateLoanTransactionData(getLoansLoanIdResponse, "loanTransactionType.accrual",
-                    Double.valueOf("25.00"));
+            runPeriodicAccrualAccounting(operationDate);
+            loanDetails = getLoanDetails(loanId);
+            evaluateLoanTransactionData(loanDetails, "loanTransactionType.accrual", Double.valueOf("25.00"));
 
             // Third Loan Charge
-            feeAmount = "25.00";
             transactionDate = transactionDate.plusDays(1);
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, transactionDate);
+            updateBusinessDate(Utils.dateFormatter.format(transactionDate));
             operationDate = Utils.dateFormatter.format(transactionDate);
-            log.info("Operation date {}", transactionDate);
-            payloadJSON = LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(chargeId.toString(), operationDate, feeAmount);
-            postLoansLoanIdChargesResponse = loanTransactionHelper.addChargeForLoan(loanId, payloadJSON, responseSpec);
-            assertNotNull(postLoansLoanIdChargesResponse);
-            final Long loanChargeId03 = postLoansLoanIdChargesResponse.getResourceId();
+            final Long loanChargeId03 = addChargesForLoan(loanId, LoanRequestBuilders.addLoanCharge(chargeId, 25.0, operationDate))
+                    .getResourceId();
             assertNotNull(loanChargeId03);
 
-            getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-            validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("40.00"), true);
-            loanTransactionHelper.evaluateLoanTransactionData(getLoansLoanIdResponse, "loanTransactionType.accrual",
-                    Double.valueOf("25.00"));
+            loanDetails = getLoanDetails(loanId);
+            validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("40.00"), true);
+            evaluateLoanTransactionData(loanDetails, "loanTransactionType.accrual", Double.valueOf("25.00"));
 
-            amount = Float.valueOf("1040.00");
-            loanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(operationDate, amount, loanId);
+            loanIdTransactionsResponse = makeRepayment(operationDate, 1040.00f, loanId);
             assertNotNull(loanIdTransactionsResponse);
-            log.info("Loan Transaction Id: {} {}", loanId, loanIdTransactionsResponse.getResourceId());
 
-            getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-            assertNotNull(getLoansLoanIdResponse);
-            loanTransactionHelper.validateLoanStatus(getLoansLoanIdResponse, "loanStatusType.closed.obligations.met");
-            loanTransactionHelper.evaluateLoanTransactionData(getLoansLoanIdResponse, "loanTransactionType.accrual",
-                    Double.valueOf("50.00"));
+            loanDetails = getLoanDetails(loanId);
+            validateLoanStatus(loanDetails, "loanStatusType.closed.obligations.met");
+            evaluateLoanTransactionData(loanDetails, "loanTransactionType.accrual", Double.valueOf("50.00"));
 
-            final Long transactionId = loanTransactionHelper.evaluateLastLoanTransactionData(getLoansLoanIdResponse,
-                    "loanTransactionType.accrual", operationDate, Double.valueOf("25.00"));
+            final Long transactionId = evaluateLastLoanTransactionData(loanDetails, "loanTransactionType.accrual", operationDate,
+                    Double.valueOf("25.00"));
             assertNotNull(transactionId);
-            log.info("transactionId {}", transactionId);
 
-            final GetJournalEntriesTransactionIdResponse journalEntriesResponse = journalEntryHelper
-                    .getJournalEntries("L" + transactionId.toString());
+            final GetJournalEntriesTransactionIdResponse journalEntriesResponse = getJournalEntries("L" + transactionId);
             assertNotNull(journalEntriesResponse);
             final List<JournalEntryTransactionItem> journalEntries = journalEntriesResponse.getPageItems();
             assertEquals(2, journalEntries.size());
@@ -587,66 +377,45 @@ public class LoanChargeSpecificDueDateTest extends BaseLoanIntegrationTest {
                     new PutGlobalConfigurationsRequest().enabled(true));
 
             final LocalDate todaysDate = Utils.getLocalDateOfTenant();
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, todaysDate);
+            updateBusinessDate(Utils.dateFormatter.format(todaysDate));
 
-            // Client and Loan account creation
-            final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProductWithPeriodicAccrual(
-                    loanTransactionHelper, null);
-            assertNotNull(getLoanProductsProductResponse);
+            final Long clientId = createClient("01 January 2012");
+            final Long loanProductId = createLoanProduct(testLoanProduct());
 
             LocalDate transactionDate = LocalDate.of(Utils.getLocalDateOfTenant().getYear(), 1, 1);
             String operationDate = Utils.dateFormatter.format(transactionDate);
-            log.info("Disbursement date {}", transactionDate);
 
-            // Create Loan Account
-            final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                    getLoanProductsProductResponse.getId().toString(), operationDate, "1", "0");
+            final Long loanId = createLoanAccount(clientId, loanProductId, operationDate, 1);
 
-            // Get loan details
-            GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-            validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("0.00"), true);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
+            validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("0.00"), true);
 
-            // Apply Loan Charge with specific due date
             String feeAmount = "10.00";
-            String payloadJSON = ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, feeAmount, true);
-            final PostChargesResponse postChargesResponse = ChargesHelper.createLoanCharge(requestSpec, responseSpec, payloadJSON);
-            assertNotNull(postChargesResponse);
-            final Long chargeId = postChargesResponse.getResourceId();
+            final Long chargeId = chargesHelper.createLoanSpecifiedDueDatePenalty(Double.parseDouble(feeAmount)).getResourceId();
             assertNotNull(chargeId);
 
             // First Loan Charge
             transactionDate = transactionDate.plusDays(1);
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, transactionDate);
+            updateBusinessDate(Utils.dateFormatter.format(transactionDate));
             operationDate = Utils.dateFormatter.format(transactionDate);
-            log.info("Operation date {}", transactionDate);
-            payloadJSON = LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(chargeId.toString(), operationDate, feeAmount);
-            PostLoansLoanIdChargesResponse postLoansLoanIdChargesResponse = loanTransactionHelper.addChargeForLoan(loanId, payloadJSON,
-                    responseSpec);
-            assertNotNull(postLoansLoanIdChargesResponse);
-            final Long loanChargeId01 = postLoansLoanIdChargesResponse.getResourceId();
+            final Long loanChargeId01 = addChargesForLoan(loanId, LoanRequestBuilders.addLoanCharge(chargeId, 10.0, operationDate))
+                    .getResourceId();
             assertNotNull(loanChargeId01);
 
-            Float amount = Float.valueOf("1020.00");
             transactionDate = transactionDate.plusDays(2);
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, transactionDate);
+            updateBusinessDate(Utils.dateFormatter.format(transactionDate));
             operationDate = Utils.dateFormatter.format(transactionDate);
-            log.info("Operation date {}", transactionDate);
-            PostLoansLoanIdTransactionsResponse loanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(operationDate, amount,
-                    loanId);
+            PostLoansLoanIdTransactionsResponse loanIdTransactionsResponse = makeRepayment(operationDate, 1020.00f, loanId);
             assertNotNull(loanIdTransactionsResponse);
-            log.info("Loan Transaction Id: {} {}", loanId, loanIdTransactionsResponse.getResourceId());
 
-            getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-            assertNotNull(getLoansLoanIdResponse);
-            loanTransactionHelper.validateLoanStatus(getLoansLoanIdResponse, "loanStatusType.overpaid");
+            loanDetails = getLoanDetails(loanId);
+            validateLoanStatus(loanDetails, "loanStatusType.overpaid");
 
-            final Long transactionId = loanTransactionHelper.evaluateLastLoanTransactionData(getLoansLoanIdResponse,
-                    "loanTransactionType.accrual", operationDate, Double.valueOf("10.00"));
+            final Long transactionId = evaluateLastLoanTransactionData(loanDetails, "loanTransactionType.accrual", operationDate,
+                    Double.valueOf("10.00"));
             assertNotNull(transactionId);
-            log.info("transactionId {}", transactionId);
 
-            final GetJournalEntriesTransactionIdResponse journalEntriesResponse = journalEntryHelper.getJournalEntries("L" + transactionId);
+            final GetJournalEntriesTransactionIdResponse journalEntriesResponse = getJournalEntries("L" + transactionId);
             assertNotNull(journalEntriesResponse);
             final List<JournalEntryTransactionItem> journalEntries = journalEntriesResponse.getPageItems();
             assertEquals(2, journalEntries.size());
@@ -662,181 +431,160 @@ public class LoanChargeSpecificDueDateTest extends BaseLoanIntegrationTest {
 
     @Test
     public void testApplyLoanSpecificDueDatePenaltyWithDisbursementDateWithMultipleDisbursement() {
-
         final LocalDate todaysDate = Utils.getLocalDateOfTenant();
 
-        // Client and Loan account creation
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-        final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProductWithPeriodicAccrual(loanTransactionHelper,
-                null);
-        assertNotNull(getLoanProductsProductResponse);
+        final Long clientId = createClient("01 January 2012");
+        final Long loanProductId = createLoanProduct(testLoanProduct());
 
-        // Older date to have more than one overdue installment
-        LocalDate transactionDate = todaysDate;
+        final LocalDate transactionDate = todaysDate;
         String operationDate = Utils.dateFormatter.format(transactionDate);
-        log.info("Operation date {}", transactionDate);
 
-        // Create Loan Account
-        final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                getLoanProductsProductResponse.getId().toString(), operationDate, "12", "0");
+        final Long loanId = createLoanAccount(clientId, loanProductId, operationDate, 12);
 
-        // Get loan details
-        GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("0.00"), true);
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
+        validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("0.00"), true);
 
-        // Apply Loan Charge with specific due date
-
-        final String feeAmount = "10.00";
-        String payloadJSON = ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, feeAmount, true);
-        final PostChargesResponse postChargesResponse = ChargesHelper.createLoanCharge(requestSpec, responseSpec, payloadJSON);
-        assertNotNull(postChargesResponse);
-        final Long loanChargeId = postChargesResponse.getResourceId();
+        final Long loanChargeId = chargesHelper.createLoanSpecifiedDueDatePenalty(10.0).getResourceId();
         assertNotNull(loanChargeId);
+        addChargesForLoan(loanId, LoanRequestBuilders.addLoanCharge(loanChargeId, 10.0, operationDate));
 
-        payloadJSON = LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(loanChargeId.toString(), operationDate, feeAmount);
-        PostLoansLoanIdChargesResponse postLoansLoanIdChargesResponse = loanTransactionHelper.addChargeForLoan(loanId, payloadJSON,
-                responseSpec);
-        assertNotNull(postLoansLoanIdChargesResponse);
+        runPeriodicAccrualAccounting(operationDate);
 
-        PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting(operationDate);
+        loanDetails = getLoanDetails(loanId);
+        validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("10.00"), true);
 
-        // Get loan details expecting to have a delinquency classification
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("10.00"), true);
+        disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate(operationDate).transactionAmount(new BigDecimal("1000"))
+                .locale("en").dateFormat(DATETIME_PATTERN));
 
-        loanTransactionHelper.disburseLoan((long) loanId, new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
-                .transactionAmount(new BigDecimal("1000")).locale("en").dateFormat("dd MMMM yyyy"));
-
-        // Get loan details expecting to have a delinquency classification
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.parseDouble(principalAmount) * 2, Double.valueOf("10.00"), true);
+        loanDetails = getLoanDetails(loanId);
+        validateLoanAccount(loanDetails, Double.parseDouble(principalAmount) * 2, Double.valueOf("10.00"), true);
 
         operationDate = Utils.dateFormatter.format(transactionDate.plusMonths(1));
-        payloadJSON = LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(loanChargeId.toString(), operationDate, feeAmount);
-        postLoansLoanIdChargesResponse = loanTransactionHelper.addChargeForLoan(loanId, payloadJSON, responseSpec);
+        addChargesForLoan(loanId, LoanRequestBuilders.addLoanCharge(loanChargeId, 10.0, operationDate));
 
-        // Get loan details expecting to have a delinquency classification
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.parseDouble(principalAmount) * 2, Double.valueOf("20.00"), true);
+        loanDetails = getLoanDetails(loanId);
+        validateLoanAccount(loanDetails, Double.parseDouble(principalAmount) * 2, Double.valueOf("20.00"), true);
     }
 
     @Test
     public void testApplyLoanSpecificDueDatePenaltyAccrualWithDisbursementDateWithMultipleDisbursement() {
-
         final LocalDate todaysDate = Utils.getLocalDateOfTenant();
 
-        // Client and Loan account creation
-        final Integer clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec, "01 January 2012");
-        final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProductWithPeriodicAccrual(loanTransactionHelper,
-                null);
-        assertNotNull(getLoanProductsProductResponse);
+        final Long clientId = createClient("01 January 2012");
+        final Long loanProductId = createLoanProduct(testLoanProduct());
 
-        // Older date to have more than one overdue installment
         LocalDate transactionDate = todaysDate.minusDays(2);
         String operationDate = Utils.dateFormatter.format(transactionDate);
-        log.info("Operation date {}", transactionDate);
 
-        // Create Loan Account
-        final Integer loanId = createLoanAccount(loanTransactionHelper, clientId.toString(),
-                getLoanProductsProductResponse.getId().toString(), operationDate, "12", "0");
+        final Long loanId = createLoanAccount(clientId, loanProductId, operationDate, 12);
 
-        // Get loan details
-        GetLoansLoanIdResponse getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("0.00"), true);
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
+        validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("0.00"), true);
 
-        // Apply Loan Charge with specific due date
-
-        final String feeAmount = "10.00";
-        String payloadJSON = ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, feeAmount, true);
-        final PostChargesResponse postChargesResponse = ChargesHelper.createLoanCharge(requestSpec, responseSpec, payloadJSON);
-        assertNotNull(postChargesResponse);
-        final Long loanChargeId = postChargesResponse.getResourceId();
+        final Long loanChargeId = chargesHelper.createLoanSpecifiedDueDatePenalty(10.0).getResourceId();
         assertNotNull(loanChargeId);
+        addChargesForLoan(loanId, LoanRequestBuilders.addLoanCharge(loanChargeId, 10.0, operationDate));
 
-        payloadJSON = LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(loanChargeId.toString(), operationDate, feeAmount);
-        PostLoansLoanIdChargesResponse postLoansLoanIdChargesResponse = loanTransactionHelper.addChargeForLoan(loanId, payloadJSON,
-                responseSpec);
-        assertNotNull(postLoansLoanIdChargesResponse);
+        runPeriodicAccrualAccounting(operationDate);
 
-        PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting(operationDate);
-
-        // Get loan details expecting to have a delinquency classification
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.valueOf(principalAmount), Double.valueOf("10.00"), true);
+        loanDetails = getLoanDetails(loanId);
+        validateLoanAccount(loanDetails, Double.valueOf(principalAmount), Double.valueOf("10.00"), true);
 
         transactionDate = transactionDate.plusDays(1);
         operationDate = Utils.dateFormatter.format(transactionDate);
 
-        loanTransactionHelper.disburseLoan((long) loanId, new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
-                .transactionAmount(new BigDecimal("1000")).locale("en").dateFormat("dd MMMM yyyy"));
+        disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate(operationDate).transactionAmount(new BigDecimal("1000"))
+                .locale("en").dateFormat(DATETIME_PATTERN));
 
-        // Get loan details expecting to have a delinquency classification
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.parseDouble(principalAmount) * 2, Double.valueOf("10.00"), true);
+        loanDetails = getLoanDetails(loanId);
+        validateLoanAccount(loanDetails, Double.parseDouble(principalAmount) * 2, Double.valueOf("10.00"), true);
 
-        PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting(operationDate);
+        runPeriodicAccrualAccounting(operationDate);
 
         operationDate = Utils.dateFormatter.format(transactionDate.plusMonths(1));
-        payloadJSON = LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(loanChargeId.toString(), operationDate, feeAmount);
-        postLoansLoanIdChargesResponse = loanTransactionHelper.addChargeForLoan(loanId, payloadJSON, responseSpec);
+        addChargesForLoan(loanId, LoanRequestBuilders.addLoanCharge(loanChargeId, 10.0, operationDate));
 
         transactionDate = transactionDate.plusDays(1);
         operationDate = Utils.dateFormatter.format(transactionDate);
-        PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting(operationDate);
-        // Get loan details expecting to have a delinquency classification
-        getLoansLoanIdResponse = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanId);
-        validateLoanAccount(getLoansLoanIdResponse, Double.parseDouble(principalAmount) * 2, Double.valueOf("20.00"), true);
+        runPeriodicAccrualAccounting(operationDate);
+
+        loanDetails = getLoanDetails(loanId);
+        validateLoanAccount(loanDetails, Double.parseDouble(principalAmount) * 2, Double.valueOf("20.00"), true);
     }
 
-    private GetLoanProductsProductIdResponse createLoanProduct(final LoanTransactionHelper loanTransactionHelper,
-            final Long delinquencyBucketId) {
-        final HashMap<String, Object> loanProductMap = new LoanProductTestBuilder().build(null, delinquencyBucketId);
-        final Integer loanProductId = loanTransactionHelper.getLoanProductId(Utils.convertToJson(loanProductMap));
-        return loanTransactionHelper.getLoanProduct(loanProductId);
+    private PostLoanProductsRequest testLoanProduct() {
+        return createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct()//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS_L)//
+                .numberOfRepayments(1)//
+                .maxNumberOfRepayments(30)//
+                .allowApprovedDisbursedAmountsOverApplied(true)//
+                .overAppliedCalculationType("percentage")//
+                .overAppliedNumber(1000);
     }
 
-    private GetLoanProductsProductIdResponse createLoanProductWithPeriodicAccrual(final LoanTransactionHelper loanTransactionHelper,
-            final Long delinquencyBucketId) {
-        final Account assetAccount = this.accountHelper.createAssetAccount();
-        final Account incomeAccount = this.accountHelper.createIncomeAccount();
-        final Account expenseAccount = this.accountHelper.createExpenseAccount();
-        final Account overpaymentAccount = this.accountHelper.createLiabilityAccount();
-
-        final HashMap<String, Object> loanProductMap = new LoanProductTestBuilder().withMultiDisburse()
-                .withInterestCalculationPeriodTypeAsRepaymentPeriod(true).withInterestTypeAsDecliningBalance()
-                .withAccountingRulePeriodicAccrual(new Account[] { assetAccount, incomeAccount, expenseAccount, overpaymentAccount })
-                .withDisallowExpectedDisbursements(true) //
-                .build(null, delinquencyBucketId);
-        final Integer loanProductId = loanTransactionHelper.getLoanProductId(Utils.convertToJson(loanProductMap));
-        return loanTransactionHelper.getLoanProduct(loanProductId);
-    }
-
-    private Integer createLoanAccount(final LoanTransactionHelper loanTransactionHelper, final String clientId, final String loanProductId,
-            final String operationDate, final String repayments, final String interestRate) {
-        final String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal(principalAmount).withLoanTermFrequency(repayments)
-                .withLoanTermFrequencyAsMonths().withNumberOfRepayments(repayments).withRepaymentEveryAfter("1")
-                .withRepaymentFrequencyTypeAsMonths() //
-                .withInterestRatePerPeriod(interestRate) //
-                .withExpectedDisbursementDate(operationDate) //
-                .withInterestTypeAsDecliningBalance() //
-                .withSubmittedOnDate(operationDate) //
-                .build(clientId, loanProductId, null);
-        final Integer loanId = loanTransactionHelper.getLoanId(loanApplicationJSON);
-        loanTransactionHelper.approveLoan(operationDate, principalAmount, loanId, null);
-        loanTransactionHelper.disburseLoanWithTransactionAmount(operationDate, loanId, principalAmount);
+    private Long createLoanAccount(final Long clientId, final Long loanProductId, final String operationDate, final int repayments) {
+        final Long loanId = applyForLoan(
+                new PostLoansRequest().clientId(clientId).productId(loanProductId).principal(new BigDecimal(principalAmount))
+                        .loanTermFrequency(repayments).loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)
+                        .numberOfRepayments(repayments).repaymentEvery(1).repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)
+                        .interestRatePerPeriod(BigDecimal.ZERO).interestType(LoanTestData.InterestType.DECLINING_BALANCE)
+                        .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)
+                        .amortizationType(LoanTestData.AmortizationType.EQUAL_PRINCIPAL).expectedDisbursementDate(operationDate)
+                        .submittedOnDate(operationDate).transactionProcessingStrategyCode("mifos-standard-strategy").loanType("individual")
+                        .dateFormat(DATETIME_PATTERN).locale("en"));
+        approveLoan(loanId, LoanRequestBuilders.approveLoan(Double.valueOf(principalAmount), operationDate));
+        disburseLoan(loanId, LoanRequestBuilders.disburseLoan(Double.valueOf(principalAmount), operationDate));
         return loanId;
     }
 
-    private void validateLoanAccount(GetLoansLoanIdResponse getLoansLoanIdResponse, Double principal, Double fees, boolean isPenalty) {
-        assertNotNull(getLoansLoanIdResponse);
-        loanTransactionHelper.printRepaymentSchedule(getLoansLoanIdResponse);
-        loanTransactionHelper.validateLoanPrincipalOustandingBalance(getLoansLoanIdResponse, principal);
-        if (isPenalty) {
-            loanTransactionHelper.validateLoanPenaltiesOustandingBalance(getLoansLoanIdResponse, fees);
-        } else {
-            loanTransactionHelper.validateLoanFeesOustandingBalance(getLoansLoanIdResponse, fees);
-        }
-        loanTransactionHelper.validateLoanTotalOustandingBalance(getLoansLoanIdResponse, (principal + fees));
+    private static ChargeRequest installmentFee() {
+        return ChargeRequestBuilders.loanInstallmentFee(1.5)
+                .chargeCalculationType(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST.getValue()).penalty(false);
     }
 
+    private PostLoansLoanIdChargesRequest installmentCharge(Long chargeId, double amount) {
+        return new PostLoansLoanIdChargesRequest().chargeId(chargeId).locale("en").amount(amount);
+    }
+
+    private PostLoansLoanIdTransactionsResponse makeRepayment(String date, float amount, Long loanId) {
+        return makeLoanRepayment(loanId, "repayment", date, (double) amount);
+    }
+
+    private void validateLoanAccount(GetLoansLoanIdResponse loanDetails, Double principal, Double fees, boolean isPenalty) {
+        assertNotNull(loanDetails);
+        final GetLoansLoanIdSummary summary = loanDetails.getSummary();
+        assertNotNull(summary);
+        assertEquals(principal, Utils.getDoubleValue(summary.getPrincipalOutstanding()));
+        if (isPenalty) {
+            assertEquals(fees, Utils.getDoubleValue(summary.getPenaltyChargesOutstanding()));
+        } else {
+            assertEquals(fees, Utils.getDoubleValue(summary.getFeeChargesOutstanding()));
+        }
+        assertEquals(principal + fees, Utils.getDoubleValue(summary.getTotalOutstanding()));
+    }
+
+    private Long evaluateLastLoanTransactionData(GetLoansLoanIdResponse loanDetails, String transactionType, String transactionExpected,
+            Double amountExpected) {
+        GetLoansLoanIdTransactions lastTransaction = null;
+        for (GetLoansLoanIdTransactions transaction : loanDetails.getTransactions()) {
+            if (transactionType.equals(transaction.getType().getCode())) {
+                lastTransaction = transaction;
+            }
+        }
+        assertNotNull(lastTransaction);
+        assertEquals(transactionExpected, Utils.dateFormatter.format(lastTransaction.getDate()));
+        assertEquals(amountExpected, Utils.getDoubleValue(lastTransaction.getAmount()));
+        return lastTransaction.getId();
+    }
+
+    private void evaluateLoanTransactionData(GetLoansLoanIdResponse loanDetails, String transactionType, Double amountExpected) {
+        Double transactionsAmount = 0.0;
+        for (GetLoansLoanIdTransactions transaction : loanDetails.getTransactions()) {
+            if (transactionType.equals(transaction.getType().getCode())) {
+                transactionsAmount += Utils.getDoubleValue(transaction.getAmount());
+            }
+        }
+        assertEquals(amountExpected, transactionsAmount);
+    }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanChargeTaxIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanChargeTaxIntegrationTest.java
@@ -26,7 +26,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.client.models.ChargeRequest;
 import org.apache.fineract.client.models.GetChargesResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdChargesChargeIdResponse;
@@ -40,13 +39,13 @@ import org.apache.fineract.client.models.PostTaxesComponentsResponse;
 import org.apache.fineract.client.models.PostTaxesGroupRequest;
 import org.apache.fineract.client.models.PostTaxesGroupResponse;
 import org.apache.fineract.client.models.PostTaxesGroupTaxComponents;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.TaxComponentHelper;
-import org.apache.fineract.integrationtests.common.TaxGroupHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignTaxComponentHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignTaxGroupHelper;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.common.accounting.Account;
-import org.apache.fineract.integrationtests.common.accounting.PeriodicAccrualAccountingHelper;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
 import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
 import org.apache.fineract.integrationtests.common.loans.LoanTestLifecycleExtension;
 import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
@@ -55,14 +54,17 @@ import org.apache.fineract.portfolio.charge.domain.ChargeTimeType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-@Slf4j
 @ExtendWith(LoanTestLifecycleExtension.class)
-public class LoanChargeTaxIntegrationTest extends BaseLoanIntegrationTest {
+public class LoanChargeTaxIntegrationTest extends FeignLoanTestBase {
 
     private static final String DATE_FORMAT = "dd MMMM yyyy";
     private static final String LOAN_DATE = "01 January 2023";
     private static final String DUE_DATE = "15 January 2023";
     private static final String TAX_START_DATE = "01 January 2013";
+
+    private final FeignTaxComponentHelper taxComponentHelper = new FeignTaxComponentHelper(
+            FineractFeignClientHelper.getFineractFeignClient());
+    private final FeignTaxGroupHelper taxGroupHelper = new FeignTaxGroupHelper(FineractFeignClientHelper.getFineractFeignClient());
 
     // -----------------------------------------------------------------------
     // 1. TaxGroup setup helpers
@@ -74,8 +76,8 @@ public class LoanChargeTaxIntegrationTest extends BaseLoanIntegrationTest {
      */
     private PostTaxesComponentsResponse createTaxComponent(float percentage) {
         PostTaxesComponentsRequest request = new PostTaxesComponentsRequest().name(Utils.uniqueRandomStringGenerator("TAX_COMP_", 6))
-                .percentage(percentage).startDate(TAX_START_DATE).dateFormat(DATE_FORMAT).locale(LOCALE);
-        PostTaxesComponentsResponse response = TaxComponentHelper.createTaxComponent(request);
+                .percentage(percentage).startDate(TAX_START_DATE).dateFormat(DATE_FORMAT).locale(LoanTestData.LOCALE);
+        PostTaxesComponentsResponse response = taxComponentHelper.createTaxComponent(request);
         assertNotNull(response);
         assertNotNull(response.getResourceId());
         return response;
@@ -90,8 +92,8 @@ public class LoanChargeTaxIntegrationTest extends BaseLoanIntegrationTest {
             components.add(new PostTaxesGroupTaxComponents().taxComponentId(id).startDate(TAX_START_DATE));
         }
         PostTaxesGroupRequest request = new PostTaxesGroupRequest().name(Utils.uniqueRandomStringGenerator("TAX_GRP_", 6))
-                .taxComponents(components).dateFormat(DATE_FORMAT).locale(LOCALE);
-        PostTaxesGroupResponse response = TaxGroupHelper.createTaxGroup(request);
+                .taxComponents(components).dateFormat(DATE_FORMAT).locale(LoanTestData.LOCALE);
+        PostTaxesGroupResponse response = taxGroupHelper.createTaxGroup(request);
         assertNotNull(response);
         assertNotNull(response.getResourceId());
         return response;
@@ -103,9 +105,9 @@ public class LoanChargeTaxIntegrationTest extends BaseLoanIntegrationTest {
      */
     private PostTaxesComponentsResponse createTaxComponent(float percentage, Long creditAccountId) {
         PostTaxesComponentsRequest request = new PostTaxesComponentsRequest().name(Utils.uniqueRandomStringGenerator("TAX_COMP_", 6))
-                .percentage(percentage).startDate(TAX_START_DATE).dateFormat(DATE_FORMAT).locale(LOCALE).creditAccountId(creditAccountId)
-                .creditAccountType(2);
-        PostTaxesComponentsResponse response = TaxComponentHelper.createTaxComponent(request);
+                .percentage(percentage).startDate(TAX_START_DATE).dateFormat(DATE_FORMAT).locale(LoanTestData.LOCALE)
+                .creditAccountId(creditAccountId).creditAccountType(2);
+        PostTaxesComponentsResponse response = taxComponentHelper.createTaxComponent(request);
         assertNotNull(response);
         assertNotNull(response.getResourceId());
         return response;
@@ -130,17 +132,17 @@ public class LoanChargeTaxIntegrationTest extends BaseLoanIntegrationTest {
                 .allowVariableInstallments(false).canUseForTopup(false).isInterestRecalculationEnabled(false).holdGuaranteeFunds(false)
                 .multiDisburseLoan(true).maxTrancheCount(10).outstandingLoanBalance(10000.0).charges(Collections.emptyList())
                 .accountingRule(2) // Cash-based
-                .fundSourceAccountId(fundSource.getAccountID().longValue())
-                .loanPortfolioAccountId(loansReceivableAccount.getAccountID().longValue())
-                .transfersInSuspenseAccountId(suspenseAccount.getAccountID().longValue())
-                .interestOnLoanAccountId(interestIncomeAccount.getAccountID().longValue())
-                .incomeFromFeeAccountId(feeIncomeAccount.getAccountID().longValue())
-                .incomeFromPenaltyAccountId(penaltyIncomeAccount.getAccountID().longValue())
-                .incomeFromRecoveryAccountId(recoveriesAccount.getAccountID().longValue())
-                .writeOffAccountId(writtenOffAccount.getAccountID().longValue())
-                .overpaymentLiabilityAccountId(overpaymentAccount.getAccountID().longValue()).dateFormat(DATETIME_PATTERN).locale("en_GB")
-                .disallowExpectedDisbursements(true).allowApprovedDisbursedAmountsOverApplied(true).overAppliedCalculationType("percentage")
-                .overAppliedNumber(50);
+                .fundSourceAccountId(getAccounts().getFundSource().getAccountID().longValue())
+                .loanPortfolioAccountId(getAccounts().getLoansReceivableAccount().getAccountID().longValue())
+                .transfersInSuspenseAccountId(getAccounts().getSuspenseAccount().getAccountID().longValue())
+                .interestOnLoanAccountId(getAccounts().getInterestIncomeAccount().getAccountID().longValue())
+                .incomeFromFeeAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())
+                .incomeFromPenaltyAccountId(getAccounts().getPenaltyIncomeAccount().getAccountID().longValue())
+                .incomeFromRecoveryAccountId(getAccounts().getRecoveriesAccount().getAccountID().longValue())
+                .writeOffAccountId(getAccounts().getWrittenOffAccount().getAccountID().longValue())
+                .overpaymentLiabilityAccountId(getAccounts().getOverpaymentAccount().getAccountID().longValue())
+                .dateFormat(DATETIME_PATTERN).locale("en_GB").disallowExpectedDisbursements(true)
+                .allowApprovedDisbursedAmountsOverApplied(true).overAppliedCalculationType("percentage").overAppliedNumber(50);
     }
 
     /**
@@ -148,15 +150,14 @@ public class LoanChargeTaxIntegrationTest extends BaseLoanIntegrationTest {
      * for {@code taxGroupId} creates a charge with no tax.
      */
     private PostChargesResponse createFlatLoanCharge(double baseAmount, Long taxGroupId) {
-        ChargesHelper chargesHelper = new ChargesHelper();
         ChargeRequest request = new ChargeRequest().penalty(false).amount(baseAmount)
                 .chargeCalculationType(ChargeCalculationType.FLAT.getValue()).chargeTimeType(ChargeTimeType.SPECIFIED_DUE_DATE.getValue())
                 .chargePaymentMode(ChargePaymentMode.REGULAR.getValue()).currencyCode("USD")
-                .name(Utils.uniqueRandomStringGenerator("CHARGE_", 6)).chargeAppliesTo(1).locale(LOCALE).active(true);
+                .name(Utils.uniqueRandomStringGenerator("CHARGE_", 6)).chargeAppliesTo(1).locale(LoanTestData.LOCALE).active(true);
         if (taxGroupId != null) {
             request.taxGroupId(taxGroupId);
         }
-        PostChargesResponse response = chargesHelper.createCharges(request);
+        PostChargesResponse response = chargesHelper.createCharge(request);
         assertNotNull(response);
         assertNotNull(response.getResourceId());
         return response;
@@ -185,22 +186,21 @@ public class LoanChargeTaxIntegrationTest extends BaseLoanIntegrationTest {
             PostChargesResponse chargeResponse = createFlatLoanCharge(100.0, taxGroup.getResourceId());
             Long chargeDefinitionId = chargeResponse.getResourceId();
 
+            Long clientId = createClient();
             // Given – a disbursed loan
-            Long clientId = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
-            Long loanProductId = loanProductHelper.createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct())
-                    .getResourceId();
+            Long loanProductId = createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct());
             Long loanId = applyAndApproveLoan(clientId, loanProductId, LOAN_DATE, 1000.0);
             disburseLoan(loanId, BigDecimal.valueOf(1000.0), LOAN_DATE);
 
             // When – the taxed charge is added to the loan
-            PostLoansLoanIdChargesResponse addResult = loanTransactionHelper.addChargesForLoan(loanId, new PostLoansLoanIdChargesRequest()
-                    .chargeId(chargeDefinitionId).amount(100.0).dueDate(DUE_DATE).dateFormat(DATE_FORMAT).locale(LOCALE));
+            PostLoansLoanIdChargesResponse addResult = addChargesForLoan(loanId, new PostLoansLoanIdChargesRequest()
+                    .chargeId(chargeDefinitionId).amount(100.0).dueDate(DUE_DATE).dateFormat(DATE_FORMAT).locale(LoanTestData.LOCALE));
             assertNotNull(addResult);
             Long loanChargeId = addResult.getResourceId();
             assertNotNull(loanChargeId);
 
             // Then – amount stays at 100; tax (10) is stored separately as taxAmount
-            GetLoansLoanIdChargesChargeIdResponse loanCharge = loanTransactionHelper.getLoanCharge(loanId, loanChargeId);
+            GetLoansLoanIdChargesChargeIdResponse loanCharge = getLoanCharge(loanId, loanChargeId);
             assertNotNull(loanCharge);
             assertEquals(100.0, loanCharge.getAmount(), 0.01, "Charge amount must remain unchanged; tax stored separately as taxAmount=10");
             assertEquals(100.0, loanCharge.getAmountOutstanding(), 0.01,
@@ -226,19 +226,19 @@ public class LoanChargeTaxIntegrationTest extends BaseLoanIntegrationTest {
 
             PostChargesResponse chargeResponse = createFlatLoanCharge(200.0, taxGroup.getResourceId());
 
-            Long clientId = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
-            Long loanProductId = loanProductHelper.createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct())
-                    .getResourceId();
+            Long clientId = createClient();
+            Long loanProductId = createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct());
             Long loanId = applyAndApproveLoan(clientId, loanProductId, LOAN_DATE, 1000.0);
             disburseLoan(loanId, BigDecimal.valueOf(1000.0), LOAN_DATE);
 
             // When
-            PostLoansLoanIdChargesResponse addResult = loanTransactionHelper.addChargesForLoan(loanId, new PostLoansLoanIdChargesRequest()
-                    .chargeId(chargeResponse.getResourceId()).amount(200.0).dueDate(DUE_DATE).dateFormat(DATE_FORMAT).locale(LOCALE));
+            PostLoansLoanIdChargesResponse addResult = addChargesForLoan(loanId,
+                    new PostLoansLoanIdChargesRequest().chargeId(chargeResponse.getResourceId()).amount(200.0).dueDate(DUE_DATE)
+                            .dateFormat(DATE_FORMAT).locale(LoanTestData.LOCALE));
             Long loanChargeId = addResult.getResourceId();
 
             // Then – amount stays 200; taxes (20+10=30) stored separately as taxAmount
-            GetLoansLoanIdChargesChargeIdResponse loanCharge = loanTransactionHelper.getLoanCharge(loanId, loanChargeId);
+            GetLoansLoanIdChargesChargeIdResponse loanCharge = getLoanCharge(loanId, loanChargeId);
             assertEquals(200.0, loanCharge.getAmount(), 0.01,
                     "Charge amount must remain 200; taxes (20+10=30) stored separately as taxAmount");
         });
@@ -257,19 +257,19 @@ public class LoanChargeTaxIntegrationTest extends BaseLoanIntegrationTest {
             // Given – charge with NO tax group
             PostChargesResponse chargeResponse = createFlatLoanCharge(100.0, null);
 
-            Long clientId = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
-            Long loanProductId = loanProductHelper.createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct())
-                    .getResourceId();
+            Long clientId = createClient();
+            Long loanProductId = createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct());
             Long loanId = applyAndApproveLoan(clientId, loanProductId, LOAN_DATE, 1000.0);
             disburseLoan(loanId, BigDecimal.valueOf(1000.0), LOAN_DATE);
 
             // When
-            PostLoansLoanIdChargesResponse addResult = loanTransactionHelper.addChargesForLoan(loanId, new PostLoansLoanIdChargesRequest()
-                    .chargeId(chargeResponse.getResourceId()).amount(100.0).dueDate(DUE_DATE).dateFormat(DATE_FORMAT).locale(LOCALE));
+            PostLoansLoanIdChargesResponse addResult = addChargesForLoan(loanId,
+                    new PostLoansLoanIdChargesRequest().chargeId(chargeResponse.getResourceId()).amount(100.0).dueDate(DUE_DATE)
+                            .dateFormat(DATE_FORMAT).locale(LoanTestData.LOCALE));
             Long loanChargeId = addResult.getResourceId();
 
             // Then – amount must stay at 100 (no tax)
-            GetLoansLoanIdChargesChargeIdResponse loanCharge = loanTransactionHelper.getLoanCharge(loanId, loanChargeId);
+            GetLoansLoanIdChargesChargeIdResponse loanCharge = getLoanCharge(loanId, loanChargeId);
             assertEquals(100.0, loanCharge.getAmount(), 0.01, "Charge without tax group must keep original amount");
         });
     }
@@ -292,8 +292,7 @@ public class LoanChargeTaxIntegrationTest extends BaseLoanIntegrationTest {
         PostChargesResponse chargeResponse = createFlatLoanCharge(50.0, taxGroup.getResourceId());
 
         // Then – retrieve and verify taxGroup is set
-        ChargesHelper chargesHelper = new ChargesHelper();
-        GetChargesResponse chargeData = chargesHelper.retrieveCharge(chargeResponse.getResourceId());
+        GetChargesResponse chargeData = chargesHelper.getCharge(chargeResponse.getResourceId());
         assertNotNull(chargeData);
         assertNotNull(chargeData.getTaxGroup(), "Charge must expose taxGroup in GET response");
         assertEquals(taxGroup.getResourceId(), chargeData.getTaxGroup().getId(),
@@ -315,7 +314,7 @@ public class LoanChargeTaxIntegrationTest extends BaseLoanIntegrationTest {
         PostTaxesGroupResponse taxGroup = createTaxGroup(taxComponent.getResourceId());
 
         // When
-        GetTaxesGroupResponse retrieved = TaxGroupHelper.retrieveTaxGroup(taxGroup.getResourceId());
+        GetTaxesGroupResponse retrieved = taxGroupHelper.retrieveTaxGroup(taxGroup.getResourceId());
 
         // Then
         assertNotNull(retrieved);
@@ -340,7 +339,7 @@ public class LoanChargeTaxIntegrationTest extends BaseLoanIntegrationTest {
         PostTaxesGroupResponse taxGroup = createTaxGroup(taxComponent.getResourceId());
 
         // When
-        List<GetTaxesGroupResponse> allGroups = TaxGroupHelper.retrieveAllTaxGroups();
+        List<GetTaxesGroupResponse> allGroups = taxGroupHelper.retrieveAllTaxGroups();
 
         // Then
         assertNotNull(allGroups);
@@ -365,10 +364,9 @@ public class LoanChargeTaxIntegrationTest extends BaseLoanIntegrationTest {
             PostChargesResponse chargeResponse = createFlatLoanCharge(100.0, taxGroup.getResourceId());
             Long chargeDefinitionId = chargeResponse.getResourceId();
 
+            Long clientId = createClient();
             // Given – two separate loans
-            Long clientId = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
-            Long loanProductId = loanProductHelper.createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct())
-                    .getResourceId();
+            Long loanProductId = createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct());
 
             Long loanId1 = applyAndApproveLoan(clientId, loanProductId, LOAN_DATE, 1000.0);
             disburseLoan(loanId1, BigDecimal.valueOf(1000.0), LOAN_DATE);
@@ -377,14 +375,14 @@ public class LoanChargeTaxIntegrationTest extends BaseLoanIntegrationTest {
             disburseLoan(loanId2, BigDecimal.valueOf(1000.0), LOAN_DATE);
 
             // When – the same charge is added to both loans
-            PostLoansLoanIdChargesResponse add1 = loanTransactionHelper.addChargesForLoan(loanId1, new PostLoansLoanIdChargesRequest()
-                    .chargeId(chargeDefinitionId).amount(100.0).dueDate(DUE_DATE).dateFormat(DATE_FORMAT).locale(LOCALE));
-            PostLoansLoanIdChargesResponse add2 = loanTransactionHelper.addChargesForLoan(loanId2, new PostLoansLoanIdChargesRequest()
-                    .chargeId(chargeDefinitionId).amount(100.0).dueDate(DUE_DATE).dateFormat(DATE_FORMAT).locale(LOCALE));
+            PostLoansLoanIdChargesResponse add1 = addChargesForLoan(loanId1, new PostLoansLoanIdChargesRequest()
+                    .chargeId(chargeDefinitionId).amount(100.0).dueDate(DUE_DATE).dateFormat(DATE_FORMAT).locale(LoanTestData.LOCALE));
+            PostLoansLoanIdChargesResponse add2 = addChargesForLoan(loanId2, new PostLoansLoanIdChargesRequest()
+                    .chargeId(chargeDefinitionId).amount(100.0).dueDate(DUE_DATE).dateFormat(DATE_FORMAT).locale(LoanTestData.LOCALE));
 
+            GetLoansLoanIdChargesChargeIdResponse charge1 = getLoanCharge(loanId1, add1.getResourceId());
             // Then – both loan charges must independently show the original base amount (tax stored separately)
-            GetLoansLoanIdChargesChargeIdResponse charge1 = loanTransactionHelper.getLoanCharge(loanId1, add1.getResourceId());
-            GetLoansLoanIdChargesChargeIdResponse charge2 = loanTransactionHelper.getLoanCharge(loanId2, add2.getResourceId());
+            GetLoansLoanIdChargesChargeIdResponse charge2 = getLoanCharge(loanId2, add2.getResourceId());
 
             assertEquals(100.0, charge1.getAmount(), 0.01, "Loan 1 charge amount must remain 100; tax stored separately");
             assertEquals(100.0, charge2.getAmount(), 0.01, "Loan 2 charge amount must remain 100; tax stored separately");
@@ -421,17 +419,16 @@ public class LoanChargeTaxIntegrationTest extends BaseLoanIntegrationTest {
             // Given – flat charge of 100 with 10 % tax, due on the loan start date
             PostChargesResponse chargeResponse = createFlatLoanCharge(100.0, taxGroup.getResourceId());
 
+            Long clientId = createClient();
             // Given – a cash-based loan (principal = 1000, no interest)
-            Long clientId = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
-            Long loanProductId = loanProductHelper.createLoanProduct(createCashBasedLoanProduct() //
-                    .multiDisburseLoan(false).disallowExpectedDisbursements(null) //
-            ).getResourceId();
+            Long loanProductId = createLoanProduct(
+                    createCashBasedLoanProduct().multiDisburseLoan(false).disallowExpectedDisbursements(null));
             Long loanId = applyAndApproveLoan(clientId, loanProductId, LOAN_DATE, 1000.0);
             disburseLoan(loanId, BigDecimal.valueOf(1000.0), LOAN_DATE);
 
             // When – add the taxed charge (due on same date) and repay principal + fee in one transaction
-            loanTransactionHelper.addChargesForLoan(loanId, new PostLoansLoanIdChargesRequest().chargeId(chargeResponse.getResourceId())
-                    .amount(100.0).dueDate(LOAN_DATE).dateFormat(DATE_FORMAT).locale(LOCALE));
+            addChargesForLoan(loanId, new PostLoansLoanIdChargesRequest().chargeId(chargeResponse.getResourceId()).amount(100.0)
+                    .dueDate(LOAN_DATE).dateFormat(DATE_FORMAT).locale(LoanTestData.LOCALE));
 
             addRepaymentForLoan(loanId, 1100.0, LOAN_DATE);
 
@@ -440,10 +437,10 @@ public class LoanChargeTaxIntegrationTest extends BaseLoanIntegrationTest {
             // Repayment: DR Fund Source 1100 / CR Loan Portfolio 1000 / CR Income from Fees 90 / CR Tax Liability 10
             verifyJournalEntries(loanId,
                     // disbursement
-                    debit(loansReceivableAccount, 1000.0), credit(fundSource, 1000.0),
+                    debit(getAccounts().getLoansReceivableAccount(), 1000.0), credit(getAccounts().getFundSource(), 1000.0),
                     // repayment
-                    debit(fundSource, 1100.0), credit(loansReceivableAccount, 1000.0), credit(feeIncomeAccount, 90.0),
-                    credit(taxLiabilityAccount, 10.0));
+                    debit(getAccounts().getFundSource(), 1100.0), credit(getAccounts().getLoansReceivableAccount(), 1000.0),
+                    credit(getAccounts().getFeeIncomeAccount(), 90.0), credit(taxLiabilityAccount, 10.0));
         });
     }
 
@@ -482,18 +479,17 @@ public class LoanChargeTaxIntegrationTest extends BaseLoanIntegrationTest {
             // Given – flat charge of 100 with 10 % tax, due on the loan start date
             PostChargesResponse chargeResponse = createFlatLoanCharge(100.0, taxGroup.getResourceId());
 
+            Long clientId = createClient();
             // Given – a periodic-accrual loan (principal = 1000, no interest)
-            Long clientId = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
-            Long loanProductId = loanProductHelper.createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct())
-                    .getResourceId();
+            Long loanProductId = createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct());
             Long loanId = applyAndApproveLoan(clientId, loanProductId, LOAN_DATE, 1000.0);
             disburseLoan(loanId, BigDecimal.valueOf(1000.0), LOAN_DATE);
 
             // When – add the taxed charge and run periodic accrual on the same date
-            loanTransactionHelper.addChargesForLoan(loanId, new PostLoansLoanIdChargesRequest().chargeId(chargeResponse.getResourceId())
-                    .amount(100.0).dueDate(LOAN_DATE).dateFormat(DATE_FORMAT).locale(LOCALE));
+            addChargesForLoan(loanId, new PostLoansLoanIdChargesRequest().chargeId(chargeResponse.getResourceId()).amount(100.0)
+                    .dueDate(LOAN_DATE).dateFormat(DATE_FORMAT).locale(LoanTestData.LOCALE));
 
-            PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting(LOAN_DATE);
+            runPeriodicAccrualAccounting(LOAN_DATE);
 
             // Make a full repayment (principal 1000 + fee 100 = 1100)
             addRepaymentForLoan(loanId, 1100.0, LOAN_DATE);
@@ -504,11 +500,13 @@ public class LoanChargeTaxIntegrationTest extends BaseLoanIntegrationTest {
             // Repayment: DR Fund Source 1100 / CR Loan Portfolio 1000 / CR Fees Receivable 100
             verifyJournalEntries(loanId,
                     // disbursement
-                    debit(loansReceivableAccount, 1000.0), credit(fundSource, 1000.0),
+                    debit(getAccounts().getLoansReceivableAccount(), 1000.0), credit(getAccounts().getFundSource(), 1000.0),
                     // accrual
-                    debit(feeReceivableAccount, 100.0), credit(feeIncomeAccount, 90.0), credit(taxLiabilityAccount, 10.0),
+                    debit(getAccounts().getFeeReceivableAccount(), 100.0), credit(getAccounts().getFeeIncomeAccount(), 90.0),
+                    credit(taxLiabilityAccount, 10.0),
                     // repayment
-                    debit(fundSource, 1100.0), credit(loansReceivableAccount, 1000.0), credit(feeReceivableAccount, 100.0));
+                    debit(getAccounts().getFundSource(), 1100.0), credit(getAccounts().getLoansReceivableAccount(), 1000.0),
+                    credit(getAccounts().getFeeReceivableAccount(), 100.0));
         });
     }
 
@@ -528,18 +526,18 @@ public class LoanChargeTaxIntegrationTest extends BaseLoanIntegrationTest {
             PostTaxesGroupResponse taxGroup = createTaxGroup(taxComponent.getResourceId());
             PostChargesResponse chargeResponse = createFlatLoanCharge(100.0, taxGroup.getResourceId());
 
-            Long clientId = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
-            Long loanProductId = loanProductHelper.createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct())
-                    .getResourceId();
+            Long clientId = createClient();
+            Long loanProductId = createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct());
             Long loanId = applyAndApproveLoan(clientId, loanProductId, LOAN_DATE, 1000.0);
             disburseLoan(loanId, BigDecimal.valueOf(1000.0), LOAN_DATE);
 
-            PostLoansLoanIdChargesResponse addResult = loanTransactionHelper.addChargesForLoan(loanId, new PostLoansLoanIdChargesRequest()
-                    .chargeId(chargeResponse.getResourceId()).amount(100.0).dueDate(DUE_DATE).dateFormat(DATE_FORMAT).locale(LOCALE));
+            PostLoansLoanIdChargesResponse addResult = addChargesForLoan(loanId,
+                    new PostLoansLoanIdChargesRequest().chargeId(chargeResponse.getResourceId()).amount(100.0).dueDate(DUE_DATE)
+                            .dateFormat(DATE_FORMAT).locale(LoanTestData.LOCALE));
             Long loanChargeId = addResult.getResourceId();
 
             // When – retrieve the full charge list
-            List<GetLoansLoanIdChargesChargeIdResponse> charges = loanTransactionHelper.getLoanCharges(loanId);
+            List<GetLoansLoanIdChargesChargeIdResponse> charges = getLoanCharges(loanId);
 
             // Then – the taxed charge must appear in the list with the correct amount
             assertNotNull(charges);

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanChargeTaxIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanChargeTaxIntegrationTest.java
@@ -26,7 +26,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.client.models.ChargeRequest;
 import org.apache.fineract.client.models.GetChargesResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdChargesChargeIdResponse;
@@ -40,13 +39,13 @@ import org.apache.fineract.client.models.PostTaxesComponentsResponse;
 import org.apache.fineract.client.models.PostTaxesGroupRequest;
 import org.apache.fineract.client.models.PostTaxesGroupResponse;
 import org.apache.fineract.client.models.PostTaxesGroupTaxComponents;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.TaxComponentHelper;
-import org.apache.fineract.integrationtests.common.TaxGroupHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignTaxComponentHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignTaxGroupHelper;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.common.accounting.Account;
-import org.apache.fineract.integrationtests.common.accounting.PeriodicAccrualAccountingHelper;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
 import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
 import org.apache.fineract.integrationtests.common.loans.LoanTestLifecycleExtension;
 import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
@@ -55,66 +54,54 @@ import org.apache.fineract.portfolio.charge.domain.ChargeTimeType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-@Slf4j
 @ExtendWith(LoanTestLifecycleExtension.class)
-public class LoanChargeTaxIntegrationTest extends BaseLoanIntegrationTest {
+public class LoanChargeTaxIntegrationTest extends FeignLoanTestBase {
 
     private static final String DATE_FORMAT = "dd MMMM yyyy";
     private static final String LOAN_DATE = "01 January 2023";
     private static final String DUE_DATE = "15 January 2023";
     private static final String TAX_START_DATE = "01 January 2013";
 
+    private final FeignTaxComponentHelper taxComponentHelper = new FeignTaxComponentHelper(
+            FineractFeignClientHelper.getFineractFeignClient());
+    private final FeignTaxGroupHelper taxGroupHelper = new FeignTaxGroupHelper(FineractFeignClientHelper.getFineractFeignClient());
+
     // -----------------------------------------------------------------------
     // 1. TaxGroup setup helpers
     // -----------------------------------------------------------------------
 
-    /**
-     * Creates a TaxComponent with the given percentage and a fixed start date in the past so it is always active during
-     * integration test runs.
-     */
     private PostTaxesComponentsResponse createTaxComponent(float percentage) {
         PostTaxesComponentsRequest request = new PostTaxesComponentsRequest().name(Utils.uniqueRandomStringGenerator("TAX_COMP_", 6))
-                .percentage(percentage).startDate(TAX_START_DATE).dateFormat(DATE_FORMAT).locale(LOCALE);
-        PostTaxesComponentsResponse response = TaxComponentHelper.createTaxComponent(request);
+                .percentage(percentage).startDate(TAX_START_DATE).dateFormat(DATE_FORMAT).locale(LoanTestData.LOCALE);
+        PostTaxesComponentsResponse response = taxComponentHelper.createTaxComponent(request);
         assertNotNull(response);
         assertNotNull(response.getResourceId());
         return response;
     }
 
-    /**
-     * Wraps a list of already-created TaxComponent IDs into a TaxGroup.
-     */
     private PostTaxesGroupResponse createTaxGroup(Long... taxComponentIds) {
         Set<PostTaxesGroupTaxComponents> components = new HashSet<>();
         for (Long id : taxComponentIds) {
             components.add(new PostTaxesGroupTaxComponents().taxComponentId(id).startDate(TAX_START_DATE));
         }
         PostTaxesGroupRequest request = new PostTaxesGroupRequest().name(Utils.uniqueRandomStringGenerator("TAX_GRP_", 6))
-                .taxComponents(components).dateFormat(DATE_FORMAT).locale(LOCALE);
-        PostTaxesGroupResponse response = TaxGroupHelper.createTaxGroup(request);
+                .taxComponents(components).dateFormat(DATE_FORMAT).locale(LoanTestData.LOCALE);
+        PostTaxesGroupResponse response = taxGroupHelper.createTaxGroup(request);
         assertNotNull(response);
         assertNotNull(response.getResourceId());
         return response;
     }
 
-    /**
-     * Creates a TaxComponent with the given percentage, linked to the provided GL account as credit account (tax
-     * liability). The credit account determines where the tax portion is posted in accounting.
-     */
     private PostTaxesComponentsResponse createTaxComponent(float percentage, Long creditAccountId) {
         PostTaxesComponentsRequest request = new PostTaxesComponentsRequest().name(Utils.uniqueRandomStringGenerator("TAX_COMP_", 6))
-                .percentage(percentage).startDate(TAX_START_DATE).dateFormat(DATE_FORMAT).locale(LOCALE).creditAccountId(creditAccountId)
-                .creditAccountType(2);
-        PostTaxesComponentsResponse response = TaxComponentHelper.createTaxComponent(request);
+                .percentage(percentage).startDate(TAX_START_DATE).dateFormat(DATE_FORMAT).locale(LoanTestData.LOCALE)
+                .creditAccountId(creditAccountId).creditAccountType(2);
+        PostTaxesComponentsResponse response = taxComponentHelper.createTaxComponent(request);
         assertNotNull(response);
         assertNotNull(response.getResourceId());
         return response;
     }
 
-    /**
-     * Creates a one-period, 30-day loan product using Cash-based accounting (accountingRule=2). Only the minimum set of
-     * GL accounts required for cash accounting is mapped.
-     */
     private PostLoanProductsRequest createCashBasedLoanProduct() {
         return new PostLoanProductsRequest().name(Utils.uniqueRandomStringGenerator("LOAN_PRODUCT_CASH_", 6))
                 .shortName(Utils.uniqueRandomStringGenerator("", 4)).description("Cash-based loan product for tax tests")
@@ -130,33 +117,28 @@ public class LoanChargeTaxIntegrationTest extends BaseLoanIntegrationTest {
                 .allowVariableInstallments(false).canUseForTopup(false).isInterestRecalculationEnabled(false).holdGuaranteeFunds(false)
                 .multiDisburseLoan(true).maxTrancheCount(10).outstandingLoanBalance(10000.0).charges(Collections.emptyList())
                 .accountingRule(2) // Cash-based
-                .fundSourceAccountId(fundSource.getAccountID().longValue())
-                .loanPortfolioAccountId(loansReceivableAccount.getAccountID().longValue())
-                .transfersInSuspenseAccountId(suspenseAccount.getAccountID().longValue())
-                .interestOnLoanAccountId(interestIncomeAccount.getAccountID().longValue())
-                .incomeFromFeeAccountId(feeIncomeAccount.getAccountID().longValue())
-                .incomeFromPenaltyAccountId(penaltyIncomeAccount.getAccountID().longValue())
-                .incomeFromRecoveryAccountId(recoveriesAccount.getAccountID().longValue())
-                .writeOffAccountId(writtenOffAccount.getAccountID().longValue())
-                .overpaymentLiabilityAccountId(overpaymentAccount.getAccountID().longValue()).dateFormat(DATETIME_PATTERN).locale("en_GB")
-                .disallowExpectedDisbursements(true).allowApprovedDisbursedAmountsOverApplied(true).overAppliedCalculationType("percentage")
-                .overAppliedNumber(50);
+                .fundSourceAccountId(getAccounts().getFundSource().getAccountID().longValue())
+                .loanPortfolioAccountId(getAccounts().getLoansReceivableAccount().getAccountID().longValue())
+                .transfersInSuspenseAccountId(getAccounts().getSuspenseAccount().getAccountID().longValue())
+                .interestOnLoanAccountId(getAccounts().getInterestIncomeAccount().getAccountID().longValue())
+                .incomeFromFeeAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())
+                .incomeFromPenaltyAccountId(getAccounts().getPenaltyIncomeAccount().getAccountID().longValue())
+                .incomeFromRecoveryAccountId(getAccounts().getRecoveriesAccount().getAccountID().longValue())
+                .writeOffAccountId(getAccounts().getWrittenOffAccount().getAccountID().longValue())
+                .overpaymentLiabilityAccountId(getAccounts().getOverpaymentAccount().getAccountID().longValue())
+                .dateFormat(DATETIME_PATTERN).locale("en_GB").disallowExpectedDisbursements(true)
+                .allowApprovedDisbursedAmountsOverApplied(true).overAppliedCalculationType("percentage").overAppliedNumber(50);
     }
 
-    /**
-     * Creates a FLAT, SPECIFIED_DUE_DATE charge definition linked to the given {@code taxGroupId}. Passing {@code null}
-     * for {@code taxGroupId} creates a charge with no tax.
-     */
     private PostChargesResponse createFlatLoanCharge(double baseAmount, Long taxGroupId) {
-        ChargesHelper chargesHelper = new ChargesHelper();
         ChargeRequest request = new ChargeRequest().penalty(false).amount(baseAmount)
                 .chargeCalculationType(ChargeCalculationType.FLAT.getValue()).chargeTimeType(ChargeTimeType.SPECIFIED_DUE_DATE.getValue())
                 .chargePaymentMode(ChargePaymentMode.REGULAR.getValue()).currencyCode("USD")
-                .name(Utils.uniqueRandomStringGenerator("CHARGE_", 6)).chargeAppliesTo(1).locale(LOCALE).active(true);
+                .name(Utils.uniqueRandomStringGenerator("CHARGE_", 6)).chargeAppliesTo(1).locale(LoanTestData.LOCALE).active(true);
         if (taxGroupId != null) {
             request.taxGroupId(taxGroupId);
         }
-        PostChargesResponse response = chargesHelper.createCharges(request);
+        PostChargesResponse response = chargesHelper.createCharge(request);
         assertNotNull(response);
         assertNotNull(response.getResourceId());
         return response;
@@ -166,41 +148,27 @@ public class LoanChargeTaxIntegrationTest extends BaseLoanIntegrationTest {
     // 2. Happy path – single tax component
     // -----------------------------------------------------------------------
 
-    /**
-     * A loan charge with a 10 % TaxGroup applied to a flat charge of 100 USD must keep its amount at 100 USD. The 10
-     * USD tax is stored separately as {@code taxAmount} and is not added to the charge amount.
-     *
-     * <pre>
-     *   base = 100, tax = 10 % → amount = 100, taxAmount = 10
-     * </pre>
-     */
     @Test
     public void testLoanChargeAmount_remainsUnchanged_whenTaxGroupIsConfigured() {
         runAt(LOAN_DATE, () -> {
-            // Given – tax infrastructure
             PostTaxesComponentsResponse taxComponent = createTaxComponent(10.0f);
             PostTaxesGroupResponse taxGroup = createTaxGroup(taxComponent.getResourceId());
 
-            // Given – charge definition with 10 % tax group, base = 100
             PostChargesResponse chargeResponse = createFlatLoanCharge(100.0, taxGroup.getResourceId());
             Long chargeDefinitionId = chargeResponse.getResourceId();
 
-            // Given – a disbursed loan
-            Long clientId = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
-            Long loanProductId = loanProductHelper.createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct())
-                    .getResourceId();
+            Long clientId = createClient();
+            Long loanProductId = createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct());
             Long loanId = applyAndApproveLoan(clientId, loanProductId, LOAN_DATE, 1000.0);
             disburseLoan(loanId, BigDecimal.valueOf(1000.0), LOAN_DATE);
 
-            // When – the taxed charge is added to the loan
-            PostLoansLoanIdChargesResponse addResult = loanTransactionHelper.addChargesForLoan(loanId, new PostLoansLoanIdChargesRequest()
-                    .chargeId(chargeDefinitionId).amount(100.0).dueDate(DUE_DATE).dateFormat(DATE_FORMAT).locale(LOCALE));
+            PostLoansLoanIdChargesResponse addResult = addChargesForLoan(loanId, new PostLoansLoanIdChargesRequest()
+                    .chargeId(chargeDefinitionId).amount(100.0).dueDate(DUE_DATE).dateFormat(DATE_FORMAT).locale(LoanTestData.LOCALE));
             assertNotNull(addResult);
             Long loanChargeId = addResult.getResourceId();
             assertNotNull(loanChargeId);
 
-            // Then – amount stays at 100; tax (10) is stored separately as taxAmount
-            GetLoansLoanIdChargesChargeIdResponse loanCharge = loanTransactionHelper.getLoanCharge(loanId, loanChargeId);
+            GetLoansLoanIdChargesChargeIdResponse loanCharge = getLoanCharge(loanId, loanChargeId);
             assertNotNull(loanCharge);
             assertEquals(100.0, loanCharge.getAmount(), 0.01, "Charge amount must remain unchanged; tax stored separately as taxAmount=10");
             assertEquals(100.0, loanCharge.getAmountOutstanding(), 0.01,
@@ -212,33 +180,26 @@ public class LoanChargeTaxIntegrationTest extends BaseLoanIntegrationTest {
     // 3. Happy path – multiple tax components
     // -----------------------------------------------------------------------
 
-    /**
-     * A TaxGroup with two components (10 % + 5 %) applied to a flat charge of 200 USD must keep the loan-charge amount
-     * at 200 USD. The taxes (20 + 10 = 30) are stored separately as {@code taxAmount}.
-     */
     @Test
     public void testLoanChargeAmount_remainsUnchanged_multipleComponents() {
         runAt(LOAN_DATE, () -> {
-            // Given – two tax components in the same group
             PostTaxesComponentsResponse comp1 = createTaxComponent(10.0f);
             PostTaxesComponentsResponse comp2 = createTaxComponent(5.0f);
             PostTaxesGroupResponse taxGroup = createTaxGroup(comp1.getResourceId(), comp2.getResourceId());
 
             PostChargesResponse chargeResponse = createFlatLoanCharge(200.0, taxGroup.getResourceId());
 
-            Long clientId = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
-            Long loanProductId = loanProductHelper.createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct())
-                    .getResourceId();
+            Long clientId = createClient();
+            Long loanProductId = createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct());
             Long loanId = applyAndApproveLoan(clientId, loanProductId, LOAN_DATE, 1000.0);
             disburseLoan(loanId, BigDecimal.valueOf(1000.0), LOAN_DATE);
 
-            // When
-            PostLoansLoanIdChargesResponse addResult = loanTransactionHelper.addChargesForLoan(loanId, new PostLoansLoanIdChargesRequest()
-                    .chargeId(chargeResponse.getResourceId()).amount(200.0).dueDate(DUE_DATE).dateFormat(DATE_FORMAT).locale(LOCALE));
+            PostLoansLoanIdChargesResponse addResult = addChargesForLoan(loanId,
+                    new PostLoansLoanIdChargesRequest().chargeId(chargeResponse.getResourceId()).amount(200.0).dueDate(DUE_DATE)
+                            .dateFormat(DATE_FORMAT).locale(LoanTestData.LOCALE));
             Long loanChargeId = addResult.getResourceId();
 
-            // Then – amount stays 200; taxes (20+10=30) stored separately as taxAmount
-            GetLoansLoanIdChargesChargeIdResponse loanCharge = loanTransactionHelper.getLoanCharge(loanId, loanChargeId);
+            GetLoansLoanIdChargesChargeIdResponse loanCharge = getLoanCharge(loanId, loanChargeId);
             assertEquals(200.0, loanCharge.getAmount(), 0.01,
                     "Charge amount must remain 200; taxes (20+10=30) stored separately as taxAmount");
         });
@@ -248,28 +209,22 @@ public class LoanChargeTaxIntegrationTest extends BaseLoanIntegrationTest {
     // 4. No TaxGroup – charge amount unchanged
     // -----------------------------------------------------------------------
 
-    /**
-     * A charge without a TaxGroup must be added to the loan at its original base amount without any modification.
-     */
     @Test
     public void testLoanChargeAmount_noTaxGroup_isNotModified() {
         runAt(LOAN_DATE, () -> {
-            // Given – charge with NO tax group
             PostChargesResponse chargeResponse = createFlatLoanCharge(100.0, null);
 
-            Long clientId = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
-            Long loanProductId = loanProductHelper.createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct())
-                    .getResourceId();
+            Long clientId = createClient();
+            Long loanProductId = createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct());
             Long loanId = applyAndApproveLoan(clientId, loanProductId, LOAN_DATE, 1000.0);
             disburseLoan(loanId, BigDecimal.valueOf(1000.0), LOAN_DATE);
 
-            // When
-            PostLoansLoanIdChargesResponse addResult = loanTransactionHelper.addChargesForLoan(loanId, new PostLoansLoanIdChargesRequest()
-                    .chargeId(chargeResponse.getResourceId()).amount(100.0).dueDate(DUE_DATE).dateFormat(DATE_FORMAT).locale(LOCALE));
+            PostLoansLoanIdChargesResponse addResult = addChargesForLoan(loanId,
+                    new PostLoansLoanIdChargesRequest().chargeId(chargeResponse.getResourceId()).amount(100.0).dueDate(DUE_DATE)
+                            .dateFormat(DATE_FORMAT).locale(LoanTestData.LOCALE));
             Long loanChargeId = addResult.getResourceId();
 
-            // Then – amount must stay at 100 (no tax)
-            GetLoansLoanIdChargesChargeIdResponse loanCharge = loanTransactionHelper.getLoanCharge(loanId, loanChargeId);
+            GetLoansLoanIdChargesChargeIdResponse loanCharge = getLoanCharge(loanId, loanChargeId);
             assertEquals(100.0, loanCharge.getAmount(), 0.01, "Charge without tax group must keep original amount");
         });
     }
@@ -278,22 +233,14 @@ public class LoanChargeTaxIntegrationTest extends BaseLoanIntegrationTest {
     // 5. Charge definition carries TaxGroup metadata
     // -----------------------------------------------------------------------
 
-    /**
-     * After creating a charge definition that references a TaxGroup, retrieving the charge via GET /charges/{id} must
-     * return the charge with the correct {@code taxGroup} attribute populated.
-     */
     @Test
     public void testChargeDefinition_hasTaxGroupPopulated() {
-        // Given – tax infrastructure (no loan needed for this test)
         PostTaxesComponentsResponse taxComponent = createTaxComponent(16.0f);
         PostTaxesGroupResponse taxGroup = createTaxGroup(taxComponent.getResourceId());
 
-        // When – create charge linked to the tax group
         PostChargesResponse chargeResponse = createFlatLoanCharge(50.0, taxGroup.getResourceId());
 
-        // Then – retrieve and verify taxGroup is set
-        ChargesHelper chargesHelper = new ChargesHelper();
-        GetChargesResponse chargeData = chargesHelper.retrieveCharge(chargeResponse.getResourceId());
+        GetChargesResponse chargeData = chargesHelper.getCharge(chargeResponse.getResourceId());
         assertNotNull(chargeData);
         assertNotNull(chargeData.getTaxGroup(), "Charge must expose taxGroup in GET response");
         assertEquals(taxGroup.getResourceId(), chargeData.getTaxGroup().getId(),
@@ -304,20 +251,13 @@ public class LoanChargeTaxIntegrationTest extends BaseLoanIntegrationTest {
     // 6. TaxGroup retrievable with its components
     // -----------------------------------------------------------------------
 
-    /**
-     * A TaxGroup created with one TaxComponent must be retrievable via GET /taxes/group/{id} and include the correct
-     * component in the mappings list.
-     */
     @Test
     public void testTaxGroupRetrieval_includesExpectedComponent() {
-        // Given
         PostTaxesComponentsResponse taxComponent = createTaxComponent(12.0f);
         PostTaxesGroupResponse taxGroup = createTaxGroup(taxComponent.getResourceId());
 
-        // When
-        GetTaxesGroupResponse retrieved = TaxGroupHelper.retrieveTaxGroup(taxGroup.getResourceId());
+        GetTaxesGroupResponse retrieved = taxGroupHelper.retrieveTaxGroup(taxGroup.getResourceId());
 
-        // Then
         assertNotNull(retrieved);
         assertEquals(taxGroup.getResourceId(), retrieved.getId());
         assertNotNull(retrieved.getTaxAssociations(), "TaxGroup must expose its component associations list");
@@ -330,19 +270,13 @@ public class LoanChargeTaxIntegrationTest extends BaseLoanIntegrationTest {
     // 7. TaxGroup appears in retrieveAll list
     // -----------------------------------------------------------------------
 
-    /**
-     * A newly created TaxGroup must be visible in the paginated list returned by GET /taxes/group.
-     */
     @Test
     public void testTaxGroup_appearsInRetrieveAllList() {
-        // Given
         PostTaxesComponentsResponse taxComponent = createTaxComponent(8.0f);
         PostTaxesGroupResponse taxGroup = createTaxGroup(taxComponent.getResourceId());
 
-        // When
-        List<GetTaxesGroupResponse> allGroups = TaxGroupHelper.retrieveAllTaxGroups();
+        List<GetTaxesGroupResponse> allGroups = taxGroupHelper.retrieveAllTaxGroups();
 
-        // Then
         assertNotNull(allGroups);
         boolean found = allGroups.stream().anyMatch(g -> taxGroup.getResourceId().equals(g.getId()));
         assertEquals(true, found, "Newly created TaxGroup must appear in the full tax group list");
@@ -352,23 +286,16 @@ public class LoanChargeTaxIntegrationTest extends BaseLoanIntegrationTest {
     // 8. Multiple loans – tax applied independently per loan charge
     // -----------------------------------------------------------------------
 
-    /**
-     * Adding the same taxed charge definition to two different loans must result in independent charge records each
-     * keeping the original base amount. Verifies that per-loan charge state is isolated.
-     */
     @Test
     public void testLoanChargeTax_appliedIndependentlyToEachLoan() {
         runAt(LOAN_DATE, () -> {
-            // Given – shared charge definition with 10 % tax
             PostTaxesComponentsResponse taxComponent = createTaxComponent(10.0f);
             PostTaxesGroupResponse taxGroup = createTaxGroup(taxComponent.getResourceId());
             PostChargesResponse chargeResponse = createFlatLoanCharge(100.0, taxGroup.getResourceId());
             Long chargeDefinitionId = chargeResponse.getResourceId();
 
-            // Given – two separate loans
-            Long clientId = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
-            Long loanProductId = loanProductHelper.createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct())
-                    .getResourceId();
+            Long clientId = createClient();
+            Long loanProductId = createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct());
 
             Long loanId1 = applyAndApproveLoan(clientId, loanProductId, LOAN_DATE, 1000.0);
             disburseLoan(loanId1, BigDecimal.valueOf(1000.0), LOAN_DATE);
@@ -376,15 +303,13 @@ public class LoanChargeTaxIntegrationTest extends BaseLoanIntegrationTest {
             Long loanId2 = applyAndApproveLoan(clientId, loanProductId, LOAN_DATE, 1000.0);
             disburseLoan(loanId2, BigDecimal.valueOf(1000.0), LOAN_DATE);
 
-            // When – the same charge is added to both loans
-            PostLoansLoanIdChargesResponse add1 = loanTransactionHelper.addChargesForLoan(loanId1, new PostLoansLoanIdChargesRequest()
-                    .chargeId(chargeDefinitionId).amount(100.0).dueDate(DUE_DATE).dateFormat(DATE_FORMAT).locale(LOCALE));
-            PostLoansLoanIdChargesResponse add2 = loanTransactionHelper.addChargesForLoan(loanId2, new PostLoansLoanIdChargesRequest()
-                    .chargeId(chargeDefinitionId).amount(100.0).dueDate(DUE_DATE).dateFormat(DATE_FORMAT).locale(LOCALE));
+            PostLoansLoanIdChargesResponse add1 = addChargesForLoan(loanId1, new PostLoansLoanIdChargesRequest()
+                    .chargeId(chargeDefinitionId).amount(100.0).dueDate(DUE_DATE).dateFormat(DATE_FORMAT).locale(LoanTestData.LOCALE));
+            PostLoansLoanIdChargesResponse add2 = addChargesForLoan(loanId2, new PostLoansLoanIdChargesRequest()
+                    .chargeId(chargeDefinitionId).amount(100.0).dueDate(DUE_DATE).dateFormat(DATE_FORMAT).locale(LoanTestData.LOCALE));
 
-            // Then – both loan charges must independently show the original base amount (tax stored separately)
-            GetLoansLoanIdChargesChargeIdResponse charge1 = loanTransactionHelper.getLoanCharge(loanId1, add1.getResourceId());
-            GetLoansLoanIdChargesChargeIdResponse charge2 = loanTransactionHelper.getLoanCharge(loanId2, add2.getResourceId());
+            GetLoansLoanIdChargesChargeIdResponse charge1 = getLoanCharge(loanId1, add1.getResourceId());
+            GetLoansLoanIdChargesChargeIdResponse charge2 = getLoanCharge(loanId2, add2.getResourceId());
 
             assertEquals(100.0, charge1.getAmount(), 0.01, "Loan 1 charge amount must remain 100; tax stored separately");
             assertEquals(100.0, charge2.getAmount(), 0.01, "Loan 2 charge amount must remain 100; tax stored separately");
@@ -392,58 +317,68 @@ public class LoanChargeTaxIntegrationTest extends BaseLoanIntegrationTest {
     }
 
     // -----------------------------------------------------------------------
-    // 10. Cash-based accounting: fee with tax splits income vs. tax liability
+    // 9. Full charge list on a loan reflects tax-inflated amounts
     // -----------------------------------------------------------------------
 
-    /**
-     * Cash-based accounting: when a loan charge with a 10 % TaxGroup (base = 100 USD) is repaid, the accounting must
-     * split the fee income credit:
-     *
-     * <pre>
-     *   DR  Fund Source         1100.00
-     *   CR  Loan Portfolio      1000.00
-     *   CR  Income from Fees      90.00  (net = base − tax)
-     *   CR  Tax Liability         10.00  (TaxComponent.creditAccount)
-     * </pre>
-     *
-     * The disbursement journal entries (DR Loan Portfolio / CR Fund Source) are also verified.
-     */
     @Test
-    public void testCashAccounting_journalEntries_feeWithTaxSplitsIncomeAndLiability() {
+    public void testLoanChargeList_containsOriginalAmount() {
         runAt(LOAN_DATE, () -> {
-            // Given – a liability account to receive the tax portion
-            Account taxLiabilityAccount = accountHelper.createLiabilityAccount("taxLiability_cash");
-
-            // Given – tax infrastructure linked to the tax liability account
-            PostTaxesComponentsResponse taxComponent = createTaxComponent(10.0f, taxLiabilityAccount.getAccountID().longValue());
+            PostTaxesComponentsResponse taxComponent = createTaxComponent(10.0f);
             PostTaxesGroupResponse taxGroup = createTaxGroup(taxComponent.getResourceId());
-
-            // Given – flat charge of 100 with 10 % tax, due on the loan start date
             PostChargesResponse chargeResponse = createFlatLoanCharge(100.0, taxGroup.getResourceId());
 
-            // Given – a cash-based loan (principal = 1000, no interest)
-            Long clientId = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
-            Long loanProductId = loanProductHelper.createLoanProduct(createCashBasedLoanProduct() //
-                    .multiDisburseLoan(false).disallowExpectedDisbursements(null) //
-            ).getResourceId();
+            Long clientId = createClient();
+            Long loanProductId = createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct());
             Long loanId = applyAndApproveLoan(clientId, loanProductId, LOAN_DATE, 1000.0);
             disburseLoan(loanId, BigDecimal.valueOf(1000.0), LOAN_DATE);
 
-            // When – add the taxed charge (due on same date) and repay principal + fee in one transaction
-            loanTransactionHelper.addChargesForLoan(loanId, new PostLoansLoanIdChargesRequest().chargeId(chargeResponse.getResourceId())
-                    .amount(100.0).dueDate(LOAN_DATE).dateFormat(DATE_FORMAT).locale(LOCALE));
+            PostLoansLoanIdChargesResponse addResult = addChargesForLoan(loanId,
+                    new PostLoansLoanIdChargesRequest().chargeId(chargeResponse.getResourceId()).amount(100.0).dueDate(DUE_DATE)
+                            .dateFormat(DATE_FORMAT).locale(LoanTestData.LOCALE));
+            Long loanChargeId = addResult.getResourceId();
+
+            List<GetLoansLoanIdChargesChargeIdResponse> charges = getLoanCharges(loanId);
+
+            assertNotNull(charges);
+            GetLoansLoanIdChargesChargeIdResponse found = charges.stream().filter(c -> loanChargeId.equals(c.getId())).findFirst()
+                    .orElse(null);
+            assertNotNull(found, "The added loan charge must appear in the charge list");
+            assertEquals(100.0, found.getAmount(), 0.01,
+                    "Listed charge amount must remain 100; the 10 % tax is stored separately as taxAmount");
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // 10. Cash-based accounting: fee with tax splits income vs. tax liability
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testCashAccounting_journalEntries_feeWithTaxSplitsIncomeAndLiability() {
+        runAt(LOAN_DATE, () -> {
+            Account taxLiabilityAccount = accountHelper.createLiabilityAccount("taxLiability_cash");
+
+            PostTaxesComponentsResponse taxComponent = createTaxComponent(10.0f, taxLiabilityAccount.getAccountID().longValue());
+            PostTaxesGroupResponse taxGroup = createTaxGroup(taxComponent.getResourceId());
+
+            PostChargesResponse chargeResponse = createFlatLoanCharge(100.0, taxGroup.getResourceId());
+
+            Long clientId = createClient();
+            Long loanProductId = createLoanProduct(
+                    createCashBasedLoanProduct().multiDisburseLoan(false).disallowExpectedDisbursements(null));
+            Long loanId = applyAndApproveLoan(clientId, loanProductId, LOAN_DATE, 1000.0);
+            disburseLoan(loanId, BigDecimal.valueOf(1000.0), LOAN_DATE);
+
+            addChargesForLoan(loanId, new PostLoansLoanIdChargesRequest().chargeId(chargeResponse.getResourceId()).amount(100.0)
+                    .dueDate(LOAN_DATE).dateFormat(DATE_FORMAT).locale(LoanTestData.LOCALE));
 
             addRepaymentForLoan(loanId, 1100.0, LOAN_DATE);
 
-            // Then – verify journal entries:
-            // Disbursement: DR Loan Portfolio 1000 / CR Fund Source 1000
-            // Repayment: DR Fund Source 1100 / CR Loan Portfolio 1000 / CR Income from Fees 90 / CR Tax Liability 10
             verifyJournalEntries(loanId,
                     // disbursement
-                    debit(loansReceivableAccount, 1000.0), credit(fundSource, 1000.0),
+                    debit(getAccounts().getLoansReceivableAccount(), 1000.0), credit(getAccounts().getFundSource(), 1000.0),
                     // repayment
-                    debit(fundSource, 1100.0), credit(loansReceivableAccount, 1000.0), credit(feeIncomeAccount, 90.0),
-                    credit(taxLiabilityAccount, 10.0));
+                    debit(getAccounts().getFundSource(), 1100.0), credit(getAccounts().getLoansReceivableAccount(), 1000.0),
+                    credit(getAccounts().getFeeIncomeAccount(), 90.0), credit(taxLiabilityAccount, 10.0));
         });
     }
 
@@ -451,103 +386,37 @@ public class LoanChargeTaxIntegrationTest extends BaseLoanIntegrationTest {
     // 11. Accrual accounting: accrual and repayment with tax on fee charge
     // -----------------------------------------------------------------------
 
-    /**
-     * Periodic-accrual accounting: when a taxed fee charge is accrued the income and liability are recognised
-     * immediately; at repayment time the receivable is cleared in full with no further tax entries.
-     *
-     * <pre>
-     * Accrual (charge application):
-     *   DR  Fees Receivable      100.00
-     *   CR  Income from Fees      90.00
-     *   CR  Tax Liability         10.00
-     *
-     * Repayment:
-     *   DR  Fund Source          1100.00
-     *   CR  Loan Portfolio       1000.00
-     *   CR  Fees Receivable       100.00
-     * </pre>
-     *
-     * The disbursement journal entries are also verified.
-     */
     @Test
     public void testAccrualAccounting_journalEntries_feeWithTaxSplitsIncomeAndLiabilityAtAccrual() {
         runAt(LOAN_DATE, () -> {
-            // Given – a liability account to receive the tax portion
             Account taxLiabilityAccount = accountHelper.createLiabilityAccount("taxLiability_accrual");
 
-            // Given – tax infrastructure linked to the tax liability account
             PostTaxesComponentsResponse taxComponent = createTaxComponent(10.0f, taxLiabilityAccount.getAccountID().longValue());
             PostTaxesGroupResponse taxGroup = createTaxGroup(taxComponent.getResourceId());
 
-            // Given – flat charge of 100 with 10 % tax, due on the loan start date
             PostChargesResponse chargeResponse = createFlatLoanCharge(100.0, taxGroup.getResourceId());
 
-            // Given – a periodic-accrual loan (principal = 1000, no interest)
-            Long clientId = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
-            Long loanProductId = loanProductHelper.createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct())
-                    .getResourceId();
+            Long clientId = createClient();
+            Long loanProductId = createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct());
             Long loanId = applyAndApproveLoan(clientId, loanProductId, LOAN_DATE, 1000.0);
             disburseLoan(loanId, BigDecimal.valueOf(1000.0), LOAN_DATE);
 
-            // When – add the taxed charge and run periodic accrual on the same date
-            loanTransactionHelper.addChargesForLoan(loanId, new PostLoansLoanIdChargesRequest().chargeId(chargeResponse.getResourceId())
-                    .amount(100.0).dueDate(LOAN_DATE).dateFormat(DATE_FORMAT).locale(LOCALE));
+            addChargesForLoan(loanId, new PostLoansLoanIdChargesRequest().chargeId(chargeResponse.getResourceId()).amount(100.0)
+                    .dueDate(LOAN_DATE).dateFormat(DATE_FORMAT).locale(LoanTestData.LOCALE));
 
-            PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting(LOAN_DATE);
+            runPeriodicAccrualAccounting(LOAN_DATE);
 
-            // Make a full repayment (principal 1000 + fee 100 = 1100)
             addRepaymentForLoan(loanId, 1100.0, LOAN_DATE);
 
-            // Then – verify ALL journal entries:
-            // Disbursement: DR Loan Portfolio 1000 / CR Fund Source 1000
-            // Accrual: DR Fees Receivable 100 / CR Income from Fees 90 / CR Tax Liability 10
-            // Repayment: DR Fund Source 1100 / CR Loan Portfolio 1000 / CR Fees Receivable 100
             verifyJournalEntries(loanId,
                     // disbursement
-                    debit(loansReceivableAccount, 1000.0), credit(fundSource, 1000.0),
+                    debit(getAccounts().getLoansReceivableAccount(), 1000.0), credit(getAccounts().getFundSource(), 1000.0),
                     // accrual
-                    debit(feeReceivableAccount, 100.0), credit(feeIncomeAccount, 90.0), credit(taxLiabilityAccount, 10.0),
+                    debit(getAccounts().getFeeReceivableAccount(), 100.0), credit(getAccounts().getFeeIncomeAccount(), 90.0),
+                    credit(taxLiabilityAccount, 10.0),
                     // repayment
-                    debit(fundSource, 1100.0), credit(loansReceivableAccount, 1000.0), credit(feeReceivableAccount, 100.0));
-        });
-    }
-
-    // -----------------------------------------------------------------------
-    // 9. Full charge list on a loan reflects tax-inflated amounts
-    // -----------------------------------------------------------------------
-
-    /**
-     * GET /loans/{loanId}/charges must return the taxed charge with the original base amount (tax stored separately)
-     * when listing all charges for the loan.
-     */
-    @Test
-    public void testLoanChargeList_containsOriginalAmount() {
-        runAt(LOAN_DATE, () -> {
-            // Given
-            PostTaxesComponentsResponse taxComponent = createTaxComponent(10.0f);
-            PostTaxesGroupResponse taxGroup = createTaxGroup(taxComponent.getResourceId());
-            PostChargesResponse chargeResponse = createFlatLoanCharge(100.0, taxGroup.getResourceId());
-
-            Long clientId = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
-            Long loanProductId = loanProductHelper.createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct())
-                    .getResourceId();
-            Long loanId = applyAndApproveLoan(clientId, loanProductId, LOAN_DATE, 1000.0);
-            disburseLoan(loanId, BigDecimal.valueOf(1000.0), LOAN_DATE);
-
-            PostLoansLoanIdChargesResponse addResult = loanTransactionHelper.addChargesForLoan(loanId, new PostLoansLoanIdChargesRequest()
-                    .chargeId(chargeResponse.getResourceId()).amount(100.0).dueDate(DUE_DATE).dateFormat(DATE_FORMAT).locale(LOCALE));
-            Long loanChargeId = addResult.getResourceId();
-
-            // When – retrieve the full charge list
-            List<GetLoansLoanIdChargesChargeIdResponse> charges = loanTransactionHelper.getLoanCharges(loanId);
-
-            // Then – the taxed charge must appear in the list with the correct amount
-            assertNotNull(charges);
-            GetLoansLoanIdChargesChargeIdResponse found = charges.stream().filter(c -> loanChargeId.equals(c.getId())).findFirst()
-                    .orElse(null);
-            assertNotNull(found, "The added loan charge must appear in the charge list");
-            assertEquals(100.0, found.getAmount(), 0.01,
-                    "Listed charge amount must remain 100; the 10 % tax is stored separately as taxAmount");
+                    debit(getAccounts().getFundSource(), 1100.0), credit(getAccounts().getLoansReceivableAccount(), 1000.0),
+                    credit(getAccounts().getFeeReceivableAccount(), 100.0));
         });
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanChargesMultipleDebitAccountsTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanChargesMultipleDebitAccountsTest.java
@@ -29,19 +29,15 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
 import org.apache.fineract.client.models.GetJournalEntriesTransactionIdResponse;
 import org.apache.fineract.client.models.JournalEntryTransactionItem;
 import org.apache.fineract.client.models.PostChargesResponse;
 import org.apache.fineract.client.models.PostLoanProductsRequest;
-import org.apache.fineract.client.models.PostLoanProductsResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdChargesResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsRequest;
 import org.apache.fineract.client.models.PostLoansRequest;
-import org.apache.fineract.client.models.PostLoansResponse;
-import org.apache.fineract.client.util.CallFailedRuntimeException;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.accounting.Account;
-import org.apache.fineract.integrationtests.common.accounting.JournalEntryHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
 import org.apache.fineract.integrationtests.common.loans.LoanTestLifecycleExtension;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -58,7 +54,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * (debits = credits) - Integration with both cash and accrual accounting methods
  */
 @ExtendWith(LoanTestLifecycleExtension.class)
-public class LoanChargesMultipleDebitAccountsTest extends BaseLoanIntegrationTest {
+public class LoanChargesMultipleDebitAccountsTest extends FeignLoanTestBase {
 
     // Helper method to validate accounting balance in journal entries
     private void validateAccountingBalance(GetJournalEntriesTransactionIdResponse journalEntries, String testContext) {
@@ -73,12 +69,11 @@ public class LoanChargesMultipleDebitAccountsTest extends BaseLoanIntegrationTes
 
     // Helper method to make repayment and return journal entries
     private GetJournalEntriesTransactionIdResponse makeRepaymentAndGetJournalEntries(Long loanId, double amount, String date) {
-        inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+        executeInlineCOB(loanId);
         PostLoansLoanIdTransactionsRequest repaymentRequest = new PostLoansLoanIdTransactionsRequest().transactionAmount(amount)
                 .transactionDate(date).dateFormat(DATETIME_PATTERN).locale("en");
-        loanTransactionHelper.makeLoanRepayment(loanId, repaymentRequest);
+        makeLoanRepayment(loanId, repaymentRequest);
 
-        JournalEntryHelper journalHelper = new JournalEntryHelper(requestSpec, responseSpec);
         return journalHelper.getJournalEntriesForLoan(loanId);
     }
 
@@ -87,8 +82,7 @@ public class LoanChargesMultipleDebitAccountsTest extends BaseLoanIntegrationTes
     public void testMultipleChargesCreateChargeSpecificJournalEntries() {
         runAt("15 January 2023", () -> {
             PostLoanProductsRequest loanProduct = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct();
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProduct);
-            Long loanProductId = loanProductResponse.getResourceId();
+            Long loanProductId = createLoanProduct(loanProduct);
             assertNotNull(loanProductId);
 
             // Create charges with different amounts to test aggregation
@@ -100,13 +94,12 @@ public class LoanChargesMultipleDebitAccountsTest extends BaseLoanIntegrationTes
             assertNotNull(charge3);
 
             // Create client and loan
-            Long clientId = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "15 January 2023", 10000.0, 4);
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
-            Long loanId = loanResponse.getLoanId();
+            Long loanId = applyForLoan(applicationRequest);
 
             // Approve and disburse loan
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(10000.0, "15 January 2023"));
+            approveLoan(loanId, approveLoanRequest(10000.0, "15 January 2023"));
             disburseLoan(loanId, BigDecimal.valueOf(10000), "15 January 2023");
 
             // Add multiple charges
@@ -153,20 +146,18 @@ public class LoanChargesMultipleDebitAccountsTest extends BaseLoanIntegrationTes
     public void testChargeAggregationByGLAccount() {
         runAt("15 January 2023", () -> {
             PostLoanProductsRequest loanProduct = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct();
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProduct);
-            Long loanProductId = loanProductResponse.getResourceId();
+            Long loanProductId = createLoanProduct(loanProduct);
 
             // Create multiple charges that would map to same GL account type
             PostChargesResponse charge1 = createCharge(75.0);
             PostChargesResponse charge2 = createCharge(125.0);
             PostChargesResponse charge3 = createCharge(50.0);
 
-            Long clientId = clientHelper.createClient(clientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "15 January 2023", 5000.0, 2);
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
-            Long loanId = loanResponse.getLoanId();
+            Long loanId = applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(5000.0, "15 January 2023"));
+            approveLoan(loanId, approveLoanRequest(5000.0, "15 January 2023"));
             disburseLoan(loanId, BigDecimal.valueOf(5000), "15 January 2023");
 
             // Add charges simultaneously to test aggregation
@@ -174,7 +165,6 @@ public class LoanChargesMultipleDebitAccountsTest extends BaseLoanIntegrationTes
             addLoanCharge(loanId, charge2.getResourceId(), "25 January 2023", 125.0);
             addLoanCharge(loanId, charge3.getResourceId(), "25 January 2023", 50.0);
 
-            JournalEntryHelper journalHelper = new JournalEntryHelper(requestSpec, responseSpec);
             GetJournalEntriesTransactionIdResponse journalEntries = journalHelper.getJournalEntriesForLoan(loanId);
             assertNotNull(journalEntries);
             assertNotNull(journalEntries.getPageItems());
@@ -194,23 +184,20 @@ public class LoanChargesMultipleDebitAccountsTest extends BaseLoanIntegrationTes
     public void testBackwardCompatibilityWithExistingConfigurations() {
         runAt("10 January 2023", () -> {
             PostLoanProductsRequest loanProduct = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct();
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProduct);
-            Long loanProductId = loanProductResponse.getResourceId();
+            Long loanProductId = createLoanProduct(loanProduct);
 
             PostChargesResponse charge = createCharge(300.0);
 
-            Long clientId = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "10 January 2023", 8000.0, 3);
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
-            Long loanId = loanResponse.getLoanId();
+            Long loanId = applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(8000.0, "10 January 2023"));
+            approveLoan(loanId, approveLoanRequest(8000.0, "10 January 2023"));
             disburseLoan(loanId, BigDecimal.valueOf(8000), "10 January 2023");
 
             // Add charge - should use product-level default GL accounts
             addLoanCharge(loanId, charge.getResourceId(), "15 January 2023", 300.0);
 
-            JournalEntryHelper journalHelper = new JournalEntryHelper(requestSpec, responseSpec);
             GetJournalEntriesTransactionIdResponse journalEntries = journalHelper.getJournalEntriesForLoan(loanId);
             assertNotNull(journalEntries);
             assertNotNull(journalEntries.getPageItems());
@@ -225,22 +212,19 @@ public class LoanChargesMultipleDebitAccountsTest extends BaseLoanIntegrationTes
     public void testAccountingIntegrityValidation() {
         runAt("20 January 2023", () -> {
             PostLoanProductsRequest loanProduct = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct();
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProduct);
-            Long loanProductId = loanProductResponse.getResourceId();
+            Long loanProductId = createLoanProduct(loanProduct);
 
             PostChargesResponse charge = createCharge(500.0);
 
-            Long clientId = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "20 January 2023", 12000.0, 4);
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
-            Long loanId = loanResponse.getLoanId();
+            Long loanId = applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(12000.0, "20 January 2023"));
+            approveLoan(loanId, approveLoanRequest(12000.0, "20 January 2023"));
             disburseLoan(loanId, BigDecimal.valueOf(12000), "20 January 2023");
 
             addLoanCharge(loanId, charge.getResourceId(), "25 January 2023", 500.0);
 
-            JournalEntryHelper journalHelper = new JournalEntryHelper(requestSpec, responseSpec);
             GetJournalEntriesTransactionIdResponse journalEntries = journalHelper.getJournalEntriesForLoan(loanId);
             assertNotNull(journalEntries);
             assertNotNull(journalEntries.getPageItems());
@@ -256,8 +240,7 @@ public class LoanChargesMultipleDebitAccountsTest extends BaseLoanIntegrationTes
     public void testChargeSpecificGLAccountValidation() {
         runAt("01 February 2023", () -> {
             PostLoanProductsRequest loanProduct = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct();
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProduct);
-            Long loanProductId = loanProductResponse.getResourceId();
+            Long loanProductId = createLoanProduct(loanProduct);
             assertNotNull(loanProductId, "Loan product should be created successfully");
 
             // Create three different charges to test individual GL account mapping
@@ -268,13 +251,12 @@ public class LoanChargesMultipleDebitAccountsTest extends BaseLoanIntegrationTes
             assertNotNull(penaltyCharge, "Penalty charge should be created");
             assertNotNull(documentationFeeCharge, "Documentation fee charge should be created");
 
-            Long clientId = clientHelper.createClient(clientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "01 February 2023", 15000.0, 4);
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
-            Long loanId = loanResponse.getLoanId();
+            Long loanId = applyForLoan(applicationRequest);
             assertNotNull(loanId, "Loan should be created successfully");
 
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(15000.0, "01 February 2023"));
+            approveLoan(loanId, approveLoanRequest(15000.0, "01 February 2023"));
             disburseLoan(loanId, BigDecimal.valueOf(15000), "01 February 2023");
 
             // Add charges with different amounts
@@ -322,20 +304,18 @@ public class LoanChargesMultipleDebitAccountsTest extends BaseLoanIntegrationTes
     public void testProportionalDistributionLogic() {
         runAt("10 February 2023", () -> {
             PostLoanProductsRequest loanProduct = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct();
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProduct);
-            Long loanProductId = loanProductResponse.getResourceId();
+            Long loanProductId = createLoanProduct(loanProduct);
 
             // Create charges with specific amounts to test proportional distribution
             PostChargesResponse charge1 = createCharge(400.0); // 40% of 1000
             PostChargesResponse charge2 = createCharge(300.0); // 30% of 1000
             PostChargesResponse charge3 = createCharge(300.0); // 30% of 1000
 
-            Long clientId = clientHelper.createClient(clientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "10 February 2023", 20000.0, 6);
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
-            Long loanId = loanResponse.getLoanId();
+            Long loanId = applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(20000.0, "10 February 2023"));
+            approveLoan(loanId, approveLoanRequest(20000.0, "10 February 2023"));
             disburseLoan(loanId, BigDecimal.valueOf(20000), "10 February 2023");
 
             // Add charges to create proportional distribution scenario
@@ -372,17 +352,15 @@ public class LoanChargesMultipleDebitAccountsTest extends BaseLoanIntegrationTes
     public void testAccountingImbalanceErrorHandling() {
         runAt("15 February 2023", () -> {
             PostLoanProductsRequest loanProduct = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct();
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProduct);
-            Long loanProductId = loanProductResponse.getResourceId();
+            Long loanProductId = createLoanProduct(loanProduct);
 
             PostChargesResponse charge = createCharge(500.0);
 
-            Long clientId = clientHelper.createClient(clientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "15 February 2023", 10000.0, 3);
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
-            Long loanId = loanResponse.getLoanId();
+            Long loanId = applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(10000.0, "15 February 2023"));
+            approveLoan(loanId, approveLoanRequest(10000.0, "15 February 2023"));
             disburseLoan(loanId, BigDecimal.valueOf(10000), "15 February 2023");
 
             addLoanCharge(loanId, charge.getResourceId(), "15 February 2023", 500.0);
@@ -410,17 +388,15 @@ public class LoanChargesMultipleDebitAccountsTest extends BaseLoanIntegrationTes
     public void testMissingGLAccountMappingHandling() {
         runAt("20 February 2023", () -> {
             PostLoanProductsRequest loanProduct = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct();
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProduct);
-            Long loanProductId = loanProductResponse.getResourceId();
+            Long loanProductId = createLoanProduct(loanProduct);
 
             PostChargesResponse charge = createCharge(300.0);
 
-            Long clientId = clientHelper.createClient(clientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "20 February 2023", 8000.0, 2);
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
-            Long loanId = loanResponse.getLoanId();
+            Long loanId = applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(8000.0, "20 February 2023"));
+            approveLoan(loanId, approveLoanRequest(8000.0, "20 February 2023"));
             disburseLoan(loanId, BigDecimal.valueOf(8000), "20 February 2023");
 
             addLoanCharge(loanId, charge.getResourceId(), "25 February 2023", 300.0);
@@ -429,7 +405,7 @@ public class LoanChargesMultipleDebitAccountsTest extends BaseLoanIntegrationTes
             try {
                 // Should either succeed with fallback accounts or fail gracefully
                 GetJournalEntriesTransactionIdResponse journalEntries = makeRepaymentAndGetJournalEntries(loanId, 500.0,
-                        "25 February 2023");
+                        "20 February 2023");
                 assertNotNull(journalEntries, "Fallback mechanism should create journal entries");
                 assertFalse(journalEntries.getPageItems().isEmpty(),
                         "Should have fallback journal entries when specific mapping unavailable");
@@ -447,19 +423,17 @@ public class LoanChargesMultipleDebitAccountsTest extends BaseLoanIntegrationTes
     public void testZeroAmountChargeHandling() {
         runAt("25 February 2023", () -> {
             PostLoanProductsRequest loanProduct = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct();
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProduct);
-            Long loanProductId = loanProductResponse.getResourceId();
+            Long loanProductId = createLoanProduct(loanProduct);
 
             // Create charges - use minimum valid amounts instead of zero
             PostChargesResponse regularCharge = createCharge(200.0);
             PostChargesResponse smallCharge = createCharge(0.01); // Minimum valid amount instead of zero
 
-            Long clientId = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "25 February 2023", 5000.0, 2);
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
-            Long loanId = loanResponse.getLoanId();
+            Long loanId = applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(5000.0, "25 February 2023"));
+            approveLoan(loanId, approveLoanRequest(5000.0, "25 February 2023"));
             disburseLoan(loanId, BigDecimal.valueOf(5000), "25 February 2023");
 
             addLoanCharge(loanId, regularCharge.getResourceId(), "25 February 2023", 200.0);
@@ -485,20 +459,18 @@ public class LoanChargesMultipleDebitAccountsTest extends BaseLoanIntegrationTes
     public void testMixedChargeTypesAndTimingScenarios() {
         runAt("05 March 2023", () -> {
             PostLoanProductsRequest loanProduct = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct();
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProduct);
-            Long loanProductId = loanProductResponse.getResourceId();
+            Long loanProductId = createLoanProduct(loanProduct);
 
             // Create different types of charges
             PostChargesResponse flatFeeCharge = createCharge(150.0);
             PostChargesResponse percentageCharge = createCharge(200.0);
             PostChargesResponse penaltyCharge = createCharge(100.0);
 
-            Long clientId = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "05 March 2023", 18000.0, 5);
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
-            Long loanId = loanResponse.getLoanId();
+            Long loanId = applyForLoan(applicationRequest);
 
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(18000.0, "05 March 2023"));
+            approveLoan(loanId, approveLoanRequest(18000.0, "05 March 2023"));
             disburseLoan(loanId, BigDecimal.valueOf(18000), "05 March 2023");
 
             // Add charges on same date as disbursement
@@ -536,8 +508,7 @@ public class LoanChargesMultipleDebitAccountsTest extends BaseLoanIntegrationTes
     public void testChargeIdParameterValidationInGLAccountMapping() {
         runAt("10 March 2023", () -> {
             PostLoanProductsRequest loanProduct = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct();
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProduct);
-            Long loanProductId = loanProductResponse.getResourceId();
+            Long loanProductId = createLoanProduct(loanProduct);
             assertNotNull(loanProductId, "Loan product should be created successfully");
 
             // Create multiple charges with different IDs to test charge-specific GL account mapping
@@ -546,13 +517,12 @@ public class LoanChargesMultipleDebitAccountsTest extends BaseLoanIntegrationTes
             assertNotNull(primaryCharge, "Primary charge should be created");
             assertNotNull(secondaryCharge, "Secondary charge should be created");
 
-            Long clientId = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "10 March 2023", 15000.0, 4);
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
-            Long loanId = loanResponse.getLoanId();
+            Long loanId = applyForLoan(applicationRequest);
             assertNotNull(loanId, "Loan should be created successfully");
 
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(15000.0, "10 March 2023"));
+            approveLoan(loanId, approveLoanRequest(15000.0, "10 March 2023"));
             disburseLoan(loanId, BigDecimal.valueOf(15000), "10 March 2023");
 
             // Add charges - this tests that chargeId parameter is properly passed to getLinkedGLAccountForLoanCharges()
@@ -599,24 +569,19 @@ public class LoanChargesMultipleDebitAccountsTest extends BaseLoanIntegrationTes
         runAt("15 March 2023", () -> {
             // Create loan product with accrual accounting
             PostLoanProductsRequest loanProduct = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct();
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProduct);
-            Long loanProductId = loanProductResponse.getResourceId();
+            Long loanProductId = createLoanProduct(loanProduct);
             assertNotNull(loanProductId, "Loan product should be created successfully");
 
             // Create charge that will test advanced accounting rules override
             PostChargesResponse feeCharge = createCharge(400.0);
             assertNotNull(feeCharge, "Fee charge should be created");
 
-            // Create additional GL accounts for advanced accounting rules override
-            Account advancedFeeIncomeAccount = accountHelper.createIncomeAccount("advancedFeeIncome");
-
-            Long clientId = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "15 March 2023", 20000.0, 6);
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
-            Long loanId = loanResponse.getLoanId();
+            Long loanId = applyForLoan(applicationRequest);
             assertNotNull(loanId, "Loan should be created successfully");
 
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(20000.0, "15 March 2023"));
+            approveLoan(loanId, approveLoanRequest(20000.0, "15 March 2023"));
             disburseLoan(loanId, BigDecimal.valueOf(20000), "15 March 2023");
 
             // Add charge - this should use default FEE INCOME GL account unless advanced rules override it
@@ -676,8 +641,7 @@ public class LoanChargesMultipleDebitAccountsTest extends BaseLoanIntegrationTes
         runAt("20 March 2023", () -> {
             // Create loan product with accrual accounting to test accrual adjustments
             PostLoanProductsRequest loanProduct = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct();
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProduct);
-            Long loanProductId = loanProductResponse.getResourceId();
+            Long loanProductId = createLoanProduct(loanProduct);
             assertNotNull(loanProductId, "Loan product should be created successfully");
 
             // Create charges that will be removed to test accrual adjustment
@@ -686,13 +650,12 @@ public class LoanChargesMultipleDebitAccountsTest extends BaseLoanIntegrationTes
             assertNotNull(feeCharge, "Fee charge should be created");
             assertNotNull(penaltyCharge, "Penalty charge should be created");
 
-            Long clientId = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "20 March 2023", 25000.0, 6);
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
-            Long loanId = loanResponse.getLoanId();
+            Long loanId = applyForLoan(applicationRequest);
             assertNotNull(loanId, "Loan should be created successfully");
 
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(25000.0, "20 March 2023"));
+            approveLoan(loanId, approveLoanRequest(25000.0, "20 March 2023"));
             disburseLoan(loanId, BigDecimal.valueOf(25000), "20 March 2023");
 
             // Add charges that will be accrued and then removed
@@ -702,10 +665,9 @@ public class LoanChargesMultipleDebitAccountsTest extends BaseLoanIntegrationTes
             assertNotNull(loanPenaltyCharge, "Penalty charge should be added successfully");
 
             // Execute COB to create initial accrual entries
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
             // Get initial journal entries to establish baseline
-            JournalEntryHelper journalHelper = new JournalEntryHelper(requestSpec, responseSpec);
             GetJournalEntriesTransactionIdResponse initialJournalEntries = journalHelper.getJournalEntriesForLoan(loanId);
             assertNotNull(initialJournalEntries, "Initial journal entries should exist");
 
@@ -714,7 +676,7 @@ public class LoanChargesMultipleDebitAccountsTest extends BaseLoanIntegrationTes
             waiveLoanCharge(loanId, loanFeeCharge.getResourceId(), 1);
 
             // Execute COB again to process accrual adjustments after charge removal
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
             // Get journal entries after charge removal and COB processing
             GetJournalEntriesTransactionIdResponse postRemovalJournalEntries = journalHelper.getJournalEntriesForLoan(loanId);
@@ -759,8 +721,7 @@ public class LoanChargesMultipleDebitAccountsTest extends BaseLoanIntegrationTes
         runAt("25 March 2023", () -> {
             // Create loan product with accrual accounting for accrual adjustment testing
             PostLoanProductsRequest loanProduct = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct();
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProduct);
-            Long loanProductId = loanProductResponse.getResourceId();
+            Long loanProductId = createLoanProduct(loanProduct);
             assertNotNull(loanProductId, "Loan product should be created successfully");
 
             // Create multiple charges that could use different debit GL accounts
@@ -774,13 +735,12 @@ public class LoanChargesMultipleDebitAccountsTest extends BaseLoanIntegrationTes
             // Create additional GL accounts for testing multiple debit accounts
             // These would be configured in a real scenario with advanced accounting rules
 
-            Long clientId = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
             PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "25 March 2023", 30000.0, 8);
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
-            Long loanId = loanResponse.getLoanId();
+            Long loanId = applyForLoan(applicationRequest);
             assertNotNull(loanId, "Loan should be created successfully");
 
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(30000.0, "25 March 2023"));
+            approveLoan(loanId, approveLoanRequest(30000.0, "25 March 2023"));
             disburseLoan(loanId, BigDecimal.valueOf(30000), "25 March 2023");
 
             // Add multiple charges that should use different debit GL accounts
@@ -792,7 +752,7 @@ public class LoanChargesMultipleDebitAccountsTest extends BaseLoanIntegrationTes
             assertNotNull(loanCharge3, "Late fee charge should be added successfully");
 
             // Execute COB to create accrual entries
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
             // Make partial payment to trigger complex accrual adjustment scenarios
             GetJournalEntriesTransactionIdResponse journalEntries = makeRepaymentAndGetJournalEntries(loanId, 1200.0, "25 March 2023");
@@ -825,10 +785,10 @@ public class LoanChargesMultipleDebitAccountsTest extends BaseLoanIntegrationTes
 
             // Test accrual adjustment scenario - create adjustment by executing COB again
             updateBusinessDate("26 March 2023");
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
             // Get updated journal entries to check accrual adjustments
-            GetJournalEntriesTransactionIdResponse updatedJournalEntries = journalEntryHelper.getJournalEntriesForLoan(loanId);
+            GetJournalEntriesTransactionIdResponse updatedJournalEntries = journalHelper.getJournalEntriesForLoan(loanId);
             assertNotNull(updatedJournalEntries, "Updated journal entries should exist");
 
             // Validate that accrual adjustments properly handle multiple debit GL accounts with charge ID resolution

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanInterestPauseApiTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanInterestPauseApiTest.java
@@ -18,93 +18,55 @@
  */
 package org.apache.fineract.integrationtests;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.fineract.client.models.AdvancedPaymentData;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
 import org.apache.fineract.client.models.CommandProcessingResult;
-import org.apache.fineract.client.models.PostLoansLoanIdRequest;
-import org.apache.fineract.client.models.PostLoansLoanIdTransactionsResponse;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.accounting.Account;
-import org.apache.fineract.integrationtests.common.accounting.AccountHelper;
-import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleProcessingType;
-import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleType;
+import org.apache.fineract.client.models.InterestPauseRequestDto;
+import org.apache.fineract.client.models.InterestPauseResponseDto;
+import org.apache.fineract.client.models.PostLoansRequest;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import retrofit2.Response;
+import org.junit.jupiter.api.function.Executable;
 
-@Slf4j
-public class LoanInterestPauseApiTest extends BaseLoanIntegrationTest {
+public class LoanInterestPauseApiTest extends FeignLoanTestBase {
 
-    private static RequestSpecification REQUEST_SPEC;
-    private static ResponseSpecification RESPONSE_SPEC;
-    private static ResponseSpecification RESPONSE_SPEC_403;
-    private static ResponseSpecification RESPONSE_SPEC_404;
-    private static ResponseSpecification RESPONSE_SPEC_204;
-    private static LoanTransactionHelper LOAN_TRANSACTION_HELPER;
-    private static LoanTransactionHelper LOAN_TRANSACTIONAL_HELPER_204;
-    private static LoanTransactionHelper LOAN_TRANSACTION_HELPER_403;
-    private static LoanTransactionHelper LOAN_TRANSACTION_HELPER_404;
-    private static AccountHelper ACCOUNT_HELPER;
-    private static final Integer nonExistLoanId = 99999;
-    private static String externalId;
-    private static final String nonExistExternalId = "7c4fb86f-a778-4d02-b7a8-ec3ec98941fa";
+    private static final Long NON_EXIST_LOAN_ID = 99999L;
+    private static final String NON_EXIST_EXTERNAL_ID = "7c4fb86f-a778-4d02-b7a8-ec3ec98941fa";
+    private static final String ISO_DATE_FORMAT = "yyyy-MM-dd";
+    private static final String TEXT_DATE_FORMAT = "d MMMM yyyy";
+    private static final String LOAN_START_DATE = "01 January 2023";
+    private static final String LOAN_PRINCIPAL_AMOUNT = "10000.00";
+    private static final int NUMBER_OF_REPAYMENTS = 12;
+    private static final double INTEREST_RATE_PER_PERIOD = 18.0;
+
     private Long clientId;
-    private Integer loanProductId;
-    private Integer loanId;
-    private final String loanPrincipalAmount = "10000.00";
-    private final String numberOfRepayments = "12";
-    private final String interestRatePerPeriod = "18";
-    private final String dateString = "01 January 2023";
+    private Long loanProductId;
+    private Long loanId;
+    private String externalId;
+    private Long zeroInterestLoanId;
 
     @BeforeEach
     public void initialize() {
-        Utils.initializeRESTAssured();
-        REQUEST_SPEC = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        REQUEST_SPEC.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        RESPONSE_SPEC = new ResponseSpecBuilder().expectStatusCode(200).build();
-        RESPONSE_SPEC_403 = new ResponseSpecBuilder().expectStatusCode(403).build();
-        RESPONSE_SPEC_404 = new ResponseSpecBuilder().expectStatusCode(404).build();
-        RESPONSE_SPEC_204 = new ResponseSpecBuilder().expectStatusCode(204).build();
-        LOAN_TRANSACTION_HELPER = new LoanTransactionHelper(REQUEST_SPEC, RESPONSE_SPEC);
-        LOAN_TRANSACTION_HELPER_403 = new LoanTransactionHelper(REQUEST_SPEC, RESPONSE_SPEC_403);
-        LOAN_TRANSACTION_HELPER_404 = new LoanTransactionHelper(REQUEST_SPEC, RESPONSE_SPEC_404);
-        LOAN_TRANSACTIONAL_HELPER_204 = new LoanTransactionHelper(REQUEST_SPEC, RESPONSE_SPEC_204);
-        ACCOUNT_HELPER = new AccountHelper(REQUEST_SPEC, RESPONSE_SPEC);
-
+        clientId = createClient();
         externalId = UUID.randomUUID().toString();
-
-        createRequiredEntities();
+        loanProductId = createLoanProduct(create4IProgressive().numberOfRepayments(NUMBER_OF_REPAYMENTS)
+                .interestRatePerPeriod(INTEREST_RATE_PER_PERIOD).principal(Double.parseDouble(LOAN_PRINCIPAL_AMOUNT)));
+        loanId = createLoan();
 
         Assertions.assertNotNull(loanProductId, "Loan Product ID should not be null after creation");
         Assertions.assertNotNull(loanId, "Loan ID should not be null after creation");
         Assertions.assertNotNull(externalId, "External Loan ID should not be null after creation");
     }
 
-    /**
-     * Creates the client, loan product, and loan entities
-     **/
-    private void createRequiredEntities() {
-        this.createClientEntity();
-        this.createLoanProductEntity();
-        this.createLoanEntity();
-    }
-
     @Test
     public void testCreateInterestPauseByLoanId_validRequest_shouldSucceed() {
-        PostLoansLoanIdTransactionsResponse response = LOAN_TRANSACTION_HELPER.createInterestPauseByLoanId("2023-01-01", "2023-01-12",
-                "yyyy-MM-dd", "en", loanId);
+        CommandProcessingResult response = loanHelper.createInterestPause(loanId, pause("2023-01-01", "2023-01-12"));
 
         Assertions.assertNotNull(response);
         Assertions.assertNotNull(response.getResourceId());
@@ -112,65 +74,37 @@ public class LoanInterestPauseApiTest extends BaseLoanIntegrationTest {
 
     @Test
     public void testCreateInterestPauseByLoanId_endDateBeforeStartDate_shouldFail() {
-        try {
-            LOAN_TRANSACTION_HELPER_403.createInterestPauseByLoanId("2024-12-05", "2023-01-12", "yyyy-MM-dd", "en", loanId);
-        } catch (Exception e) {
-            String responseBody = e.getMessage();
-            Assertions.assertNotNull(responseBody, "Response body should not be null");
-            Assertions.assertTrue(responseBody.contains("interest.pause.end.date.before.start.date"),
-                    "Response should contain the validation error message for end date before start date");
-        }
+        assertPauseFails(403, "interest.pause.end.date.before.start.date",
+                () -> loanHelper.createInterestPause(loanId, pause("2024-12-05", "2023-01-12")));
     }
 
     @Test
     public void testCreateInterestPauseByLoanId_startDateBeforeLoanStart_shouldFail() {
-        try {
-            LOAN_TRANSACTION_HELPER_403.createInterestPauseByLoanId("2022-12-01", "2023-01-12", "yyyy-MM-dd", "en", loanId);
-        } catch (Exception e) {
-            String responseBody = e.getMessage();
-            Assertions.assertNotNull(responseBody, "Response body should not be null");
-            Assertions.assertTrue(responseBody.contains("interest.pause.start.date.before.loan.start.date"),
-                    "Response should contain the validation error message for start date before loan start date");
-        }
+        assertPauseFails(403, "interest.pause.start.date.before.loan.start.date",
+                () -> loanHelper.createInterestPause(loanId, pause("2022-12-01", "2023-01-12")));
     }
 
     @Test
     public void testCreateInterestPauseByLoanId_endDateAfterLoanMaturity_shouldFail() {
-        try {
-            LOAN_TRANSACTION_HELPER_403.createInterestPauseByLoanId("2024-12-01", "2025-12-05", "yyyy-MM-dd", "en", loanId);
-        } catch (Exception e) {
-            String responseBody = e.getMessage();
-            Assertions.assertNotNull(responseBody, "Response body should not be null");
-            Assertions.assertTrue(responseBody.contains("interest.pause.end.date.after.loan.maturity.date"),
-                    "Response should contain the validation error message for end date after loan maturity date");
-        }
+        assertPauseFails(403, "interest.pause.end.date.after.loan.maturity.date",
+                () -> loanHelper.createInterestPause(loanId, pause("2024-12-01", "2025-12-05")));
     }
 
     @Test
     public void testRetrieveInterestPausesByLoanId_noPauses_shouldReturnEmpty() {
-        String response = LOAN_TRANSACTION_HELPER.retrieveInterestPauseByLoanId(nonExistLoanId);
-
-        Assertions.assertNotNull(response, "Response should not be null");
-        Assertions.assertFalse(response.contains("id"));
-        Assertions.assertFalse(response.contains("startDate"));
-        Assertions.assertFalse(response.contains("endDate"));
+        Assertions.assertTrue(loanHelper.retrieveInterestPauses(NON_EXIST_LOAN_ID).isEmpty());
     }
 
     @Test
     public void testRetrieveInterestPausesByLoanId_shouldReturnData() {
-        LOAN_TRANSACTION_HELPER.createInterestPauseByLoanId("2023-01-01", "2023-01-12", "yyyy-MM-dd", "en", loanId);
+        loanHelper.createInterestPause(loanId, pause("2023-01-01", "2023-01-12"));
 
-        String response = LOAN_TRANSACTION_HELPER.retrieveInterestPauseByLoanId(loanId);
-
-        Assertions.assertNotNull(response, "Response should not be null");
-        Assertions.assertTrue(response.contains("2023-01-01"));
-        Assertions.assertTrue(response.contains("2023-01-12"));
+        assertContainsPause(loanHelper.retrieveInterestPauses(loanId), "2023-01-01", "2023-01-12");
     }
 
     @Test
     public void testCreateInterestPauseByExternalLoanId_validRequest_shouldSucceed() {
-        PostLoansLoanIdTransactionsResponse response = LOAN_TRANSACTION_HELPER.createInterestPauseByExternalId("2023-01-01", "2023-01-12",
-                "yyyy-MM-dd", "en", externalId);
+        CommandProcessingResult response = loanHelper.createInterestPauseByExternalId(externalId, pause("2023-01-01", "2023-01-12"));
 
         Assertions.assertNotNull(response);
         Assertions.assertNotNull(response.getResourceId());
@@ -178,464 +112,220 @@ public class LoanInterestPauseApiTest extends BaseLoanIntegrationTest {
 
     @Test
     public void testCreateInterestPauseByExternalLoanId_endDateBeforeStartDate_shouldFail() {
-        try {
-            LOAN_TRANSACTION_HELPER_403.createInterestPauseByExternalId("2023-01-01", "2022-01-12", "yyyy-MM-dd", "en", externalId);
-        } catch (Exception e) {
-            String responseBody = e.getMessage();
-            Assertions.assertNotNull(responseBody, "Response body should not be null");
-            Assertions.assertTrue(responseBody.contains("interest.pause.end.date.before.start.date"),
-                    "Response should contain the validation error message for end date before start date");
-        }
+        assertPauseFails(403, "interest.pause.end.date.before.start.date",
+                () -> loanHelper.createInterestPauseByExternalId(externalId, pause("2023-01-01", "2022-01-12")));
     }
 
     @Test
     public void testCreateInterestPauseByExternalLoanId_startDateBeforeLoanStart_shouldFail() {
-        try {
-            LOAN_TRANSACTION_HELPER_403.createInterestPauseByExternalId("2022-12-01", "2024-12-05", "yyyy-MM-dd", "en", externalId);
-        } catch (Exception e) {
-            String responseBody = e.getMessage();
-            Assertions.assertNotNull(responseBody, "Response body should not be null");
-            Assertions.assertTrue(responseBody.contains("interest.pause.start.date.before.loan.start.date"),
-                    "Response should contain the validation error message for start date before loan start date");
-        }
+        assertPauseFails(403, "interest.pause.start.date.before.loan.start.date",
+                () -> loanHelper.createInterestPauseByExternalId(externalId, pause("2022-12-01", "2024-12-05")));
     }
 
     @Test
     public void testCreateInterestPauseByExternalLoanId_endDateAfterLoanMaturity_shouldFail() {
-        try {
-            LOAN_TRANSACTION_HELPER_403.createInterestPauseByExternalId("2024-12-01", "2025-12-05", "yyyy-MM-dd", "en", externalId);
-        } catch (Exception e) {
-            String responseBody = e.getMessage();
-            Assertions.assertNotNull(responseBody, "Response body should not be null");
-            Assertions.assertTrue(responseBody.contains("interest.pause.end.date.after.loan.maturity.date"),
-                    "Response should contain the validation error message for end date after loan maturity date");
-        }
+        assertPauseFails(403, "interest.pause.end.date.after.loan.maturity.date",
+                () -> loanHelper.createInterestPauseByExternalId(externalId, pause("2024-12-01", "2025-12-05")));
     }
 
     @Test
     public void testRetrieveInterestPausesByExternalLoanId_noPauses_shouldReturnEmpty() {
-        String response = LOAN_TRANSACTION_HELPER.retrieveInterestPauseByExternalId(nonExistExternalId);
-
-        Assertions.assertNotNull(response, "Response should not be null");
-        Assertions.assertFalse(response.contains("id"));
-        Assertions.assertFalse(response.contains("startDate"));
-        Assertions.assertFalse(response.contains("endDate"));
+        Assertions.assertTrue(loanHelper.retrieveInterestPausesByExternalId(NON_EXIST_EXTERNAL_ID).isEmpty());
     }
 
     @Test
     public void testRetrieveInterestPausesByExternalLoanId_shouldReturnData() {
-        LOAN_TRANSACTION_HELPER.createInterestPauseByExternalId("2023-01-01", "2023-01-12", "yyyy-MM-dd", "en", externalId);
+        loanHelper.createInterestPauseByExternalId(externalId, pause("2023-01-01", "2023-01-12"));
 
-        String response = LOAN_TRANSACTION_HELPER.retrieveInterestPauseByExternalId(externalId);
-
-        Assertions.assertNotNull(response, "Response should not be null");
-        Assertions.assertTrue(response.contains("2023-01-01"));
-        Assertions.assertTrue(response.contains("2023-01-12"));
+        assertContainsPause(loanHelper.retrieveInterestPausesByExternalId(externalId), "2023-01-01", "2023-01-12");
     }
 
     @Test
     public void testUpdateInterestPauseByLoanId_overlapping_shouldFail() {
-        PostLoansLoanIdTransactionsResponse createResponse = LOAN_TRANSACTION_HELPER.createInterestPauseByLoanId("2023-01-01", "2023-01-03",
-                "yyyy-MM-dd", "en", loanId);
-        PostLoansLoanIdTransactionsResponse createResponse2 = LOAN_TRANSACTION_HELPER.createInterestPauseByLoanId("2023-01-08",
-                "2023-01-10", "yyyy-MM-dd", "en", loanId);
+        Long variationId = createPauseByLoanId("2023-01-01", "2023-01-03");
+        loanHelper.createInterestPause(loanId, pause("2023-01-08", "2023-01-10"));
 
-        Assertions.assertNotNull(createResponse);
-        Assertions.assertNotNull(createResponse.getResourceId());
-
-        Long variationId = createResponse.getResourceId();
-
-        try {
-            LOAN_TRANSACTION_HELPER_403.updateInterestPauseByLoanId(variationId, "2023-01-01", "2023-01-12", "yyyy-MM-dd", "en", loanId);
-        } catch (Exception e) {
-            String responseBody = e.getMessage();
-            Assertions.assertNotNull(responseBody, "Response body should not be null");
-            Assertions.assertTrue(responseBody.contains("interest.pause.overlapping"),
-                    "Response should contain the validation error message for end date after loan maturity date");
-        }
+        assertPauseFails(403, "interest.pause.overlapping",
+                () -> loanHelper.updateInterestPause(loanId, variationId, pause("2023-01-01", "2023-01-12")));
     }
 
     @Test
     public void testUpdateInterestPauseByLoanId_overlapping_shouldNotFail() {
-        PostLoansLoanIdTransactionsResponse createResponse = LOAN_TRANSACTION_HELPER.createInterestPauseByLoanId("2023-01-01", "2023-01-03",
-                "yyyy-MM-dd", "en", loanId);
-        PostLoansLoanIdTransactionsResponse createResponse2 = LOAN_TRANSACTION_HELPER.createInterestPauseByLoanId("2023-01-08",
-                "2023-01-10", "yyyy-MM-dd", "en", loanId);
+        Long variationId = createPauseByLoanId("2023-01-01", "2023-01-03");
+        loanHelper.createInterestPause(loanId, pause("2023-01-08", "2023-01-10"));
 
-        Assertions.assertNotNull(createResponse);
-        Assertions.assertNotNull(createResponse.getResourceId());
+        CommandProcessingResult updateResponse = loanHelper.updateInterestPause(loanId, variationId, pause("2023-01-01", "2023-01-07"));
 
-        Long variationId = createResponse.getResourceId();
-
-        try {
-            LOAN_TRANSACTION_HELPER.updateInterestPauseByLoanId(variationId, "2023-01-01", "2023-01-07", "yyyy-MM-dd", "en", loanId);
-        } catch (Exception e) {
-            String responseBody = e.getMessage();
-            Assertions.assertNotNull(responseBody, "Response body should not be null");
-            Assertions.assertTrue(responseBody.contains("interest.pause.overlapping"),
-                    "Response should contain the validation error message for end date after loan maturity date");
-        }
+        Assertions.assertNotNull(updateResponse.getResourceId());
+        Assertions.assertEquals(variationId, updateResponse.getResourceId());
     }
 
     @Test
     public void testUpdateInterestPauseByLoanId_overlapping_shouldFail2() {
-        PostLoansLoanIdTransactionsResponse createResponse = LOAN_TRANSACTION_HELPER.createInterestPauseByLoanId("2023-01-01", "2023-01-06",
-                "yyyy-MM-dd", "en", loanId);
-        PostLoansLoanIdTransactionsResponse createResponse2 = LOAN_TRANSACTION_HELPER.createInterestPauseByLoanId("2023-01-07",
-                "2023-01-12", "yyyy-MM-dd", "en", loanId);
+        Long variationId = createPauseByLoanId("2023-01-01", "2023-01-06");
+        loanHelper.createInterestPause(loanId, pause("2023-01-07", "2023-01-12"));
 
-        Assertions.assertNotNull(createResponse);
-        Assertions.assertNotNull(createResponse.getResourceId());
-
-        Long variationId = createResponse.getResourceId();
-
-        try {
-            LOAN_TRANSACTION_HELPER_403.updateInterestPauseByLoanId(variationId, "2023-01-02", "2023-01-13", "yyyy-MM-dd", "en", loanId);
-        } catch (Exception e) {
-            String responseBody = e.getMessage();
-            Assertions.assertNotNull(responseBody, "Response body should not be null");
-            Assertions.assertTrue(responseBody.contains("interest.pause.overlapping"),
-                    "Response should contain the validation error message for end date after loan maturity date");
-        }
+        assertPauseFails(403, "interest.pause.overlapping",
+                () -> loanHelper.updateInterestPause(loanId, variationId, pause("2023-01-02", "2023-01-13")));
     }
 
     @Test
     public void testUpdateInterestPauseByLoanId_overlapping_shouldFail3() {
-        PostLoansLoanIdTransactionsResponse createResponse = LOAN_TRANSACTION_HELPER.createInterestPauseByLoanId("2023-01-03", "2023-01-06",
-                "yyyy-MM-dd", "en", loanId);
-        PostLoansLoanIdTransactionsResponse createResponse2 = LOAN_TRANSACTION_HELPER.createInterestPauseByLoanId("2023-01-07",
-                "2023-01-12", "yyyy-MM-dd", "en", loanId);
+        Long variationId = createPauseByLoanId("2023-01-03", "2023-01-06");
+        loanHelper.createInterestPause(loanId, pause("2023-01-07", "2023-01-12"));
 
-        Assertions.assertNotNull(createResponse);
-        Assertions.assertNotNull(createResponse.getResourceId());
-
-        Long variationId = createResponse.getResourceId();
-
-        try {
-            LOAN_TRANSACTION_HELPER_403.updateInterestPauseByLoanId(variationId, "2023-01-01", "2023-01-11", "yyyy-MM-dd", "en", loanId);
-        } catch (Exception e) {
-            String responseBody = e.getMessage();
-            Assertions.assertNotNull(responseBody, "Response body should not be null");
-            Assertions.assertTrue(responseBody.contains("interest.pause.overlapping"),
-                    "Response should contain the validation error message for end date after loan maturity date");
-        }
+        assertPauseFails(403, "interest.pause.overlapping",
+                () -> loanHelper.updateInterestPause(loanId, variationId, pause("2023-01-01", "2023-01-11")));
     }
 
     @Test
     public void testUpdateInterestPauseByLoanId_validRequest_shouldSucceed() {
-        PostLoansLoanIdTransactionsResponse createResponse = LOAN_TRANSACTION_HELPER.createInterestPauseByLoanId("2023-01-01", "2023-01-02",
-                "yyyy-MM-dd", "en", loanId);
+        Long variationId = createPauseByLoanId("2023-01-01", "2023-01-02");
 
-        Assertions.assertNotNull(createResponse);
-        Assertions.assertNotNull(createResponse.getResourceId());
+        CommandProcessingResult updateResponse = loanHelper.updateInterestPause(loanId, variationId, pause("2023-01-03", "2023-01-04"));
 
-        Long variationId = createResponse.getResourceId();
-
-        PostLoansLoanIdTransactionsResponse updateResponse = LOAN_TRANSACTION_HELPER.updateInterestPauseByLoanId(variationId, "2023-01-03",
-                "2023-01-04", "yyyy-MM-dd", "en", loanId);
-
-        Assertions.assertNotNull(updateResponse);
         Assertions.assertNotNull(updateResponse.getResourceId());
         Assertions.assertEquals(variationId, updateResponse.getResourceId());
     }
 
     @Test
     public void testUpdateInterestPauseByLoanId_endDateBeforeStartDate_shouldFail() {
-        PostLoansLoanIdTransactionsResponse createResponse = LOAN_TRANSACTION_HELPER.createInterestPauseByLoanId("2023-01-01", "2023-01-12",
-                "yyyy-MM-dd", "en", loanId);
+        Long variationId = createPauseByLoanId("2023-01-01", "2023-01-12");
 
-        Assertions.assertNotNull(createResponse);
-        Assertions.assertNotNull(createResponse.getResourceId());
-
-        Long variationId = createResponse.getResourceId();
-
-        try {
-            LOAN_TRANSACTION_HELPER_403.updateInterestPauseByLoanId(variationId, "2023-03-01", "2023-01-12", "yyyy-MM-dd", "en", loanId);
-        } catch (Exception e) {
-            String responseBody = e.getMessage();
-            Assertions.assertNotNull(responseBody, "Response body should not be null");
-            Assertions.assertTrue(responseBody.contains("interest.pause.end.date.before.start.date"),
-                    "Response should contain the validation error message for end date before start date");
-        }
+        assertPauseFails(403, "interest.pause.end.date.before.start.date",
+                () -> loanHelper.updateInterestPause(loanId, variationId, pause("2023-03-01", "2023-01-12")));
     }
 
     @Test
     public void testUpdateInterestPauseByLoanId_startDateBeforeLoanStart_shouldFail() {
-        PostLoansLoanIdTransactionsResponse createResponse = LOAN_TRANSACTION_HELPER.createInterestPauseByLoanId("2023-01-01", "2023-01-12",
-                "yyyy-MM-dd", "en", loanId);
+        Long variationId = createPauseByLoanId("2023-01-01", "2023-01-12");
 
-        Assertions.assertNotNull(createResponse);
-        Assertions.assertNotNull(createResponse.getResourceId());
-
-        Long variationId = createResponse.getResourceId();
-
-        try {
-            LOAN_TRANSACTION_HELPER_403.updateInterestPauseByLoanId(variationId, "2022-12-01", "2023-01-12", "yyyy-MM-dd", "en", loanId);
-        } catch (Exception e) {
-            String responseBody = e.getMessage();
-            Assertions.assertNotNull(responseBody, "Response body should not be null");
-            Assertions.assertTrue(responseBody.contains("interest.pause.start.date.before.loan.start.date"),
-                    "Response should contain the validation error message for start date before loan start date");
-        }
+        assertPauseFails(403, "interest.pause.start.date.before.loan.start.date",
+                () -> loanHelper.updateInterestPause(loanId, variationId, pause("2022-12-01", "2023-01-12")));
     }
 
     @Test
     public void testDeleteInterestPauseByLoanId_validRequest_shouldSucceed() {
-        PostLoansLoanIdTransactionsResponse createResponse = LOAN_TRANSACTION_HELPER.createInterestPauseByLoanId("2023-01-01", "2023-01-12",
-                "yyyy-MM-dd", "en", loanId);
+        Long variationId = createPauseByLoanId("2023-01-01", "2023-01-12");
 
-        Assertions.assertNotNull(createResponse, "Create response should not be null");
-        Assertions.assertNotNull(createResponse.getResourceId(), "Resource ID should not be null");
+        loanHelper.deleteInterestPause(loanId, variationId);
 
-        Long variationId = createResponse.getResourceId();
-
-        try {
-            LOAN_TRANSACTIONAL_HELPER_204.deleteInterestPauseByLoanId(variationId, loanId);
-        } catch (Exception e) {
-            Assertions.fail("Delete operation failed: " + e.getMessage());
-        }
-
-        String response = LOAN_TRANSACTION_HELPER.retrieveInterestPauseByLoanId(loanId);
-        Assertions.assertFalse(response.contains(String.valueOf(variationId)), "Response should not contain the deleted variation ID");
+        assertDoesNotContainPause(loanHelper.retrieveInterestPauses(loanId), variationId);
     }
 
     @Test
     public void testDeleteInterestPauseByLoanId_nonExistentVariation_shouldFail() {
-        try {
-            LOAN_TRANSACTION_HELPER_403.deleteInterestPauseByLoanId(99999L, loanId);
-        } catch (Exception e) {
-            String responseBody = e.getMessage();
-            Assertions.assertNotNull(responseBody, "Response body should not be null");
-            Assertions.assertTrue(responseBody.contains("error.msg.variation.not.found"),
-                    "Response should contain the validation error message for variation not found");
-        }
+        assertPauseFails(403, "error.msg.variation.not.found", () -> loanHelper.deleteInterestPause(loanId, NON_EXIST_LOAN_ID));
     }
 
     @Test
     public void testDeleteInterestPauseByLoanId_invalidLoanId_shouldFail() {
-        PostLoansLoanIdTransactionsResponse createResponse = LOAN_TRANSACTION_HELPER.createInterestPauseByLoanId("2023-01-01", "2023-01-12",
-                "yyyy-MM-dd", "en", loanId);
+        Long variationId = createPauseByLoanId("2023-01-01", "2023-01-12");
 
-        Assertions.assertNotNull(createResponse);
-        Assertions.assertNotNull(createResponse.getResourceId());
-
-        Long variationId = createResponse.getResourceId();
-
-        try {
-            LOAN_TRANSACTION_HELPER_404.deleteInterestPauseByLoanId(variationId, nonExistLoanId);
-        } catch (Exception e) {
-            String responseBody = e.getMessage();
-            Assertions.assertNotNull(responseBody, "Response body should not be null");
-            Assertions.assertTrue(responseBody.contains("error.msg.loan.id.invalid"),
-                    "Response should contain the validation error message for variation not found");
-        }
+        assertPauseFails(404, "error.msg.loan.id.invalid", () -> loanHelper.deleteInterestPause(NON_EXIST_LOAN_ID, variationId));
     }
 
     @Test
     public void testUpdateInterestPauseByExternalId_validRequest_shouldSucceed() {
-        PostLoansLoanIdTransactionsResponse createResponse = LOAN_TRANSACTION_HELPER.createInterestPauseByExternalId("2023-01-01",
-                "2023-01-02", "yyyy-MM-dd", "en", externalId);
+        Long variationId = createPauseByExternalId("2023-01-01", "2023-01-02");
 
-        Assertions.assertNotNull(createResponse);
-        Assertions.assertNotNull(createResponse.getResourceId());
+        CommandProcessingResult updateResponse = loanHelper.updateInterestPauseByExternalId(externalId, variationId,
+                pause("2023-01-03", "2023-01-04"));
 
-        Long variationId = createResponse.getResourceId();
-
-        PostLoansLoanIdTransactionsResponse updateResponse = LOAN_TRANSACTION_HELPER.updateInterestPauseByExternalId(variationId,
-                "2023-01-03", "2023-01-04", "yyyy-MM-dd", "en", externalId);
-
-        Assertions.assertNotNull(updateResponse);
         Assertions.assertNotNull(updateResponse.getResourceId());
         Assertions.assertEquals(variationId, updateResponse.getResourceId());
     }
 
     @Test
     public void testUpdateInterestPauseByExternalId_overlapping_shouldFail() {
-        PostLoansLoanIdTransactionsResponse createResponse = LOAN_TRANSACTION_HELPER.createInterestPauseByExternalId("2023-01-01",
-                "2023-01-06", "yyyy-MM-dd", "en", externalId);
-        PostLoansLoanIdTransactionsResponse createResponse2 = LOAN_TRANSACTION_HELPER.createInterestPauseByExternalId("2023-01-07",
-                "2023-01-12", "yyyy-MM-dd", "en", externalId);
+        Long variationId = createPauseByExternalId("2023-01-01", "2023-01-06");
+        loanHelper.createInterestPauseByExternalId(externalId, pause("2023-01-07", "2023-01-12"));
 
-        Assertions.assertNotNull(createResponse);
-        Assertions.assertNotNull(createResponse.getResourceId());
-
-        Long variationId = createResponse.getResourceId();
-        try {
-            LOAN_TRANSACTION_HELPER_403.updateInterestPauseByExternalId(variationId, "2023-01-01", "2023-01-12", "yyyy-MM-dd", "en",
-                    externalId);
-        } catch (Exception e) {
-            String responseBody = e.getMessage();
-            Assertions.assertNotNull(responseBody, "Response body should not be null");
-            Assertions.assertTrue(responseBody.contains("interest.pause.overlapping"),
-                    "Response should contain the validation error message for end date after loan maturity date");
-        }
+        assertPauseFails(403, "interest.pause.overlapping",
+                () -> loanHelper.updateInterestPauseByExternalId(externalId, variationId, pause("2023-01-01", "2023-01-12")));
     }
 
     @Test
     public void testUpdateInterestPauseByExternalId_overlapping_shouldFail2() {
-        PostLoansLoanIdTransactionsResponse createResponse = LOAN_TRANSACTION_HELPER.createInterestPauseByExternalId("2023-01-01",
-                "2023-01-06", "yyyy-MM-dd", "en", externalId);
-        PostLoansLoanIdTransactionsResponse createResponse2 = LOAN_TRANSACTION_HELPER.createInterestPauseByExternalId("2023-01-07",
-                "2023-01-12", "yyyy-MM-dd", "en", externalId);
+        Long variationId = createPauseByExternalId("2023-01-01", "2023-01-06");
+        loanHelper.createInterestPauseByExternalId(externalId, pause("2023-01-07", "2023-01-12"));
 
-        Assertions.assertNotNull(createResponse);
-        Assertions.assertNotNull(createResponse.getResourceId());
-
-        Long variationId = createResponse.getResourceId();
-        try {
-            LOAN_TRANSACTION_HELPER_403.updateInterestPauseByExternalId(variationId, "2023-01-02", "2023-01-13", "yyyy-MM-dd", "en",
-                    externalId);
-        } catch (Exception e) {
-            String responseBody = e.getMessage();
-            Assertions.assertNotNull(responseBody, "Response body should not be null");
-            Assertions.assertTrue(responseBody.contains("interest.pause.overlapping"),
-                    "Response should contain the validation error message for end date after loan maturity date");
-        }
+        assertPauseFails(403, "interest.pause.overlapping",
+                () -> loanHelper.updateInterestPauseByExternalId(externalId, variationId, pause("2023-01-02", "2023-01-13")));
     }
 
     @Test
     public void testUpdateInterestPauseByExternalId_overlapping_shouldFail3() {
-        PostLoansLoanIdTransactionsResponse createResponse = LOAN_TRANSACTION_HELPER.createInterestPauseByExternalId("2023-01-03",
-                "2023-01-06", "yyyy-MM-dd", "en", externalId);
-        PostLoansLoanIdTransactionsResponse createResponse2 = LOAN_TRANSACTION_HELPER.createInterestPauseByExternalId("2023-01-07",
-                "2023-01-12", "yyyy-MM-dd", "en", externalId);
+        Long variationId = createPauseByExternalId("2023-01-03", "2023-01-06");
+        loanHelper.createInterestPauseByExternalId(externalId, pause("2023-01-07", "2023-01-12"));
 
-        Assertions.assertNotNull(createResponse);
-        Assertions.assertNotNull(createResponse.getResourceId());
-
-        Long variationId = createResponse.getResourceId();
-        try {
-            LOAN_TRANSACTION_HELPER_403.updateInterestPauseByExternalId(variationId, "2023-01-01", "2023-01-11", "yyyy-MM-dd", "en",
-                    externalId);
-        } catch (Exception e) {
-            String responseBody = e.getMessage();
-            Assertions.assertNotNull(responseBody, "Response body should not be null");
-            Assertions.assertTrue(responseBody.contains("interest.pause.overlapping"),
-                    "Response should contain the validation error message for end date after loan maturity date");
-        }
+        assertPauseFails(403, "interest.pause.overlapping",
+                () -> loanHelper.updateInterestPauseByExternalId(externalId, variationId, pause("2023-01-01", "2023-01-11")));
     }
 
     @Test
     public void testUpdateInterestPauseByExternalId_endDateBeforeStartDate_shouldFail() {
-        PostLoansLoanIdTransactionsResponse createResponse = LOAN_TRANSACTION_HELPER.createInterestPauseByExternalId("2023-01-03",
-                "2023-01-12", "yyyy-MM-dd", "en", externalId);
+        Long variationId = createPauseByExternalId("2023-01-03", "2023-01-12");
 
-        Assertions.assertNotNull(createResponse);
-        Assertions.assertNotNull(createResponse.getResourceId());
-
-        Long variationId = createResponse.getResourceId();
-
-        try {
-            LOAN_TRANSACTION_HELPER_403.updateInterestPauseByExternalId(variationId, "2023-03-01", "2023-01-12", "yyyy-MM-dd", "en",
-                    externalId);
-        } catch (Exception e) {
-            String responseBody = e.getMessage();
-            Assertions.assertNotNull(responseBody, "Response body should not be null");
-            Assertions.assertTrue(responseBody.contains("interest.pause.end.date.before.start.date"),
-                    "Response should contain the validation error message for end date before start date");
-        }
+        assertPauseFails(403, "interest.pause.end.date.before.start.date",
+                () -> loanHelper.updateInterestPauseByExternalId(externalId, variationId, pause("2023-03-01", "2023-01-12")));
     }
 
     @Test
     public void testUpdateInterestPauseByExternalId_startDateBeforeLoanStart_shouldFail() {
-        PostLoansLoanIdTransactionsResponse createResponse = LOAN_TRANSACTION_HELPER.createInterestPauseByExternalId("2023-01-03",
-                "2023-01-12", "yyyy-MM-dd", "en", externalId);
+        Long variationId = createPauseByExternalId("2023-01-03", "2023-01-12");
 
-        Assertions.assertNotNull(createResponse);
-        Assertions.assertNotNull(createResponse.getResourceId());
-
-        Long variationId = createResponse.getResourceId();
-
-        try {
-            LOAN_TRANSACTION_HELPER_403.updateInterestPauseByExternalId(variationId, "2022-12-01", "2023-01-12", "yyyy-MM-dd", "en",
-                    externalId);
-        } catch (Exception e) {
-            String responseBody = e.getMessage();
-            Assertions.assertNotNull(responseBody, "Response body should not be null");
-            Assertions.assertTrue(responseBody.contains("interest.pause.start.date.before.loan.start.date"),
-                    "Response should contain the validation error message for start date before loan start date");
-        }
+        assertPauseFails(403, "interest.pause.start.date.before.loan.start.date",
+                () -> loanHelper.updateInterestPauseByExternalId(externalId, variationId, pause("2022-12-01", "2023-01-12")));
     }
 
     @Test
     public void testDeleteInterestPauseByExternalId_validRequest_shouldSucceed() {
-        PostLoansLoanIdTransactionsResponse createResponse = LOAN_TRANSACTION_HELPER.createInterestPauseByExternalId("2023-01-03",
-                "2023-01-12", "yyyy-MM-dd", "en", externalId);
+        Long variationId = createPauseByExternalId("2023-01-03", "2023-01-12");
 
-        Assertions.assertNotNull(createResponse, "Create response should not be null");
-        Assertions.assertNotNull(createResponse.getResourceId(), "Resource ID should not be null");
+        loanHelper.deleteInterestPauseByExternalId(externalId, variationId);
 
-        Long variationId = createResponse.getResourceId();
-
-        try {
-            LOAN_TRANSACTIONAL_HELPER_204.deleteInterestPauseByExternalId(variationId, externalId);
-        } catch (Exception e) {
-            Assertions.fail("Delete operation failed: " + e.getMessage());
-        }
-
-        String response = LOAN_TRANSACTION_HELPER.retrieveInterestPauseByExternalId(externalId);
-        Assertions.assertFalse(response.contains(String.valueOf(variationId)), "Response should not contain the deleted variation ID");
+        assertDoesNotContainPause(loanHelper.retrieveInterestPausesByExternalId(externalId), variationId);
     }
 
     @Test
     public void testDeleteInterestPauseByExternalId_nonExistentVariation_shouldFail() {
-        try {
-            LOAN_TRANSACTION_HELPER_403.deleteInterestPauseByExternalId(99999L, externalId);
-        } catch (Exception e) {
-            String responseBody = e.getMessage();
-            Assertions.assertNotNull(responseBody, "Response body should not be null");
-            Assertions.assertTrue(responseBody.contains("error.msg.variation.not.found"),
-                    "Response should contain the validation error message for variation not found");
-        }
+        assertPauseFails(403, "error.msg.variation.not.found",
+                () -> loanHelper.deleteInterestPauseByExternalId(externalId, NON_EXIST_LOAN_ID));
     }
 
     @Test
     public void testDeleteInterestPauseByExternalId_invalidExternalId_shouldFail() {
-        PostLoansLoanIdTransactionsResponse createResponse = LOAN_TRANSACTION_HELPER.createInterestPauseByExternalId("2023-01-03",
-                "2023-01-12", "yyyy-MM-dd", "en", externalId);
+        Long variationId = createPauseByExternalId("2023-01-03", "2023-01-12");
 
-        Assertions.assertNotNull(createResponse);
-        Assertions.assertNotNull(createResponse.getResourceId());
-
-        Long variationId = createResponse.getResourceId();
-
-        try {
-            LOAN_TRANSACTION_HELPER_404.deleteInterestPauseByExternalId(variationId, nonExistExternalId);
-        } catch (Exception e) {
-            String responseBody = e.getMessage();
-            Assertions.assertNotNull(responseBody, "Response body should not be null");
-            Assertions.assertTrue(responseBody.contains("error.msg.loan.external.id.invalid"),
-                    "Response should contain the validation error message for variation not found");
-        }
+        assertPauseFails(404, "error.msg.loan.external.id.invalid",
+                () -> loanHelper.deleteInterestPauseByExternalId(NON_EXIST_EXTERNAL_ID, variationId));
     }
-
-    Long loan;
 
     @Test
     public void testInterestPauseOnZeroInterestRate() {
         runAt("1 September 2019", () -> {
-            Long loanProductId = loanProductHelper.createLoanProduct(create4IProgressive()).getResourceId();
-            loan = applyAndApproveProgressiveLoan(clientId, loanProductId, "1 September 2019", 1200.0, 0.0, 4, null);
-            disburseLoan(loan, BigDecimal.valueOf(1200.0), "1 September 2019");
+            Long loanProductId = createLoanProduct(create4IProgressive());
+            zeroInterestLoanId = applyAndApproveProgressiveLoan(clientId, loanProductId, "1 September 2019", 1200.0, 0.0, 4, null);
+            disburseLoan(zeroInterestLoanId, BigDecimal.valueOf(1200.0), "1 September 2019");
         });
         runAt("1 October 2019", () -> {
-            loanTransactionHelper.makeLoanRepayment(loan, "Repayment", "1 October 2019", 300.0);
+            makeLoanRepayment(zeroInterestLoanId, "Repayment", "1 October 2019", 300.0);
         });
         runAt("1 November 2019", () -> {
-            loanTransactionHelper.makeLoanRepayment(loan, "Repayment", "1 November 2019", 300.0);
+            makeLoanRepayment(zeroInterestLoanId, "Repayment", "1 November 2019", 300.0);
         });
         runAt("1 December 2019", () -> {
-            loanTransactionHelper.makeLoanRepayment(loan, "Repayment", "1 December 2019", 300.0);
-            verifyTransactions(loan, //
+            makeLoanRepayment(zeroInterestLoanId, "Repayment", "1 December 2019", 300.0);
+            verifyTransactions(zeroInterestLoanId, //
                     transaction(1200.0, "Disbursement", "01 September 2019", 1200.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0), //
                     transaction(300.0, "Repayment", "01 October 2019", 900.0, 300.0, 0.0, 0.0, 0.0, 0.0, 0.0), //
                     transaction(300.0, "Repayment", "01 November 2019", 600.0, 300.0, 0.0, 0.0, 0.0, 0.0, 0.0), //
                     transaction(300.0, "Repayment", "01 December 2019", 300.0, 300.0, 0.0, 0.0, 0.0, 0.0, 0.0) //
             );
-            Response<CommandProcessingResult> response = loanTransactionHelper.createInterestPause(loan, "1 October 2019",
-                    "15 December 2019");
-            Assertions.assertEquals(403, response.code());
-            verifyTransactions(loan, //
+            assertPauseFails(403, "", () -> loanHelper.createInterestPause(zeroInterestLoanId,
+                    pause("1 October 2019", "15 December 2019", TEXT_DATE_FORMAT)));
+            verifyTransactions(zeroInterestLoanId, //
                     transaction(1200.0, "Disbursement", "01 September 2019", 1200.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0), //
                     transaction(300.0, "Repayment", "01 October 2019", 900.0, 300.0, 0.0, 0.0, 0.0, 0.0, 0.0), //
                     transaction(300.0, "Repayment", "01 November 2019", 600.0, 300.0, 0.0, 0.0, 0.0, 0.0, 0.0), //
@@ -647,20 +337,19 @@ public class LoanInterestPauseApiTest extends BaseLoanIntegrationTest {
     @Test
     public void testInterestPauseOnZeroInterestRateRightAfterDisbursement() {
         runAt("1 September 2019", () -> {
-            Long loanProductId = loanProductHelper.createLoanProduct(create4IProgressive()).getResourceId();
-            loan = applyAndApproveProgressiveLoan(clientId, loanProductId, "1 September 2019", 1200.0, 0.0, 4, null);
-            disburseLoan(loan, BigDecimal.valueOf(1200.0), "1 September 2019");
-            verifyRepaymentSchedule(loan, //
+            Long loanProductId = createLoanProduct(create4IProgressive());
+            zeroInterestLoanId = applyAndApproveProgressiveLoan(clientId, loanProductId, "1 September 2019", 1200.0, 0.0, 4, null);
+            disburseLoan(zeroInterestLoanId, BigDecimal.valueOf(1200.0), "1 September 2019");
+            verifyRepaymentSchedule(zeroInterestLoanId, //
                     installment(1200.0, null, "01 September 2019"), //
                     installment(300.0, 0.0, 300.0, false, "01 October 2019"), //
                     installment(300.0, 0.0, 300.0, false, "01 November 2019"), //
                     installment(300.0, 0.0, 300.0, false, "01 December 2019"), //
                     installment(300.0, 0.0, 300.0, false, "01 January 2020") //
             );
-            Response<CommandProcessingResult> response = loanTransactionHelper.createInterestPause(loan, "1 October 2019",
-                    "15 December 2019");
-            Assertions.assertEquals(403, response.code());
-            verifyRepaymentSchedule(loan, //
+            assertPauseFails(403, "", () -> loanHelper.createInterestPause(zeroInterestLoanId,
+                    pause("1 October 2019", "15 December 2019", TEXT_DATE_FORMAT)));
+            verifyRepaymentSchedule(zeroInterestLoanId, //
                     installment(1200.0, null, "01 September 2019"), //
                     installment(300.0, 0.0, 300.0, false, "01 October 2019"), //
                     installment(300.0, 0.0, 300.0, false, "01 November 2019"), //
@@ -670,88 +359,56 @@ public class LoanInterestPauseApiTest extends BaseLoanIntegrationTest {
         });
     }
 
-    /**
-     * create a new client
-     **/
-    private void createClientEntity() {
-        this.clientId = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getResourceId();
-        Assertions.assertNotNull(clientId);
-        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientId.intValue());
+    private Long createLoan() {
+        PostLoansRequest request = applyLP2ProgressiveLoanRequest(clientId, loanProductId, LOAN_START_DATE,
+                Double.parseDouble(LOAN_PRINCIPAL_AMOUNT), INTEREST_RATE_PER_PERIOD, NUMBER_OF_REPAYMENTS,
+                r -> r.repaymentEvery(1).repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.DAYS)
+                        .loanTermFrequency(NUMBER_OF_REPAYMENTS).loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.DAYS)
+                        .externalId(externalId));
+        Long newLoanId = applyForLoan(request);
+        approveLoan(newLoanId, approveLoanRequest(Double.parseDouble(LOAN_PRINCIPAL_AMOUNT), LOAN_START_DATE));
+        disburseLoan(newLoanId, new BigDecimal(LOAN_PRINCIPAL_AMOUNT), LOAN_START_DATE);
+        return newLoanId;
     }
 
-    /**
-     * create a new loan product
-     **/
-    private void createLoanProductEntity() {
-        log.info("---------------------------------CREATING LOAN PRODUCT------------------------------------------");
-
-        final String interestRecalculationCompoundingMethod = LoanProductTestBuilder.RECALCULATION_COMPOUNDING_METHOD_NONE;
-        final String rescheduleStrategyMethod = LoanProductTestBuilder.RECALCULATION_STRATEGY_ADJUST_LAST_UNPAID_PERIOD;
-        final String preCloseInterestCalculationStrategy = LoanProductTestBuilder.INTEREST_APPLICABLE_STRATEGY_ON_PRE_CLOSE_DATE;
-
-        final Account assetAccount = ACCOUNT_HELPER.createAssetAccount();
-        final Account incomeAccount = ACCOUNT_HELPER.createIncomeAccount();
-        final Account expenseAccount = ACCOUNT_HELPER.createExpenseAccount();
-        final Account overpaymentAccount = ACCOUNT_HELPER.createLiabilityAccount();
-
-        String futureInstallmentAllocationRule = "NEXT_INSTALLMENT";
-        AdvancedPaymentData defaultAllocation = createDefaultPaymentAllocation(futureInstallmentAllocationRule);
-        String loanProductJSON = new LoanProductTestBuilder().withPrincipal(loanPrincipalAmount).withNumberOfRepayments(numberOfRepayments)
-                .withRepaymentAfterEvery("1").withRepaymentTypeAsMonth().withinterestRatePerPeriod(interestRatePerPeriod)
-                .withInterestRateFrequencyTypeAsYear().withAmortizationTypeAsEqualInstallments().withInterestTypeAsDecliningBalance()
-                .withAccountingRulePeriodicAccrual(new Account[] { assetAccount, incomeAccount, expenseAccount, overpaymentAccount })
-                .withInterestCalculationPeriodTypeAsRepaymentPeriod(true).addAdvancedPaymentAllocation(defaultAllocation)
-                .withLoanScheduleType(LoanScheduleType.PROGRESSIVE).withLoanScheduleProcessingType(LoanScheduleProcessingType.HORIZONTAL)
-                .withMultiDisburse().withDisallowExpectedDisbursements(true).withInterestRecalculationDetails(
-                        interestRecalculationCompoundingMethod, rescheduleStrategyMethod, preCloseInterestCalculationStrategy)
-                .build();
-
-        loanProductId = LOAN_TRANSACTION_HELPER.getLoanProductId(loanProductJSON);
-        log.info("Successfully created loan product  (ID:{}) ", loanProductId);
+    private Long createPauseByLoanId(String startDate, String endDate) {
+        CommandProcessingResult response = loanHelper.createInterestPause(loanId, pause(startDate, endDate));
+        Assertions.assertNotNull(response.getResourceId());
+        return response.getResourceId();
     }
 
-    /**
-     * submit a new loan application, approve and disburse the loan
-     **/
-    private void createLoanEntity() {
-        log.info("---------------------------------NEW LOAN APPLICATION------------------------------------------");
-
-        String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal(loanPrincipalAmount)
-                .withLoanTermFrequency(numberOfRepayments).withLoanTermFrequencyAsDays().withNumberOfRepayments(numberOfRepayments)
-                .withRepaymentEveryAfter("1").withRepaymentFrequencyTypeAsDays().withInterestRatePerPeriod(interestRatePerPeriod)
-                .withInterestTypeAsDecliningBalance().withAmortizationTypeAsEqualInstallments().withInterestCalculationPeriodTypeAsDays()
-                .withExpectedDisbursementDate(dateString).withSubmittedOnDate(dateString).withLoanType("individual")
-                .withExternalId(externalId).withRepaymentStrategy("advanced-payment-allocation-strategy")
-                .build(clientId.toString(), loanProductId.toString(), null);
-
-        loanId = LOAN_TRANSACTION_HELPER.getLoanId(loanApplicationJSON);
-
-        log.info("Sucessfully created loan (ID: {} )", loanId);
-
-        approveLoanApplication();
-        disburseLoan();
+    private Long createPauseByExternalId(String startDate, String endDate) {
+        CommandProcessingResult response = loanHelper.createInterestPauseByExternalId(externalId, pause(startDate, endDate));
+        Assertions.assertNotNull(response.getResourceId());
+        return response.getResourceId();
     }
 
-    /**
-     * approve the loan application
-     **/
-    private void approveLoanApplication() {
-
-        if (loanId != null) {
-            LOAN_TRANSACTION_HELPER.approveLoan(dateString, loanId);
-            log.info("Successfully approved loan (ID: {} )", loanId);
-        }
+    private static InterestPauseRequestDto pause(String startDate, String endDate) {
+        return pause(startDate, endDate, ISO_DATE_FORMAT);
     }
 
-    /**
-     * disburse the newly created loan
-     **/
-    private void disburseLoan() {
+    private static InterestPauseRequestDto pause(String startDate, String endDate, String dateFormat) {
+        return new InterestPauseRequestDto().startDate(startDate).endDate(endDate).dateFormat(dateFormat).locale("en");
+    }
 
-        if (loanId != null) {
-            LOAN_TRANSACTION_HELPER.disburseLoan(externalId, new PostLoansLoanIdRequest().actualDisbursementDate(dateString)
-                    .transactionAmount(new BigDecimal(loanPrincipalAmount)).locale("en").dateFormat("dd MMMM yyyy"));
-            log.info("Successfully disbursed loan (ID: {} )", loanId);
-        }
+    private static void assertPauseFails(int expectedStatus, String expectedError, Executable call) {
+        CallFailedRuntimeException exception = Assertions.assertThrows(CallFailedRuntimeException.class, call);
+        Assertions.assertEquals(expectedStatus, exception.getStatus());
+        Assertions.assertTrue(exception.getMessage().contains(expectedError),
+                "Expected error '" + expectedError + "' but was: " + exception.getMessage());
+    }
+
+    private static void assertContainsPause(List<InterestPauseResponseDto> pauses, String startDate, String endDate) {
+        Assertions
+                .assertTrue(
+                        pauses.stream()
+                                .anyMatch(p -> LocalDate.parse(startDate).equals(p.getStartDate())
+                                        && LocalDate.parse(endDate).equals(p.getEndDate())),
+                        "Expected a pause from " + startDate + " to " + endDate + " but found: " + pauses);
+    }
+
+    private static void assertDoesNotContainPause(List<InterestPauseResponseDto> pauses, Long variationId) {
+        Assertions.assertTrue(pauses.stream().noneMatch(p -> variationId.equals(p.getId())),
+                "Response should not contain the deleted variation ID " + variationId);
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanInterestRecalculationCOBTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanInterestRecalculationCOBTest.java
@@ -18,66 +18,45 @@
  */
 package org.apache.fineract.integrationtests;
 
-import static org.apache.fineract.integrationtests.BaseLoanIntegrationTest.InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD;
-import static org.apache.fineract.integrationtests.BaseLoanIntegrationTest.RepaymentFrequencyType.DAYS;
-import static org.apache.fineract.integrationtests.BaseLoanIntegrationTest.RepaymentFrequencyType.MONTHS;
+import static org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD;
+import static org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.RepaymentFrequencyType.DAYS;
+import static org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.RepaymentFrequencyType.MONTHS;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
+import org.apache.fineract.client.models.GetLoansLoanIdTransactionsTemplateResponse;
 import org.apache.fineract.client.models.PostChargesResponse;
 import org.apache.fineract.client.models.PostClientsResponse;
-import org.apache.fineract.client.models.PostLoanProductsResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdChargesResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsResponse;
-import org.apache.fineract.integrationtests.common.BusinessStepHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignBusinessStepHelper;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.RecalculationRestFrequencyType;
 import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.SchedulerJobHelper;
-import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.apache.fineract.integrationtests.inlinecob.InlineLoanCOBHelper;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 @Slf4j
-public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
+public class LoanInterestRecalculationCOBTest extends FeignLoanTestBase {
 
-    private static ResponseSpecification responseSpec;
-    private static RequestSpecification requestSpec;
-    private static LoanTransactionHelper loanTransactionHelper;
     private static PostClientsResponse client;
-    private static InlineLoanCOBHelper inlineLoanCOBHelper;
-    private static BusinessStepHelper businessStepHelper;
 
     @BeforeAll
     public static void setup() {
-        Utils.initializeRESTAssured();
-        requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        requestSpec.header("Fineract-Platform-TenantId", Utils.DEFAULT_TENANT);
-        responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-        ClientHelper clientHelper = new ClientHelper(requestSpec, responseSpec);
         client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
-        inlineLoanCOBHelper = new InlineLoanCOBHelper(requestSpec, responseSpec);
-        businessStepHelper = new BusinessStepHelper();
         // setup COB Business Steps to prevent test failing due other integration test configurations
-        businessStepHelper.updateSteps("LOAN_CLOSE_OF_BUSINESS", "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION",
-                "CHECK_LOAN_REPAYMENT_DUE", "CHECK_LOAN_REPAYMENT_OVERDUE", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
+        new FeignBusinessStepHelper(FineractFeignClientHelper.getFineractFeignClient()).updateSteps("LOAN_CLOSE_OF_BUSINESS",
+                "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION", "CHECK_LOAN_REPAYMENT_DUE",
+                "CHECK_LOAN_REPAYMENT_OVERDUE", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
                 "EXTERNAL_ASSET_OWNER_TRANSFER", "CHECK_DUE_INSTALLMENTS", "ACCRUAL_ACTIVITY_POSTING", "LOAN_INTEREST_RECALCULATION");
     }
 
@@ -95,37 +74,36 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
     public void testInterestRecalculationInCaseOfTinyAmountOfRepaymentsEveryRepaymentPeriodForProgressiveLoanSameAsRepaymentPeriod() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2023", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(create4IProgressive() //
+            Long loanProduct = createLoanProduct(create4IProgressive() //
                     .recalculationRestFrequencyType(RecalculationRestFrequencyType.SAME_AS_REPAYMENT_PERIOD) //
             );//
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2023", 10000.0,
-                    86.42, 6, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2023", 10000.0, 86.42, 6, null);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(8000), "1 January 2023");
         });
         runAt("1 February 2023", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "Repayment", "1 February 2023", 0.01);
+            makeLoanRepayment(loanId, "Repayment", "1 February 2023", 0.01);
         });
         runAt("1 March 2023", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "Repayment", "1 March 2023", 0.01);
+            makeLoanRepayment(loanId, "Repayment", "1 March 2023", 0.01);
         });
         runAt("1 April 2023", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "Repayment", "1 April 2023", 0.01);
+            makeLoanRepayment(loanId, "Repayment", "1 April 2023", 0.01);
         });
         runAt("1 May 2023", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "Repayment", "1 May 2023", 0.01);
+            makeLoanRepayment(loanId, "Repayment", "1 May 2023", 0.01);
         });
         runAt("1 June 2023", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "Repayment", "1 June 2023", 0.01);
+            makeLoanRepayment(loanId, "Repayment", "1 June 2023", 0.01);
         });
         runAt("17 June 2023", () -> {
             Long loanId = loanIdRef.get();
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
             verifyRepaymentSchedule(loanId, //
                     installment(8000.0, null, "01 January 2023"), //
                     installment(1112.7, 576.13, 1688.78, false, "01 February 2023"), //
@@ -142,17 +120,15 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
     public void verifyLoanInstallmentRecalculatedIfThereIsOverdueInstallmentOn4IProgressiveLoanCOBStepDaily() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2023", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
 
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2023", 8000.0, 10.0,
-                    4, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2023", 8000.0, 10.0, 4, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(8000), "1 January 2023");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -165,9 +141,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("1 February 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -178,9 +154,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("2 February 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -191,9 +167,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("1 March 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -207,12 +183,12 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
 
     private void payoffOnDateAndVerifyStatus(final String date, final Long loanId) {
         runAt(date, () -> {
-            HashMap prepayAmount = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, loanId.intValue());
+            GetLoansLoanIdTransactionsTemplateResponse prepayAmount = getPrepayAmount(loanId, date);
             Assertions.assertNotNull(prepayAmount);
-            Float amount = (Float) prepayAmount.get("amount");
-            PostLoansLoanIdTransactionsResponse response = loanTransactionHelper.makeLoanRepayment(date, amount, loanId.intValue());
+            Double amount = prepayAmount.getAmount();
+            PostLoansLoanIdTransactionsResponse response = makeLoanRepayment(loanId, "Repayment", date, amount);
             Assertions.assertNotNull(response);
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             Assertions.assertNotNull(loanDetails);
             Assertions.assertNotNull(loanDetails.getStatus());
             log.info("Loan status {}", loanDetails.getStatus().getId());
@@ -221,25 +197,23 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
     }
 
     private void executeInterestRecalculationJobs() {
-        SchedulerJobHelper.executeAndAwaitJob("Update Loan Arrears Ageing");
-        SchedulerJobHelper.executeAndAwaitJob("Recalculate Interest For Loans");
+        schedulerHelper.executeAndAwaitJob("Update Loan Arrears Ageing");
+        schedulerHelper.executeAndAwaitJob("Recalculate Interest For Loans");
     }
 
     @Test
     public void verifyLoanInstallmentRecalculatedIfThereIsOverdueInstallmentOn4IProgressiveLoanCOBStepLatePayPayOnDuePayLatePayOnDateDaily() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2023", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
 
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2023", 8000.0, 10.0,
-                    4, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2023", 8000.0, 10.0, 4, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(8000), "1 January 2023");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -251,9 +225,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("20 February 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -265,9 +239,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("1 March 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -275,10 +249,10 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
             validateFullyUnpaidRepaymentPeriod(loanDetails, 3, "01 April 2023", 2008.09, 0.0, 0.0, 33.75);
             validateFullyUnpaidRepaymentPeriod(loanDetails, 4, "01 May 2023", 2041.57, 0.0, 0.0, 17.01);
 
-            loanTransactionHelper.makeLoanRepayment("20 February 2023", 2041.84f, loanId.intValue());
-            loanTransactionHelper.makeLoanRepayment("01 March 2023", 2041.84f, loanId.intValue());
+            makeLoanRepayment(loanId, "repayment", "20 February 2023", 2041.84);
+            makeLoanRepayment(loanId, "repayment", "01 March 2023", 2041.84);
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67, 2041.84);
@@ -289,9 +263,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("10 April 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67, 2041.84);
@@ -299,9 +273,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
             validateFullyUnpaidRepaymentPeriod(loanDetails, 3, "01 April 2023", 2008.14, 0.0, 0.0, 33.7);
             validateFullyUnpaidRepaymentPeriod(loanDetails, 4, "01 May 2023", 2036.23, 0.0, 0.0, 21.99);
 
-            loanTransactionHelper.makeLoanRepayment("10 April 2023", 2041.84f, loanId.intValue());
+            makeLoanRepayment(loanId, "repayment", "10 April 2023", 2041.84);
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67, 2041.84);
@@ -316,17 +290,15 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
     public void verifyLoanInstallmentRecalculatedIfThereIsOverdueInstallmentOn4IProgressiveLoanCOBStepLatePartialRepaymentDailyInterestCalculation() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2023", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
 
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2023", 8000.0, 10.0,
-                    4, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2023", 8000.0, 10.0, 4, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(8000), "1 January 2023");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -338,11 +310,11 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("1 February 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            loanTransactionHelper.makeLoanRepayment("01 February 2023", 2041.84f, loanId.intValue());
+            makeLoanRepayment(loanId, "repayment", "01 February 2023", 2041.84);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -354,9 +326,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("10 March 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -364,9 +336,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
             validateFullyUnpaidRepaymentPeriod(loanDetails, 3, "01 April 2023", 2003.41, 0.0, 0.0, 38.43);
             validateFullyUnpaidRepaymentPeriod(loanDetails, 4, "01 May 2023", 2029.79, 0.0, 0.0, 16.91);
 
-            loanTransactionHelper.makeLoanRepayment("10 March 2023", 500.00f, loanId.intValue());
+            makeLoanRepayment(loanId, "repayment", "10 March 2023", 500.00);
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -375,9 +347,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
             validateFullyUnpaidRepaymentPeriod(loanDetails, 3, "01 April 2023", 2003.41, 0.0, 0.0, 38.43);
             validateFullyUnpaidRepaymentPeriod(loanDetails, 4, "01 May 2023", 2029.79, 0.0, 0.0, 16.91);
 
-            loanTransactionHelper.makeLoanRepayment("10 March 2023", 541.84f, loanId.intValue());
+            makeLoanRepayment(loanId, "repayment", "10 March 2023", 541.84);
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -389,9 +361,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("20 March 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -400,9 +372,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
             validateFullyUnpaidRepaymentPeriod(loanDetails, 3, "01 April 2023", 2000.86, 0.0, 0.0, 40.98);
             validateFullyUnpaidRepaymentPeriod(loanDetails, 4, "01 May 2023", 2032.34, 0.0, 0.0, 16.94);
 
-            loanTransactionHelper.makeLoanRepayment("20 March 2023", 1000f, loanId.intValue());
+            makeLoanRepayment(loanId, "repayment", "20 March 2023", 1000d);
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -417,16 +389,15 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
     public void verifyLoanInstallmentRecalculatedIfThereIsOverdueInstallmentOn4IProgressiveLoanCOBStep() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2023", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(
+            Long loanProduct = createLoanProduct(
                     create4IProgressive().recalculationRestFrequencyType(RecalculationRestFrequencyType.SAME_AS_REPAYMENT_PERIOD));
 
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2023", 8000.0, 10.0,
-                    4, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2023", 8000.0, 10.0, 4, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(8000), "1 January 2023");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -439,9 +410,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("1 February 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -452,9 +423,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("2 February 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -465,9 +436,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("2 March 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -482,16 +453,15 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
     public void verifyLoanInstallmentRecalculatedIfThereIsOverdueInstallmentOn4IProgressiveLoanCOBStepLatePaidPaidOnTimeLatePaidPayoffOnTime() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2023", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(
+            Long loanProduct = createLoanProduct(
                     create4IProgressive().recalculationRestFrequencyType(RecalculationRestFrequencyType.SAME_AS_REPAYMENT_PERIOD));
 
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2023", 8000.0, 10.0,
-                    4, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2023", 8000.0, 10.0, 4, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(8000), "1 January 2023");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -504,9 +474,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("2 February 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -516,8 +486,8 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         });
         runAt("15 February 2023", () -> {
             Long loanId = loanIdRef.get();
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            executeInlineCOB(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -525,9 +495,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
             validateFullyUnpaidRepaymentPeriod(loanDetails, 3, "01 April 2023", 2008.16, 0.0, 0.0, 33.68);
             validateFullyUnpaidRepaymentPeriod(loanDetails, 4, "01 May 2023", 2033.27, 0.0, 0.0, 16.94);
 
-            loanTransactionHelper.makeLoanRepayment("15 February 2023", 500.0F, loanId.intValue());
+            makeLoanRepayment(loanId, "repayment", "15 February 2023", 500.0d);
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 1975.17, 500, 1475.17, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 66.67, 0,
@@ -536,9 +506,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
             validateFullyUnpaidRepaymentPeriod(loanDetails, 3, "01 April 2023", 2008.16, 0.0, 0.0, 33.68);
             validateFullyUnpaidRepaymentPeriod(loanDetails, 4, "01 May 2023", 2033.27, 0.0, 0.0, 16.94);
 
-            loanTransactionHelper.makeLoanRepayment("15 February 2023", 500f, loanId.intValue());
+            makeLoanRepayment(loanId, "repayment", "15 February 2023", 500d);
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 1975.17, 1000, 975.17, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 66.67, 0,
@@ -551,9 +521,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("20 February 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            loanTransactionHelper.makeLoanRepayment("20 February 2023", 1041.84f, loanId.intValue());
+            makeLoanRepayment(loanId, "repayment", "20 February 2023", 1041.84);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67, 2041.84);
@@ -565,11 +535,11 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("1 March 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            loanTransactionHelper.makeLoanRepayment("01 March 2023", 2041.84f, loanId.intValue());
+            makeLoanRepayment(loanId, "repayment", "01 March 2023", 2041.84);
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67, 2041.84);
@@ -580,9 +550,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("2 April 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 1975.17, 1975.17, 0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 66.67,
@@ -594,12 +564,12 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("1 May 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            loanTransactionHelper.makeLoanRepayment("15 April 2023", 2041.84f, loanId.intValue());
-            loanTransactionHelper.makeLoanRepayment("01 May 2023", 2075.32f, loanId.intValue());
+            makeLoanRepayment(loanId, "repayment", "15 April 2023", 2041.84);
+            makeLoanRepayment(loanId, "repayment", "01 May 2023", 2075.32);
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 1975.17, 1975.17, 0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 66.67,
@@ -615,17 +585,16 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
     public void verifyEarlyLateRepaymentOnProgressiveLoanNextInstallmentAllocationRepayLessThenEmi() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2024", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(create4IProgressive() //
+            Long loanProduct = createLoanProduct(create4IProgressive() //
                     .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
 
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2024", 100.0, 7.0, 6,
-                    null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2024", 100.0, 7.0, 6, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(100), "1 January 2024");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2024", 16.43, 0.0, 0.0, 0.58);
@@ -639,11 +608,11 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("15 February 2024", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            loanTransactionHelper.makeLoanRepayment("15 February 2024", 15.0F, loanId.intValue());
+            makeLoanRepayment(loanId, "repayment", "15 February 2024", 15.0d);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 1), 16.43, 15.0, 1.43, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.58, 0,
@@ -660,17 +629,16 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
     public void verifyChargeCreationAfterMaturityDateOnInterestBearingProgressiveLoan() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2024", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(create4IProgressive() //
+            Long loanProduct = createLoanProduct(create4IProgressive() //
                     .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
                     .currencyCode("USD"));
 
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2024", 100.0, 7.0, 6,
-                    null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2024", 100.0, 7.0, 6, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(100), "1 January 2024");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2024", 16.43, 0.0, 0.0, 0.58);
@@ -684,7 +652,7 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("10 July 2024", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
             // create charge
             PostChargesResponse chargeResult = createCharge(10.0);
@@ -697,7 +665,7 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
             Assertions.assertNotNull(loanChargeResult.getResourceId());
 
             // verify N+1 installment in schedule
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2024", 16.43, 0.0, 0.0, 0.58);
@@ -714,8 +682,8 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("15 July 2024", () -> {
             Long loanId = loanIdRef.get();
 
-            loanTransactionHelper.makeLoanRepayment("15 July 2024", 113.48F, loanId.intValue());
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            makeLoanRepayment(loanId, "repayment", "15 July 2024", 113.48d);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2024", 16.43, 0.0, 0.0, 0.58, 17.01);
@@ -743,7 +711,7 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
             Assertions.assertNotNull(loanChargeResult.getResourceId());
 
             // verify N+1 installment in schedule
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2024", 16.43, 0.0, 0.0, 0.58, 17.01);
@@ -761,8 +729,8 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("20 July 2024", () -> {
             Long loanId = loanIdRef.get();
 
-            loanTransactionHelper.makeLoanRepayment("20 July 2024", 15.0F, loanId.intValue());
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            makeLoanRepayment(loanId, "repayment", "20 July 2024", 15.0d);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2024", 16.43, 0.0, 0.0, 0.58, 17.01);
@@ -782,17 +750,16 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
     public void verifyEarlyLateRepaymentOnProgressiveLoanNextInstallmentAllocationRepayEmi() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2024", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(create4IProgressive() //
+            Long loanProduct = createLoanProduct(create4IProgressive() //
                     .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
 
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2024", 100.0, 7.0, 6,
-                    null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2024", 100.0, 7.0, 6, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(100), "1 January 2024");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2024", 16.43, 0.0, 0.0, 0.58);
@@ -806,11 +773,11 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("15 February 2024", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            loanTransactionHelper.makeLoanRepayment("15 February 2024", 17.01F, loanId.intValue());
+            makeLoanRepayment(loanId, "repayment", "15 February 2024", 17.01d);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2024", 16.43, 0.0, 0.0, 0.58, 17.01);
@@ -826,16 +793,15 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
     public void verifyLoanInstallmentRecalculatedIfThereIsOverdueInstallmentOn4IProgressiveLoanCOBStepOnePaid() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2023", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(
+            Long loanProduct = createLoanProduct(
                     create4IProgressive().recalculationRestFrequencyType(RecalculationRestFrequencyType.SAME_AS_REPAYMENT_PERIOD));
 
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2023", 8000.0, 10.0,
-                    4, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2023", 8000.0, 10.0, 4, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(8000), "1 January 2023");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -848,11 +814,11 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("1 February 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            loanTransactionHelper.makeLoanRepayment("01 February 2023", 2041.84f, loanId.intValue());
+            makeLoanRepayment(loanId, "repayment", "01 February 2023", 2041.84);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -863,9 +829,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("1 March 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -876,9 +842,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("2 March 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -893,13 +859,12 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
     public void verifyLoanInstallmentRecalculatedIfThereIsOverdueInstallmentOnCumulativeLoanCOBStep() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2023", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(createOnePeriod30DaysPeriodicAccrualProduct(10.0)
-                    .isInterestRecalculationEnabled(true)//
+            Long loanProduct = createLoanProduct(createOnePeriod30DaysPeriodicAccrualProduct(10.0).isInterestRecalculationEnabled(true)//
                     .maxPrincipal(10000.0).minNumberOfRepayments(1).rescheduleStrategyMethod(1).recalculationRestFrequencyType(MONTHS)
                     .recalculationRestFrequencyInterval(1).recalculationCompoundingFrequencyType(MONTHS)
                     .recalculationCompoundingFrequencyInterval(30).interestRecalculationCompoundingMethod(1));
 
-            Long loanId = applyAndApproveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2023", 8000.0, 2,
+            Long loanId = applyAndApproveLoan(client.getClientId(), loanProduct, "1 January 2023", 8000.0, 2,
                     postLoansRequest -> postLoansRequest.loanTermFrequency(2)//
                             .loanTermFrequencyType(MONTHS)//
                             .interestRatePerPeriod(BigDecimal.valueOf(10.0)).interestCalculationPeriodType(DAYS)//
@@ -910,7 +875,7 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
 
             disburseLoan(loanId, BigDecimal.valueOf(8000), "1 January 2023");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
 
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 3783.06, 0.0, 3783.06, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 817.94,
                     0.0, 817.94, 0.0, 0.0);
@@ -920,9 +885,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("2 February 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
 
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 3783.06, 0.0, 3783.06, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 817.94,
                     0.0, 817.94, 0.0, 0.0);
@@ -936,11 +901,10 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
     public void verifyLoanInstallmentRecalculatedIfThereIsOverdueInstallmentOnProgressiveLoanJob() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2023", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(
+            Long loanProduct = createLoanProduct(
                     create4IProgressive().recalculationRestFrequencyType(RecalculationRestFrequencyType.SAME_AS_REPAYMENT_PERIOD));
 
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2023", 8000.0, 10.0,
-                    4, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2023", 8000.0, 10.0, 4, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(8000), "1 January 2023");
@@ -952,7 +916,7 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
 
             executeInterestRecalculationJobs();
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -967,18 +931,17 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
     public void verifyLoanInstallmentRecalculatedIfThereIsOverdueInstallmentOnCumulativeLoanJob() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2023", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(createOnePeriod30DaysPeriodicAccrualProduct(10.0).isInterestRecalculationEnabled(true)//
-                            .maxPrincipal(10000.0) //
-                            .minNumberOfRepayments(1) //
-                            .rescheduleStrategyMethod(1) //
-                            .recalculationRestFrequencyType(MONTHS) //
-                            .recalculationRestFrequencyInterval(1) //
-                            .recalculationCompoundingFrequencyType(MONTHS) //
-                            .recalculationCompoundingFrequencyInterval(30) //
-                            .interestRecalculationCompoundingMethod(1)); //
+            Long loanProduct = createLoanProduct(createOnePeriod30DaysPeriodicAccrualProduct(10.0).isInterestRecalculationEnabled(true)//
+                    .maxPrincipal(10000.0) //
+                    .minNumberOfRepayments(1) //
+                    .rescheduleStrategyMethod(1) //
+                    .recalculationRestFrequencyType(MONTHS) //
+                    .recalculationRestFrequencyInterval(1) //
+                    .recalculationCompoundingFrequencyType(MONTHS) //
+                    .recalculationCompoundingFrequencyInterval(30) //
+                    .interestRecalculationCompoundingMethod(1)); //
 
-            Long loanId = applyAndApproveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2023", 8000.0, 2,
+            Long loanId = applyAndApproveLoan(client.getClientId(), loanProduct, "1 January 2023", 8000.0, 2,
                     postLoansRequest -> postLoansRequest.loanTermFrequency(2)//
                             .loanTermFrequencyType(MONTHS)//
                             .interestRatePerPeriod(BigDecimal.valueOf(10.0)).interestCalculationPeriodType(DAYS)//
@@ -995,7 +958,7 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
 
             executeInterestRecalculationJobs();
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
 
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 3783.06, 0.0, 3783.06, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 817.94,
                     0.0, 817.94, 0.0, 0.0);
@@ -1010,15 +973,14 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
     public void verifyLoanInstallmentRecalculatedIfThereIsOverdueInstallmentOn4IProgressiveLoanMultiOverdueSingleRepayment() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2023", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(create4IProgressive());
+            Long loanProduct = createLoanProduct(create4IProgressive());
 
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2023", 8000.0, 10.0,
-                    4, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2023", 8000.0, 10.0, 4, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(8000), "1 January 2023");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -1030,9 +992,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("1 March 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            loanTransactionHelper.makeLoanRepayment("01 March 2023", 4083.68f, loanId.intValue());
+            makeLoanRepayment(loanId, "repayment", "01 March 2023", 4083.68);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67, 2041.84);
@@ -1048,21 +1010,20 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
     public void verifyLoanInstallmentRecalculatedIfThereIsOverdueInstallmentOnCumulativeLoanJobSameAsRepaymentPeriod() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2023", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(createOnePeriod30DaysPeriodicAccrualProduct(10.0).isInterestRecalculationEnabled(true)//
-                            .maxPrincipal(10000.0) //
-                            .minNumberOfRepayments(1) //
-                            .maxNumberOfRepayments(10) //
-                            .rescheduleStrategyMethod(1) //
-                            .daysInYearType(360) //
-                            .daysInMonthType(30) //
-                            .recalculationRestFrequencyType(SAME_AS_REPAYMENT_PERIOD) //
-                            .recalculationRestFrequencyInterval(1) //
-                            .recalculationCompoundingFrequencyType(1) //
-                            .recalculationCompoundingFrequencyInterval(1) //
-                            .interestRecalculationCompoundingMethod(0)); //
+            Long loanProduct = createLoanProduct(createOnePeriod30DaysPeriodicAccrualProduct(10.0).isInterestRecalculationEnabled(true)//
+                    .maxPrincipal(10000.0) //
+                    .minNumberOfRepayments(1) //
+                    .maxNumberOfRepayments(10) //
+                    .rescheduleStrategyMethod(1) //
+                    .daysInYearType(360) //
+                    .daysInMonthType(30) //
+                    .recalculationRestFrequencyType(SAME_AS_REPAYMENT_PERIOD) //
+                    .recalculationRestFrequencyInterval(1) //
+                    .recalculationCompoundingFrequencyType(1) //
+                    .recalculationCompoundingFrequencyInterval(1) //
+                    .interestRecalculationCompoundingMethod(0)); //
 
-            Long loanId = applyAndApproveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2023", 8000.0, 2,
+            Long loanId = applyAndApproveLoan(client.getClientId(), loanProduct, "1 January 2023", 8000.0, 2,
                     postLoansRequest -> postLoansRequest.loanTermFrequency(4)//
                             .loanTermFrequencyType(MONTHS)//
                             .numberOfRepayments(4).interestRatePerPeriod(BigDecimal.valueOf(10.0)).interestCalculationPeriodType(DAYS)//
@@ -1073,7 +1034,7 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
 
             disburseLoan(loanId, BigDecimal.valueOf(8000), "1 January 2023");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1724.0, 0.0, 0.0, 800.0);
@@ -1086,7 +1047,7 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
 
             executeInterestRecalculationJobs();
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1724.0, 0.0, 0.0, 800.0);
@@ -1101,21 +1062,20 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
     public void verifyLoanInstallmentRecalculatedIfThereIsOverdueInstallmentOnCumulativeLoanCOBSameAsRepaymentPeriod() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2023", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(createOnePeriod30DaysPeriodicAccrualProduct(10.0).isInterestRecalculationEnabled(true)//
-                            .maxPrincipal(10000.0) //
-                            .minNumberOfRepayments(1) //
-                            .maxNumberOfRepayments(10) //
-                            .rescheduleStrategyMethod(1) //
-                            .daysInYearType(360) //
-                            .daysInMonthType(30) //
-                            .recalculationRestFrequencyType(SAME_AS_REPAYMENT_PERIOD) //
-                            .recalculationRestFrequencyInterval(1) //
-                            .recalculationCompoundingFrequencyType(1) //
-                            .recalculationCompoundingFrequencyInterval(1) //
-                            .interestRecalculationCompoundingMethod(0)); //
+            Long loanProduct = createLoanProduct(createOnePeriod30DaysPeriodicAccrualProduct(10.0).isInterestRecalculationEnabled(true)//
+                    .maxPrincipal(10000.0) //
+                    .minNumberOfRepayments(1) //
+                    .maxNumberOfRepayments(10) //
+                    .rescheduleStrategyMethod(1) //
+                    .daysInYearType(360) //
+                    .daysInMonthType(30) //
+                    .recalculationRestFrequencyType(SAME_AS_REPAYMENT_PERIOD) //
+                    .recalculationRestFrequencyInterval(1) //
+                    .recalculationCompoundingFrequencyType(1) //
+                    .recalculationCompoundingFrequencyInterval(1) //
+                    .interestRecalculationCompoundingMethod(0)); //
 
-            Long loanId = applyAndApproveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2023", 8000.0, 2,
+            Long loanId = applyAndApproveLoan(client.getClientId(), loanProduct, "1 January 2023", 8000.0, 2,
                     postLoansRequest -> postLoansRequest.loanTermFrequency(4)//
                             .loanTermFrequencyType(MONTHS)//
                             .numberOfRepayments(4).interestRatePerPeriod(BigDecimal.valueOf(10.0)).interestCalculationPeriodType(DAYS)//
@@ -1126,7 +1086,7 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
 
             disburseLoan(loanId, BigDecimal.valueOf(8000), "1 January 2023");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1724.0, 0.0, 0.0, 800.0);
@@ -1137,9 +1097,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("8 February 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1724.0, 0.0, 0.0, 800.0);
@@ -1154,19 +1114,17 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
     public void verifyEarlyLateRepaymentOnProgressiveLoanThePastDueHasNoEffect() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2024", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper //
-                    .createLoanProduct(create4IProgressive() //
-                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
-                            .disallowInterestCalculationOnPastDue(true) //
+            Long loanProduct = createLoanProduct(create4IProgressive() //
+                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+                    .disallowInterestCalculationOnPastDue(true) //
             );
 
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2024", 100.0, 7.0, 6,
-                    null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2024", 100.0, 7.0, 6, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(100), "1 January 2024");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2024", 16.43, 0.0, 0.0, 0.58);
@@ -1180,10 +1138,10 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("15 February 2024", () -> { // we have past due and should not count extra interest
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
-            loanTransactionHelper.makeLoanRepayment("15 February 2024", 15.0F, loanId.intValue());
+            executeInlineCOB(loanId);
+            makeLoanRepayment(loanId, "repayment", "15 February 2024", 15.0d);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 1), 16.43, 15.0, 1.43, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.58, 0,
@@ -1197,10 +1155,10 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("15 February 2024", () -> { // we turn from past due into early repayment and should have less interest
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
-            loanTransactionHelper.makeLoanRepayment("15 February 2024", 19.02F, loanId.intValue());
+            executeInlineCOB(loanId);
+            makeLoanRepayment(loanId, "repayment", "15 February 2024", 19.02d);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 1), 16.43, 16.43, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.58, 0.58,

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanInterestRecalculationCOBTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanInterestRecalculationCOBTest.java
@@ -18,68 +18,45 @@
  */
 package org.apache.fineract.integrationtests;
 
-import static org.apache.fineract.integrationtests.BaseLoanIntegrationTest.InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD;
-import static org.apache.fineract.integrationtests.BaseLoanIntegrationTest.RepaymentFrequencyType.DAYS;
-import static org.apache.fineract.integrationtests.BaseLoanIntegrationTest.RepaymentFrequencyType.MONTHS;
+import static org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD;
+import static org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.RepaymentFrequencyType.DAYS;
+import static org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.RepaymentFrequencyType.MONTHS;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
+import org.apache.fineract.client.models.GetLoansLoanIdTransactionsTemplateResponse;
 import org.apache.fineract.client.models.PostChargesResponse;
 import org.apache.fineract.client.models.PostClientsResponse;
-import org.apache.fineract.client.models.PostLoanProductsResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdChargesResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsResponse;
-import org.apache.fineract.integrationtests.common.BusinessStepHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignBusinessStepHelper;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.RecalculationRestFrequencyType;
 import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.SchedulerJobHelper;
-import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.apache.fineract.integrationtests.inlinecob.InlineLoanCOBHelper;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 @Slf4j
-public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
+public class LoanInterestRecalculationCOBTest extends FeignLoanTestBase {
 
-    private static ResponseSpecification responseSpec;
-    private static RequestSpecification requestSpec;
-    private static LoanTransactionHelper loanTransactionHelper;
     private static PostClientsResponse client;
-    private static InlineLoanCOBHelper inlineLoanCOBHelper;
-    private static BusinessStepHelper businessStepHelper;
-    private static SchedulerJobHelper schedulerJobHelper;
 
     @BeforeAll
     public static void setup() {
-        Utils.initializeRESTAssured();
-        requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        requestSpec.header("Fineract-Platform-TenantId", Utils.DEFAULT_TENANT);
-        responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-        schedulerJobHelper = new SchedulerJobHelper(requestSpec);
-        ClientHelper clientHelper = new ClientHelper(requestSpec, responseSpec);
         client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
-        inlineLoanCOBHelper = new InlineLoanCOBHelper(requestSpec, responseSpec);
-        businessStepHelper = new BusinessStepHelper();
         // setup COB Business Steps to prevent test failing due other integration test configurations
-        businessStepHelper.updateSteps("LOAN_CLOSE_OF_BUSINESS", "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION",
-                "CHECK_LOAN_REPAYMENT_DUE", "CHECK_LOAN_REPAYMENT_OVERDUE", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
+        new FeignBusinessStepHelper(FineractFeignClientHelper.getFineractFeignClient()).updateSteps("LOAN_CLOSE_OF_BUSINESS",
+                "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION", "CHECK_LOAN_REPAYMENT_DUE",
+                "CHECK_LOAN_REPAYMENT_OVERDUE", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
                 "EXTERNAL_ASSET_OWNER_TRANSFER", "CHECK_DUE_INSTALLMENTS", "ACCRUAL_ACTIVITY_POSTING", "LOAN_INTEREST_RECALCULATION");
     }
 
@@ -97,37 +74,36 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
     public void testInterestRecalculationInCaseOfTinyAmountOfRepaymentsEveryRepaymentPeriodForProgressiveLoanSameAsRepaymentPeriod() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2023", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(create4IProgressive() //
+            Long loanProduct = createLoanProduct(create4IProgressive() //
                     .recalculationRestFrequencyType(RecalculationRestFrequencyType.SAME_AS_REPAYMENT_PERIOD) //
             );//
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2023", 10000.0,
-                    86.42, 6, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2023", 10000.0, 86.42, 6, null);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(8000), "1 January 2023");
         });
         runAt("1 February 2023", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "Repayment", "1 February 2023", 0.01);
+            makeLoanRepayment(loanId, "Repayment", "1 February 2023", 0.01);
         });
         runAt("1 March 2023", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "Repayment", "1 March 2023", 0.01);
+            makeLoanRepayment(loanId, "Repayment", "1 March 2023", 0.01);
         });
         runAt("1 April 2023", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "Repayment", "1 April 2023", 0.01);
+            makeLoanRepayment(loanId, "Repayment", "1 April 2023", 0.01);
         });
         runAt("1 May 2023", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "Repayment", "1 May 2023", 0.01);
+            makeLoanRepayment(loanId, "Repayment", "1 May 2023", 0.01);
         });
         runAt("1 June 2023", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "Repayment", "1 June 2023", 0.01);
+            makeLoanRepayment(loanId, "Repayment", "1 June 2023", 0.01);
         });
         runAt("17 June 2023", () -> {
             Long loanId = loanIdRef.get();
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
             verifyRepaymentSchedule(loanId, //
                     installment(8000.0, null, "01 January 2023"), //
                     installment(1112.7, 576.13, 1688.78, false, "01 February 2023"), //
@@ -144,17 +120,15 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
     public void verifyLoanInstallmentRecalculatedIfThereIsOverdueInstallmentOn4IProgressiveLoanCOBStepDaily() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2023", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
 
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2023", 8000.0, 10.0,
-                    4, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2023", 8000.0, 10.0, 4, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(8000), "1 January 2023");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -167,9 +141,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("1 February 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -180,9 +154,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("2 February 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -193,9 +167,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("1 March 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -209,12 +183,12 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
 
     private void payoffOnDateAndVerifyStatus(final String date, final Long loanId) {
         runAt(date, () -> {
-            HashMap prepayAmount = loanTransactionHelper.getPrepayAmount(requestSpec, responseSpec, loanId.intValue());
+            GetLoansLoanIdTransactionsTemplateResponse prepayAmount = getPrepayAmount(loanId, date);
             Assertions.assertNotNull(prepayAmount);
-            Float amount = (Float) prepayAmount.get("amount");
-            PostLoansLoanIdTransactionsResponse response = loanTransactionHelper.makeLoanRepayment(date, amount, loanId.intValue());
+            Double amount = prepayAmount.getAmount();
+            PostLoansLoanIdTransactionsResponse response = makeLoanRepayment(loanId, "Repayment", date, amount);
             Assertions.assertNotNull(response);
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             Assertions.assertNotNull(loanDetails);
             Assertions.assertNotNull(loanDetails.getStatus());
             log.info("Loan status {}", loanDetails.getStatus().getId());
@@ -223,25 +197,23 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
     }
 
     private void executeInterestRecalculationJobs() {
-        schedulerJobHelper.executeAndAwaitJob("Update Loan Arrears Ageing");
-        schedulerJobHelper.executeAndAwaitJob("Recalculate Interest For Loans");
+        schedulerHelper.executeAndAwaitJob("Update Loan Arrears Ageing");
+        schedulerHelper.executeAndAwaitJob("Recalculate Interest For Loans");
     }
 
     @Test
     public void verifyLoanInstallmentRecalculatedIfThereIsOverdueInstallmentOn4IProgressiveLoanCOBStepLatePayPayOnDuePayLatePayOnDateDaily() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2023", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
 
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2023", 8000.0, 10.0,
-                    4, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2023", 8000.0, 10.0, 4, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(8000), "1 January 2023");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -253,9 +225,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("20 February 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -267,9 +239,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("1 March 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -277,10 +249,10 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
             validateFullyUnpaidRepaymentPeriod(loanDetails, 3, "01 April 2023", 2008.09, 0.0, 0.0, 33.75);
             validateFullyUnpaidRepaymentPeriod(loanDetails, 4, "01 May 2023", 2041.57, 0.0, 0.0, 17.01);
 
-            loanTransactionHelper.makeLoanRepayment("20 February 2023", 2041.84f, loanId.intValue());
-            loanTransactionHelper.makeLoanRepayment("01 March 2023", 2041.84f, loanId.intValue());
+            makeLoanRepayment(loanId, "repayment", "20 February 2023", 2041.84);
+            makeLoanRepayment(loanId, "repayment", "01 March 2023", 2041.84);
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67, 2041.84);
@@ -291,9 +263,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("10 April 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67, 2041.84);
@@ -301,9 +273,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
             validateFullyUnpaidRepaymentPeriod(loanDetails, 3, "01 April 2023", 2008.14, 0.0, 0.0, 33.7);
             validateFullyUnpaidRepaymentPeriod(loanDetails, 4, "01 May 2023", 2036.23, 0.0, 0.0, 21.99);
 
-            loanTransactionHelper.makeLoanRepayment("10 April 2023", 2041.84f, loanId.intValue());
+            makeLoanRepayment(loanId, "repayment", "10 April 2023", 2041.84);
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67, 2041.84);
@@ -318,17 +290,15 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
     public void verifyLoanInstallmentRecalculatedIfThereIsOverdueInstallmentOn4IProgressiveLoanCOBStepLatePartialRepaymentDailyInterestCalculation() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2023", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
 
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2023", 8000.0, 10.0,
-                    4, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2023", 8000.0, 10.0, 4, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(8000), "1 January 2023");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -340,11 +310,11 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("1 February 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            loanTransactionHelper.makeLoanRepayment("01 February 2023", 2041.84f, loanId.intValue());
+            makeLoanRepayment(loanId, "repayment", "01 February 2023", 2041.84);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -356,9 +326,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("10 March 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -366,9 +336,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
             validateFullyUnpaidRepaymentPeriod(loanDetails, 3, "01 April 2023", 2003.41, 0.0, 0.0, 38.43);
             validateFullyUnpaidRepaymentPeriod(loanDetails, 4, "01 May 2023", 2029.79, 0.0, 0.0, 16.91);
 
-            loanTransactionHelper.makeLoanRepayment("10 March 2023", 500.00f, loanId.intValue());
+            makeLoanRepayment(loanId, "repayment", "10 March 2023", 500.00);
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -377,9 +347,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
             validateFullyUnpaidRepaymentPeriod(loanDetails, 3, "01 April 2023", 2003.41, 0.0, 0.0, 38.43);
             validateFullyUnpaidRepaymentPeriod(loanDetails, 4, "01 May 2023", 2029.79, 0.0, 0.0, 16.91);
 
-            loanTransactionHelper.makeLoanRepayment("10 March 2023", 541.84f, loanId.intValue());
+            makeLoanRepayment(loanId, "repayment", "10 March 2023", 541.84);
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -391,9 +361,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("20 March 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -402,9 +372,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
             validateFullyUnpaidRepaymentPeriod(loanDetails, 3, "01 April 2023", 2000.86, 0.0, 0.0, 40.98);
             validateFullyUnpaidRepaymentPeriod(loanDetails, 4, "01 May 2023", 2032.34, 0.0, 0.0, 16.94);
 
-            loanTransactionHelper.makeLoanRepayment("20 March 2023", 1000f, loanId.intValue());
+            makeLoanRepayment(loanId, "repayment", "20 March 2023", 1000d);
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -419,16 +389,15 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
     public void verifyLoanInstallmentRecalculatedIfThereIsOverdueInstallmentOn4IProgressiveLoanCOBStep() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2023", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(
+            Long loanProduct = createLoanProduct(
                     create4IProgressive().recalculationRestFrequencyType(RecalculationRestFrequencyType.SAME_AS_REPAYMENT_PERIOD));
 
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2023", 8000.0, 10.0,
-                    4, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2023", 8000.0, 10.0, 4, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(8000), "1 January 2023");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -441,9 +410,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("1 February 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -454,9 +423,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("2 February 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -467,9 +436,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("2 March 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -484,16 +453,15 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
     public void verifyLoanInstallmentRecalculatedIfThereIsOverdueInstallmentOn4IProgressiveLoanCOBStepLatePaidPaidOnTimeLatePaidPayoffOnTime() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2023", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(
+            Long loanProduct = createLoanProduct(
                     create4IProgressive().recalculationRestFrequencyType(RecalculationRestFrequencyType.SAME_AS_REPAYMENT_PERIOD));
 
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2023", 8000.0, 10.0,
-                    4, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2023", 8000.0, 10.0, 4, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(8000), "1 January 2023");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -506,9 +474,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("2 February 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -518,8 +486,8 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         });
         runAt("15 February 2023", () -> {
             Long loanId = loanIdRef.get();
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            executeInlineCOB(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -527,9 +495,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
             validateFullyUnpaidRepaymentPeriod(loanDetails, 3, "01 April 2023", 2008.16, 0.0, 0.0, 33.68);
             validateFullyUnpaidRepaymentPeriod(loanDetails, 4, "01 May 2023", 2033.27, 0.0, 0.0, 16.94);
 
-            loanTransactionHelper.makeLoanRepayment("15 February 2023", 500.0F, loanId.intValue());
+            makeLoanRepayment(loanId, "repayment", "15 February 2023", 500.0d);
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 1975.17, 500, 1475.17, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 66.67, 0,
@@ -538,9 +506,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
             validateFullyUnpaidRepaymentPeriod(loanDetails, 3, "01 April 2023", 2008.16, 0.0, 0.0, 33.68);
             validateFullyUnpaidRepaymentPeriod(loanDetails, 4, "01 May 2023", 2033.27, 0.0, 0.0, 16.94);
 
-            loanTransactionHelper.makeLoanRepayment("15 February 2023", 500f, loanId.intValue());
+            makeLoanRepayment(loanId, "repayment", "15 February 2023", 500d);
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 1975.17, 1000, 975.17, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 66.67, 0,
@@ -553,9 +521,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("20 February 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            loanTransactionHelper.makeLoanRepayment("20 February 2023", 1041.84f, loanId.intValue());
+            makeLoanRepayment(loanId, "repayment", "20 February 2023", 1041.84);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67, 2041.84);
@@ -567,11 +535,11 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("1 March 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            loanTransactionHelper.makeLoanRepayment("01 March 2023", 2041.84f, loanId.intValue());
+            makeLoanRepayment(loanId, "repayment", "01 March 2023", 2041.84);
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67, 2041.84);
@@ -582,9 +550,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("2 April 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 1975.17, 1975.17, 0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 66.67,
@@ -596,12 +564,12 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("1 May 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            loanTransactionHelper.makeLoanRepayment("15 April 2023", 2041.84f, loanId.intValue());
-            loanTransactionHelper.makeLoanRepayment("01 May 2023", 2075.32f, loanId.intValue());
+            makeLoanRepayment(loanId, "repayment", "15 April 2023", 2041.84);
+            makeLoanRepayment(loanId, "repayment", "01 May 2023", 2075.32);
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 1975.17, 1975.17, 0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 66.67,
@@ -617,17 +585,16 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
     public void verifyEarlyLateRepaymentOnProgressiveLoanNextInstallmentAllocationRepayLessThenEmi() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2024", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(create4IProgressive() //
+            Long loanProduct = createLoanProduct(create4IProgressive() //
                     .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
 
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2024", 100.0, 7.0, 6,
-                    null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2024", 100.0, 7.0, 6, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(100), "1 January 2024");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2024", 16.43, 0.0, 0.0, 0.58);
@@ -641,11 +608,11 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("15 February 2024", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            loanTransactionHelper.makeLoanRepayment("15 February 2024", 15.0F, loanId.intValue());
+            makeLoanRepayment(loanId, "repayment", "15 February 2024", 15.0d);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 1), 16.43, 15.0, 1.43, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.58, 0,
@@ -662,17 +629,16 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
     public void verifyChargeCreationAfterMaturityDateOnInterestBearingProgressiveLoan() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2024", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(create4IProgressive() //
+            Long loanProduct = createLoanProduct(create4IProgressive() //
                     .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
                     .currencyCode("USD"));
 
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2024", 100.0, 7.0, 6,
-                    null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2024", 100.0, 7.0, 6, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(100), "1 January 2024");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2024", 16.43, 0.0, 0.0, 0.58);
@@ -686,7 +652,7 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("10 July 2024", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
             // create charge
             PostChargesResponse chargeResult = createCharge(10.0);
@@ -699,7 +665,7 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
             Assertions.assertNotNull(loanChargeResult.getResourceId());
 
             // verify N+1 installment in schedule
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2024", 16.43, 0.0, 0.0, 0.58);
@@ -716,8 +682,8 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("15 July 2024", () -> {
             Long loanId = loanIdRef.get();
 
-            loanTransactionHelper.makeLoanRepayment("15 July 2024", 113.48F, loanId.intValue());
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            makeLoanRepayment(loanId, "repayment", "15 July 2024", 113.48d);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2024", 16.43, 0.0, 0.0, 0.58, 17.01);
@@ -745,7 +711,7 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
             Assertions.assertNotNull(loanChargeResult.getResourceId());
 
             // verify N+1 installment in schedule
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2024", 16.43, 0.0, 0.0, 0.58, 17.01);
@@ -763,8 +729,8 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("20 July 2024", () -> {
             Long loanId = loanIdRef.get();
 
-            loanTransactionHelper.makeLoanRepayment("20 July 2024", 15.0F, loanId.intValue());
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            makeLoanRepayment(loanId, "repayment", "20 July 2024", 15.0d);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2024", 16.43, 0.0, 0.0, 0.58, 17.01);
@@ -784,17 +750,16 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
     public void verifyEarlyLateRepaymentOnProgressiveLoanNextInstallmentAllocationRepayEmi() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2024", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(create4IProgressive() //
+            Long loanProduct = createLoanProduct(create4IProgressive() //
                     .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
 
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2024", 100.0, 7.0, 6,
-                    null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2024", 100.0, 7.0, 6, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(100), "1 January 2024");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2024", 16.43, 0.0, 0.0, 0.58);
@@ -808,11 +773,11 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("15 February 2024", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            loanTransactionHelper.makeLoanRepayment("15 February 2024", 17.01F, loanId.intValue());
+            makeLoanRepayment(loanId, "repayment", "15 February 2024", 17.01d);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2024", 16.43, 0.0, 0.0, 0.58, 17.01);
@@ -828,16 +793,15 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
     public void verifyLoanInstallmentRecalculatedIfThereIsOverdueInstallmentOn4IProgressiveLoanCOBStepOnePaid() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2023", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(
+            Long loanProduct = createLoanProduct(
                     create4IProgressive().recalculationRestFrequencyType(RecalculationRestFrequencyType.SAME_AS_REPAYMENT_PERIOD));
 
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2023", 8000.0, 10.0,
-                    4, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2023", 8000.0, 10.0, 4, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(8000), "1 January 2023");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -850,11 +814,11 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("1 February 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            loanTransactionHelper.makeLoanRepayment("01 February 2023", 2041.84f, loanId.intValue());
+            makeLoanRepayment(loanId, "repayment", "01 February 2023", 2041.84);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -865,9 +829,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("1 March 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -878,9 +842,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("2 March 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -895,13 +859,12 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
     public void verifyLoanInstallmentRecalculatedIfThereIsOverdueInstallmentOnCumulativeLoanCOBStep() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2023", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(createOnePeriod30DaysPeriodicAccrualProduct(10.0)
-                    .isInterestRecalculationEnabled(true)//
+            Long loanProduct = createLoanProduct(createOnePeriod30DaysPeriodicAccrualProduct(10.0).isInterestRecalculationEnabled(true)//
                     .maxPrincipal(10000.0).minNumberOfRepayments(1).rescheduleStrategyMethod(1).recalculationRestFrequencyType(MONTHS)
                     .recalculationRestFrequencyInterval(1).recalculationCompoundingFrequencyType(MONTHS)
                     .recalculationCompoundingFrequencyInterval(30).interestRecalculationCompoundingMethod(1));
 
-            Long loanId = applyAndApproveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2023", 8000.0, 2,
+            Long loanId = applyAndApproveLoan(client.getClientId(), loanProduct, "1 January 2023", 8000.0, 2,
                     postLoansRequest -> postLoansRequest.loanTermFrequency(2)//
                             .loanTermFrequencyType(MONTHS)//
                             .interestRatePerPeriod(BigDecimal.valueOf(10.0)).interestCalculationPeriodType(DAYS)//
@@ -912,7 +875,7 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
 
             disburseLoan(loanId, BigDecimal.valueOf(8000), "1 January 2023");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
 
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 3783.06, 0.0, 3783.06, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 817.94,
                     0.0, 817.94, 0.0, 0.0);
@@ -922,9 +885,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("2 February 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
 
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 3783.06, 0.0, 3783.06, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 817.94,
                     0.0, 817.94, 0.0, 0.0);
@@ -938,11 +901,10 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
     public void verifyLoanInstallmentRecalculatedIfThereIsOverdueInstallmentOnProgressiveLoanJob() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2023", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(
+            Long loanProduct = createLoanProduct(
                     create4IProgressive().recalculationRestFrequencyType(RecalculationRestFrequencyType.SAME_AS_REPAYMENT_PERIOD));
 
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2023", 8000.0, 10.0,
-                    4, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2023", 8000.0, 10.0, 4, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(8000), "1 January 2023");
@@ -954,7 +916,7 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
 
             executeInterestRecalculationJobs();
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -969,18 +931,17 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
     public void verifyLoanInstallmentRecalculatedIfThereIsOverdueInstallmentOnCumulativeLoanJob() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2023", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(createOnePeriod30DaysPeriodicAccrualProduct(10.0).isInterestRecalculationEnabled(true)//
-                            .maxPrincipal(10000.0) //
-                            .minNumberOfRepayments(1) //
-                            .rescheduleStrategyMethod(1) //
-                            .recalculationRestFrequencyType(MONTHS) //
-                            .recalculationRestFrequencyInterval(1) //
-                            .recalculationCompoundingFrequencyType(MONTHS) //
-                            .recalculationCompoundingFrequencyInterval(30) //
-                            .interestRecalculationCompoundingMethod(1)); //
+            Long loanProduct = createLoanProduct(createOnePeriod30DaysPeriodicAccrualProduct(10.0).isInterestRecalculationEnabled(true)//
+                    .maxPrincipal(10000.0) //
+                    .minNumberOfRepayments(1) //
+                    .rescheduleStrategyMethod(1) //
+                    .recalculationRestFrequencyType(MONTHS) //
+                    .recalculationRestFrequencyInterval(1) //
+                    .recalculationCompoundingFrequencyType(MONTHS) //
+                    .recalculationCompoundingFrequencyInterval(30) //
+                    .interestRecalculationCompoundingMethod(1)); //
 
-            Long loanId = applyAndApproveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2023", 8000.0, 2,
+            Long loanId = applyAndApproveLoan(client.getClientId(), loanProduct, "1 January 2023", 8000.0, 2,
                     postLoansRequest -> postLoansRequest.loanTermFrequency(2)//
                             .loanTermFrequencyType(MONTHS)//
                             .interestRatePerPeriod(BigDecimal.valueOf(10.0)).interestCalculationPeriodType(DAYS)//
@@ -997,7 +958,7 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
 
             executeInterestRecalculationJobs();
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
 
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 3783.06, 0.0, 3783.06, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 817.94,
                     0.0, 817.94, 0.0, 0.0);
@@ -1012,15 +973,14 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
     public void verifyLoanInstallmentRecalculatedIfThereIsOverdueInstallmentOn4IProgressiveLoanMultiOverdueSingleRepayment() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2023", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(create4IProgressive());
+            Long loanProduct = createLoanProduct(create4IProgressive());
 
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2023", 8000.0, 10.0,
-                    4, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2023", 8000.0, 10.0, 4, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(8000), "1 January 2023");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67);
@@ -1032,9 +992,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("1 March 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            loanTransactionHelper.makeLoanRepayment("01 March 2023", 4083.68f, loanId.intValue());
+            makeLoanRepayment(loanId, "repayment", "01 March 2023", 4083.68);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyPaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1975.17, 0.0, 0.0, 66.67, 2041.84);
@@ -1050,21 +1010,20 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
     public void verifyLoanInstallmentRecalculatedIfThereIsOverdueInstallmentOnCumulativeLoanJobSameAsRepaymentPeriod() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2023", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(createOnePeriod30DaysPeriodicAccrualProduct(10.0).isInterestRecalculationEnabled(true)//
-                            .maxPrincipal(10000.0) //
-                            .minNumberOfRepayments(1) //
-                            .maxNumberOfRepayments(10) //
-                            .rescheduleStrategyMethod(1) //
-                            .daysInYearType(360) //
-                            .daysInMonthType(30) //
-                            .recalculationRestFrequencyType(SAME_AS_REPAYMENT_PERIOD) //
-                            .recalculationRestFrequencyInterval(1) //
-                            .recalculationCompoundingFrequencyType(1) //
-                            .recalculationCompoundingFrequencyInterval(1) //
-                            .interestRecalculationCompoundingMethod(0)); //
+            Long loanProduct = createLoanProduct(createOnePeriod30DaysPeriodicAccrualProduct(10.0).isInterestRecalculationEnabled(true)//
+                    .maxPrincipal(10000.0) //
+                    .minNumberOfRepayments(1) //
+                    .maxNumberOfRepayments(10) //
+                    .rescheduleStrategyMethod(1) //
+                    .daysInYearType(360) //
+                    .daysInMonthType(30) //
+                    .recalculationRestFrequencyType(SAME_AS_REPAYMENT_PERIOD) //
+                    .recalculationRestFrequencyInterval(1) //
+                    .recalculationCompoundingFrequencyType(1) //
+                    .recalculationCompoundingFrequencyInterval(1) //
+                    .interestRecalculationCompoundingMethod(0)); //
 
-            Long loanId = applyAndApproveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2023", 8000.0, 2,
+            Long loanId = applyAndApproveLoan(client.getClientId(), loanProduct, "1 January 2023", 8000.0, 2,
                     postLoansRequest -> postLoansRequest.loanTermFrequency(4)//
                             .loanTermFrequencyType(MONTHS)//
                             .numberOfRepayments(4).interestRatePerPeriod(BigDecimal.valueOf(10.0)).interestCalculationPeriodType(DAYS)//
@@ -1075,7 +1034,7 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
 
             disburseLoan(loanId, BigDecimal.valueOf(8000), "1 January 2023");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1724.0, 0.0, 0.0, 800.0);
@@ -1088,7 +1047,7 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
 
             executeInterestRecalculationJobs();
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1724.0, 0.0, 0.0, 800.0);
@@ -1103,21 +1062,20 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
     public void verifyLoanInstallmentRecalculatedIfThereIsOverdueInstallmentOnCumulativeLoanCOBSameAsRepaymentPeriod() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2023", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(createOnePeriod30DaysPeriodicAccrualProduct(10.0).isInterestRecalculationEnabled(true)//
-                            .maxPrincipal(10000.0) //
-                            .minNumberOfRepayments(1) //
-                            .maxNumberOfRepayments(10) //
-                            .rescheduleStrategyMethod(1) //
-                            .daysInYearType(360) //
-                            .daysInMonthType(30) //
-                            .recalculationRestFrequencyType(SAME_AS_REPAYMENT_PERIOD) //
-                            .recalculationRestFrequencyInterval(1) //
-                            .recalculationCompoundingFrequencyType(1) //
-                            .recalculationCompoundingFrequencyInterval(1) //
-                            .interestRecalculationCompoundingMethod(0)); //
+            Long loanProduct = createLoanProduct(createOnePeriod30DaysPeriodicAccrualProduct(10.0).isInterestRecalculationEnabled(true)//
+                    .maxPrincipal(10000.0) //
+                    .minNumberOfRepayments(1) //
+                    .maxNumberOfRepayments(10) //
+                    .rescheduleStrategyMethod(1) //
+                    .daysInYearType(360) //
+                    .daysInMonthType(30) //
+                    .recalculationRestFrequencyType(SAME_AS_REPAYMENT_PERIOD) //
+                    .recalculationRestFrequencyInterval(1) //
+                    .recalculationCompoundingFrequencyType(1) //
+                    .recalculationCompoundingFrequencyInterval(1) //
+                    .interestRecalculationCompoundingMethod(0)); //
 
-            Long loanId = applyAndApproveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2023", 8000.0, 2,
+            Long loanId = applyAndApproveLoan(client.getClientId(), loanProduct, "1 January 2023", 8000.0, 2,
                     postLoansRequest -> postLoansRequest.loanTermFrequency(4)//
                             .loanTermFrequencyType(MONTHS)//
                             .numberOfRepayments(4).interestRatePerPeriod(BigDecimal.valueOf(10.0)).interestCalculationPeriodType(DAYS)//
@@ -1128,7 +1086,7 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
 
             disburseLoan(loanId, BigDecimal.valueOf(8000), "1 January 2023");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1724.0, 0.0, 0.0, 800.0);
@@ -1139,9 +1097,9 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("8 February 2023", () -> {
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
+            executeInlineCOB(loanId);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2023", 1724.0, 0.0, 0.0, 800.0);
@@ -1156,19 +1114,17 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
     public void verifyEarlyLateRepaymentOnProgressiveLoanThePastDueHasNoEffect() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2024", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper //
-                    .createLoanProduct(create4IProgressive() //
-                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
-                            .disallowInterestCalculationOnPastDue(true) //
+            Long loanProduct = createLoanProduct(create4IProgressive() //
+                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+                    .disallowInterestCalculationOnPastDue(true) //
             );
 
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2024", 100.0, 7.0, 6,
-                    null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2024", 100.0, 7.0, 6, null);
             loanIdRef.set(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(100), "1 January 2024");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateFullyUnpaidRepaymentPeriod(loanDetails, 1, "01 February 2024", 16.43, 0.0, 0.0, 0.58);
@@ -1182,10 +1138,10 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("15 February 2024", () -> { // we have past due and should not count extra interest
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
-            loanTransactionHelper.makeLoanRepayment("15 February 2024", 15.0F, loanId.intValue());
+            executeInlineCOB(loanId);
+            makeLoanRepayment(loanId, "repayment", "15 February 2024", 15.0d);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 1), 16.43, 15.0, 1.43, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.58, 0,
@@ -1199,10 +1155,10 @@ public class LoanInterestRecalculationCOBTest extends BaseLoanIntegrationTest {
         runAt("15 February 2024", () -> { // we turn from past due into early repayment and should have less interest
             Long loanId = loanIdRef.get();
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId));
-            loanTransactionHelper.makeLoanRepayment("15 February 2024", 19.02F, loanId.intValue());
+            executeInlineCOB(loanId);
+            makeLoanRepayment(loanId, "repayment", "15 February 2024", 19.02d);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             logLoanDetails(loanDetails);
 
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2024, 2, 1), 16.43, 16.43, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.58, 0.58,

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanInterestRefundTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanInterestRefundTest.java
@@ -18,16 +18,12 @@
  */
 package org.apache.fineract.integrationtests;
 
+import static org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.LOCALE;
 import static org.apache.fineract.portfolio.loanaccount.domain.LoanTransactionRelationTypeEnum.REPLAYED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Objects;
@@ -36,20 +32,25 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
 import org.apache.fineract.client.models.AdvancedPaymentData;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdTransactions;
 import org.apache.fineract.client.models.GetLoansLoanIdTransactionsTransactionIdResponse;
 import org.apache.fineract.client.models.PaymentAllocationOrder;
 import org.apache.fineract.client.models.PostClientsResponse;
-import org.apache.fineract.client.models.PostLoanProductsResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsTransactionIdRequest;
-import org.apache.fineract.client.util.CallFailedRuntimeException;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.DaysInMonthType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.DaysInYearType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.FuturePaymentAllocationRule;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.RecalculationRestFrequencyType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.SupportedInterestRefundTypesItem;
 import org.apache.fineract.integrationtests.common.ClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanStatus;
 import org.apache.fineract.portfolio.loanproduct.domain.PaymentAllocationType;
 import org.junit.jupiter.api.Assertions;
@@ -57,22 +58,12 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 @Slf4j
-public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
+public class LoanInterestRefundTest extends FeignLoanTestBase {
 
-    private static ResponseSpecification responseSpec;
-    private static RequestSpecification requestSpec;
-    private static LoanTransactionHelper loanTransactionHelper;
     private static PostClientsResponse client;
 
     @BeforeAll
     public static void setup() {
-        Utils.initializeRESTAssured();
-        requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        requestSpec.header("Fineract-Platform-TenantId", "default");
-        responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-        ClientHelper clientHelper = new ClientHelper(requestSpec, responseSpec);
         client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
     }
 
@@ -80,21 +71,19 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
     public void verifyInterestRefundNotCreatedForPayoutRefundWhenTypesAreEmpty() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2021", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
-                            .daysInYearType(DaysInYearType.ACTUAL) //
-                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 1000.0, 9.9,
-                    12, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2021", 1000.0, 9.9, 12, null);
             Assertions.assertNotNull(loanId);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(1000), "1 January 2021");
         });
         runAt("22 January 2021", () -> {
             Long loanId = loanIdRef.get();
-            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(loanId,
-                    "PayoutRefund", "22 January 2021", 1000.0);
+            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = makeLoanRepayment(loanId, "PayoutRefund",
+                    "22 January 2021", 1000.0);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse.getResourceId());
 
@@ -107,21 +96,19 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
     public void verifyInterestRefundNotCreatedForMerchantIssuedRefundWhenTypesAreEmpty() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2021", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
-                            .daysInYearType(DaysInYearType.ACTUAL) //
-                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 1000.0, 9.9,
-                    12, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2021", 1000.0, 9.9, 12, null);
             Assertions.assertNotNull(loanId);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(1000), "1 January 2021");
         });
         runAt("22 January 2021", () -> {
             Long loanId = loanIdRef.get();
-            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(loanId,
-                    "MerchantIssuedRefund", "22 January 2021", 1000.0);
+            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = makeLoanRepayment(loanId, "MerchantIssuedRefund",
+                    "22 January 2021", 1000.0);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse.getResourceId());
 
@@ -133,19 +120,17 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
     @Test
     public void verifyFullMerchantIssuedRefundWithReAmortizationOnDay0HighInterest6month() {
         runAt("1 January 2021", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
-                            .daysInYearType(DaysInYearType.ACTUAL) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
-                            .paymentAllocation(List.of(createDefaultPaymentAllocation("REAMORTIZATION")))//
-                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
+                    .paymentAllocation(List.of(createDefaultPaymentAllocation("REAMORTIZATION")))//
+                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 600.0, 60.0,
-                    6, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2021", 600.0, 60.0, 6, null);
             Assertions.assertNotNull(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(600), "1 January 2021");
-            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(loanId,
-                    "MerchantIssuedRefund", "1 January 2021", 600.0);
+            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = makeLoanRepayment(loanId, "MerchantIssuedRefund",
+                    "1 January 2021", 600.0);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse.getResourceId());
 
@@ -166,20 +151,18 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
     @Test
     public void verifyAlmostFullMerchantIssuedRefundWithReAmortizationOnDay0HighInterest12month() {
         runAt("1 January 2021", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
-                            .daysInYearType(DaysInYearType.ACTUAL) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
-                            .paymentAllocation(List.of(createDefaultPaymentAllocation("REAMORTIZATION")))//
-                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
+                    .paymentAllocation(List.of(createDefaultPaymentAllocation("REAMORTIZATION")))//
+                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 1000.0, 26.0,
-                    12, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2021", 1000.0, 26.0, 12, null);
             Assertions.assertNotNull(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(1000), "1 January 2021");
 
-            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(loanId,
-                    "MerchantIssuedRefund", "1 January 2021", 980.0);
+            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = makeLoanRepayment(loanId, "MerchantIssuedRefund",
+                    "1 January 2021", 980.0);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse.getResourceId());
 
@@ -207,20 +190,18 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
     @Test
     public void verifyFullMerchantIssuedRefundWithReAmortizationOnDay0HighInterest12month() {
         runAt("1 January 2021", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
-                            .daysInYearType(DaysInYearType.ACTUAL) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
-                            .paymentAllocation(List.of(createDefaultPaymentAllocation("REAMORTIZATION")))//
-                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
+                    .paymentAllocation(List.of(createDefaultPaymentAllocation("REAMORTIZATION")))//
+                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 1000.0, 26.0,
-                    12, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2021", 1000.0, 26.0, 12, null);
             Assertions.assertNotNull(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(1000), "1 January 2021");
 
-            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(loanId,
-                    "MerchantIssuedRefund", "1 January 2021", 1000.0);
+            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = makeLoanRepayment(loanId, "MerchantIssuedRefund",
+                    "1 January 2021", 1000.0);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse.getResourceId());
 
@@ -248,22 +229,20 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
     public void verifyInterestRefundCreatedForPayoutRefund() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2021", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
-                            .daysInYearType(DaysInYearType.ACTUAL) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
-                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
+                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 1000.0, 9.99,
-                    12, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2021", 1000.0, 9.99, 12, null);
             Assertions.assertNotNull(loanId);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(1000), "1 January 2021");
         });
         runAt("22 January 2021", () -> {
             Long loanId = loanIdRef.get();
-            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(loanId,
-                    "PayoutRefund", "22 January 2021", 1000.0);
+            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = makeLoanRepayment(loanId, "PayoutRefund",
+                    "22 January 2021", 1000.0);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse.getResourceId());
 
@@ -279,19 +258,18 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
                     postLoansLoanIdTransactionsResponse.getSubResourceId());
 
             verifyTRJournalEntries(postLoansLoanIdTransactionsResponse.getResourceId(), //
-                    journalEntry(1000, fundSource, "DEBIT"), //
-                    journalEntry(5.75, interestReceivableAccount, "CREDIT"), //
-                    journalEntry(994.25, loansReceivableAccount, "CREDIT"));
+                    journalEntry(1000, getAccounts().getFundSource(), "DEBIT"), //
+                    journalEntry(5.75, getAccounts().getInterestReceivableAccount(), "CREDIT"), //
+                    journalEntry(994.25, getAccounts().getLoansReceivableAccount(), "CREDIT"));
 
             verifyTRJournalEntries(postLoansLoanIdTransactionsResponse.getSubResourceId(),
-                    journalEntry(5.75, interestIncomeAccount, "DEBIT"), //
-                    journalEntry(5.75, loansReceivableAccount, "CREDIT")); //
+                    journalEntry(5.75, getAccounts().getInterestIncomeAccount(), "DEBIT"), //
+                    journalEntry(5.75, getAccounts().getLoansReceivableAccount(), "CREDIT")); //
         });
     }
 
     private void checkTransactionWasNotReverseReplayed(Long loanId, Long transactionId) {
-        GetLoansLoanIdTransactionsTransactionIdResponse loanTransactionDetails = loanTransactionHelper.getLoanTransactionDetails(loanId,
-                transactionId);
+        GetLoansLoanIdTransactionsTransactionIdResponse loanTransactionDetails = getLoanTransactionDetails(loanId, transactionId);
         if (loanTransactionDetails.getTransactionRelations() != null) {
             loanTransactionDetails.getTransactionRelations().forEach(transactionRelation -> {
                 if (REPLAYED.name().equals(transactionRelation.getRelationType())) {
@@ -305,22 +283,20 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
     public void verifyInterestRefundCreatedForMerchantIssuedRefund() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2021", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
-                            .daysInYearType(DaysInYearType.ACTUAL) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
-                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
+                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 1000.0, 9.99,
-                    12, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2021", 1000.0, 9.99, 12, null);
             Assertions.assertNotNull(loanId);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(1000), "1 January 2021");
         });
         runAt("22 January 2021", () -> {
             Long loanId = loanIdRef.get();
-            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(loanId,
-                    "MerchantIssuedRefund", "22 January 2021", 1000.0);
+            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = makeLoanRepayment(loanId, "MerchantIssuedRefund",
+                    "22 January 2021", 1000.0);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse.getResourceId());
 
@@ -336,22 +312,20 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
     public void verifyInterestRefundCreatedForMerchantIssuedRefundDay22HighInterest12month() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2021", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
-                            .daysInYearType(DaysInYearType.ACTUAL) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
-                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
+                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 1000.0, 26.0,
-                    12, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2021", 1000.0, 26.0, 12, null);
             Assertions.assertNotNull(loanId);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(1000), "1 January 2021");
         });
         runAt("22 January 2021", () -> {
             Long loanId = loanIdRef.get();
-            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(loanId,
-                    "MerchantIssuedRefund", "22 January 2021", 1000.0);
+            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = makeLoanRepayment(loanId, "MerchantIssuedRefund",
+                    "22 January 2021", 1000.0);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse.getResourceId());
 
@@ -380,18 +354,16 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
     @Test
     public void verifyFullMerchantIssuedRefundOnDay0HighInterest12month() {
         runAt("1 January 2021", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
-                            .daysInYearType(DaysInYearType.ACTUAL) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
-                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
+                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 1000.0, 26.0,
-                    12, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2021", 1000.0, 26.0, 12, null);
             Assertions.assertNotNull(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(1000), "1 January 2021");
-            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(loanId,
-                    "MerchantIssuedRefund", "1 January 2021", 1000.0);
+            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = makeLoanRepayment(loanId, "MerchantIssuedRefund",
+                    "1 January 2021", 1000.0);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse.getResourceId());
 
@@ -418,18 +390,16 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
     @Test
     public void verifyRepaymentDay0HighInterest12month() {
         runAt("1 January 2021", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
-                            .daysInYearType(DaysInYearType.ACTUAL) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
-                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
+                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 1000.0, 26.0,
-                    12, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2021", 1000.0, 26.0, 12, null);
             Assertions.assertNotNull(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(1000), "1 January 2021");
-            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(loanId,
-                    "Repayment", "1 January 2021", 1000.0);
+            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = makeLoanRepayment(loanId, "Repayment",
+                    "1 January 2021", 1000.0);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse.getResourceId());
 
@@ -457,23 +427,21 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
     public void verifyUC01() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2021", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
-                            .daysInYearType(DaysInYearType.ACTUAL) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
-                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
+                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 1000.0, 9.99,
-                    12, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2021", 1000.0, 9.99, 12, null);
             Assertions.assertNotNull(loanId);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(1000), "1 January 2021");
         });
         runAt("22 January 2021", () -> {
             Long loanId = loanIdRef.get();
-            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(loanId,
-                    "PayoutRefund", "22 January 2021", 1000.0);
+            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = makeLoanRepayment(loanId, "PayoutRefund",
+                    "22 January 2021", 1000.0);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse.getResourceId());
 
@@ -489,23 +457,21 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
     public void verifyUC02a() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2021", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
-                            .daysInYearType(DaysInYearType.ACTUAL) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
-                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
+                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 1000.0, 9.99,
-                    12, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2021", 1000.0, 9.99, 12, null);
             Assertions.assertNotNull(loanId);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(1000), "1 January 2021");
         });
         runAt("1 February 2021", () -> {
             Long loanId = loanIdRef.get();
-            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(loanId,
-                    "PayoutRefund", "1 February 2021", 1000.0);
+            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = makeLoanRepayment(loanId, "PayoutRefund",
+                    "1 February 2021", 1000.0);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse.getResourceId());
 
@@ -520,23 +486,21 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
     public void verifyUC02b() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2021", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
-                            .daysInYearType(DaysInYearType.ACTUAL) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
-                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
+                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 1000.0, 9.99,
-                    12, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2021", 1000.0, 9.99, 12, null);
             Assertions.assertNotNull(loanId);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(1000), "1 January 2021");
         });
         runAt("1 February 2021", () -> {
             Long loanId = loanIdRef.get();
-            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(loanId,
-                    "Repayment", "1 February 2021", 87.89);
+            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = makeLoanRepayment(loanId, "Repayment",
+                    "1 February 2021", 87.89);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse.getResourceId());
 
@@ -546,8 +510,8 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
 
         runAt("9 February 2021", () -> {
             Long loanId = loanIdRef.get();
-            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(loanId,
-                    "PayoutRefund", "9 February 2021", 1000.0);
+            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = makeLoanRepayment(loanId, "PayoutRefund",
+                    "9 February 2021", 1000.0);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse.getResourceId());
 
@@ -564,18 +528,16 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
     public void verifyUC03() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2021", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
-                            .daysInYearType(DaysInYearType.ACTUAL) //
-                            //
-                            .disallowExpectedDisbursements(true)//
-                            .multiDisburseLoan(true)//
-                            .maxTrancheCount(2).addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
-                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    //
+                    .disallowExpectedDisbursements(true)//
+                    .multiDisburseLoan(true)//
+                    .maxTrancheCount(2).addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
+                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 1000.0, 9.99,
-                    12, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2021", 1000.0, 9.99, 12, null);
             Assertions.assertNotNull(loanId);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(750), "1 January 2021");
@@ -583,8 +545,8 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
         });
         runAt("22 January 2021", () -> {
             Long loanId = loanIdRef.get();
-            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(loanId,
-                    "PayoutRefund", "22 January 2021", 1000.0);
+            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = makeLoanRepayment(loanId, "PayoutRefund",
+                    "22 January 2021", 1000.0);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse.getResourceId());
 
@@ -601,16 +563,14 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
     public void verifyUC04() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2021", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
-                            .daysInYearType(DaysInYearType.ACTUAL) //
-                            .disallowExpectedDisbursements(true).multiDisburseLoan(true).maxTrancheCount(2)
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
-                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .disallowExpectedDisbursements(true).multiDisburseLoan(true).maxTrancheCount(2)
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
+                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 1000.0, 9.99,
-                    12, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2021", 1000.0, 9.99, 12, null);
             Assertions.assertNotNull(loanId);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(250), "1 January 2021");
@@ -621,8 +581,8 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
         });
         runAt("22 January 2021", () -> {
             Long loanId = loanIdRef.get();
-            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(loanId,
-                    "PayoutRefund", "22 January 2021", 1000.0);
+            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = makeLoanRepayment(loanId, "PayoutRefund",
+                    "22 January 2021", 1000.0);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse.getResourceId());
 
@@ -639,17 +599,15 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
     public void verifyUC05() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2021", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
-                            .daysInYearType(DaysInYearType.ACTUAL) //
-                            .multiDisburseLoan(true) //
-                            .disallowExpectedDisbursements(true) //
-                            .maxTrancheCount(2).addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
-                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .multiDisburseLoan(true) //
+                    .disallowExpectedDisbursements(true) //
+                    .maxTrancheCount(2).addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
+                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 1000.0, 9.99,
-                    12, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2021", 1000.0, 9.99, 12, null);
             Assertions.assertNotNull(loanId);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(500), "1 January 2021");
@@ -660,8 +618,8 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
         });
         runAt("1 February 2021", () -> {
             Long loanId = loanIdRef.get();
-            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(loanId,
-                    "Repayment", "1 February 2021", 87.82);
+            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = makeLoanRepayment(loanId, "Repayment",
+                    "1 February 2021", 87.82);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse.getResourceId());
 
@@ -671,8 +629,8 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
 
         runAt("9 February 2021", () -> {
             Long loanId = loanIdRef.get();
-            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(loanId,
-                    "PayoutRefund", "9 February 2021", 1000.0);
+            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = makeLoanRepayment(loanId, "PayoutRefund",
+                    "9 February 2021", 1000.0);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse.getResourceId());
 
@@ -690,15 +648,13 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
     public void verifyUC06() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 December 2020", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
-                            .daysInYearType(DaysInYearType.ACTUAL) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
-                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
+                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 December 2020", 1000.0, 9.99,
-                    6, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 December 2020", 1000.0, 9.99, 6, null);
             Assertions.assertNotNull(loanId);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(1000), "1 December 2020");
@@ -706,8 +662,8 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
         });
         runAt("14 December 2020", () -> {
             Long loanId = loanIdRef.get();
-            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(loanId,
-                    "PayoutRefund", "14 December 2020", 500.0);
+            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = makeLoanRepayment(loanId, "PayoutRefund",
+                    "14 December 2020", 500.0);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse.getResourceId());
 
@@ -721,23 +677,21 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
     public void verifyUC07() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2021", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
-                            .daysInYearType(DaysInYearType.ACTUAL) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
-                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
+                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 1000.0, 9.99,
-                    12, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2021", 1000.0, 9.99, 12, null);
             Assertions.assertNotNull(loanId);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(1000), "1 January 2021");
         });
         runAt("1 February 2021", () -> {
             Long loanId = loanIdRef.get();
-            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(loanId,
-                    "Repayment", "1 February 2021", 87.89);
+            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = makeLoanRepayment(loanId, "Repayment",
+                    "1 February 2021", 87.89);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse.getResourceId());
 
@@ -746,8 +700,8 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
         });
         runAt("9 February 2021", () -> {
             Long loanId = loanIdRef.get();
-            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(loanId,
-                    "PayoutRefund", "09 February 2021", 500.0);
+            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = makeLoanRepayment(loanId, "PayoutRefund",
+                    "09 February 2021", 500.0);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse.getResourceId());
 
@@ -762,17 +716,15 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
     public void verifyUC08() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2021", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
-                            .daysInYearType(DaysInYearType.ACTUAL) //
-                            .disallowExpectedDisbursements(true)//
-                            .multiDisburseLoan(true)//
-                            .maxTrancheCount(2).addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
-                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .disallowExpectedDisbursements(true)//
+                    .multiDisburseLoan(true)//
+                    .maxTrancheCount(2).addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
+                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 1000.0, 9.99,
-                    6, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2021", 1000.0, 9.99, 6, null);
             Assertions.assertNotNull(loanId);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(250), "1 January 2021");
@@ -780,8 +732,8 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
         });
         runAt("22 January 2021", () -> {
             Long loanId = loanIdRef.get();
-            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(loanId,
-                    "PayoutRefund", "22 January 2021", 500.0);
+            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = makeLoanRepayment(loanId, "PayoutRefund",
+                    "22 January 2021", 500.0);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse.getResourceId());
 
@@ -796,16 +748,14 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
     public void verifyUC09() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2021", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
-                            .daysInYearType(DaysInYearType.ACTUAL) //
-                            .disallowExpectedDisbursements(true).multiDisburseLoan(true).maxTrancheCount(2)
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
-                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .disallowExpectedDisbursements(true).multiDisburseLoan(true).maxTrancheCount(2)
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
+                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 1000.0, 9.99,
-                    6, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2021", 1000.0, 9.99, 6, null);
             Assertions.assertNotNull(loanId);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(250), "1 January 2021");
@@ -816,8 +766,8 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
         });
         runAt("22 January 2021", () -> {
             Long loanId = loanIdRef.get();
-            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(loanId,
-                    "PayoutRefund", "22 January 2021", 500.0);
+            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = makeLoanRepayment(loanId, "PayoutRefund",
+                    "22 January 2021", 500.0);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse.getResourceId());
 
@@ -832,16 +782,14 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
     public void verifyUC10() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2021", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
-                            .daysInYearType(DaysInYearType.ACTUAL) //
-                            .disallowExpectedDisbursements(true).multiDisburseLoan(true).maxTrancheCount(2)
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
-                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .disallowExpectedDisbursements(true).multiDisburseLoan(true).maxTrancheCount(2)
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
+                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 1000.0, 9.99,
-                    6, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2021", 1000.0, 9.99, 6, null);
             Assertions.assertNotNull(loanId);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(250), "1 January 2021");
@@ -853,12 +801,12 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
         });
         runAt("1 July 2021", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "Repayment", "1 February 2021", 171.29);
-            loanTransactionHelper.makeLoanRepayment(loanId, "Repayment", "1 March 2021", 171.29);
-            loanTransactionHelper.makeLoanRepayment(loanId, "Repayment", "1 April 2021", 171.29);
-            loanTransactionHelper.makeLoanRepayment(loanId, "Repayment", "1 May 2021", 171.29);
-            loanTransactionHelper.makeLoanRepayment(loanId, "Repayment", "1 June 2021", 171.29);
-            loanTransactionHelper.makeLoanRepayment(loanId, "Repayment", "1 July 2021", 171.32);
+            makeLoanRepayment(loanId, "Repayment", "1 February 2021", 171.29);
+            makeLoanRepayment(loanId, "Repayment", "1 March 2021", 171.29);
+            makeLoanRepayment(loanId, "Repayment", "1 April 2021", 171.29);
+            makeLoanRepayment(loanId, "Repayment", "1 May 2021", 171.29);
+            makeLoanRepayment(loanId, "Repayment", "1 June 2021", 171.29);
+            makeLoanRepayment(loanId, "Repayment", "1 July 2021", 171.32);
 
             verifyTransactions(loanId, transaction(250.0, "Disbursement", "01 January 2021"), //
                     transaction(750.0, "Disbursement", "07 January 2021"), //
@@ -873,8 +821,8 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
         });
         runAt("11 July 2021", () -> {
             Long loanId = loanIdRef.get();
-            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = loanTransactionHelper.makeLoanRepayment(loanId,
-                    "PayoutRefund", "11 July 2021", 500.0);
+            PostLoansLoanIdTransactionsResponse postLoansLoanIdTransactionsResponse = makeLoanRepayment(loanId, "PayoutRefund",
+                    "11 July 2021", 500.0);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse);
             Assertions.assertNotNull(postLoansLoanIdTransactionsResponse.getResourceId());
 
@@ -897,15 +845,13 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
     public void verifyUC11() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2021", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
-                            .daysInYearType(DaysInYearType.ACTUAL) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
-                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
+                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 1000.0, 9.99,
-                    6, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2021", 1000.0, 9.99, 6, null);
             Assertions.assertNotNull(loanId);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(1000), "1 January 2021");
@@ -913,7 +859,7 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
         });
         runAt("14 January 2021", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "MerchantIssuedRefund", "14 January 2021", 500.0);
+            makeLoanRepayment(loanId, "MerchantIssuedRefund", "14 January 2021", 500.0);
 
             verifyTransactions(loanId, transaction(1000.0, "Disbursement", "01 January 2021"), //
                     transaction(500.0, "Merchant Issued Refund", "14 January 2021"), //
@@ -921,7 +867,7 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
         });
         runAt("22 January 2021", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "PayoutRefund", "22 January 2021", 500.0);
+            makeLoanRepayment(loanId, "PayoutRefund", "22 January 2021", 500.0);
             verifyTransactions(loanId, transaction(1000.0, "Disbursement", "01 January 2021"), //
                     transaction(500.0, "Merchant Issued Refund", "14 January 2021"), //
                     transaction(1.78, "Interest Refund", "14 January 2021"), //
@@ -936,15 +882,13 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
     public void verifyUC12() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2021", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
-                            .daysInYearType(DaysInYearType.ACTUAL) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
-                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
+                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 1000.0, 9.99,
-                    6, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2021", 1000.0, 9.99, 6, null);
             Assertions.assertNotNull(loanId);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(1000), "1 January 2021");
@@ -952,14 +896,14 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
         });
         runAt("1 February 2021", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "Repayment", "1 February 2021", 171.50);
+            makeLoanRepayment(loanId, "Repayment", "1 February 2021", 171.50);
 
             verifyTransactions(loanId, transaction(1000.0, "Disbursement", "01 January 2021"), //
                     transaction(171.5, "Repayment", "01 February 2021"));
         });
         runAt("9 February 2021", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "MerchantIssuedRefund", "9 February 2021", 500.0);
+            makeLoanRepayment(loanId, "MerchantIssuedRefund", "9 February 2021", 500.0);
 
             verifyTransactions(loanId, transaction(1000.0, "Disbursement", "01 January 2021"), //
                     transaction(171.5, "Repayment", "01 February 2021"), //
@@ -968,7 +912,7 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
         });
         runAt("25 February 2021", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "PayoutRefund", "25 February 2021", 250.0);
+            makeLoanRepayment(loanId, "PayoutRefund", "25 February 2021", 250.0);
 
             verifyTransactions(loanId, transaction(1000.0, "Disbursement", "01 January 2021"), //
                     transaction(171.5, "Repayment", "01 February 2021"), //
@@ -984,17 +928,15 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
     public void verifyUC13() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2021", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
-                            .daysInYearType(DaysInYearType.ACTUAL) //
-                            .multiDisburseLoan(true)//
-                            .disallowExpectedDisbursements(true)//
-                            .maxTrancheCount(2).addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
-                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .multiDisburseLoan(true)//
+                    .disallowExpectedDisbursements(true)//
+                    .maxTrancheCount(2).addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
+                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 1000.0, 9.99,
-                    12, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2021", 1000.0, 9.99, 12, null);
             Assertions.assertNotNull(loanId);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(250), "1 January 2021");
@@ -1003,7 +945,7 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
         });
         runAt("22 January 2021", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "MerchantIssuedRefund", "22 January 2021", 500.0);
+            makeLoanRepayment(loanId, "MerchantIssuedRefund", "22 January 2021", 500.0);
 
             verifyTransactions(loanId, transaction(250.0, "Disbursement", "01 January 2021"), //
                     transaction(750.0, "Disbursement", "01 January 2021"), //
@@ -1013,7 +955,7 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
         });
         runAt("26 January 2021", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "PayoutRefund", "26 January 2021", 400.0);
+            makeLoanRepayment(loanId, "PayoutRefund", "26 January 2021", 400.0);
 
             verifyTransactions(loanId, transaction(250.0, "Disbursement", "01 January 2021"), //
                     transaction(750.0, "Disbursement", "01 January 2021"), //
@@ -1025,7 +967,7 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
         });
         runAt("1 February 2021", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "Repayment", "1 February 2021", 100.84);
+            makeLoanRepayment(loanId, "Repayment", "1 February 2021", 100.84);
 
             verifyTransactions(loanId, transaction(250.0, "Disbursement", "01 January 2021"), //
                     transaction(750.0, "Disbursement", "01 January 2021"), //
@@ -1036,7 +978,7 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
                     transaction(100.84, "Repayment", "01 February 2021"), //
                     transaction(6.46, "Accrual", "01 February 2021")); //
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             Assertions.assertNotNull(loanDetails);
             Assertions.assertNotNull(loanDetails.getStatus());
             Assertions.assertEquals(600, loanDetails.getStatus().getId());
@@ -1047,17 +989,15 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
     public void verifyUC14() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2021", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
-                            .daysInYearType(DaysInYearType.ACTUAL) //
-                            .multiDisburseLoan(true)//
-                            .disallowExpectedDisbursements(true)//
-                            .maxTrancheCount(3).addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
-                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .multiDisburseLoan(true)//
+                    .disallowExpectedDisbursements(true)//
+                    .maxTrancheCount(3).addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
+                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 1000.0, 9.99,
-                    6, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2021", 1000.0, 9.99, 6, null);
             Assertions.assertNotNull(loanId);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(200), "1 January 2021");
@@ -1070,7 +1010,7 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
         });
         runAt("22 January 2021", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "MerchantIssuedRefund", "22 January 2021", 250.0);
+            makeLoanRepayment(loanId, "MerchantIssuedRefund", "22 January 2021", 250.0);
 
             verifyTransactions(loanId, transaction(200.0, "Disbursement", "01 January 2021"), //
                     transaction(300.0, "Disbursement", "01 January 2021"), //
@@ -1081,7 +1021,7 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
         });
         runAt("26 January 2021", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "PayoutRefund", "26 January 2021", 400.0);
+            makeLoanRepayment(loanId, "PayoutRefund", "26 January 2021", 400.0);
 
             verifyTransactions(loanId, transaction(200.0, "Disbursement", "01 January 2021"), //
                     transaction(300.0, "Disbursement", "01 January 2021"), //
@@ -1094,9 +1034,9 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
         });
         runAt("1 April 2021", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "Repayment", "1 February 2021", 171.41);
-            loanTransactionHelper.makeLoanRepayment(loanId, "Repayment", "1 March 2021", 171.41);
-            loanTransactionHelper.makeLoanRepayment(loanId, "Repayment", "1 April 2021", 11.24);
+            makeLoanRepayment(loanId, "Repayment", "1 February 2021", 171.41);
+            makeLoanRepayment(loanId, "Repayment", "1 March 2021", 171.41);
+            makeLoanRepayment(loanId, "Repayment", "1 April 2021", 11.24);
 
             verifyTransactions(loanId, transaction(200.0, "Disbursement", "01 January 2021"), //
                     transaction(300.0, "Disbursement", "01 January 2021"), //
@@ -1111,7 +1051,7 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
                     transaction(8.08, "Accrual", "01 April 2021") //
             );
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             Assertions.assertNotNull(loanDetails);
             Assertions.assertNotNull(loanDetails.getStatus());
             Assertions.assertEquals(600, loanDetails.getStatus().getId());
@@ -1122,17 +1062,15 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
     public void verifyUC15() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2021", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
-                            .daysInYearType(DaysInYearType.ACTUAL) //
-                            .multiDisburseLoan(true)//
-                            .disallowExpectedDisbursements(true)//
-                            .maxTrancheCount(3).addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
-                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .multiDisburseLoan(true)//
+                    .disallowExpectedDisbursements(true)//
+                    .maxTrancheCount(3).addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
+                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 1000.0, 9.99,
-                    6, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2021", 1000.0, 9.99, 6, null);
             Assertions.assertNotNull(loanId);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(500), "1 January 2021");
@@ -1144,7 +1082,7 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
         });
         runAt("1 February 2021", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "Repayment", "1 February 2021", 171.41);
+            makeLoanRepayment(loanId, "Repayment", "1 February 2021", 171.41);
 
             verifyTransactions(loanId, transaction(500.0, "Disbursement", "01 January 2021"), //
                     transaction(500.0, "Disbursement", "05 January 2021"), //
@@ -1152,7 +1090,7 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
         });
         runAt("13 February 2021", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "PayoutRefund", "13 February 2021", 250.0);
+            makeLoanRepayment(loanId, "PayoutRefund", "13 February 2021", 250.0);
 
             verifyTransactions(loanId, transaction(500.0, "Disbursement", "01 January 2021"), //
                     transaction(500.0, "Disbursement", "05 January 2021"), //
@@ -1163,7 +1101,7 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
         });
         runAt("24 February 2021", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "MerchantIssuedRefund", "24 February 2021", 400.0);
+            makeLoanRepayment(loanId, "MerchantIssuedRefund", "24 February 2021", 400.0);
 
             verifyTransactions(loanId, transaction(500.0, "Disbursement", "01 January 2021"), //
                     transaction(500.0, "Disbursement", "05 January 2021"), //
@@ -1176,9 +1114,9 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
         });
         runAt("1 April 2021", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "Repayment", "1 March 2021", 171.41);
-            loanTransactionHelper.makeLoanRepayment(loanId, "Repayment", "1 April 2021", 11.25);
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            makeLoanRepayment(loanId, "Repayment", "1 March 2021", 171.41);
+            makeLoanRepayment(loanId, "Repayment", "1 April 2021", 11.25);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
 
             Assertions.assertNotNull(loanDetails);
             Assertions.assertNotNull(loanDetails.getStatus());
@@ -1190,17 +1128,15 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
     public void verifyUC16() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2021", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
-                            .daysInYearType(DaysInYearType.ACTUAL) //
-                            .multiDisburseLoan(true)//
-                            .disallowExpectedDisbursements(true)//
-                            .maxTrancheCount(3).addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
-                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .multiDisburseLoan(true)//
+                    .disallowExpectedDisbursements(true)//
+                    .maxTrancheCount(3).addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
+                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 1000.0, 9.99,
-                    6, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2021", 1000.0, 9.99, 6, null);
             Assertions.assertNotNull(loanId);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(500), "1 January 2021");
@@ -1212,7 +1148,7 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
         });
         runAt("1 February 2021", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "Repayment", "1 February 2021", 171.41);
+            makeLoanRepayment(loanId, "Repayment", "1 February 2021", 171.41);
 
             verifyTransactions(loanId, transaction(500.0, "Disbursement", "01 January 2021"), //
                     transaction(500.0, "Disbursement", "05 January 2021"), //
@@ -1220,7 +1156,7 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
         });
         runAt("13 February 2021", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "PayoutRefund", "13 February 2021", 250.0);
+            makeLoanRepayment(loanId, "PayoutRefund", "13 February 2021", 250.0);
 
             verifyTransactions(loanId, transaction(500.0, "Disbursement", "01 January 2021"), //
                     transaction(500.0, "Disbursement", "05 January 2021"), //
@@ -1232,12 +1168,12 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
 
         runAt("1 April 2021", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "Repayment", "1 March 2021", 171.41);
-            loanTransactionHelper.makeLoanRepayment(loanId, "Repayment", "1 April 2021", 171.41);
+            makeLoanRepayment(loanId, "Repayment", "1 March 2021", 171.41);
+            makeLoanRepayment(loanId, "Repayment", "1 April 2021", 171.41);
         });
         runAt("6 April 2021", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "MerchantIssuedRefund", "6 April 2021", 400.0);
+            makeLoanRepayment(loanId, "MerchantIssuedRefund", "6 April 2021", 400.0);
 
             verifyTransactions(loanId, transaction(500.0, "Disbursement", "01 January 2021"), //
                     transaction(500.0, "Disbursement", "05 January 2021"), //
@@ -1250,7 +1186,7 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
                     transaction(10.12, "Interest Refund", "06 April 2021"), //
                     transaction(17.14, "Accrual", "06 April 2021") //
             );
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
 
             Assertions.assertNotNull(loanDetails);
             Assertions.assertNotNull(loanDetails.getStatus());
@@ -1263,17 +1199,15 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
     public void verifyUC17() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2021", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
-                            .daysInYearType(DaysInYearType.ACTUAL) //
-                            .multiDisburseLoan(true)//
-                            .disallowExpectedDisbursements(true)//
-                            .maxTrancheCount(2).addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
-                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .multiDisburseLoan(true)//
+                    .disallowExpectedDisbursements(true)//
+                    .maxTrancheCount(2).addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
+                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 1000.0, 9.99,
-                    12, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2021", 1000.0, 9.99, 12, null);
             Assertions.assertNotNull(loanId);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(1000), "1 January 2021");
@@ -1281,7 +1215,7 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
         });
         runAt("12 January 2021", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "PayoutRefund", "12 January 2021", 400.0);
+            makeLoanRepayment(loanId, "PayoutRefund", "12 January 2021", 400.0);
 
             verifyTransactions(loanId, //
                     transaction(1000.0, "Disbursement", "01 January 2021"), //
@@ -1291,7 +1225,7 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
         });
         runAt("22 January 2021", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "MerchantIssuedRefund", "17 January 2021", 150.0);
+            makeLoanRepayment(loanId, "MerchantIssuedRefund", "17 January 2021", 150.0);
 
             verifyTransactions(loanId, transaction(1000.0, "Disbursement", "01 January 2021"), //
                     transaction(400.0, "Payout Refund", "12 January 2021"), //
@@ -1303,11 +1237,11 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
 
         runAt("1 February 2021", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "Repayment", "1 February 2021", 171.5);
+            makeLoanRepayment(loanId, "Repayment", "1 February 2021", 171.5);
         });
         runAt("8 February 2021", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "PayoutRefund", "8 February 2021", 250.0);
+            makeLoanRepayment(loanId, "PayoutRefund", "8 February 2021", 250.0);
 
             verifyTransactions(loanId, transaction(1000.0, "Disbursement", "01 January 2021"), //
                     transaction(400.0, "Payout Refund", "12 January 2021"), //
@@ -1321,8 +1255,8 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
         });
         runAt("1 March 2021", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "Repayment", "1 March 2021", 30.43);
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            makeLoanRepayment(loanId, "Repayment", "1 March 2021", 30.43);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             Assertions.assertNotNull(loanDetails);
             Assertions.assertNotNull(loanDetails.getStatus());
             Assertions.assertEquals(600, loanDetails.getStatus().getId());
@@ -1333,32 +1267,30 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
     public void verifyUC18S1() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2021", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
-                            .daysInYearType(DaysInYearType.ACTUAL) //
-                            .multiDisburseLoan(true)//
-                            .disallowExpectedDisbursements(true)//
-                            .maxTrancheCount(2)//
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
-                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .multiDisburseLoan(true)//
+                    .disallowExpectedDisbursements(true)//
+                    .maxTrancheCount(2)//
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
+                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 1000.0, 9.9,
-                    12, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2021", 1000.0, 9.9, 12, null);
             Assertions.assertNotNull(loanId);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(1000), "1 January 2021");
         });
         runAt("22 January 2021", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "MerchantIssuedRefund", "22 January 2021", 1000.0);
+            makeLoanRepayment(loanId, "MerchantIssuedRefund", "22 January 2021", 1000.0);
 
             verifyTransactions(loanId, transaction(1000.0, "Disbursement", "01 January 2021"), //
                     transaction(1000.0, "Merchant Issued Refund", "22 January 2021"), //
                     transaction(5.70, "Interest Refund", "22 January 2021"), //
                     transaction(5.70, "Accrual", "22 January 2021") //
             );
-            loanTransactionHelper.makeLoanRepayment(loanId, "Repayment", "10 January 2021", 85.63);
+            makeLoanRepayment(loanId, "Repayment", "10 January 2021", 85.63);
 
             verifyTransactions(loanId, transaction(1000.0, "Disbursement", "01 January 2021"), //
                     transaction(85.63, "Repayment", "10 January 2021"), //
@@ -1373,22 +1305,20 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
     @Test
     public void verifyNoEmptyInterestRefundTransaction() {
         runAt("1 January 2021", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
-                            .daysInYearType(DaysInYearType.ACTUAL) //
-                            .multiDisburseLoan(true)//
-                            .disallowExpectedDisbursements(true)//
-                            .maxTrancheCount(2)//
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
-                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .multiDisburseLoan(true)//
+                    .disallowExpectedDisbursements(true)//
+                    .maxTrancheCount(2)//
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
+                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 1000.0, 9.9,
-                    12, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2021", 1000.0, 9.9, 12, null);
             Assertions.assertNotNull(loanId);
 
             disburseLoan(loanId, BigDecimal.valueOf(1000), "1 January 2021");
-            loanTransactionHelper.makeLoanRepayment(loanId, "MerchantIssuedRefund", "1 January 2021", 1000.0);
+            makeLoanRepayment(loanId, "MerchantIssuedRefund", "1 January 2021", 1000.0);
 
             verifyTransactions(loanId, //
                     transaction(1000.0, "Disbursement", "01 January 2021"), //
@@ -1402,24 +1332,22 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         AtomicReference<Long> repaymentIdRef = new AtomicReference<>();
         runAt("1 January 2021", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
-                            .daysInYearType(DaysInYearType.ACTUAL) //
-                            .multiDisburseLoan(true)//
-                            .disallowExpectedDisbursements(true)//
-                            .maxTrancheCount(2).addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
-                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .multiDisburseLoan(true)//
+                    .disallowExpectedDisbursements(true)//
+                    .maxTrancheCount(2).addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
+                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 1000.0, 9.9,
-                    12, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2021", 1000.0, 9.9, 12, null);
             Assertions.assertNotNull(loanId);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(1000), "1 January 2021");
         });
         runAt("10 January 2021", () -> {
             Long loanId = loanIdRef.get();
-            Long response = loanTransactionHelper.makeLoanRepayment(loanId, "Repayment", "10 January 2021", 85.63).getResourceId();
+            Long response = makeLoanRepayment(loanId, "Repayment", "10 January 2021", 85.63).getResourceId();
             Assertions.assertNotNull(response);
             repaymentIdRef.set(response);
 
@@ -1429,7 +1357,7 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
         });
         runAt("22 January 2021", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "MerchantIssuedRefund", "22 January 2021", 1000.0);
+            makeLoanRepayment(loanId, "MerchantIssuedRefund", "22 January 2021", 1000.0);
 
             verifyTransactions(loanId, transaction(1000.0, "Disbursement", "01 January 2021"), //
                     transaction(85.63, "Repayment", "10 January 2021"), //
@@ -1439,7 +1367,7 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
             );
 
             Long repaymentId = repaymentIdRef.get();
-            loanTransactionHelper.reverseLoanTransaction(loanId, repaymentId, "10 January 2021");
+            reverseLoanTransaction(loanId, repaymentId, "10 January 2021");
 
             verifyTransactions(loanId, transaction(1000.0, "Disbursement", "01 January 2021"), //
                     reversedTransaction(85.63, "Repayment", "10 January 2021"), //
@@ -1463,26 +1391,24 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
     public void verifyUC19() {
         AtomicReference<Long> loanIdRef = new AtomicReference<>();
         runAt("1 January 2021", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
-                            .daysInYearType(DaysInYearType.ACTUAL) //
-                            .multiDisburseLoan(true)//
-                            .disallowExpectedDisbursements(true)//
-                            .maxTrancheCount(2)//
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
-                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .multiDisburseLoan(true)//
+                    .disallowExpectedDisbursements(true)//
+                    .maxTrancheCount(2)//
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
+                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "1 January 2021", 1000.0, 9.9,
-                    12, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "1 January 2021", 1000.0, 9.9, 12, null);
             Assertions.assertNotNull(loanId);
             loanIdRef.set(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(1000), "1 January 2021");
         });
         runAt("22 January 2021", () -> {
             Long loanId = loanIdRef.get();
-            loanTransactionHelper.makeLoanRepayment(loanId, "MerchantIssuedRefund", "22 January 2021", 1000.0);
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            makeLoanRepayment(loanId, "MerchantIssuedRefund", "22 January 2021", 1000.0);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             Assertions.assertNotNull(loanDetails.getTransactions());
             Optional<GetLoansLoanIdTransactions> optInterestRefundTransaction = loanDetails.getTransactions().stream().filter(item -> {
                 Assertions.assertNotNull(item.getType());
@@ -1491,21 +1417,19 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
             final Long interestRefundTransactionId = optInterestRefundTransaction.orElseThrow().getId();
 
             CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.reverseLoanTransaction(loanId, interestRefundTransactionId,
-                            new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN)
-                                    .transactionDate("22 January 2021").transactionAmount(0.0).locale("en")));
-            assertEquals(403, exception.getResponse().code());
+                    () -> reverseLoanTransaction(loanId, interestRefundTransactionId, new PostLoansLoanIdTransactionsTransactionIdRequest()
+                            .dateFormat(DATETIME_PATTERN).transactionDate("22 January 2021").transactionAmount(0.0).locale("en")));
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("error.msg.loan.transaction.update.not.allowed"));
 
             Optional<GetLoansLoanIdTransactions> optMerchantIssuedTransaction = loanDetails.getTransactions().stream()
                     .filter(item -> Objects.equals(item.getType().getValue(), "Merchant Issued Refund")).findFirst();
             final Long merchantIssuedTransactionId = optMerchantIssuedTransaction.orElseThrow().getId();
 
-            loanTransactionHelper.reverseLoanTransaction(loanId, merchantIssuedTransactionId,
-                    new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("22 January 2021")
-                            .transactionAmount(0.0).locale("en"));
+            reverseLoanTransaction(loanId, merchantIssuedTransactionId, new PostLoansLoanIdTransactionsTransactionIdRequest()
+                    .dateFormat(DATETIME_PATTERN).transactionDate("22 January 2021").transactionAmount(0.0).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             Assertions.assertNotNull(loanDetails.getTransactions());
             optInterestRefundTransaction = loanDetails.getTransactions().stream()
                     .filter(item -> Objects.equals(item.getType().getValue(), "Interest Refund")).findFirst();
@@ -1521,27 +1445,25 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
         AtomicReferenceArray<PostLoansLoanIdTransactionsResponse> merchantIssuedRefundTransactions = new AtomicReferenceArray<>(
                 totalTransactions);
         runAt("07 March 2025", () -> {
-            PostLoanProductsResponse loanProduct = loanProductHelper
-                    .createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
-                            .daysInYearType(DaysInYearType.ACTUAL) //
-                            .chargeOffBehaviour("ZERO_INTEREST")//
-                            .enableAccrualActivityPosting(true)//
-                            .allowApprovedDisbursedAmountsOverApplied(true)//
-                            .overAppliedCalculationType("flat")//
-                            .overAppliedNumber(10000)//
-                            .enableInstallmentLevelDelinquency(true)//
-                            .multiDisburseLoan(true)//
-                            .loanScheduleType("PROGRESSIVE")//
-                            .loanScheduleProcessingType("HORIZONTAL")//
-                            .interestRecognitionOnDisbursementDate(true)//
-                            .disallowExpectedDisbursements(true)//
-                            .maxTrancheCount(500)//
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
-                            .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
-                            .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
+            Long loanProduct = createLoanProduct(create4IProgressive().daysInMonthType(DaysInMonthType.ACTUAL) //
+                    .daysInYearType(DaysInYearType.ACTUAL) //
+                    .chargeOffBehaviour("ZERO_INTEREST")//
+                    .enableAccrualActivityPosting(true)//
+                    .allowApprovedDisbursedAmountsOverApplied(true)//
+                    .overAppliedCalculationType("flat")//
+                    .overAppliedNumber(10000)//
+                    .enableInstallmentLevelDelinquency(true)//
+                    .multiDisburseLoan(true)//
+                    .loanScheduleType("PROGRESSIVE")//
+                    .loanScheduleProcessingType("HORIZONTAL")//
+                    .interestRecognitionOnDisbursementDate(true)//
+                    .disallowExpectedDisbursements(true)//
+                    .maxTrancheCount(500)//
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND) //
+                    .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.PAYOUT_REFUND) //
+                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY) //
             );
-            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct.getResourceId(), "07 March 2025", 915.88, 24.99,
-                    24, null);
+            Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProduct, "07 March 2025", 915.88, 24.99, 24, null);
             Assertions.assertNotNull(loanId);
             loanIdRef.set(loanId);
         });
@@ -1553,45 +1475,44 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
         });
 
         runAt("04 April 2025", () -> {
-            Long response = loanTransactionHelper.makeLoanRepayment(loanIdRef.get(), "Repayment", "04 April 2025", 48.91).getResourceId();
+            Long response = makeLoanRepayment(loanIdRef.get(), "Repayment", "04 April 2025", 48.91).getResourceId();
             Assertions.assertNotNull(response);
         });
 
         runAt("02 May 2025", () -> {
-            Long response = loanTransactionHelper.makeLoanRepayment(loanIdRef.get(), "Repayment", "02 May 2025", 48.91).getResourceId();
+            Long response = makeLoanRepayment(loanIdRef.get(), "Repayment", "02 May 2025", 48.91).getResourceId();
             Assertions.assertNotNull(response);
         });
 
         runAt("30 May 2025", () -> {
-            Long response = loanTransactionHelper.makeLoanRepayment(loanIdRef.get(), "Repayment", "30 May 2025", 48.91).getResourceId();
+            Long response = makeLoanRepayment(loanIdRef.get(), "Repayment", "30 May 2025", 48.91).getResourceId();
             Assertions.assertNotNull(response);
         });
 
         runAt("27 June 2025", () -> {
-            Long response = loanTransactionHelper.makeLoanRepayment(loanIdRef.get(), "Repayment", "27 June 2025", 48.91).getResourceId();
+            Long response = makeLoanRepayment(loanIdRef.get(), "Repayment", "27 June 2025", 48.91).getResourceId();
             Assertions.assertNotNull(response);
         });
 
         runAt("08 August 2025", () -> {
-            Long response = loanTransactionHelper.makeLoanRepayment(loanIdRef.get(), "Repayment", "08 August 2025", 48.91).getResourceId();
+            Long response = makeLoanRepayment(loanIdRef.get(), "Repayment", "08 August 2025", 48.91).getResourceId();
             Assertions.assertNotNull(response);
         });
 
         runAt("05 September 2025", () -> {
-            Long response = loanTransactionHelper.makeLoanRepayment(loanIdRef.get(), "Repayment", "05 September 2025", 48.91)
-                    .getResourceId();
+            Long response = makeLoanRepayment(loanIdRef.get(), "Repayment", "05 September 2025", 48.91).getResourceId();
             Assertions.assertNotNull(response);
         });
 
         runAt("03 October 2025", () -> {
-            Long response = loanTransactionHelper.makeLoanRepayment(loanIdRef.get(), "Repayment", "03 October 2025", 48.91).getResourceId();
+            Long response = makeLoanRepayment(loanIdRef.get(), "Repayment", "03 October 2025", 48.91).getResourceId();
             Assertions.assertNotNull(response);
         });
 
         runAt("08 October 2025", () -> {
             for (int i = 0; i < totalTransactions; i++) {
                 final String transactionExternalId = UUID.randomUUID().toString();
-                PostLoansLoanIdTransactionsResponse refundResponse = loanTransactionHelper.makeMerchantIssuedRefund(loanIdRef.get(),
+                PostLoansLoanIdTransactionsResponse refundResponse = makeMerchantIssuedRefund(loanIdRef.get(),
                         new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate("08 October 2025")
                                 .locale(LOCALE).transactionAmount(228.97).externalId(transactionExternalId)
                                 .interestRefundCalculation(false));
@@ -1601,15 +1522,14 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
         });
 
         runAt("09 October 2025", () -> {
-            loanTransactionHelper.makeCreditBalanceRefund(loanIdRef.get(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("09 October 2025").locale(LOCALE).transactionAmount(225.15));
+            makeCreditBalanceRefund(loanIdRef.get(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("09 October 2025").locale(LOCALE).transactionAmount(225.15));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanIdRef.get());
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanIdRef.get());
             assertTrue(loanDetails.getStatus().getClosedObligationsMet());
 
             for (int i = 0; i < totalTransactions; i++) {
-                loanTransactionHelper.createManualInterestRefund(loanIdRef.get(), merchantIssuedRefundTransactions.get(i).getResourceId(),
-                        null, 0.01, null);
+                createManualInterestRefund(loanIdRef.get(), merchantIssuedRefundTransactions.get(i).getResourceId(), null, 0.01, null);
             }
         });
     }
@@ -1619,18 +1539,18 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
         advancedPaymentData.setTransactionType(transactionType);
         advancedPaymentData.setFutureInstallmentAllocationRule(futureInstallmentAllocationRule);
 
-        List<PaymentAllocationOrder> paymentAllocationOrders = getPaymentAllocationOrder(PaymentAllocationType.PAST_DUE_INTEREST,
-                PaymentAllocationType.PAST_DUE_PRINCIPAL, PaymentAllocationType.PAST_DUE_PENALTY, PaymentAllocationType.PAST_DUE_FEE,
-                PaymentAllocationType.DUE_INTEREST, PaymentAllocationType.DUE_PRINCIPAL, PaymentAllocationType.DUE_PENALTY,
-                PaymentAllocationType.DUE_FEE, PaymentAllocationType.IN_ADVANCE_INTEREST, PaymentAllocationType.IN_ADVANCE_PRINCIPAL,
-                PaymentAllocationType.IN_ADVANCE_PENALTY, PaymentAllocationType.IN_ADVANCE_FEE);
+        List<PaymentAllocationOrder> paymentAllocationOrders = LoanRequestBuilders.paymentAllocationOrder(
+                PaymentAllocationType.PAST_DUE_INTEREST, PaymentAllocationType.PAST_DUE_PRINCIPAL, PaymentAllocationType.PAST_DUE_PENALTY,
+                PaymentAllocationType.PAST_DUE_FEE, PaymentAllocationType.DUE_INTEREST, PaymentAllocationType.DUE_PRINCIPAL,
+                PaymentAllocationType.DUE_PENALTY, PaymentAllocationType.DUE_FEE, PaymentAllocationType.IN_ADVANCE_INTEREST,
+                PaymentAllocationType.IN_ADVANCE_PRINCIPAL, PaymentAllocationType.IN_ADVANCE_PENALTY, PaymentAllocationType.IN_ADVANCE_FEE);
 
         advancedPaymentData.setPaymentAllocationOrder(paymentAllocationOrders);
         return advancedPaymentData;
     }
 
     private Long createLoanProduct() {
-        PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(create4IProgressive() //
+        Long loanProduct = createLoanProduct(create4IProgressive() //
                 .daysInMonthType(DaysInMonthType.ACTUAL) //
                 .daysInYearType(DaysInYearType.ACTUAL) //
                 .isInterestRecalculationEnabled(true) //
@@ -1643,8 +1563,8 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
                         createPaymentAllocationInterestPrincipalPenaltyFee("MERCHANT_ISSUED_REFUND",
                                 FuturePaymentAllocationRule.LAST_INSTALLMENT))) //
         );
-        Assertions.assertNotNull(loanProduct.getResourceId());
-        return loanProduct.getResourceId();
+        Assertions.assertNotNull(loanProduct);
+        return loanProduct;
     }
 
     private Long loanProductId = null;
@@ -1664,8 +1584,7 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
             Assertions.assertNotNull(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(450.0), "29 August 2024");
 
-            PostLoansLoanIdTransactionsResponse repayment = loanTransactionHelper.makeLoanRepayment(loanId, "MerchantIssuedRefund",
-                    "29 January 2025", 500.0);
+            PostLoansLoanIdTransactionsResponse repayment = makeLoanRepayment(loanId, "MerchantIssuedRefund", "29 January 2025", 500.0);
             Assertions.assertNotNull(repayment);
             Assertions.assertNotNull(repayment.getResourceId());
 
@@ -1694,8 +1613,8 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
             Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProductId, "1 January 2025", 100.0, 26.0, 6, null);
             Assertions.assertNotNull(loanId);
             disburseLoan(loanId, BigDecimal.valueOf(100.0), "1 January 2025");
-            loanTransactionHelper.makeLoanRepayment(loanId, "Repayment", "1 February 2025", 17.94);
-            loanTransactionHelper.makeLoanRepayment(loanId, "MerchantIssuedRefund", "1 February 2025", 66.41);
+            makeLoanRepayment(loanId, "Repayment", "1 February 2025", 17.94);
+            makeLoanRepayment(loanId, "MerchantIssuedRefund", "1 February 2025", 66.41);
             verifyTransactions(loanId, //
                     transaction(100.0, "Disbursement", "01 January 2025"), //
                     transaction(17.94, "Repayment", "01 February 2025"), //
@@ -1711,7 +1630,7 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
                     installment(17.94, 0.0, 0.0, true, "01 June 2025"), //
                     installment(17.94, 0.0, 0.0, true, "01 July 2025") //
             );
-            loanTransactionHelper.makeLoanRepayment(loanId, "MerchantIssuedRefund", "1 February 2025", 16.39);
+            makeLoanRepayment(loanId, "MerchantIssuedRefund", "1 February 2025", 16.39);
             verifyTransactions(loanId, //
                     transaction(100.0, "Disbursement", "01 January 2025"), //
                     transaction(17.94, "Repayment", "01 February 2025"), //
@@ -1730,7 +1649,7 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
                     installment(17.94, 0.0, 0.0, true, "01 June 2025"), //
                     installment(17.94, 0.0, 0.0, true, "01 July 2025") //
             );
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, LoanStatus.OVERPAID);
             Assertions.assertEquals(0.36, Utils.getDoubleValue(loanDetails.getTotalOverpaid()));
         });
@@ -1745,7 +1664,7 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
             disburseLoan(loanId, BigDecimal.valueOf(100.0), "1 January 2025");
 
             final String transactionExternalId = UUID.randomUUID().toString();
-            final PostLoansLoanIdTransactionsResponse refundResponse = loanTransactionHelper.makeMerchantIssuedRefund(loanId,
+            final PostLoansLoanIdTransactionsResponse refundResponse = makeMerchantIssuedRefund(loanId,
                     new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate("1 February 2025").locale("en")
                             .transactionAmount(66.41).externalId(transactionExternalId).interestRefundCalculation(false));
             Assertions.assertNotNull(refundResponse.getResourceId());
@@ -1756,7 +1675,7 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
             );
 
             // Create manual interest refund via API
-            loanTransactionHelper.createManualInterestRefund(loanId, refundResponse.getResourceId(), "1 February 2025", 0.47, null);
+            createManualInterestRefund(loanId, refundResponse.getResourceId(), "1 February 2025", 0.47, null);
 
             verifyTransactions(loanId, //
                     transaction(100.0, "Disbursement", "01 January 2025"), //
@@ -1764,9 +1683,8 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
                     transaction(0.47, "Interest Refund", "01 February 2025") //
             );
 
-            PostLoansLoanIdTransactionsResponse repaymentResponse = loanTransactionHelper.makeLoanRepayment(loanId, "Repayment",
-                    "20 January 2025", 17.94);
-            loanTransactionHelper.makeLoanRepayment(loanId, "Repayment", "25 January 2025", 10.94);
+            PostLoansLoanIdTransactionsResponse repaymentResponse = makeLoanRepayment(loanId, "Repayment", "20 January 2025", 17.94);
+            makeLoanRepayment(loanId, "Repayment", "25 January 2025", 10.94);
 
             verifyTransactions(loanId, //
                     transaction(100.0, "Disbursement", "01 January 2025"), //
@@ -1776,9 +1694,8 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
                     transaction(1.47, "Interest Refund", "01 February 2025") //
             );
 
-            loanTransactionHelper.reverseLoanTransaction(loanId, repaymentResponse.getResourceId(),
-                    new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("25 January 2025")
-                            .transactionAmount(0.0).locale("en"));
+            reverseLoanTransaction(loanId, repaymentResponse.getResourceId(), new PostLoansLoanIdTransactionsTransactionIdRequest()
+                    .dateFormat(DATETIME_PATTERN).transactionDate("25 January 2025").transactionAmount(0.0).locale("en"));
 
             verifyTransactions(loanId, //
                     transaction(100.0, "Disbursement", "01 January 2025"), //
@@ -1788,7 +1705,7 @@ public class LoanInterestRefundTest extends BaseLoanIntegrationTest {
                     transaction(1.47, "Interest Refund", "01 February 2025") //
             );
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, LoanStatus.ACTIVE);
             Assertions.assertEquals(23.97, Utils.getDoubleValue(loanDetails.getSummary().getTotalOutstanding()));
         });

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanMultipleDisbursementRepaymentScheduleTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanMultipleDisbursementRepaymentScheduleTest.java
@@ -22,212 +22,86 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
+import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.UUID;
-import org.apache.fineract.client.models.GetLoanProductsProductIdResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdRepaymentPeriod;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
+import org.apache.fineract.client.models.GetLoansLoanIdTransactions;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsResponse;
-import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
-import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
-import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
-import org.apache.fineract.infrastructure.core.service.DateUtils;
-import org.apache.fineract.integrationtests.common.BusinessDateHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.SchedulerJobHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
 import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.accounting.Account;
-import org.apache.fineract.integrationtests.common.accounting.AccountHelper;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
-import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 
 @Order(1)
-public class LoanMultipleDisbursementRepaymentScheduleTest extends BaseLoanIntegrationTest {
-
-    private static final DateTimeFormatter DATE_FORMATTER = new DateTimeFormatterBuilder().appendPattern("dd MMMM yyyy").toFormatter();
-    private ResponseSpecification responseSpec;
-    private RequestSpecification requestSpec;
-    private LoanTransactionHelper loanTransactionHelper;
-    private ClientHelper clientHelper;
-    private AccountHelper accountHelper;
-
-    @BeforeEach
-    public void setup() {
-        Utils.initializeRESTAssured();
-        this.requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        this.requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        this.responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        this.loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-        this.clientHelper = new ClientHelper(this.requestSpec, this.responseSpec);
-        this.accountHelper = new AccountHelper(this.requestSpec, this.responseSpec);
-    }
+public class LoanMultipleDisbursementRepaymentScheduleTest extends FeignLoanTestBase {
 
     @Test
     public void loanNoDuplicateRepaymentScheduleWithMultipleDisbursementTest() {
-        try {
+        runAt("07 July 2023", () -> {
+            // Client and multi-disburse periodic-accrual loan account creation
+            Long clientId = createClient();
             // Accounts oof periodic accrual
-            final Account assetAccount = this.accountHelper.createAssetAccount();
-            final Account incomeAccount = this.accountHelper.createIncomeAccount();
-            final Account expenseAccount = this.accountHelper.createExpenseAccount();
-            final Account overpaymentAccount = this.accountHelper.createLiabilityAccount();
+            Long loanProductId = createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct());
 
-            // Set business date
-            LocalDate currentDate = LocalDate.of(2023, 7, 7);
-
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, currentDate);
-
-            // Loan ExternalId
-            String loanExternalIdStr = UUID.randomUUID().toString();
-
-            // Client and Loan account creation
-
-            final Integer clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId().intValue();
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProductMultipleDisbursements(
-                    loanTransactionHelper, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
-            assertNotNull(getLoanProductsProductResponse);
-
-            final Integer loanId = createLoanAccountAndDisbursePartialAmount(clientId, getLoanProductsProductResponse.getId().intValue(),
-                    loanExternalIdStr);
+            Long loanId = applyForLoan(applyLoanRequest(clientId, loanProductId, "07 July 2023", 1000.0, 1));
+            approveLoan(loanId, approveLoanRequest(1000.0, "07 July 2023"));
+            disburseLoan(loanId, BigDecimal.valueOf(370.55), "07 July 2023");
 
             // Add Charge fee
-            Integer fee = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "5.15", false));
-
-            LocalDate targetDate = LocalDate.of(2023, 7, 11);
-            final String feeCharge1AddedDate = DATE_FORMATTER.format(targetDate);
-
-            Integer feeLoanChargeId = this.loanTransactionHelper.addChargesForLoan(loanId,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(fee), feeCharge1AddedDate, "5.15"));
-
-            assertNotNull(feeLoanChargeId);
+            addCharge(loanId, false, 5.15, "11 July 2023");
 
             // run cob
-
-            currentDate = LocalDate.of(2023, 7, 12);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, currentDate);
-
-            final String jobName = "Loan COB";
-            SchedulerJobHelper.executeAndAwaitJob(jobName);
+            updateBusinessDate("12 July 2023");
+            schedulerHelper.executeAndAwaitJob("Loan COB");
 
             // verify accrual transaction created for charge due date
-            checkAccrualTransaction(targetDate, 0.0f, 5.15f, 0.0f, loanId);
+            checkAccrualTransaction("11 July 2023", 0.0, 5.15, 0.0, loanId);
 
             // make Merchant Issued Refund
-
-            currentDate = LocalDate.of(2023, 7, 21);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, currentDate);
-
-            final PostLoansLoanIdTransactionsResponse merchantIssuedRefund_1 = loanTransactionHelper.makeMerchantIssuedRefund((long) loanId,
-                    new PostLoansLoanIdTransactionsRequest().dateFormat("dd MMMM yyyy").transactionDate("21 July 2023").locale("en")
-                            .transactionAmount(167.4));
-
-            assertNotNull(merchantIssuedRefund_1);
+            updateBusinessDate("21 July 2023");
+            PostLoansLoanIdTransactionsResponse merchantIssuedRefund = makeMerchantIssuedRefund(loanId,
+                    new PostLoansLoanIdTransactionsRequest().dateFormat(LoanTestData.DATETIME_PATTERN).transactionDate("21 July 2023")
+                            .locale(LoanTestData.LOCALE).transactionAmount(167.4));
+            assertNotNull(merchantIssuedRefund);
 
             // run cob
-            SchedulerJobHelper.executeAndAwaitJob(jobName);
+            schedulerHelper.executeAndAwaitJob("Loan COB");
 
             // make another disbursement
-            currentDate = LocalDate.of(2023, 7, 24);
+            updateBusinessDate("24 July 2023");
+            disburseLoan(loanId, BigDecimal.valueOf(18), "24 July 2023");
 
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, currentDate);
-
-            loanTransactionHelper.disburseLoanWithTransactionAmount("24 July 2023", loanId, "18");
-
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails((long) loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             assertTrue(loanDetails.getStatus().getActive());
 
             List<GetLoansLoanIdRepaymentPeriod> periods = loanDetails.getRepaymentSchedule().getPeriods();
-
             assertNotNull(periods);
 
             // verify only one active period
             long activePeriods = periods.stream().filter(p -> p.getPeriod() != null && p.getPeriod().equals(1)).count();
-
             assertEquals(1, activePeriods);
-
-        } finally {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
-        }
-
+        });
     }
 
-    private void checkAccrualTransaction(final LocalDate transactionDate, final Float interestPortion, final Float feePortion,
-            final Float penaltyPortion, final Integer loanID) {
-
-        ArrayList<HashMap> transactions = (ArrayList<HashMap>) loanTransactionHelper.getLoanTransactions(this.requestSpec,
-                this.responseSpec, loanID);
+    private void checkAccrualTransaction(final String transactionDate, final double interestPortion, final double feePortion,
+            final double penaltyPortion, final Long loanId) {
+        final LocalDate accrualDate = LocalDate.parse(transactionDate, dateTimeFormatter);
+        final GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
         boolean isTransactionFound = false;
-        for (int i = 0; i < transactions.size(); i++) {
-            HashMap transactionType = (HashMap) transactions.get(i).get("type");
-            boolean isAccrualTransaction = (Boolean) transactionType.get("accrual");
-
-            if (isAccrualTransaction) {
-                ArrayList<Integer> accrualEntryDateAsArray = (ArrayList<Integer>) transactions.get(i).get("date");
-                LocalDate accrualEntryDate = LocalDate.of(accrualEntryDateAsArray.get(0), accrualEntryDateAsArray.get(1),
-                        accrualEntryDateAsArray.get(2));
-
-                if (DateUtils.isEqual(transactionDate, accrualEntryDate)) {
-                    isTransactionFound = true;
-                    assertEquals(interestPortion, Float.valueOf(String.valueOf(transactions.get(i).get("interestPortion"))),
-                            "Mismatch in transaction amounts");
-                    assertEquals(feePortion, Float.valueOf(String.valueOf(transactions.get(i).get("feeChargesPortion"))),
-                            "Mismatch in transaction amounts");
-                    assertEquals(penaltyPortion, Float.valueOf(String.valueOf(transactions.get(i).get("penaltyChargesPortion"))),
-                            "Mismatch in transaction amounts");
-                    break;
-                }
+        for (GetLoansLoanIdTransactions transaction : loanDetails.getTransactions()) {
+            if (Boolean.TRUE.equals(transaction.getType().getAccrual()) && accrualDate.equals(transaction.getDate())) {
+                isTransactionFound = true;
+                assertEquals(interestPortion, Utils.getDoubleValue(transaction.getInterestPortion()), "Mismatch in transaction amounts");
+                assertEquals(feePortion, Utils.getDoubleValue(transaction.getFeeChargesPortion()), "Mismatch in transaction amounts");
+                assertEquals(penaltyPortion, Utils.getDoubleValue(transaction.getPenaltyChargesPortion()),
+                        "Mismatch in transaction amounts");
+                break;
             }
         }
         assertTrue(isTransactionFound, "No Accrual entries are posted");
     }
-
-    private GetLoanProductsProductIdResponse createLoanProductMultipleDisbursements(final LoanTransactionHelper loanTransactionHelper,
-            final Account... accounts) {
-
-        final String loanProductJSON = new LoanProductTestBuilder().withPrincipal("1000").withRepaymentTypeAsMonth()
-                .withRepaymentAfterEvery("1").withNumberOfRepayments("1").withRepaymentTypeAsMonth().withinterestRatePerPeriod("0")
-                .withInterestRateFrequencyTypeAsMonths().withAmortizationTypeAsEqualPrincipalPayment().withInterestTypeAsDecliningBalance()
-                .withAccountingRulePeriodicAccrual(accounts).withInterestCalculationPeriodTypeAsRepaymentPeriod(true).withDaysInMonth("30")
-                .withDaysInYear("365").withMoratorium("0", "0").withMultiDisburse().withDisallowExpectedDisbursements(true).build(null);
-        final Integer loanProductId = loanTransactionHelper.getLoanProductId(loanProductJSON);
-        return loanTransactionHelper.getLoanProduct(loanProductId);
-    }
-
-    private Integer createLoanAccountAndDisbursePartialAmount(final Integer clientID, final Integer loanProductID,
-            final String externalId) {
-
-        String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal("1000").withLoanTermFrequency("30")
-                .withLoanTermFrequencyAsDays().withNumberOfRepayments("1").withRepaymentEveryAfter("30").withRepaymentFrequencyTypeAsDays()
-                .withInterestRatePerPeriod("0").withInterestTypeAsDecliningBalance().withAmortizationTypeAsEqualPrincipalPayments()
-                .withInterestCalculationPeriodTypeSameAsRepaymentPeriod().withExpectedDisbursementDate("07 July 2023")
-                .withSubmittedOnDate("07 July 2023").withLoanType("individual").withExternalId(externalId)
-                .build(clientID.toString(), loanProductID.toString(), null);
-
-        final Integer loanId = loanTransactionHelper.getLoanId(loanApplicationJSON);
-        loanTransactionHelper.approveLoan("07 July 2023", "1000", loanId, null);
-        loanTransactionHelper.disburseLoanWithTransactionAmount("07 July 2023", loanId, "370.55");
-        return loanId;
-    }
-
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanMultipleDisbursementRepaymentScheduleTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanMultipleDisbursementRepaymentScheduleTest.java
@@ -22,211 +22,83 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
+import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.UUID;
-import org.apache.fineract.client.models.GetLoanProductsProductIdResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdRepaymentPeriod;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
+import org.apache.fineract.client.models.GetLoansLoanIdTransactions;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsResponse;
-import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
-import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
-import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
-import org.apache.fineract.infrastructure.core.service.DateUtils;
-import org.apache.fineract.integrationtests.common.BusinessDateHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.SchedulerJobHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
 import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.accounting.Account;
-import org.apache.fineract.integrationtests.common.accounting.AccountHelper;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
-import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class LoanMultipleDisbursementRepaymentScheduleTest extends BaseLoanIntegrationTest {
-
-    private static final DateTimeFormatter DATE_FORMATTER = new DateTimeFormatterBuilder().appendPattern("dd MMMM yyyy").toFormatter();
-    private ResponseSpecification responseSpec;
-    private RequestSpecification requestSpec;
-    private LoanTransactionHelper loanTransactionHelper;
-    private ClientHelper clientHelper;
-    private AccountHelper accountHelper;
-
-    @BeforeEach
-    public void setup() {
-        Utils.initializeRESTAssured();
-        this.requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        this.requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        this.responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        this.loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
-        this.clientHelper = new ClientHelper(this.requestSpec, this.responseSpec);
-        this.accountHelper = new AccountHelper(this.requestSpec, this.responseSpec);
-    }
+public class LoanMultipleDisbursementRepaymentScheduleTest extends FeignLoanTestBase {
 
     @Test
     public void loanNoDuplicateRepaymentScheduleWithMultipleDisbursementTest() {
-        try {
-            final SchedulerJobHelper schedulerJobHelper = new SchedulerJobHelper(requestSpec);
-            // Accounts oof periodic accrual
-            final Account assetAccount = this.accountHelper.createAssetAccount();
-            final Account incomeAccount = this.accountHelper.createIncomeAccount();
-            final Account expenseAccount = this.accountHelper.createExpenseAccount();
-            final Account overpaymentAccount = this.accountHelper.createLiabilityAccount();
+        runAt("07 July 2023", () -> {
+            // Client and multi-disburse periodic-accrual loan account creation
+            Long clientId = createClient();
+            Long loanProductId = createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct());
 
-            // Set business date
-            LocalDate currentDate = LocalDate.of(2023, 7, 7);
-
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, currentDate);
-
-            // Loan ExternalId
-            String loanExternalIdStr = UUID.randomUUID().toString();
-
-            // Client and Loan account creation
-
-            final Integer clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId().intValue();
-            final GetLoanProductsProductIdResponse getLoanProductsProductResponse = createLoanProductMultipleDisbursements(
-                    loanTransactionHelper, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
-            assertNotNull(getLoanProductsProductResponse);
-
-            final Integer loanId = createLoanAccountAndDisbursePartialAmount(clientId, getLoanProductsProductResponse.getId().intValue(),
-                    loanExternalIdStr);
+            Long loanId = applyForLoan(applyLoanRequest(clientId, loanProductId, "07 July 2023", 1000.0, 1));
+            approveLoan(loanId, approveLoanRequest(1000.0, "07 July 2023"));
+            disburseLoan(loanId, BigDecimal.valueOf(370.55), "07 July 2023");
 
             // Add Charge fee
-            Integer fee = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "5.15", false));
-
-            LocalDate targetDate = LocalDate.of(2023, 7, 11);
-            final String feeCharge1AddedDate = DATE_FORMATTER.format(targetDate);
-
-            Integer feeLoanChargeId = this.loanTransactionHelper.addChargesForLoan(loanId,
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(fee), feeCharge1AddedDate, "5.15"));
-
-            assertNotNull(feeLoanChargeId);
+            addCharge(loanId, false, 5.15, "11 July 2023");
 
             // run cob
-
-            currentDate = LocalDate.of(2023, 7, 12);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, currentDate);
-
-            final String jobName = "Loan COB";
-            schedulerJobHelper.executeAndAwaitJob(jobName);
+            updateBusinessDate("12 July 2023");
+            schedulerHelper.executeAndAwaitJob("Loan COB");
 
             // verify accrual transaction created for charge due date
-            checkAccrualTransaction(targetDate, 0.0f, 5.15f, 0.0f, loanId);
+            checkAccrualTransaction("11 July 2023", 0.0, 5.15, 0.0, loanId);
 
             // make Merchant Issued Refund
-
-            currentDate = LocalDate.of(2023, 7, 21);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, currentDate);
-
-            final PostLoansLoanIdTransactionsResponse merchantIssuedRefund_1 = loanTransactionHelper.makeMerchantIssuedRefund((long) loanId,
-                    new PostLoansLoanIdTransactionsRequest().dateFormat("dd MMMM yyyy").transactionDate("21 July 2023").locale("en")
-                            .transactionAmount(167.4));
-
-            assertNotNull(merchantIssuedRefund_1);
+            updateBusinessDate("21 July 2023");
+            PostLoansLoanIdTransactionsResponse merchantIssuedRefund = makeMerchantIssuedRefund(loanId,
+                    new PostLoansLoanIdTransactionsRequest().dateFormat(LoanTestData.DATETIME_PATTERN).transactionDate("21 July 2023")
+                            .locale(LoanTestData.LOCALE).transactionAmount(167.4));
+            assertNotNull(merchantIssuedRefund);
 
             // run cob
-            schedulerJobHelper.executeAndAwaitJob(jobName);
+            schedulerHelper.executeAndAwaitJob("Loan COB");
 
             // make another disbursement
-            currentDate = LocalDate.of(2023, 7, 24);
+            updateBusinessDate("24 July 2023");
+            disburseLoan(loanId, BigDecimal.valueOf(18), "24 July 2023");
 
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, currentDate);
-
-            loanTransactionHelper.disburseLoanWithTransactionAmount("24 July 2023", loanId, "18");
-
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails((long) loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             assertTrue(loanDetails.getStatus().getActive());
 
             List<GetLoansLoanIdRepaymentPeriod> periods = loanDetails.getRepaymentSchedule().getPeriods();
-
             assertNotNull(periods);
 
             // verify only one active period
             long activePeriods = periods.stream().filter(p -> p.getPeriod() != null && p.getPeriod().equals(1)).count();
-
             assertEquals(1, activePeriods);
-
-        } finally {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
-        }
-
+        });
     }
 
-    private void checkAccrualTransaction(final LocalDate transactionDate, final Float interestPortion, final Float feePortion,
-            final Float penaltyPortion, final Integer loanID) {
-
-        ArrayList<HashMap> transactions = (ArrayList<HashMap>) loanTransactionHelper.getLoanTransactions(this.requestSpec,
-                this.responseSpec, loanID);
+    private void checkAccrualTransaction(final String transactionDate, final double interestPortion, final double feePortion,
+            final double penaltyPortion, final Long loanId) {
+        final LocalDate accrualDate = LocalDate.parse(transactionDate, dateTimeFormatter);
+        final GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
         boolean isTransactionFound = false;
-        for (int i = 0; i < transactions.size(); i++) {
-            HashMap transactionType = (HashMap) transactions.get(i).get("type");
-            boolean isAccrualTransaction = (Boolean) transactionType.get("accrual");
-
-            if (isAccrualTransaction) {
-                ArrayList<Integer> accrualEntryDateAsArray = (ArrayList<Integer>) transactions.get(i).get("date");
-                LocalDate accrualEntryDate = LocalDate.of(accrualEntryDateAsArray.get(0), accrualEntryDateAsArray.get(1),
-                        accrualEntryDateAsArray.get(2));
-
-                if (DateUtils.isEqual(transactionDate, accrualEntryDate)) {
-                    isTransactionFound = true;
-                    assertEquals(interestPortion, Float.valueOf(String.valueOf(transactions.get(i).get("interestPortion"))),
-                            "Mismatch in transaction amounts");
-                    assertEquals(feePortion, Float.valueOf(String.valueOf(transactions.get(i).get("feeChargesPortion"))),
-                            "Mismatch in transaction amounts");
-                    assertEquals(penaltyPortion, Float.valueOf(String.valueOf(transactions.get(i).get("penaltyChargesPortion"))),
-                            "Mismatch in transaction amounts");
-                    break;
-                }
+        for (GetLoansLoanIdTransactions transaction : loanDetails.getTransactions()) {
+            if (Boolean.TRUE.equals(transaction.getType().getAccrual()) && accrualDate.equals(transaction.getDate())) {
+                isTransactionFound = true;
+                assertEquals(interestPortion, Utils.getDoubleValue(transaction.getInterestPortion()), "Mismatch in transaction amounts");
+                assertEquals(feePortion, Utils.getDoubleValue(transaction.getFeeChargesPortion()), "Mismatch in transaction amounts");
+                assertEquals(penaltyPortion, Utils.getDoubleValue(transaction.getPenaltyChargesPortion()),
+                        "Mismatch in transaction amounts");
+                break;
             }
         }
         assertTrue(isTransactionFound, "No Accrual entries are posted");
     }
-
-    private GetLoanProductsProductIdResponse createLoanProductMultipleDisbursements(final LoanTransactionHelper loanTransactionHelper,
-            final Account... accounts) {
-
-        final String loanProductJSON = new LoanProductTestBuilder().withPrincipal("1000").withRepaymentTypeAsMonth()
-                .withRepaymentAfterEvery("1").withNumberOfRepayments("1").withRepaymentTypeAsMonth().withinterestRatePerPeriod("0")
-                .withInterestRateFrequencyTypeAsMonths().withAmortizationTypeAsEqualPrincipalPayment().withInterestTypeAsDecliningBalance()
-                .withAccountingRulePeriodicAccrual(accounts).withInterestCalculationPeriodTypeAsRepaymentPeriod(true).withDaysInMonth("30")
-                .withDaysInYear("365").withMoratorium("0", "0").withMultiDisburse().withDisallowExpectedDisbursements(true).build(null);
-        final Integer loanProductId = loanTransactionHelper.getLoanProductId(loanProductJSON);
-        return loanTransactionHelper.getLoanProduct(loanProductId);
-    }
-
-    private Integer createLoanAccountAndDisbursePartialAmount(final Integer clientID, final Integer loanProductID,
-            final String externalId) {
-
-        String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal("1000").withLoanTermFrequency("30")
-                .withLoanTermFrequencyAsDays().withNumberOfRepayments("1").withRepaymentEveryAfter("30").withRepaymentFrequencyTypeAsDays()
-                .withInterestRatePerPeriod("0").withInterestTypeAsDecliningBalance().withAmortizationTypeAsEqualPrincipalPayments()
-                .withInterestCalculationPeriodTypeSameAsRepaymentPeriod().withExpectedDisbursementDate("07 July 2023")
-                .withSubmittedOnDate("07 July 2023").withLoanType("individual").withExternalId(externalId)
-                .build(clientID.toString(), loanProductID.toString(), null);
-
-        final Integer loanId = loanTransactionHelper.getLoanId(loanApplicationJSON);
-        loanTransactionHelper.approveLoan("07 July 2023", "1000", loanId, null);
-        loanTransactionHelper.disburseLoanWithTransactionAmount("07 July 2023", loanId, "370.55");
-        return loanId;
-    }
-
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanOriginationValidationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanOriginationValidationTest.java
@@ -19,73 +19,30 @@
 package org.apache.fineract.integrationtests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
 import java.math.BigDecimal;
-import org.apache.fineract.client.models.AdvancedPaymentData;
-import org.apache.fineract.client.models.PostClientsResponse;
-import org.apache.fineract.client.models.PostLoanProductsResponse;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
 import org.apache.fineract.client.models.PostLoansLoanIdRequest;
 import org.apache.fineract.client.models.PostLoansRequest;
-import org.apache.fineract.client.models.PostLoansResponse;
-import org.apache.fineract.client.util.CallFailedRuntimeException;
-import org.apache.fineract.integrationtests.common.BusinessDateHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.accounting.Account;
-import org.apache.fineract.integrationtests.common.accounting.AccountHelper;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
 import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.apache.fineract.portfolio.loanaccount.domain.transactionprocessor.impl.AdvancedPaymentScheduleTransactionProcessor;
-import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleProcessingType;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleType;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public class LoanOriginationValidationTest extends BaseLoanIntegrationTest {
+public class LoanOriginationValidationTest extends FeignLoanTestBase {
 
-    private static final Logger LOG = LoggerFactory.getLogger(AdvancedPaymentAllocationLoanRepaymentScheduleTest.class);
     private static final String DATETIME_PATTERN = "dd MMMM yyyy";
-    private static ResponseSpecification responseSpec;
-    private static RequestSpecification requestSpec;
-    private static BusinessDateHelper businessDateHelper;
-    private static LoanTransactionHelper loanTransactionHelper;
-    private static AccountHelper accountHelper;
-    private static Integer commonLoanProductId;
-    private static PostClientsResponse client;
-    private static ChargesHelper chargesHelper;
+    private static Long clientId;
 
     @BeforeAll
-    public static void setup() {
-        Utils.initializeRESTAssured();
-        requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        requestSpec.header("Fineract-Platform-TenantId", "default");
-        responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-        businessDateHelper = new BusinessDateHelper();
-        accountHelper = new AccountHelper(requestSpec, responseSpec);
-        ClientHelper clientHelper = new ClientHelper(requestSpec, responseSpec);
-        chargesHelper = new ChargesHelper();
-
-        final Account assetAccount = accountHelper.createAssetAccount();
-        final Account incomeAccount = accountHelper.createIncomeAccount();
-        final Account expenseAccount = accountHelper.createExpenseAccount();
-        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-
-        commonLoanProductId = createLoanProduct("500", "15", "4", true, "25", true, LoanScheduleType.PROGRESSIVE,
-                LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
-        client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+    public static void createCommonClient() {
+        clientId = clientHelper.createClient();
     }
 
+    // uc1: Negative Test: Loan approval transaction without approvedOnDate parameter
     // uc1: Negative Test: Loan approval transaction without approvedOnDate parameter
     // 1. Create a Loan product
     // 2. Submit a Loan application
@@ -95,33 +52,24 @@ public class LoanOriginationValidationTest extends BaseLoanIntegrationTest {
     public void uc1() {
         String operationDate = "15 August 2024";
         runAt(operationDate, () -> {
+            Long loanProductId = createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
+                    .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()));
+            PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, operationDate, 100.0, 5).numberOfRepayments(6)
+                    .loanTermFrequency(6).loanTermFrequencyType(2)
+                    .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(1)
+                    .repaymentFrequencyType(2).maxOutstandingLoanBalance(BigDecimal.valueOf(10000.0));
 
-            LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-            PostLoanProductsResponse loanProductResponse = loanProductHelper
-                    .createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
-                            .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()));
-            PostLoansRequest applicationRequest = applyLoanRequest(client.getClientId(), loanProductResponse.getResourceId(), operationDate,
-                    100.0, 5);
+            Long loanId = applyForLoan(applicationRequest);
 
-            applicationRequest = applicationRequest.numberOfRepayments(6)//
-                    .loanTermFrequency(6)//
-                    .loanTermFrequencyType(2)//
-                    .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)//
-                    .repaymentEvery(1)//
-                    .repaymentFrequencyType(2)//
-                    .maxOutstandingLoanBalance(BigDecimal.valueOf(10000.0))//
-            ;//
+            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
+                    () -> approveLoan(loanId, new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(100))
+                            .dateFormat(DATETIME_PATTERN).approvedOnDate(null).locale("en")));
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
-
-            CallFailedRuntimeException callFailedRuntimeException = Assertions.assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()
-                            .approvedLoanAmount(BigDecimal.valueOf(100)).dateFormat(DATETIME_PATTERN).approvedOnDate(null).locale("en")));
-
-            Assertions.assertTrue(callFailedRuntimeException.getMessage().contains("The parameter `approvedOnDate` is mandatory."));
+            assertTrue(exception.getMessage().contains("The parameter `approvedOnDate` is mandatory."));
         });
     }
 
+    // uc2: Negative Test: Loan disbursement transaction without actualDisbursementDate parameter
     // uc2: Negative Test: Loan disbursement transaction without actualDisbursementDate parameter
     // 1. Create a Loan product
     // 2. Submit and Approve Loan application
@@ -131,37 +79,27 @@ public class LoanOriginationValidationTest extends BaseLoanIntegrationTest {
     public void uc2() {
         String operationDate = "15 August 2024";
         runAt(operationDate, () -> {
+            Long loanProductId = createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
+                    .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()));
+            PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, operationDate, 100.0, 5).numberOfRepayments(6)
+                    .loanTermFrequency(6).loanTermFrequencyType(2)
+                    .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(1)
+                    .repaymentFrequencyType(2).maxOutstandingLoanBalance(BigDecimal.valueOf(10000.0));
 
-            LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-            PostLoanProductsResponse loanProductResponse = loanProductHelper
-                    .createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
-                            .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()));
-            PostLoansRequest applicationRequest = applyLoanRequest(client.getClientId(), loanProductResponse.getResourceId(), operationDate,
-                    100.0, 5);
+            Long loanId = applyForLoan(applicationRequest);
 
-            applicationRequest = applicationRequest.numberOfRepayments(6)//
-                    .loanTermFrequency(6)//
-                    .loanTermFrequencyType(2)//
-                    .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)//
-                    .repaymentEvery(1)//
-                    .repaymentFrequencyType(2)//
-                    .maxOutstandingLoanBalance(BigDecimal.valueOf(10000.0))//
-            ;//
+            approveLoan(loanId, new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(100)).dateFormat(DATETIME_PATTERN)
+                    .approvedOnDate(operationDate).locale("en"));
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
+                    () -> disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate(null).dateFormat(DATETIME_PATTERN)
+                            .transactionAmount(BigDecimal.valueOf(100.0)).locale("en")));
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()
-                    .approvedLoanAmount(BigDecimal.valueOf(100)).dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
-
-            CallFailedRuntimeException callFailedRuntimeException = Assertions.assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                            new PostLoansLoanIdRequest().actualDisbursementDate(null).dateFormat(DATETIME_PATTERN)
-                                    .transactionAmount(BigDecimal.valueOf(100.0)).locale("en")));
-
-            Assertions.assertTrue(callFailedRuntimeException.getMessage().contains("The parameter `actualDisbursementDate` is mandatory."));
+            assertTrue(exception.getMessage().contains("The parameter `actualDisbursementDate` is mandatory."));
         });
     }
 
+    // uc3: Negative Test: Loan application without required parameters
     // uc3: Negative Test: Loan application without required parameters
     // 1. Create a Loan product
     // 2. Submit Loan application without required parameters
@@ -169,108 +107,50 @@ public class LoanOriginationValidationTest extends BaseLoanIntegrationTest {
     public void uc3() {
         String operationDate = "15 August 2024";
         runAt(operationDate, () -> {
+            Long loanProductId = createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
+                    .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()));
 
-            LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-            PostLoanProductsResponse loanProductResponse = loanProductHelper
-                    .createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
-                            .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()));
             // Product Id null
-            final PostLoansRequest applicationRequest01 = applyLoanRequest(client.getClientId(), null, operationDate, 100.0, 5)
-                    .numberOfRepayments(6)//
-                    .loanTermFrequency(6)//
-                    .loanTermFrequencyType(2)//
-                    .repaymentEvery(1)//
-                    .repaymentFrequencyType(2)//
-            ;//
-            CallFailedRuntimeException callFailedRuntimeException = Assertions.assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.applyLoan(applicationRequest01));
-            assertEquals(400, callFailedRuntimeException.getResponse().code());
-            Assertions.assertTrue(callFailedRuntimeException.getMessage().contains("The parameter `productId` is mandatory."));
+            final PostLoansRequest applicationRequest01 = applyLoanRequest(clientId, null, operationDate, 100.0, 5).numberOfRepayments(6)
+                    .loanTermFrequency(6).loanTermFrequencyType(2).repaymentEvery(1).repaymentFrequencyType(2);
+            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class, () -> applyForLoan(applicationRequest01));
+            assertEquals(400, exception.getStatus());
+            assertTrue(exception.getMessage().contains("The parameter `productId` is mandatory."));
 
             // Transaction Processing Strategy Code null
-            final PostLoansRequest applicationRequest02 = applyLoanRequest(client.getClientId(), loanProductResponse.getResourceId(),
-                    operationDate, 100.0, 5).numberOfRepayments(6)//
-                    .loanTermFrequency(6)//
-                    .loanTermFrequencyType(2)//
-                    .transactionProcessingStrategyCode(null)//
-                    .repaymentEvery(1)//
-                    .repaymentFrequencyType(2)//
-            ;//
+            final PostLoansRequest applicationRequest02 = applyLoanRequest(clientId, loanProductId, operationDate, 100.0, 5)
+                    .numberOfRepayments(6).loanTermFrequency(6).loanTermFrequencyType(2).transactionProcessingStrategyCode(null)
+                    .repaymentEvery(1).repaymentFrequencyType(2);
+            exception = assertThrows(CallFailedRuntimeException.class, () -> applyForLoan(applicationRequest02));
+            assertEquals(400, exception.getStatus());
+            assertTrue(exception.getMessage().contains("The parameter `transactionProcessingStrategyCode` is mandatory."));
 
-            callFailedRuntimeException = Assertions.assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.applyLoan(applicationRequest02));
-            assertEquals(400, callFailedRuntimeException.getResponse().code());
-            Assertions.assertTrue(
-                    callFailedRuntimeException.getMessage().contains("The parameter `transactionProcessingStrategyCode` is mandatory."));
-
-            final PostLoansRequest applicationRequest03 = applyLoanRequest(null, loanProductResponse.getResourceId(), operationDate, 100.0,
-                    5).numberOfRepayments(6)//
-                    .loanTermFrequency(6)//
-                    .loanTermFrequencyType(2)//
-                    .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)//
-                    .repaymentEvery(1)//
-                    .repaymentFrequencyType(2)//
-            ;//
-            callFailedRuntimeException = Assertions.assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.applyLoan(applicationRequest03));
-            LOG.info("DETAIL: {}", callFailedRuntimeException.getMessage());
-            assertEquals(400, callFailedRuntimeException.getResponse().code());
-            Assertions.assertTrue(callFailedRuntimeException.getMessage().contains("The parameter `clientId` is mandatory."));
+            // Client Id null
+            final PostLoansRequest applicationRequest03 = applyLoanRequest(null, loanProductId, operationDate, 100.0, 5)
+                    .numberOfRepayments(6).loanTermFrequency(6).loanTermFrequencyType(2)
+                    .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(1)
+                    .repaymentFrequencyType(2);
+            exception = assertThrows(CallFailedRuntimeException.class, () -> applyForLoan(applicationRequest03));
+            assertEquals(400, exception.getStatus());
+            assertTrue(exception.getMessage().contains("The parameter `clientId` is mandatory."));
 
             // Submitted Date null
-            final PostLoansRequest applicationRequest04 = applyLoanRequest(client.getClientId(), loanProductResponse.getResourceId(),
-                    operationDate, 100.0, 5).numberOfRepayments(6)//
-                    .submittedOnDate(null) //
-                    .loanTermFrequency(6)//
-                    .loanTermFrequencyType(2)//
-                    .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)//
-                    .repaymentEvery(1)//
-                    .repaymentFrequencyType(2)//
-            ;//
-            callFailedRuntimeException = Assertions.assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.applyLoan(applicationRequest04));
-            assertEquals(400, callFailedRuntimeException.getResponse().code());
-            Assertions.assertTrue(callFailedRuntimeException.getMessage().contains("The parameter `submittedOnDate` is mandatory."));
+            final PostLoansRequest applicationRequest04 = applyLoanRequest(clientId, loanProductId, operationDate, 100.0, 5)
+                    .numberOfRepayments(6).submittedOnDate(null).loanTermFrequency(6).loanTermFrequencyType(2)
+                    .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(1)
+                    .repaymentFrequencyType(2);
+            exception = assertThrows(CallFailedRuntimeException.class, () -> applyForLoan(applicationRequest04));
+            assertEquals(400, exception.getStatus());
+            assertTrue(exception.getMessage().contains("The parameter `submittedOnDate` is mandatory."));
 
             // Expected disbursement Date null
-            final PostLoansRequest applicationRequest05 = applyLoanRequest(client.getClientId(), loanProductResponse.getResourceId(),
-                    operationDate, 100.0, 5).numberOfRepayments(6)//
-                    .expectedDisbursementDate(null) //
-                    .loanTermFrequency(6)//
-                    .loanTermFrequencyType(2)//
-                    .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)//
-                    .repaymentEvery(1)//
-                    .repaymentFrequencyType(2)//
-            ;//
-            callFailedRuntimeException = Assertions.assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.applyLoan(applicationRequest05));
-            assertEquals(400, callFailedRuntimeException.getResponse().code());
-            Assertions
-                    .assertTrue(callFailedRuntimeException.getMessage().contains("The parameter `expectedDisbursementDate` is mandatory."));
+            final PostLoansRequest applicationRequest05 = applyLoanRequest(clientId, loanProductId, operationDate, 100.0, 5)
+                    .numberOfRepayments(6).expectedDisbursementDate(null).loanTermFrequency(6).loanTermFrequencyType(2)
+                    .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(1)
+                    .repaymentFrequencyType(2);
+            exception = assertThrows(CallFailedRuntimeException.class, () -> applyForLoan(applicationRequest05));
+            assertEquals(400, exception.getStatus());
+            assertTrue(exception.getMessage().contains("The parameter `expectedDisbursementDate` is mandatory."));
         });
     }
-
-    private static Integer createLoanProduct(final String principal, final String repaymentAfterEvery, final String numberOfRepayments,
-            boolean downPaymentEnabled, String downPaymentPercentage, boolean autoPayForDownPayment, LoanScheduleType loanScheduleType,
-            LoanScheduleProcessingType loanScheduleProcessingType, final Account... accounts) {
-        AdvancedPaymentData defaultAllocation = createDefaultPaymentAllocation();
-        AdvancedPaymentData goodwillCreditAllocation = createPaymentAllocation("GOODWILL_CREDIT", "LAST_INSTALLMENT");
-        AdvancedPaymentData merchantIssuedRefundAllocation = createPaymentAllocation("MERCHANT_ISSUED_REFUND", "REAMORTIZATION");
-        AdvancedPaymentData payoutRefundAllocation = createPaymentAllocation("PAYOUT_REFUND", "NEXT_INSTALLMENT");
-        LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-        final String loanProductJSON = new LoanProductTestBuilder().withMinPrincipal(principal).withPrincipal(principal)
-                .withRepaymentTypeAsDays().withRepaymentAfterEvery(repaymentAfterEvery).withNumberOfRepayments(numberOfRepayments)
-                .withEnableDownPayment(downPaymentEnabled, downPaymentPercentage, autoPayForDownPayment).withinterestRatePerPeriod("0")
-                .withInterestRateFrequencyTypeAsMonths()
-                .withRepaymentStrategy(AdvancedPaymentScheduleTransactionProcessor.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)
-                .withAmortizationTypeAsEqualPrincipalPayment().withInterestTypeAsFlat().withAccountingRulePeriodicAccrual(accounts)
-                .addAdvancedPaymentAllocation(defaultAllocation, goodwillCreditAllocation, merchantIssuedRefundAllocation,
-                        payoutRefundAllocation)
-                .withInterestCalculationPeriodTypeAsRepaymentPeriod(true).withInterestTypeAsDecliningBalance().withMultiDisburse()
-                .withDisallowExpectedDisbursements(true).withLoanScheduleType(loanScheduleType)
-                .withLoanScheduleProcessingType(loanScheduleProcessingType).withDaysInMonth("30").withDaysInYear("365")
-                .withMoratorium("0", "0").build(null);
-        return loanTransactionHelper.getLoanProductId(loanProductJSON);
-    }
-
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanOriginationValidationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanOriginationValidationTest.java
@@ -19,258 +19,125 @@
 package org.apache.fineract.integrationtests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
 import java.math.BigDecimal;
-import org.apache.fineract.client.models.AdvancedPaymentData;
-import org.apache.fineract.client.models.PostClientsResponse;
-import org.apache.fineract.client.models.PostLoanProductsResponse;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
 import org.apache.fineract.client.models.PostLoansLoanIdRequest;
 import org.apache.fineract.client.models.PostLoansRequest;
-import org.apache.fineract.client.models.PostLoansResponse;
-import org.apache.fineract.client.util.CallFailedRuntimeException;
-import org.apache.fineract.integrationtests.common.BusinessDateHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.accounting.Account;
-import org.apache.fineract.integrationtests.common.accounting.AccountHelper;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
 import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.apache.fineract.portfolio.loanaccount.domain.transactionprocessor.impl.AdvancedPaymentScheduleTransactionProcessor;
-import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleProcessingType;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleType;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public class LoanOriginationValidationTest extends BaseLoanIntegrationTest {
+public class LoanOriginationValidationTest extends FeignLoanTestBase {
 
-    private static final Logger LOG = LoggerFactory.getLogger(AdvancedPaymentAllocationLoanRepaymentScheduleTest.class);
     private static final String DATETIME_PATTERN = "dd MMMM yyyy";
-    private static ResponseSpecification responseSpec;
-    private static RequestSpecification requestSpec;
-    private static BusinessDateHelper businessDateHelper;
-    private static LoanTransactionHelper loanTransactionHelper;
-    private static AccountHelper accountHelper;
-    private static Integer commonLoanProductId;
-    private static PostClientsResponse client;
-    private static ChargesHelper chargesHelper;
+    private static Long clientId;
 
     @BeforeAll
-    public static void setup() {
-        Utils.initializeRESTAssured();
-        requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        requestSpec.header("Fineract-Platform-TenantId", "default");
-        responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-        businessDateHelper = new BusinessDateHelper();
-        accountHelper = new AccountHelper(requestSpec, responseSpec);
-        ClientHelper clientHelper = new ClientHelper(requestSpec, responseSpec);
-        chargesHelper = new ChargesHelper();
-
-        final Account assetAccount = accountHelper.createAssetAccount();
-        final Account incomeAccount = accountHelper.createIncomeAccount();
-        final Account expenseAccount = accountHelper.createExpenseAccount();
-        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-
-        commonLoanProductId = createLoanProduct("500", "15", "4", true, "25", true, LoanScheduleType.PROGRESSIVE,
-                LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
-        client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+    public static void createCommonClient() {
+        clientId = clientHelper.createClient();
     }
 
     // uc1: Negative Test: Loan approval transaction without approvedOnDate parameter
-    // 1. Create a Loan product
-    // 2. Submit a Loan application
-    // 3. Try to Approve a Loan account without approvedOnDate parameter to catch The request was invalid error due
-    // missed required attribute
     @Test
     public void uc1() {
         String operationDate = "15 August 2024";
         runAt(operationDate, () -> {
+            Long loanProductId = createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
+                    .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()));
+            PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, operationDate, 100.0, 5).numberOfRepayments(6)
+                    .loanTermFrequency(6).loanTermFrequencyType(2)
+                    .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(1)
+                    .repaymentFrequencyType(2).maxOutstandingLoanBalance(BigDecimal.valueOf(10000.0));
 
-            LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-            PostLoanProductsResponse loanProductResponse = loanProductHelper
-                    .createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
-                            .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()));
-            PostLoansRequest applicationRequest = applyLoanRequest(client.getClientId(), loanProductResponse.getResourceId(), operationDate,
-                    100.0, 5);
+            Long loanId = applyForLoan(applicationRequest);
 
-            applicationRequest = applicationRequest.numberOfRepayments(6)//
-                    .loanTermFrequency(6)//
-                    .loanTermFrequencyType(2)//
-                    .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)//
-                    .repaymentEvery(1)//
-                    .repaymentFrequencyType(2)//
-                    .maxOutstandingLoanBalance(BigDecimal.valueOf(10000.0))//
-            ;//
+            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
+                    () -> approveLoan(loanId, new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(100))
+                            .dateFormat(DATETIME_PATTERN).approvedOnDate(null).locale("en")));
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
-
-            CallFailedRuntimeException callFailedRuntimeException = Assertions.assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()
-                            .approvedLoanAmount(BigDecimal.valueOf(100)).dateFormat(DATETIME_PATTERN).approvedOnDate(null).locale("en")));
-
-            Assertions.assertTrue(callFailedRuntimeException.getMessage().contains("The parameter `approvedOnDate` is mandatory."));
+            assertTrue(exception.getMessage().contains("The parameter `approvedOnDate` is mandatory."));
         });
     }
 
     // uc2: Negative Test: Loan disbursement transaction without actualDisbursementDate parameter
-    // 1. Create a Loan product
-    // 2. Submit and Approve Loan application
-    // 3. Try to Disburse a Loan account without actualDisbursementDate parameter to catch The request was invalid error
-    // due missed required attribute
     @Test
     public void uc2() {
         String operationDate = "15 August 2024";
         runAt(operationDate, () -> {
+            Long loanProductId = createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
+                    .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()));
+            PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, operationDate, 100.0, 5).numberOfRepayments(6)
+                    .loanTermFrequency(6).loanTermFrequencyType(2)
+                    .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(1)
+                    .repaymentFrequencyType(2).maxOutstandingLoanBalance(BigDecimal.valueOf(10000.0));
 
-            LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-            PostLoanProductsResponse loanProductResponse = loanProductHelper
-                    .createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
-                            .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()));
-            PostLoansRequest applicationRequest = applyLoanRequest(client.getClientId(), loanProductResponse.getResourceId(), operationDate,
-                    100.0, 5);
+            Long loanId = applyForLoan(applicationRequest);
 
-            applicationRequest = applicationRequest.numberOfRepayments(6)//
-                    .loanTermFrequency(6)//
-                    .loanTermFrequencyType(2)//
-                    .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)//
-                    .repaymentEvery(1)//
-                    .repaymentFrequencyType(2)//
-                    .maxOutstandingLoanBalance(BigDecimal.valueOf(10000.0))//
-            ;//
+            approveLoan(loanId, new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(100)).dateFormat(DATETIME_PATTERN)
+                    .approvedOnDate(operationDate).locale("en"));
 
-            PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
+                    () -> disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate(null).dateFormat(DATETIME_PATTERN)
+                            .transactionAmount(BigDecimal.valueOf(100.0)).locale("en")));
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest()
-                    .approvedLoanAmount(BigDecimal.valueOf(100)).dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
-
-            CallFailedRuntimeException callFailedRuntimeException = Assertions.assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                            new PostLoansLoanIdRequest().actualDisbursementDate(null).dateFormat(DATETIME_PATTERN)
-                                    .transactionAmount(BigDecimal.valueOf(100.0)).locale("en")));
-
-            Assertions.assertTrue(callFailedRuntimeException.getMessage().contains("The parameter `actualDisbursementDate` is mandatory."));
+            assertTrue(exception.getMessage().contains("The parameter `actualDisbursementDate` is mandatory."));
         });
     }
 
     // uc3: Negative Test: Loan application without required parameters
-    // 1. Create a Loan product
-    // 2. Submit Loan application without required parameters
     @Test
     public void uc3() {
         String operationDate = "15 August 2024";
         runAt(operationDate, () -> {
+            Long loanProductId = createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
+                    .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()));
 
-            LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-            PostLoanProductsResponse loanProductResponse = loanProductHelper
-                    .createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
-                            .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()));
             // Product Id null
-            final PostLoansRequest applicationRequest01 = applyLoanRequest(client.getClientId(), null, operationDate, 100.0, 5)
-                    .numberOfRepayments(6)//
-                    .loanTermFrequency(6)//
-                    .loanTermFrequencyType(2)//
-                    .repaymentEvery(1)//
-                    .repaymentFrequencyType(2)//
-            ;//
-            CallFailedRuntimeException callFailedRuntimeException = Assertions.assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.applyLoan(applicationRequest01));
-            assertEquals(400, callFailedRuntimeException.getResponse().code());
-            Assertions.assertTrue(callFailedRuntimeException.getMessage().contains("The parameter `productId` is mandatory."));
+            final PostLoansRequest applicationRequest01 = applyLoanRequest(clientId, null, operationDate, 100.0, 5).numberOfRepayments(6)
+                    .loanTermFrequency(6).loanTermFrequencyType(2).repaymentEvery(1).repaymentFrequencyType(2);
+            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class, () -> applyForLoan(applicationRequest01));
+            assertEquals(400, exception.getStatus());
+            assertTrue(exception.getMessage().contains("The parameter `productId` is mandatory."));
 
             // Transaction Processing Strategy Code null
-            final PostLoansRequest applicationRequest02 = applyLoanRequest(client.getClientId(), loanProductResponse.getResourceId(),
-                    operationDate, 100.0, 5).numberOfRepayments(6)//
-                    .loanTermFrequency(6)//
-                    .loanTermFrequencyType(2)//
-                    .transactionProcessingStrategyCode(null)//
-                    .repaymentEvery(1)//
-                    .repaymentFrequencyType(2)//
-            ;//
+            final PostLoansRequest applicationRequest02 = applyLoanRequest(clientId, loanProductId, operationDate, 100.0, 5)
+                    .numberOfRepayments(6).loanTermFrequency(6).loanTermFrequencyType(2).transactionProcessingStrategyCode(null)
+                    .repaymentEvery(1).repaymentFrequencyType(2);
+            exception = assertThrows(CallFailedRuntimeException.class, () -> applyForLoan(applicationRequest02));
+            assertEquals(400, exception.getStatus());
+            assertTrue(exception.getMessage().contains("The parameter `transactionProcessingStrategyCode` is mandatory."));
 
-            callFailedRuntimeException = Assertions.assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.applyLoan(applicationRequest02));
-            assertEquals(400, callFailedRuntimeException.getResponse().code());
-            Assertions.assertTrue(
-                    callFailedRuntimeException.getMessage().contains("The parameter `transactionProcessingStrategyCode` is mandatory."));
-
-            final PostLoansRequest applicationRequest03 = applyLoanRequest(null, loanProductResponse.getResourceId(), operationDate, 100.0,
-                    5).numberOfRepayments(6)//
-                    .loanTermFrequency(6)//
-                    .loanTermFrequencyType(2)//
-                    .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)//
-                    .repaymentEvery(1)//
-                    .repaymentFrequencyType(2)//
-            ;//
-            callFailedRuntimeException = Assertions.assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.applyLoan(applicationRequest03));
-            LOG.info("DETAIL: {}", callFailedRuntimeException.getMessage());
-            assertEquals(400, callFailedRuntimeException.getResponse().code());
-            Assertions.assertTrue(callFailedRuntimeException.getMessage().contains("The parameter `clientId` is mandatory."));
+            // Client Id null
+            final PostLoansRequest applicationRequest03 = applyLoanRequest(null, loanProductId, operationDate, 100.0, 5)
+                    .numberOfRepayments(6).loanTermFrequency(6).loanTermFrequencyType(2)
+                    .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(1)
+                    .repaymentFrequencyType(2);
+            exception = assertThrows(CallFailedRuntimeException.class, () -> applyForLoan(applicationRequest03));
+            assertEquals(400, exception.getStatus());
+            assertTrue(exception.getMessage().contains("The parameter `clientId` is mandatory."));
 
             // Submitted Date null
-            final PostLoansRequest applicationRequest04 = applyLoanRequest(client.getClientId(), loanProductResponse.getResourceId(),
-                    operationDate, 100.0, 5).numberOfRepayments(6)//
-                    .submittedOnDate(null) //
-                    .loanTermFrequency(6)//
-                    .loanTermFrequencyType(2)//
-                    .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)//
-                    .repaymentEvery(1)//
-                    .repaymentFrequencyType(2)//
-            ;//
-            callFailedRuntimeException = Assertions.assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.applyLoan(applicationRequest04));
-            assertEquals(400, callFailedRuntimeException.getResponse().code());
-            Assertions.assertTrue(callFailedRuntimeException.getMessage().contains("The parameter `submittedOnDate` is mandatory."));
+            final PostLoansRequest applicationRequest04 = applyLoanRequest(clientId, loanProductId, operationDate, 100.0, 5)
+                    .numberOfRepayments(6).submittedOnDate(null).loanTermFrequency(6).loanTermFrequencyType(2)
+                    .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(1)
+                    .repaymentFrequencyType(2);
+            exception = assertThrows(CallFailedRuntimeException.class, () -> applyForLoan(applicationRequest04));
+            assertEquals(400, exception.getStatus());
+            assertTrue(exception.getMessage().contains("The parameter `submittedOnDate` is mandatory."));
 
             // Expected disbursement Date null
-            final PostLoansRequest applicationRequest05 = applyLoanRequest(client.getClientId(), loanProductResponse.getResourceId(),
-                    operationDate, 100.0, 5).numberOfRepayments(6)//
-                    .expectedDisbursementDate(null) //
-                    .loanTermFrequency(6)//
-                    .loanTermFrequencyType(2)//
-                    .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)//
-                    .repaymentEvery(1)//
-                    .repaymentFrequencyType(2)//
-            ;//
-            callFailedRuntimeException = Assertions.assertThrows(CallFailedRuntimeException.class,
-                    () -> loanTransactionHelper.applyLoan(applicationRequest05));
-            assertEquals(400, callFailedRuntimeException.getResponse().code());
-            Assertions
-                    .assertTrue(callFailedRuntimeException.getMessage().contains("The parameter `expectedDisbursementDate` is mandatory."));
+            final PostLoansRequest applicationRequest05 = applyLoanRequest(clientId, loanProductId, operationDate, 100.0, 5)
+                    .numberOfRepayments(6).expectedDisbursementDate(null).loanTermFrequency(6).loanTermFrequencyType(2)
+                    .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).repaymentEvery(1)
+                    .repaymentFrequencyType(2);
+            exception = assertThrows(CallFailedRuntimeException.class, () -> applyForLoan(applicationRequest05));
+            assertEquals(400, exception.getStatus());
+            assertTrue(exception.getMessage().contains("The parameter `expectedDisbursementDate` is mandatory."));
         });
     }
-
-    private static Integer createLoanProduct(final String principal, final String repaymentAfterEvery, final String numberOfRepayments,
-            boolean downPaymentEnabled, String downPaymentPercentage, boolean autoPayForDownPayment, LoanScheduleType loanScheduleType,
-            LoanScheduleProcessingType loanScheduleProcessingType, final Account... accounts) {
-        AdvancedPaymentData defaultAllocation = createDefaultPaymentAllocation();
-        AdvancedPaymentData goodwillCreditAllocation = createPaymentAllocation("GOODWILL_CREDIT", "LAST_INSTALLMENT");
-        AdvancedPaymentData merchantIssuedRefundAllocation = createPaymentAllocation("MERCHANT_ISSUED_REFUND", "REAMORTIZATION");
-        AdvancedPaymentData payoutRefundAllocation = createPaymentAllocation("PAYOUT_REFUND", "NEXT_INSTALLMENT");
-        LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-        final String loanProductJSON = new LoanProductTestBuilder().withMinPrincipal(principal).withPrincipal(principal)
-                .withRepaymentTypeAsDays().withRepaymentAfterEvery(repaymentAfterEvery).withNumberOfRepayments(numberOfRepayments)
-                .withEnableDownPayment(downPaymentEnabled, downPaymentPercentage, autoPayForDownPayment).withinterestRatePerPeriod("0")
-                .withInterestRateFrequencyTypeAsMonths()
-                .withRepaymentStrategy(AdvancedPaymentScheduleTransactionProcessor.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)
-                .withAmortizationTypeAsEqualPrincipalPayment().withInterestTypeAsFlat().withAccountingRulePeriodicAccrual(accounts)
-                .addAdvancedPaymentAllocation(defaultAllocation, goodwillCreditAllocation, merchantIssuedRefundAllocation,
-                        payoutRefundAllocation)
-                .withInterestCalculationPeriodTypeAsRepaymentPeriod(true).withInterestTypeAsDecliningBalance().withMultiDisburse()
-                .withDisallowExpectedDisbursements(true).withLoanScheduleType(loanScheduleType)
-                .withLoanScheduleProcessingType(loanScheduleProcessingType).withDaysInMonth("30").withDaysInYear("365")
-                .withMoratorium("0", "0").build(null);
-        return loanTransactionHelper.getLoanProductId(loanProductJSON);
-    }
-
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanProductChargeOffReasonMappingsTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanProductChargeOffReasonMappingsTest.java
@@ -18,11 +18,9 @@
  */
 package org.apache.fineract.integrationtests;
 
-import static org.apache.fineract.integrationtests.common.funds.FundsResourceHandler.createFund;
-
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
 import org.apache.fineract.client.models.AllowAttributeOverrides;
 import org.apache.fineract.client.models.GetLoanPaymentChannelToFundSourceMappings;
 import org.apache.fineract.client.models.GetLoanProductsProductIdResponse;
@@ -31,47 +29,44 @@ import org.apache.fineract.client.models.LoanProductChargeToGLAccountMapper;
 import org.apache.fineract.client.models.PostChargeOffReasonToExpenseAccountMappings;
 import org.apache.fineract.client.models.PostLoanProductsRequest;
 import org.apache.fineract.client.models.PutLoanProductsProductIdRequest;
-import org.apache.fineract.client.util.CallFailedRuntimeException;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignDelinquencyHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignFundHelper;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.common.accounting.Account;
-import org.apache.fineract.integrationtests.common.products.DelinquencyBucketsHelper;
-import org.apache.fineract.integrationtests.common.system.CodeHelper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.lang.NonNull;
 
-public class LoanProductChargeOffReasonMappingsTest extends BaseLoanIntegrationTest {
-
-    private static final String CODE_VALUE_NAME = "ChargeOffReasons";
-    private final Account expenseAccount = accountHelper.createExpenseAccount();
-    private final Account otherExpenseAccount = accountHelper.createExpenseAccount();
+public class LoanProductChargeOffReasonMappingsTest extends FeignLoanTestBase {
 
     @Test
     public void testCreateAndUpdateLoanProductWithValidChargeOffReason() {
         runAt("15 January 2023", () -> {
-            Integer chargeOffReasons = createChargeOffReason();
-            Long localLoanProductId = loanTransactionHelper
-                    .createLoanProduct(loanProductsRequest(Long.valueOf(chargeOffReasons), expenseAccount.getAccountID().longValue()))
-                    .getResourceId();
+            final Account expenseAccount = accountHelper.createExpenseAccount("expense");
+            final Account otherExpenseAccount = accountHelper.createExpenseAccount("expense");
+            Long chargeOffReasons = createChargeOffReason();
+            Long localLoanProductId = createLoanProduct(loanProductsRequest(chargeOffReasons, expenseAccount.getAccountID().longValue()));
 
             Assertions.assertNotNull(localLoanProductId);
 
-            GetLoanProductsProductIdResponse loanProductDetails = loanTransactionHelper.getLoanProduct(localLoanProductId.intValue());
+            GetLoanProductsProductIdResponse loanProductDetails = retrieveLoanProduct(localLoanProductId);
             Assertions.assertEquals(expenseAccount.getAccountID().longValue(),
                     loanProductDetails.getChargeOffReasonToExpenseAccountMappings().get(0).getExpenseAccount().getId());
-            Assertions.assertEquals(Long.valueOf(chargeOffReasons),
+            Assertions.assertEquals(chargeOffReasons,
                     loanProductDetails.getChargeOffReasonToExpenseAccountMappings().get(0).getReasonCodeValue().getId());
 
             List<PostChargeOffReasonToExpenseAccountMappings> chargeOffReasonToExpenseAccountMappings = createPostChargeOffReasonToExpenseAccountMappings(
-                    Long.valueOf(chargeOffReasons), otherExpenseAccount.getAccountID().longValue());
+                    chargeOffReasons, otherExpenseAccount.getAccountID().longValue());
 
-            loanTransactionHelper.updateLoanProduct(localLoanProductId, new PutLoanProductsProductIdRequest().locale("en")
-                    .chargeOffReasonToExpenseAccountMappings(chargeOffReasonToExpenseAccountMappings)).getResourceId();
+            updateLoanProduct(localLoanProductId, new PutLoanProductsProductIdRequest().locale("en")
+                    .chargeOffReasonToExpenseAccountMappings(chargeOffReasonToExpenseAccountMappings));
 
-            loanProductDetails = loanTransactionHelper.getLoanProduct(localLoanProductId.intValue());
+            loanProductDetails = retrieveLoanProduct(localLoanProductId);
             Assertions.assertEquals(otherExpenseAccount.getAccountID().longValue(),
                     loanProductDetails.getChargeOffReasonToExpenseAccountMappings().get(0).getExpenseAccount().getId());
-            Assertions.assertEquals(Long.valueOf(chargeOffReasons),
+            Assertions.assertEquals(chargeOffReasons,
                     loanProductDetails.getChargeOffReasonToExpenseAccountMappings().get(0).getReasonCodeValue().getId());
         });
     }
@@ -80,8 +75,8 @@ public class LoanProductChargeOffReasonMappingsTest extends BaseLoanIntegrationT
     public void testCreateLoanProductWithInvalidGLAccount() {
         runAt("15 January 2023", () -> {
             try {
-                Integer chargeOffReasons = createChargeOffReason();
-                loanTransactionHelper.createLoanProduct(loanProductsRequest(Long.valueOf(chargeOffReasons), -1L));
+                Long chargeOffReasons = createChargeOffReason();
+                createLoanProduct(loanProductsRequest(chargeOffReasons, -1L));
             } catch (CallFailedRuntimeException e) {
                 Assertions.assertTrue(e.getMessage().contains("validation.msg.glaccount.not.found"));
             }
@@ -92,7 +87,8 @@ public class LoanProductChargeOffReasonMappingsTest extends BaseLoanIntegrationT
     public void testCreateLoanProductWithInvalidChargeOffReason() {
         runAt("15 January 2023", () -> {
             try {
-                loanTransactionHelper.createLoanProduct(loanProductsRequest(-1L, expenseAccount.getAccountID().longValue()));
+                final Account expenseAccount = accountHelper.createExpenseAccount("expense");
+                createLoanProduct(loanProductsRequest(-1L, expenseAccount.getAccountID().longValue()));
             } catch (CallFailedRuntimeException e) {
                 Assertions.assertTrue(e.getMessage().contains("validation.msg.chargeoffreason.invalid"));
             }
@@ -115,14 +111,15 @@ public class LoanProductChargeOffReasonMappingsTest extends BaseLoanIntegrationT
 
         List<GetLoanPaymentChannelToFundSourceMappings> paymentChannelToFundSourceMappings = new ArrayList<>();
         GetLoanPaymentChannelToFundSourceMappings loanPaymentChannelToFundSourceMappings = new GetLoanPaymentChannelToFundSourceMappings();
-        loanPaymentChannelToFundSourceMappings.fundSourceAccountId(fundSource.getAccountID().longValue());
+        loanPaymentChannelToFundSourceMappings.fundSourceAccountId(getAccounts().getFundSource().getAccountID().longValue());
         loanPaymentChannelToFundSourceMappings.paymentTypeId(1L);
         paymentChannelToFundSourceMappings.add(loanPaymentChannelToFundSourceMappings);
 
-        final Integer fundId = createFund(requestSpec, responseSpec);
+        final Long fundId = new FeignFundHelper(FineractFeignClientHelper.getFineractFeignClient()).createFund().getResourceId();
         Assertions.assertNotNull(fundId);
 
-        final Long delinquencyBucketId = DelinquencyBucketsHelper.createDefaultBucket();
+        final Long delinquencyBucketId = new FeignDelinquencyHelper(FineractFeignClientHelper.getFineractFeignClient())
+                .createDefaultBucket();
         Assertions.assertNotNull(delinquencyBucketId);
 
         return new PostLoanProductsRequest()//
@@ -185,27 +182,27 @@ public class LoanProductChargeOffReasonMappingsTest extends BaseLoanIntegrationT
                 .charges(charges)//
                 .accountingRule(3)//
 
-                .fundSourceAccountId(suspenseAccount.getAccountID().longValue())//
-                .loanPortfolioAccountId(loansReceivableAccount.getAccountID().longValue())//
-                .transfersInSuspenseAccountId(suspenseAccount.getAccountID().longValue())//
-                .interestOnLoanAccountId(interestIncomeAccount.getAccountID().longValue())//
-                .incomeFromFeeAccountId(feeIncomeAccount.getAccountID().longValue())//
-                .incomeFromPenaltyAccountId(penaltyIncomeAccount.getAccountID().longValue())//
-                .incomeFromRecoveryAccountId(recoveriesAccount.getAccountID().longValue())//
-                .writeOffAccountId(writtenOffAccount.getAccountID().longValue())//
-                .overpaymentLiabilityAccountId(overpaymentAccount.getAccountID().longValue())//
-                .receivableInterestAccountId(interestReceivableAccount.getAccountID().longValue())//
-                .receivableFeeAccountId(feeReceivableAccount.getAccountID().longValue())//
-                .receivablePenaltyAccountId(penaltyReceivableAccount.getAccountID().longValue())//
-                .goodwillCreditAccountId(goodwillExpenseAccount.getAccountID().longValue())//
-                .incomeFromGoodwillCreditInterestAccountId(interestIncomeChargeOffAccount.getAccountID().longValue())//
-                .incomeFromGoodwillCreditFeesAccountId(feeChargeOffAccount.getAccountID().longValue())//
-                .incomeFromGoodwillCreditPenaltyAccountId(feeChargeOffAccount.getAccountID().longValue())//
-                .incomeFromChargeOffInterestAccountId(interestIncomeChargeOffAccount.getAccountID().longValue())//
-                .incomeFromChargeOffFeesAccountId(feeChargeOffAccount.getAccountID().longValue())//
-                .chargeOffExpenseAccountId(chargeOffExpenseAccount.getAccountID().longValue())//
-                .chargeOffFraudExpenseAccountId(chargeOffFraudExpenseAccount.getAccountID().longValue())//
-                .incomeFromChargeOffPenaltyAccountId(penaltyChargeOffAccount.getAccountID().longValue())//
+                .fundSourceAccountId(getAccounts().getSuspenseAccount().getAccountID().longValue())//
+                .loanPortfolioAccountId(getAccounts().getLoansReceivableAccount().getAccountID().longValue())//
+                .transfersInSuspenseAccountId(getAccounts().getSuspenseAccount().getAccountID().longValue())//
+                .interestOnLoanAccountId(getAccounts().getInterestIncomeAccount().getAccountID().longValue())//
+                .incomeFromFeeAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())//
+                .incomeFromPenaltyAccountId(getAccounts().getPenaltyIncomeAccount().getAccountID().longValue())//
+                .incomeFromRecoveryAccountId(getAccounts().getRecoveriesAccount().getAccountID().longValue())//
+                .writeOffAccountId(getAccounts().getWrittenOffAccount().getAccountID().longValue())//
+                .overpaymentLiabilityAccountId(getAccounts().getOverpaymentAccount().getAccountID().longValue())//
+                .receivableInterestAccountId(getAccounts().getInterestReceivableAccount().getAccountID().longValue())//
+                .receivableFeeAccountId(getAccounts().getFeeReceivableAccount().getAccountID().longValue())//
+                .receivablePenaltyAccountId(getAccounts().getPenaltyReceivableAccount().getAccountID().longValue())//
+                .goodwillCreditAccountId(getAccounts().getGoodwillExpenseAccount().getAccountID().longValue())//
+                .incomeFromGoodwillCreditInterestAccountId(getAccounts().getInterestIncomeChargeOffAccount().getAccountID().longValue())//
+                .incomeFromGoodwillCreditFeesAccountId(getAccounts().getFeeChargeOffAccount().getAccountID().longValue())//
+                .incomeFromGoodwillCreditPenaltyAccountId(getAccounts().getFeeChargeOffAccount().getAccountID().longValue())//
+                .incomeFromChargeOffInterestAccountId(getAccounts().getInterestIncomeChargeOffAccount().getAccountID().longValue())//
+                .incomeFromChargeOffFeesAccountId(getAccounts().getFeeChargeOffAccount().getAccountID().longValue())//
+                .chargeOffExpenseAccountId(getAccounts().getChargeOffExpenseAccount().getAccountID().longValue())//
+                .chargeOffFraudExpenseAccountId(getAccounts().getChargeOffFraudExpenseAccount().getAccountID().longValue())//
+                .incomeFromChargeOffPenaltyAccountId(getAccounts().getPenaltyChargeOffAccount().getAccountID().longValue())//
 
                 .dateFormat("dd MMMM yyyy")//
                 .locale("en")//
@@ -236,17 +233,7 @@ public class LoanProductChargeOffReasonMappingsTest extends BaseLoanIntegrationT
         return chargeOffReasonToExpenseAccountMappings;
     }
 
-    private Integer createChargeOffReason() {
-        Integer chargeOffReasonId;
-        HashMap<String, Object> codes = CodeHelper.getCodeByName(requestSpec, responseSpec, CODE_VALUE_NAME);
-        if (codes.isEmpty()) {
-            CodeHelper.createCode(requestSpec, responseSpec, CODE_VALUE_NAME, "");
-        }
-        codes = CodeHelper.getCodeByName(requestSpec, responseSpec, CODE_VALUE_NAME);
-        Integer codeId = (Integer) codes.get("id");
-        HashMap<String, Object> codeValues = CodeHelper.getOrCreateCodeValueByCodeIdAndCodeName(requestSpec, responseSpec, codeId,
-                CODE_VALUE_NAME, 1);
-        chargeOffReasonId = (Integer) codeValues.get("id");
-        return chargeOffReasonId;
+    private Long createChargeOffReason() {
+        return codeHelper.createChargeOffCodeValue(Utils.uniqueRandomStringGenerator("REASON_", 6), 1);
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanProductTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanProductTest.java
@@ -21,21 +21,17 @@ package org.apache.fineract.integrationtests;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Objects;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.client.models.GetChargeOffReasonToExpenseAccountMappings;
 import org.apache.fineract.client.models.GetLoanProductsProductIdResponse;
 import org.apache.fineract.client.models.GetLoanProductsTemplateResponse;
 import org.apache.fineract.client.models.GetLoanProductsWriteOffReasonOptions;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
-import org.apache.fineract.client.models.PostClientsResponse;
 import org.apache.fineract.client.models.PostCodeValueDataResponse;
 import org.apache.fineract.client.models.PostCodeValuesDataRequest;
 import org.apache.fineract.client.models.PostLoanProductsRequest;
-import org.apache.fineract.client.models.PostLoanProductsResponse;
 import org.apache.fineract.client.models.PostWriteOffReasonToExpenseAccountMappings;
 import org.apache.fineract.client.models.PutLoanProductsProductIdRequest;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.FineractClientHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanBuyDownFeeCalculationType;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanBuyDownFeeIncomeType;
@@ -47,26 +43,25 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-@Slf4j
-public class LoanProductTest extends BaseLoanIntegrationTest {
+public class LoanProductTest extends FeignLoanTestBase {
+
+    private static final Long WRITE_OFF_REASON_CODE_ID = 26L;
 
     @Nested
     public class IncomeCapitalizationTest {
 
         @Test
         public void testIncomeCapitalizationEnabled() {
-            final PostClientsResponse client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+            final Long clientId = createClient();
 
-            final PostLoanProductsResponse loanProductsResponse = loanProductHelper
-                    .createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
-                            .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
-                            .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
-                            .deferredIncomeLiabilityAccountId(deferredIncomeLiabilityAccount.getAccountID().longValue())
-                            .incomeFromCapitalizationAccountId(feeIncomeAccount.getAccountID().longValue())
-                            .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
+            final Long loanProductId = createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
+                    .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
+                    .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
+                    .deferredIncomeLiabilityAccountId(getAccounts().getDeferredIncomeLiabilityAccount().getAccountID().longValue())
+                    .incomeFromCapitalizationAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())
+                    .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
 
-            final GetLoanProductsProductIdResponse loanProductsProductIdResponse = loanProductHelper
-                    .retrieveLoanProductById(loanProductsResponse.getResourceId());
+            final GetLoanProductsProductIdResponse loanProductsProductIdResponse = retrieveLoanProduct(loanProductId);
             Assertions.assertEquals(Boolean.TRUE, loanProductsProductIdResponse.getEnableIncomeCapitalization());
             Assertions.assertNotNull(loanProductsProductIdResponse.getCapitalizedIncomeCalculationType());
             Assertions.assertEquals(LoanCapitalizedIncomeCalculationType.FLAT.getCode(),
@@ -79,10 +74,9 @@ public class LoanProductTest extends BaseLoanIntegrationTest {
                     loanProductsProductIdResponse.getCapitalizedIncomeType().getCode());
 
             runAt("20 December 2024", () -> {
-                Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProductsResponse.getResourceId(), "20 December 2024",
-                        430.0, 7.0, 6, null);
+                Long loanId = applyAndApproveProgressiveLoan(clientId, loanProductId, "20 December 2024", 430.0, 7.0, 6, null);
 
-                final GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+                final GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
                 Assertions.assertEquals(Boolean.TRUE, loanDetails.getEnableIncomeCapitalization());
                 Assertions.assertNotNull(loanDetails.getCapitalizedIncomeCalculationType());
                 Assertions.assertEquals(LoanCapitalizedIncomeCalculationType.FLAT.getCode(),
@@ -99,18 +93,16 @@ public class LoanProductTest extends BaseLoanIntegrationTest {
 
         @Test
         public void testIncomeCapitalizationDisabled() {
-            final PostClientsResponse client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+            final Long clientId = createClient();
 
-            final PostLoanProductsResponse loanProductsResponse = loanProductHelper
-                    .createLoanProduct(create4IProgressive().enableIncomeCapitalization(false)
-                            .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
-                            .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
-                            .deferredIncomeLiabilityAccountId(deferredIncomeLiabilityAccount.getAccountID().longValue())
-                            .incomeFromCapitalizationAccountId(feeIncomeAccount.getAccountID().longValue())
-                            .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
+            final Long loanProductId = createLoanProduct(create4IProgressive().enableIncomeCapitalization(false)
+                    .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
+                    .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
+                    .deferredIncomeLiabilityAccountId(getAccounts().getDeferredIncomeLiabilityAccount().getAccountID().longValue())
+                    .incomeFromCapitalizationAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())
+                    .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
 
-            final GetLoanProductsProductIdResponse loanProductsProductIdResponse = loanProductHelper
-                    .retrieveLoanProductById(loanProductsResponse.getResourceId());
+            final GetLoanProductsProductIdResponse loanProductsProductIdResponse = retrieveLoanProduct(loanProductId);
             Assertions.assertEquals(Boolean.FALSE, loanProductsProductIdResponse.getEnableIncomeCapitalization());
             Assertions.assertNotNull(loanProductsProductIdResponse.getCapitalizedIncomeCalculationType());
             Assertions.assertEquals(LoanCapitalizedIncomeCalculationType.FLAT.getCode(),
@@ -123,10 +115,9 @@ public class LoanProductTest extends BaseLoanIntegrationTest {
                     loanProductsProductIdResponse.getCapitalizedIncomeType().getCode());
 
             runAt("20 December 2024", () -> {
-                Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProductsResponse.getResourceId(), "20 December 2024",
-                        430.0, 7.0, 6, null);
+                Long loanId = applyAndApproveProgressiveLoan(clientId, loanProductId, "20 December 2024", 430.0, 7.0, 6, null);
 
-                final GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+                final GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
                 Assertions.assertEquals(Boolean.FALSE, loanDetails.getEnableIncomeCapitalization());
                 Assertions.assertNotNull(loanDetails.getCapitalizedIncomeCalculationType());
                 Assertions.assertEquals(LoanCapitalizedIncomeCalculationType.FLAT.getCode(),
@@ -143,16 +134,14 @@ public class LoanProductTest extends BaseLoanIntegrationTest {
 
         @Test
         public void testIncomeCapitalizationUpdateProduct() {
-            final PostLoanProductsResponse loanProductsResponse = loanProductHelper
-                    .createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
-                            .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
-                            .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
-                            .deferredIncomeLiabilityAccountId(deferredIncomeLiabilityAccount.getAccountID().longValue())
-                            .incomeFromCapitalizationAccountId(feeIncomeAccount.getAccountID().longValue())
-                            .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
+            final Long loanProductId = createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
+                    .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
+                    .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
+                    .deferredIncomeLiabilityAccountId(getAccounts().getDeferredIncomeLiabilityAccount().getAccountID().longValue())
+                    .incomeFromCapitalizationAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())
+                    .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
 
-            final GetLoanProductsProductIdResponse loanProductsProductIdResponse = loanProductHelper
-                    .retrieveLoanProductById(loanProductsResponse.getResourceId());
+            final GetLoanProductsProductIdResponse loanProductsProductIdResponse = retrieveLoanProduct(loanProductId);
             Assertions.assertEquals(Boolean.TRUE, loanProductsProductIdResponse.getEnableIncomeCapitalization());
             Assertions.assertNotNull(loanProductsProductIdResponse.getCapitalizedIncomeCalculationType());
             Assertions.assertEquals(LoanCapitalizedIncomeCalculationType.FLAT.getCode(),
@@ -161,18 +150,17 @@ public class LoanProductTest extends BaseLoanIntegrationTest {
             Assertions.assertEquals(LoanCapitalizedIncomeStrategy.EQUAL_AMORTIZATION.getCode(),
                     loanProductsProductIdResponse.getCapitalizedIncomeStrategy().getCode());
             Assertions.assertNotNull(loanProductsProductIdResponse.getAccountingMappings());
-            Assertions.assertEquals(feeIncomeAccount.getAccountID().longValue(),
+            Assertions.assertEquals(getAccounts().getFeeIncomeAccount().getAccountID().longValue(),
                     loanProductsProductIdResponse.getAccountingMappings().getIncomeFromCapitalizationAccount().getId());
             Assertions.assertNotNull(loanProductsProductIdResponse.getCapitalizedIncomeType());
             Assertions.assertEquals(LoanCapitalizedIncomeType.FEE.getCode(),
                     loanProductsProductIdResponse.getCapitalizedIncomeType().getCode());
 
-            loanProductHelper.updateLoanProductById(loanProductsResponse.getResourceId(),
+            updateLoanProduct(loanProductId,
                     new PutLoanProductsProductIdRequest()
-                            .incomeFromCapitalizationAccountId(interestIncomeAccount.getAccountID().longValue())
+                            .incomeFromCapitalizationAccountId(getAccounts().getInterestIncomeAccount().getAccountID().longValue())
                             .capitalizedIncomeType(PutLoanProductsProductIdRequest.CapitalizedIncomeTypeEnum.INTEREST));
-            GetLoanProductsProductIdResponse updatedLoanProductsProductIdResponse = loanProductHelper
-                    .retrieveLoanProductById(loanProductsResponse.getResourceId());
+            GetLoanProductsProductIdResponse updatedLoanProductsProductIdResponse = retrieveLoanProduct(loanProductId);
             Assertions.assertEquals(Boolean.TRUE, updatedLoanProductsProductIdResponse.getEnableIncomeCapitalization());
             Assertions.assertNotNull(updatedLoanProductsProductIdResponse.getCapitalizedIncomeCalculationType());
             Assertions.assertEquals(LoanCapitalizedIncomeCalculationType.FLAT.getCode(),
@@ -181,13 +169,12 @@ public class LoanProductTest extends BaseLoanIntegrationTest {
             Assertions.assertEquals(LoanCapitalizedIncomeStrategy.EQUAL_AMORTIZATION.getCode(),
                     updatedLoanProductsProductIdResponse.getCapitalizedIncomeStrategy().getCode());
             Assertions.assertNotNull(updatedLoanProductsProductIdResponse.getAccountingMappings());
-            Assertions.assertEquals(interestIncomeAccount.getAccountID().longValue(),
+            Assertions.assertEquals(getAccounts().getInterestIncomeAccount().getAccountID().longValue(),
                     updatedLoanProductsProductIdResponse.getAccountingMappings().getIncomeFromCapitalizationAccount().getId());
 
-            loanProductHelper.updateLoanProductById(loanProductsResponse.getResourceId(),
-                    new PutLoanProductsProductIdRequest().enableIncomeCapitalization(false));
+            updateLoanProduct(loanProductId, new PutLoanProductsProductIdRequest().enableIncomeCapitalization(false));
 
-            updatedLoanProductsProductIdResponse = loanProductHelper.retrieveLoanProductById(loanProductsResponse.getResourceId());
+            updatedLoanProductsProductIdResponse = retrieveLoanProduct(loanProductId);
             Assertions.assertEquals(Boolean.FALSE, updatedLoanProductsProductIdResponse.getEnableIncomeCapitalization());
             Assertions.assertNotNull(updatedLoanProductsProductIdResponse.getAccountingMappings());
             Assertions.assertNull(updatedLoanProductsProductIdResponse.getAccountingMappings().getIncomeFromCapitalizationAccount());
@@ -198,65 +185,63 @@ public class LoanProductTest extends BaseLoanIntegrationTest {
 
         @Test
         public void testIncomeCapitalizationCumulativeNotSupported() {
-            Assertions
-                    .assertThrows(RuntimeException.class,
-                            () -> loanProductHelper.createLoanProduct(createOnePeriod30DaysPeriodicAccrualProduct(7.0)
-                                    .enableIncomeCapitalization(true)
-                                    .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
-                                    .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
-                                    .deferredIncomeLiabilityAccountId(deferredIncomeLiabilityAccount.getAccountID().longValue())
-                                    .incomeFromCapitalizationAccountId(feeIncomeAccount.getAccountID().longValue())
-                                    .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE)));
+            Assertions.assertThrows(RuntimeException.class,
+                    () -> createLoanProduct(createOnePeriod30DaysPeriodicAccrualProduct(7.0).enableIncomeCapitalization(true)
+                            .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
+                            .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
+                            .deferredIncomeLiabilityAccountId(getAccounts().getDeferredIncomeLiabilityAccount().getAccountID().longValue())
+                            .incomeFromCapitalizationAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())
+                            .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE)));
         }
 
         @Test
         public void testIncomeCapitalizationEnabledCalculationTypeNotProvided() {
             Assertions.assertThrows(RuntimeException.class,
-                    () -> loanProductHelper.createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
+                    () -> createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
                             .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
-                            .deferredIncomeLiabilityAccountId(deferredIncomeLiabilityAccount.getAccountID().longValue())
-                            .incomeFromCapitalizationAccountId(feeIncomeAccount.getAccountID().longValue())
+                            .deferredIncomeLiabilityAccountId(getAccounts().getDeferredIncomeLiabilityAccount().getAccountID().longValue())
+                            .incomeFromCapitalizationAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())
                             .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE)));
         }
 
         @Test
         public void testIncomeCapitalizationEnabledStrategyNotProvided() {
             Assertions.assertThrows(RuntimeException.class,
-                    () -> loanProductHelper.createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
+                    () -> createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
                             .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
-                            .deferredIncomeLiabilityAccountId(deferredIncomeLiabilityAccount.getAccountID().longValue())
-                            .incomeFromCapitalizationAccountId(feeIncomeAccount.getAccountID().longValue())
+                            .deferredIncomeLiabilityAccountId(getAccounts().getDeferredIncomeLiabilityAccount().getAccountID().longValue())
+                            .incomeFromCapitalizationAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())
                             .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE)));
         }
 
         @Test
         public void testIncomeCapitalizationEnabledDeferredIncomeLiabilityNotProvided() {
             Assertions.assertThrows(RuntimeException.class,
-                    () -> loanProductHelper.createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
+                    () -> createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
                             .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
                             .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
-                            .incomeFromCapitalizationAccountId(feeIncomeAccount.getAccountID().longValue())
+                            .incomeFromCapitalizationAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())
                             .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE)));
         }
 
         @Test
         public void testIncomeCapitalizationEnabledIncomeFromCapitalizationNotProvided() {
             Assertions.assertThrows(RuntimeException.class,
-                    () -> loanProductHelper.createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
+                    () -> createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
                             .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
                             .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
-                            .deferredIncomeLiabilityAccountId(deferredIncomeLiabilityAccount.getAccountID().longValue())
+                            .deferredIncomeLiabilityAccountId(getAccounts().getDeferredIncomeLiabilityAccount().getAccountID().longValue())
                             .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE)));
         }
 
         @Test
         public void testIncomeCapitalizationEnabledIncomeTypeNotProvided() {
             Assertions.assertThrows(RuntimeException.class,
-                    () -> loanProductHelper.createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
+                    () -> createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
                             .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
                             .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
-                            .deferredIncomeLiabilityAccountId(deferredIncomeLiabilityAccount.getAccountID().longValue())
-                            .incomeFromCapitalizationAccountId(feeIncomeAccount.getAccountID().longValue())));
+                            .deferredIncomeLiabilityAccountId(getAccounts().getDeferredIncomeLiabilityAccount().getAccountID().longValue())
+                            .incomeFromCapitalizationAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())));
         }
     }
 
@@ -265,17 +250,16 @@ public class LoanProductTest extends BaseLoanIntegrationTest {
 
         @Test
         public void testBuyDownFeeEnabled() {
-            final PostClientsResponse client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+            final Long clientId = createClient();
 
-            final PostLoanProductsResponse loanProductsResponse = loanProductHelper.createLoanProduct(create4IProgressive()
-                    .enableBuyDownFee(true).buyDownFeeCalculationType(PostLoanProductsRequest.BuyDownFeeCalculationTypeEnum.FLAT)
+            final Long loanProductId = createLoanProduct(create4IProgressive().enableBuyDownFee(true)
+                    .buyDownFeeCalculationType(PostLoanProductsRequest.BuyDownFeeCalculationTypeEnum.FLAT)
                     .buyDownFeeStrategy(PostLoanProductsRequest.BuyDownFeeStrategyEnum.EQUAL_AMORTIZATION)
                     .buyDownFeeIncomeType(PostLoanProductsRequest.BuyDownFeeIncomeTypeEnum.FEE)
-                    .buyDownExpenseAccountId(buyDownExpenseAccount.getAccountID().longValue()).merchantBuyDownFee(true)
-                    .incomeFromBuyDownAccountId(feeIncomeAccount.getAccountID().longValue()));
+                    .buyDownExpenseAccountId(getAccounts().getBuyDownExpenseAccount().getAccountID().longValue()).merchantBuyDownFee(true)
+                    .incomeFromBuyDownAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue()));
 
-            final GetLoanProductsProductIdResponse loanProductsProductIdResponse = loanProductHelper
-                    .retrieveLoanProductById(loanProductsResponse.getResourceId());
+            final GetLoanProductsProductIdResponse loanProductsProductIdResponse = retrieveLoanProduct(loanProductId);
             Assertions.assertEquals(Boolean.TRUE, loanProductsProductIdResponse.getEnableBuyDownFee());
             Assertions.assertNotNull(loanProductsProductIdResponse.getBuyDownFeeCalculationType());
             Assertions.assertEquals(LoanBuyDownFeeCalculationType.FLAT.getCode(),
@@ -288,10 +272,9 @@ public class LoanProductTest extends BaseLoanIntegrationTest {
                     loanProductsProductIdResponse.getBuyDownFeeIncomeType().getCode());
 
             runAt("20 December 2024", () -> {
-                Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProductsResponse.getResourceId(), "20 December 2024",
-                        430.0, 7.0, 6, null);
+                Long loanId = applyAndApproveProgressiveLoan(clientId, loanProductId, "20 December 2024", 430.0, 7.0, 6, null);
 
-                final GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+                final GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
                 Assertions.assertEquals(Boolean.TRUE, loanDetails.getEnableBuyDownFee());
                 Assertions.assertNotNull(loanDetails.getBuyDownFeeCalculationType());
                 Assertions.assertEquals(LoanBuyDownFeeCalculationType.FLAT.getCode(), loanDetails.getBuyDownFeeCalculationType().getCode());
@@ -306,17 +289,16 @@ public class LoanProductTest extends BaseLoanIntegrationTest {
 
         @Test
         public void testBuyDownFeeDisabled() {
-            final PostClientsResponse client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+            final Long clientId = createClient();
 
-            final PostLoanProductsResponse loanProductsResponse = loanProductHelper.createLoanProduct(create4IProgressive()
-                    .enableBuyDownFee(false).buyDownFeeCalculationType(PostLoanProductsRequest.BuyDownFeeCalculationTypeEnum.FLAT)
+            final Long loanProductId = createLoanProduct(create4IProgressive().enableBuyDownFee(false)
+                    .buyDownFeeCalculationType(PostLoanProductsRequest.BuyDownFeeCalculationTypeEnum.FLAT)
                     .buyDownFeeStrategy(PostLoanProductsRequest.BuyDownFeeStrategyEnum.EQUAL_AMORTIZATION)
                     .buyDownFeeIncomeType(PostLoanProductsRequest.BuyDownFeeIncomeTypeEnum.FEE)
-                    .buyDownExpenseAccountId(buyDownExpenseAccount.getAccountID().longValue())
-                    .incomeFromBuyDownAccountId(feeIncomeAccount.getAccountID().longValue()));
+                    .buyDownExpenseAccountId(getAccounts().getBuyDownExpenseAccount().getAccountID().longValue())
+                    .incomeFromBuyDownAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue()));
 
-            final GetLoanProductsProductIdResponse loanProductsProductIdResponse = loanProductHelper
-                    .retrieveLoanProductById(loanProductsResponse.getResourceId());
+            final GetLoanProductsProductIdResponse loanProductsProductIdResponse = retrieveLoanProduct(loanProductId);
             Assertions.assertEquals(Boolean.FALSE, loanProductsProductIdResponse.getEnableBuyDownFee());
             Assertions.assertNotNull(loanProductsProductIdResponse.getBuyDownFeeCalculationType());
             Assertions.assertEquals(LoanBuyDownFeeCalculationType.FLAT.getCode(),
@@ -329,10 +311,9 @@ public class LoanProductTest extends BaseLoanIntegrationTest {
                     loanProductsProductIdResponse.getBuyDownFeeIncomeType().getCode());
 
             runAt("20 December 2024", () -> {
-                Long loanId = applyAndApproveProgressiveLoan(client.getClientId(), loanProductsResponse.getResourceId(), "20 December 2024",
-                        430.0, 7.0, 6, null);
+                Long loanId = applyAndApproveProgressiveLoan(clientId, loanProductId, "20 December 2024", 430.0, 7.0, 6, null);
 
-                final GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+                final GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
                 Assertions.assertEquals(Boolean.FALSE, loanDetails.getEnableBuyDownFee());
                 Assertions.assertNotNull(loanDetails.getBuyDownFeeCalculationType());
                 Assertions.assertEquals(LoanBuyDownFeeCalculationType.FLAT.getCode(), loanDetails.getBuyDownFeeCalculationType().getCode());
@@ -347,15 +328,14 @@ public class LoanProductTest extends BaseLoanIntegrationTest {
 
         @Test
         public void testBuyDownFeeUpdateProduct() {
-            final PostLoanProductsResponse loanProductsResponse = loanProductHelper.createLoanProduct(create4IProgressive()
-                    .enableBuyDownFee(true).buyDownFeeCalculationType(PostLoanProductsRequest.BuyDownFeeCalculationTypeEnum.FLAT)
+            final Long loanProductId = createLoanProduct(create4IProgressive().enableBuyDownFee(true)
+                    .buyDownFeeCalculationType(PostLoanProductsRequest.BuyDownFeeCalculationTypeEnum.FLAT)
                     .buyDownFeeStrategy(PostLoanProductsRequest.BuyDownFeeStrategyEnum.EQUAL_AMORTIZATION)
                     .buyDownFeeIncomeType(PostLoanProductsRequest.BuyDownFeeIncomeTypeEnum.FEE)
-                    .buyDownExpenseAccountId(buyDownExpenseAccount.getAccountID().longValue()).merchantBuyDownFee(true)
-                    .incomeFromBuyDownAccountId(feeIncomeAccount.getAccountID().longValue()));
+                    .buyDownExpenseAccountId(getAccounts().getBuyDownExpenseAccount().getAccountID().longValue()).merchantBuyDownFee(true)
+                    .incomeFromBuyDownAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue()));
 
-            final GetLoanProductsProductIdResponse loanProductsProductIdResponse = loanProductHelper
-                    .retrieveLoanProductById(loanProductsResponse.getResourceId());
+            final GetLoanProductsProductIdResponse loanProductsProductIdResponse = retrieveLoanProduct(loanProductId);
             Assertions.assertEquals(Boolean.TRUE, loanProductsProductIdResponse.getEnableBuyDownFee());
             Assertions.assertNotNull(loanProductsProductIdResponse.getBuyDownFeeCalculationType());
             Assertions.assertEquals(LoanBuyDownFeeCalculationType.FLAT.getCode(),
@@ -368,18 +348,17 @@ public class LoanProductTest extends BaseLoanIntegrationTest {
                     loanProductsProductIdResponse.getBuyDownFeeIncomeType().getCode());
 
             Assertions.assertNotNull(loanProductsProductIdResponse.getAccountingMappings());
-            Assertions.assertEquals(buyDownExpenseAccount.getAccountID().longValue(),
+            Assertions.assertEquals(getAccounts().getBuyDownExpenseAccount().getAccountID().longValue(),
                     loanProductsProductIdResponse.getAccountingMappings().getBuyDownExpenseAccount().getId());
-            Assertions.assertEquals(feeIncomeAccount.getAccountID().longValue(),
+            Assertions.assertEquals(getAccounts().getFeeIncomeAccount().getAccountID().longValue(),
                     loanProductsProductIdResponse.getAccountingMappings().getIncomeFromBuyDownAccount().getId());
 
-            loanProductHelper.updateLoanProductById(loanProductsResponse.getResourceId(),
+            updateLoanProduct(loanProductId,
                     new PutLoanProductsProductIdRequest()
                             .buyDownFeeIncomeType(PutLoanProductsProductIdRequest.BuyDownFeeIncomeTypeEnum.INTEREST)
-                            .incomeFromBuyDownAccountId(interestIncomeAccount.getAccountID().longValue()));
+                            .incomeFromBuyDownAccountId(getAccounts().getInterestIncomeAccount().getAccountID().longValue()));
 
-            GetLoanProductsProductIdResponse updatedLoanProductsProductIdResponse = loanProductHelper
-                    .retrieveLoanProductById(loanProductsResponse.getResourceId());
+            GetLoanProductsProductIdResponse updatedLoanProductsProductIdResponse = retrieveLoanProduct(loanProductId);
             Assertions.assertEquals(Boolean.TRUE, updatedLoanProductsProductIdResponse.getEnableBuyDownFee());
             Assertions.assertEquals(LoanBuyDownFeeStrategy.EQUAL_AMORTIZATION.getCode(),
                     updatedLoanProductsProductIdResponse.getBuyDownFeeStrategy().getCode());
@@ -387,15 +366,14 @@ public class LoanProductTest extends BaseLoanIntegrationTest {
             Assertions.assertEquals(LoanBuyDownFeeIncomeType.INTEREST.getCode(),
                     updatedLoanProductsProductIdResponse.getBuyDownFeeIncomeType().getCode());
             Assertions.assertNotNull(updatedLoanProductsProductIdResponse.getAccountingMappings());
-            Assertions.assertEquals(buyDownExpenseAccount.getAccountID().longValue(),
+            Assertions.assertEquals(getAccounts().getBuyDownExpenseAccount().getAccountID().longValue(),
                     updatedLoanProductsProductIdResponse.getAccountingMappings().getBuyDownExpenseAccount().getId());
-            Assertions.assertEquals(interestIncomeAccount.getAccountID().longValue(),
+            Assertions.assertEquals(getAccounts().getInterestIncomeAccount().getAccountID().longValue(),
                     updatedLoanProductsProductIdResponse.getAccountingMappings().getIncomeFromBuyDownAccount().getId());
 
-            loanProductHelper.updateLoanProductById(loanProductsResponse.getResourceId(),
-                    new PutLoanProductsProductIdRequest().enableBuyDownFee(false));
+            updateLoanProduct(loanProductId, new PutLoanProductsProductIdRequest().enableBuyDownFee(false));
 
-            updatedLoanProductsProductIdResponse = loanProductHelper.retrieveLoanProductById(loanProductsResponse.getResourceId());
+            updatedLoanProductsProductIdResponse = retrieveLoanProduct(loanProductId);
             Assertions.assertEquals(Boolean.FALSE, updatedLoanProductsProductIdResponse.getEnableBuyDownFee());
             Assertions.assertNotNull(updatedLoanProductsProductIdResponse.getBuyDownFeeCalculationType());
             Assertions.assertEquals(LoanBuyDownFeeCalculationType.FLAT.getCode(),
@@ -411,63 +389,59 @@ public class LoanProductTest extends BaseLoanIntegrationTest {
 
         @Test
         public void testBuyDownFeeCumulativeNotSupported() {
-            Assertions.assertThrows(RuntimeException.class,
-                    () -> loanProductHelper.createLoanProduct(createOnePeriod30DaysPeriodicAccrualProduct(7.0).enableBuyDownFee(true)
-                            .buyDownFeeCalculationType(PostLoanProductsRequest.BuyDownFeeCalculationTypeEnum.FLAT)
-                            .buyDownFeeStrategy(PostLoanProductsRequest.BuyDownFeeStrategyEnum.EQUAL_AMORTIZATION)
-                            .buyDownFeeIncomeType(PostLoanProductsRequest.BuyDownFeeIncomeTypeEnum.FEE)
-                            .buyDownExpenseAccountId(buyDownExpenseAccount.getAccountID().longValue()).merchantBuyDownFee(true)
-                            .incomeFromBuyDownAccountId(feeIncomeAccount.getAccountID().longValue())));
+            Assertions.assertThrows(RuntimeException.class, () -> createLoanProduct(createOnePeriod30DaysPeriodicAccrualProduct(7.0)
+                    .enableBuyDownFee(true).buyDownFeeCalculationType(PostLoanProductsRequest.BuyDownFeeCalculationTypeEnum.FLAT)
+                    .buyDownFeeStrategy(PostLoanProductsRequest.BuyDownFeeStrategyEnum.EQUAL_AMORTIZATION)
+                    .buyDownFeeIncomeType(PostLoanProductsRequest.BuyDownFeeIncomeTypeEnum.FEE)
+                    .buyDownExpenseAccountId(getAccounts().getBuyDownExpenseAccount().getAccountID().longValue()).merchantBuyDownFee(true)
+                    .incomeFromBuyDownAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())));
         }
 
         @Test
         public void testBuyDownFeeEnabledCalculationTypeNotProvided() {
-            Assertions.assertThrows(RuntimeException.class,
-                    () -> loanProductHelper.createLoanProduct(create4IProgressive().enableBuyDownFee(true)
-                            .buyDownFeeStrategy(PostLoanProductsRequest.BuyDownFeeStrategyEnum.EQUAL_AMORTIZATION)
-                            .buyDownFeeIncomeType(PostLoanProductsRequest.BuyDownFeeIncomeTypeEnum.FEE)
-                            .buyDownExpenseAccountId(buyDownExpenseAccount.getAccountID().longValue()).merchantBuyDownFee(true)
-                            .incomeFromBuyDownAccountId(feeIncomeAccount.getAccountID().longValue())));
+            Assertions.assertThrows(RuntimeException.class, () -> createLoanProduct(create4IProgressive().enableBuyDownFee(true)
+                    .buyDownFeeStrategy(PostLoanProductsRequest.BuyDownFeeStrategyEnum.EQUAL_AMORTIZATION)
+                    .buyDownFeeIncomeType(PostLoanProductsRequest.BuyDownFeeIncomeTypeEnum.FEE)
+                    .buyDownExpenseAccountId(getAccounts().getBuyDownExpenseAccount().getAccountID().longValue()).merchantBuyDownFee(true)
+                    .incomeFromBuyDownAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())));
         }
 
         @Test
         public void testBuyDownFeeEnabledStrategyNotProvided() {
-            Assertions.assertThrows(RuntimeException.class,
-                    () -> loanProductHelper.createLoanProduct(create4IProgressive().enableBuyDownFee(true)
-                            .buyDownFeeCalculationType(PostLoanProductsRequest.BuyDownFeeCalculationTypeEnum.FLAT)
-                            .buyDownFeeIncomeType(PostLoanProductsRequest.BuyDownFeeIncomeTypeEnum.FEE)
-                            .buyDownExpenseAccountId(buyDownExpenseAccount.getAccountID().longValue()).merchantBuyDownFee(true)
-                            .incomeFromBuyDownAccountId(feeIncomeAccount.getAccountID().longValue())));
+            Assertions.assertThrows(RuntimeException.class, () -> createLoanProduct(create4IProgressive().enableBuyDownFee(true)
+                    .buyDownFeeCalculationType(PostLoanProductsRequest.BuyDownFeeCalculationTypeEnum.FLAT)
+                    .buyDownFeeIncomeType(PostLoanProductsRequest.BuyDownFeeIncomeTypeEnum.FEE)
+                    .buyDownExpenseAccountId(getAccounts().getBuyDownExpenseAccount().getAccountID().longValue()).merchantBuyDownFee(true)
+                    .incomeFromBuyDownAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())));
         }
 
         @Test
         public void testBuyDownFeeEnabledIncomeTypeNotProvided() {
-            Assertions.assertThrows(RuntimeException.class,
-                    () -> loanProductHelper.createLoanProduct(create4IProgressive().enableBuyDownFee(true)
-                            .buyDownFeeCalculationType(PostLoanProductsRequest.BuyDownFeeCalculationTypeEnum.FLAT)
-                            .buyDownFeeStrategy(PostLoanProductsRequest.BuyDownFeeStrategyEnum.EQUAL_AMORTIZATION)
-                            .buyDownExpenseAccountId(buyDownExpenseAccount.getAccountID().longValue()).merchantBuyDownFee(true)
-                            .incomeFromBuyDownAccountId(feeIncomeAccount.getAccountID().longValue())));
+            Assertions.assertThrows(RuntimeException.class, () -> createLoanProduct(create4IProgressive().enableBuyDownFee(true)
+                    .buyDownFeeCalculationType(PostLoanProductsRequest.BuyDownFeeCalculationTypeEnum.FLAT)
+                    .buyDownFeeStrategy(PostLoanProductsRequest.BuyDownFeeStrategyEnum.EQUAL_AMORTIZATION)
+                    .buyDownExpenseAccountId(getAccounts().getBuyDownExpenseAccount().getAccountID().longValue()).merchantBuyDownFee(true)
+                    .incomeFromBuyDownAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())));
         }
 
         @Test
         public void testBuyDownFeeEnabledBuyDownExpenseNotProvided() {
             Assertions.assertThrows(RuntimeException.class,
-                    () -> loanProductHelper.createLoanProduct(create4IProgressive().enableBuyDownFee(true)
+                    () -> createLoanProduct(create4IProgressive().enableBuyDownFee(true)
                             .buyDownFeeCalculationType(PostLoanProductsRequest.BuyDownFeeCalculationTypeEnum.FLAT)
                             .buyDownFeeStrategy(PostLoanProductsRequest.BuyDownFeeStrategyEnum.EQUAL_AMORTIZATION)
                             .buyDownFeeIncomeType(PostLoanProductsRequest.BuyDownFeeIncomeTypeEnum.FEE).merchantBuyDownFee(true)
-                            .incomeFromBuyDownAccountId(feeIncomeAccount.getAccountID().longValue())));
+                            .incomeFromBuyDownAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())));
         }
 
         @Test
         public void testBuyDownFeeEnabledIncomeFromBuyDownNotProvided() {
             Assertions.assertThrows(RuntimeException.class,
-                    () -> loanProductHelper.createLoanProduct(create4IProgressive().enableBuyDownFee(true)
+                    () -> createLoanProduct(create4IProgressive().enableBuyDownFee(true)
                             .buyDownFeeCalculationType(PostLoanProductsRequest.BuyDownFeeCalculationTypeEnum.FLAT)
                             .buyDownFeeStrategy(PostLoanProductsRequest.BuyDownFeeStrategyEnum.EQUAL_AMORTIZATION)
                             .buyDownFeeIncomeType(PostLoanProductsRequest.BuyDownFeeIncomeTypeEnum.FEE).merchantBuyDownFee(true)
-                            .buyDownExpenseAccountId(buyDownExpenseAccount.getAccountID().longValue())));
+                            .buyDownExpenseAccountId(getAccounts().getBuyDownExpenseAccount().getAccountID().longValue())));
         }
     }
 
@@ -477,7 +451,7 @@ public class LoanProductTest extends BaseLoanIntegrationTest {
         @Test
         public void testWriteOffReasonToExpenseAccountMapping_shouldFail_on_nonExistingGLAccount_And_nonExistingWriteOffReason() {
             try {
-                loanProductHelper.createLoanProduct(
+                createLoanProduct(
                         create4IProgressive().addWriteOffReasonsToExpenseMappingsItem(new PostWriteOffReasonToExpenseAccountMappings()
                                 .expenseAccountId("101230023").writeOffReasonCodeValueId("201230023")));
                 Assertions.fail("Should have thrown an IllegalArgumentException");
@@ -491,7 +465,7 @@ public class LoanProductTest extends BaseLoanIntegrationTest {
         @Test
         public void testWriteOffReasonToExpenseAccountMapping_shouldFail_on_nonExistingGLAccount_And_Invalid_expenseAccountId() {
             try {
-                loanProductHelper.createLoanProduct(create4IProgressive().addWriteOffReasonsToExpenseMappingsItem(
+                createLoanProduct(create4IProgressive().addWriteOffReasonsToExpenseMappingsItem(
                         new PostWriteOffReasonToExpenseAccountMappings().expenseAccountId("asdf323").writeOffReasonCodeValueId("111")));
                 Assertions.fail("Should have thrown an IllegalArgumentException");
             } catch (final RuntimeException ex) {
@@ -505,11 +479,10 @@ public class LoanProductTest extends BaseLoanIntegrationTest {
         @Test
         public void testWriteOffReasonToExpenseAccountMapping_shouldFail_on_nonExistingGLAccount_And_Invalid_writeOffReasonCodeValueId() {
             try {
-                loanProductHelper.createLoanProduct(create4IProgressive().addWriteOffReasonsToExpenseMappingsItem(
+                createLoanProduct(create4IProgressive().addWriteOffReasonsToExpenseMappingsItem(
                         new PostWriteOffReasonToExpenseAccountMappings().expenseAccountId("111").writeOffReasonCodeValueId("asdf323")));
                 Assertions.fail("Should have thrown an IllegalArgumentException");
             } catch (final RuntimeException ex) {
-                log.info("Exception: {}", ex.getMessage());
                 Assertions.assertTrue(ex.getMessage()
                         .contains("validation.msg.loanproduct.writeOffReasonsToExpenseMappings[0].writeOffReasonCodeValueId.not.a.number"));
                 Assertions.assertTrue(ex.getMessage()
@@ -519,13 +492,12 @@ public class LoanProductTest extends BaseLoanIntegrationTest {
 
         @Test
         public void testWriteOffReasonsToExpenseMappings() {
-
             // create Write Off reasons
             Long reasonCode1 = createTestWriteOffReason();
             Long reasonCode2 = createTestWriteOffReason();
 
             // check if write Off reasons appears on loan product template
-            GetLoanProductsTemplateResponse loanProductTemplate = loanProductHelper.getLoanProductTemplate(false);
+            GetLoanProductsTemplateResponse loanProductTemplate = getLoanProductTemplate(false);
             List<GetLoanProductsWriteOffReasonOptions> writeOffReasonOptions = loanProductTemplate.getWriteOffReasonOptions();
             Assertions.assertNotNull(writeOffReasonOptions);
 
@@ -538,15 +510,14 @@ public class LoanProductTest extends BaseLoanIntegrationTest {
 
             // Create Test Loan Product
             String reasonCodeId = reasonCode1.toString();
-            String expenseAccountId = buyDownExpenseAccount.getAccountID().toString();
+            String expenseAccountId = getAccounts().getBuyDownExpenseAccount().getAccountID().toString();
 
-            Long loanProductId = loanProductHelper.createLoanProduct(
+            Long loanProductId = createLoanProduct(
                     create4IProgressive().addWriteOffReasonsToExpenseMappingsItem(new PostWriteOffReasonToExpenseAccountMappings()
-                            .expenseAccountId(expenseAccountId).writeOffReasonCodeValueId(reasonCodeId)))
-                    .getResourceId();
+                            .expenseAccountId(expenseAccountId).writeOffReasonCodeValueId(reasonCodeId)));
 
             // Verify that get loan product API has the corresponding fields
-            GetLoanProductsProductIdResponse getLoanProductsProductIdResponse = loanProductHelper.retrieveLoanProductById(loanProductId);
+            GetLoanProductsProductIdResponse getLoanProductsProductIdResponse = retrieveLoanProduct(loanProductId);
             List<GetChargeOffReasonToExpenseAccountMappings> writeOffReasonToExpenseAccountMappings = getLoanProductsProductIdResponse
                     .getWriteOffReasonsToExpenseMappings();
             Assertions.assertNotNull(writeOffReasonToExpenseAccountMappings);
@@ -563,23 +534,21 @@ public class LoanProductTest extends BaseLoanIntegrationTest {
             }
 
             // test Update loan product API - delete writeOffReasonsToExpenseMappings
+            GetLoanProductsProductIdResponse getLoanProductsProductId = retrieveLoanProduct(loanProductId);
 
-            GetLoanProductsProductIdResponse getLoanProductsProductId = loanProductHelper.retrieveLoanProductById(loanProductId);
-
-            loanProductHelper.updateLoanProductById(loanProductId,
+            updateLoanProduct(loanProductId,
                     update4IProgressive(getLoanProductsProductId.getName(), getLoanProductsProductId.getShortName(),
                             getLoanProductsProductId.getDelinquencyBucket().getId()).writeOffReasonsToExpenseMappings(List.of()));
 
             // Verify that get loan product API has the corresponding fields
-            Assertions.assertNull(loanProductHelper.retrieveLoanProductById(loanProductId).getWriteOffReasonsToExpenseMappings());
+            Assertions.assertNull(retrieveLoanProduct(loanProductId).getWriteOffReasonsToExpenseMappings());
         }
     }
 
     private Long createTestWriteOffReason() {
-        PostCodeValueDataResponse response = okR(FineractClientHelper.getFineractClient().codeValues.createCodeValue(26L,
+        PostCodeValueDataResponse response = codeHelper.createCodeValue(WRITE_OFF_REASON_CODE_ID,
                 new PostCodeValuesDataRequest().name(Utils.uniqueRandomStringGenerator("TestWriteOffReason_1_", 6))
-                        .description("Test write off reason value 1").isActive(true).position(0)))
-                .body();
+                        .description("Test write off reason value 1").isActive(true).position(0));
         Assertions.assertNotNull(response);
         Assertions.assertNotNull(response.getSubResourceId());
         return response.getSubResourceId();

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanSpecificDueDateChargeAfterMaturityTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanSpecificDueDateChargeAfterMaturityTest.java
@@ -19,29 +19,18 @@
 package org.apache.fineract.integrationtests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.path.json.JsonPath;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.HashMap;
 import java.util.List;
-import org.apache.fineract.client.models.BusinessDateUpdateRequest;
-import org.apache.fineract.client.models.ChargeRequest;
+import org.apache.fineract.client.models.GetLoansLoanIdRepaymentPeriod;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
+import org.apache.fineract.client.models.GetLoansLoanIdTransactions;
 import org.apache.fineract.client.models.PostChargesResponse;
-import org.apache.fineract.client.models.PostClientsResponse;
+import org.apache.fineract.client.models.PostLoanProductsRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdChargesRequest;
-import org.apache.fineract.client.models.PostLoansLoanIdChargesResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsResponse;
@@ -50,382 +39,254 @@ import org.apache.fineract.client.models.PostLoansRequest;
 import org.apache.fineract.client.models.PostLoansResponse;
 import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
-import org.apache.fineract.integrationtests.common.BusinessDateHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
 import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.accounting.Account;
-import org.apache.fineract.integrationtests.common.accounting.AccountHelper;
-import org.apache.fineract.integrationtests.common.accounting.PeriodicAccrualAccountingHelper;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
-import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
 import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanStatusChecker;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.apache.fineract.integrationtests.common.savings.SavingsProductHelper;
-import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
-import org.apache.fineract.portfolio.charge.domain.ChargePaymentMode;
-import org.apache.fineract.portfolio.charge.domain.ChargeTimeType;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-@SuppressWarnings({ "unchecked" })
-public class LoanSpecificDueDateChargeAfterMaturityTest extends BaseLoanIntegrationTest {
+public class LoanSpecificDueDateChargeAfterMaturityTest extends FeignLoanTestBase {
 
-    private static final String DATETIME_PATTERN = "dd MMMM yyyy";
-    private static final String ACCOUNT_TYPE_INDIVIDUAL = "INDIVIDUAL";
-    private static final String MINIMUM_OPENING_BALANCE = "1000.0";
-    private static final String DEPOSIT_AMOUNT = "7000";
-    private static final Logger LOG = LoggerFactory.getLogger(LoanSpecificDueDateChargeAfterMaturityTest.class);
     private static final String DATE_OF_JOINING = "01 January 2011";
-    private static final Float LP_PRINCIPAL = 10000.0f;
-    private static final String LP_REPAYMENTS = "1";
-    private static final String LP_REPAYMENT_PERIOD = "1";
+    private static final Double LP_PRINCIPAL = 10000.0;
     private static final String EXPECTED_DISBURSAL_DATE = "04 March 2011";
     private static final String LOAN_APPLICATION_SUBMISSION_DATE = "03 March 2011";
-    private static final String LOAN_TERM_FREQUENCY = "1";
-    private static final String INDIVIDUAL_LOAN = "individual";
-    private static final BusinessDateHelper BUSINESS_DATE_HELPER = new BusinessDateHelper();
-    private static final DateTimeFormatter DATE_FORMATTER = new DateTimeFormatterBuilder().appendPattern(DATETIME_PATTERN).toFormatter();
-    private static final ChargesHelper CHARGES_HELPER = new ChargesHelper();
-    private static RequestSpecification requestSpec;
-    private static ResponseSpecification responseSpec;
-    private static LoanTransactionHelper loanTransactionHelper;
-    private static AccountHelper accountHelper;
-    private static Integer commonLoanProductId;
-    private static PostClientsResponse client;
+    private static final String STRATEGY = LoanProductTestBuilder.DUE_PENALTY_FEE_INTEREST_PRINCIPAL_IN_ADVANCE_PRINCIPAL_PENALTY_FEE_INTEREST_STRATEGY;
 
-    public static Integer createSavingsProduct(final String minOpenningBalance, final Account... accounts) {
-        LOG.info("------------------------------CREATING NEW SAVINGS PRODUCT ---------------------------------------");
-        final String savingsProductJSON = new SavingsProductHelper().withInterestCompoundingPeriodTypeAsDaily() //
-                .withInterestPostingPeriodTypeAsQuarterly() //
-                .withInterestCalculationPeriodTypeAsDailyBalance() //
-                .withMinimumOpenningBalance(minOpenningBalance).withAccountingRuleAsCashBased(accounts).build();
-        return SavingsProductHelper.createSavingsProduct(savingsProductJSON, requestSpec, responseSpec);
-    }
+    private Long commonLoanProductId;
+    private Long clientId;
 
     @BeforeAll
-    public static void setupCommon() {
-        Utils.initializeRESTAssured();
-        ClientHelper clientHelper = new ClientHelper(requestSpec, responseSpec);
-        requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        requestSpec.header("Fineract-Platform-TenantId", "default");
-        responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-
-        loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-        accountHelper = new AccountHelper(requestSpec, responseSpec);
-        final Account assetAccount = accountHelper.createAssetAccount();
-        final Account incomeAccount = accountHelper.createIncomeAccount();
-        final Account expenseAccount = accountHelper.createExpenseAccount();
-        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-        commonLoanProductId = createLoanProduct("500", "15", "4", assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
-        client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+    public void setupCommon() {
+        commonLoanProductId = createLoanProduct(noInterestPeriodicAccrualProduct(500.0, 15, LoanTestData.RepaymentFrequencyType.DAYS_L, 4));
+        clientId = createClient();
     }
 
     @Test
     public void checkPeriodicAccrualAccountingAPIFlow() {
-        final Account assetAccount = this.accountHelper.createAssetAccount();
-        final Account incomeAccount = this.accountHelper.createIncomeAccount();
-        final Account expenseAccount = this.accountHelper.createExpenseAccount();
-        final Account overpaymentAccount = this.accountHelper.createLiabilityAccount();
+        final Long loanProductID = createLoanProduct(
+                noInterestPeriodicAccrualProduct(LP_PRINCIPAL, 1, LoanTestData.RepaymentFrequencyType.MONTHS_L, 1));
 
-        final Integer loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount, expenseAccount,
-                overpaymentAccount);
+        final Long clientID = createClient(DATE_OF_JOINING);
 
-        final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec, DATE_OF_JOINING);
+        final Long loanID = applyForNoInterestLoan(clientID, loanProductID);
 
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, "0");
+        final double FEE_PORTION = 50.0;
+        final double PENALTY_PORTION = 100.0;
+        final double NEXT_FEE_PORTION = 55.0;
+        final double NEXT_PENALTY_PORTION = 105.0;
 
-        final float FEE_PORTION = 50.0f;
-        final float PENALTY_PORTION = 100.0f;
-        final float NEXT_FEE_PORTION = 55.0f;
-        final float NEXT_PENALTY_PORTION = 105.0f;
+        Long flat = chargesHelper.createLoanSpecifiedDueDateCharge(FEE_PORTION).getResourceId();
+        Long flatSpecifiedDueDate = chargesHelper.createLoanSpecifiedDueDatePenalty(PENALTY_PORTION).getResourceId();
+        Long flatNext = chargesHelper.createLoanSpecifiedDueDateCharge(NEXT_FEE_PORTION).getResourceId();
+        Long flatSpecifiedDueDateNext = chargesHelper.createLoanSpecifiedDueDatePenalty(NEXT_PENALTY_PORTION).getResourceId();
 
-        Integer flat = ChargesHelper.createCharges(requestSpec, responseSpec,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, String.valueOf(FEE_PORTION), false));
-        Integer flatSpecifiedDueDate = ChargesHelper.createCharges(requestSpec, responseSpec, ChargesHelper
-                .getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, String.valueOf(PENALTY_PORTION), true));
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanID);
+        assertTrue(loanDetails.getStatus().getPendingApproval());
 
-        Integer flatNext = ChargesHelper.createCharges(requestSpec, responseSpec, ChargesHelper
-                .getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, String.valueOf(NEXT_FEE_PORTION), false));
-        Integer flatSpecifiedDueDateNext = ChargesHelper.createCharges(requestSpec, responseSpec, ChargesHelper
-                .getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, String.valueOf(NEXT_PENALTY_PORTION), true));
+        approveLoan(loanID, LoanRequestBuilders.approveLoan(LP_PRINCIPAL, EXPECTED_DISBURSAL_DATE));
+        loanDetails = getLoanDetails(loanID);
+        assertTrue(loanDetails.getStatus().getWaitingForDisbursal());
 
-        HashMap<String, Object> loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        disburseLoan(loanID, LoanRequestBuilders.disburseLoan(LP_PRINCIPAL, EXPECTED_DISBURSAL_DATE));
+        loanDetails = getLoanDetails(loanID);
+        assertTrue(loanDetails.getStatus().getActive());
 
-        loanStatusHashMap = this.loanTransactionHelper.approveLoan(EXPECTED_DISBURSAL_DATE, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
-
-        LocalDate targetDate = LocalDate.of(2011, 3, 4);
-        final String loanDisbursementDate = DATE_FORMATTER.format(targetDate);
-
-        String loanDetails = this.loanTransactionHelper.getLoanDetails(requestSpec, responseSpec, loanID);
-        loanStatusHashMap = this.loanTransactionHelper.disburseLoanWithNetDisbursalAmount(loanDisbursementDate, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-
-        ArrayList<HashMap> loanSchedule = this.loanTransactionHelper.getLoanRepaymentSchedule(requestSpec, responseSpec, loanID);
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getRepaymentSchedule(loanID);
         assertEquals(2, loanSchedule.size());
-        assertEquals(0, loanSchedule.get(1).get("feeChargesDue"));
-        assertEquals(0, loanSchedule.get(1).get("feeChargesOutstanding"));
-        assertEquals(0, loanSchedule.get(1).get("penaltyChargesDue"));
-        assertEquals(0, loanSchedule.get(1).get("penaltyChargesOutstanding"));
-        assertEquals(10000.0f, loanSchedule.get(1).get("totalDueForPeriod"));
-        assertEquals(10000.0f, loanSchedule.get(1).get("totalOutstandingForPeriod"));
-        targetDate = LocalDate.of(2011, 4, 5);
-        final String penaltyCharge1AddedDate = DATE_FORMATTER.format(targetDate);
-        Integer penalty1LoanChargeId = this.loanTransactionHelper.addChargesForLoan(loanID,
-                LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flatSpecifiedDueDate), penaltyCharge1AddedDate,
-                        String.valueOf(PENALTY_PORTION)));
+        assertEquals(0.0, feeChargesDue(loanSchedule, 1));
+        assertEquals(0.0, feeChargesOutstanding(loanSchedule, 1));
+        assertEquals(0.0, penaltyChargesDue(loanSchedule, 1));
+        assertEquals(0.0, penaltyChargesOutstanding(loanSchedule, 1));
+        assertEquals(10000.0, totalDueForPeriod(loanSchedule, 1));
+        assertEquals(10000.0, totalOutstandingForPeriod(loanSchedule, 1));
 
-        this.loanTransactionHelper.noAccrualTransactionForRepayment(loanID);
+        final String penaltyCharge1AddedDate = "05 April 2011";
+        addChargesForLoan(loanID, LoanRequestBuilders.addLoanCharge(flatSpecifiedDueDate, PENALTY_PORTION, penaltyCharge1AddedDate));
 
-        loanSchedule = this.loanTransactionHelper.getLoanRepaymentSchedule(requestSpec, responseSpec, loanID);
+        noAccrualTransactionForRepayment(loanID);
+
+        loanSchedule = getRepaymentSchedule(loanID);
         assertEquals(3, loanSchedule.size());
-        assertEquals(0, loanSchedule.get(2).get("feeChargesDue"));
-        assertEquals(0, loanSchedule.get(2).get("feeChargesOutstanding"));
-        assertEquals(PENALTY_PORTION, loanSchedule.get(2).get("penaltyChargesDue"));
-        assertEquals(PENALTY_PORTION, loanSchedule.get(2).get("penaltyChargesOutstanding"));
-        assertEquals(PENALTY_PORTION, loanSchedule.get(2).get("totalDueForPeriod"));
-        assertEquals(PENALTY_PORTION, loanSchedule.get(2).get("totalOutstandingForPeriod"));
-        assertEquals(LocalDate.of(2011, 4, 5), LocalDate.of((int) ((List) loanSchedule.get(2).get("dueDate")).get(0),
-                (int) ((List) loanSchedule.get(2).get("dueDate")).get(1), (int) ((List) loanSchedule.get(2).get("dueDate")).get(2)));
+        assertEquals(0.0, feeChargesDue(loanSchedule, 2));
+        assertEquals(0.0, feeChargesOutstanding(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION, penaltyChargesDue(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION, penaltyChargesOutstanding(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION, totalDueForPeriod(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION, totalOutstandingForPeriod(loanSchedule, 2));
+        assertEquals(LocalDate.of(2011, 4, 5), loanSchedule.get(2).getDueDate());
 
-        String runOnDateStr = penaltyCharge1AddedDate;
-        LocalDate runOnDate = targetDate;
-        PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting(runOnDateStr);
+        runPeriodicAccrualAccounting(penaltyCharge1AddedDate);
+        checkAccrualTransactionForRepayment(LocalDate.of(2011, 4, 5), 0.0, 0.0, PENALTY_PORTION, loanID);
 
-        this.loanTransactionHelper.checkAccrualTransactionForRepayment(runOnDate, 0.0f, 0.0f, PENALTY_PORTION, loanID);
+        final String feeCharge1AddedDate = "06 April 2011";
+        addChargesForLoan(loanID, LoanRequestBuilders.addLoanCharge(flat, FEE_PORTION, feeCharge1AddedDate));
 
-        targetDate = LocalDate.of(2011, 4, 6);
-        final String feeCharge1AddedDate = DATE_FORMATTER.format(targetDate);
-        Integer fee1LoanChargeId = this.loanTransactionHelper.addChargesForLoan(loanID, LoanTransactionHelper
-                .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flat), feeCharge1AddedDate, String.valueOf(FEE_PORTION)));
-
-        loanSchedule = this.loanTransactionHelper.getLoanRepaymentSchedule(requestSpec, responseSpec, loanID);
+        loanSchedule = getRepaymentSchedule(loanID);
         assertEquals(3, loanSchedule.size());
-        assertEquals(FEE_PORTION, loanSchedule.get(2).get("feeChargesDue"));
-        assertEquals(FEE_PORTION, loanSchedule.get(2).get("feeChargesOutstanding"));
-        assertEquals(PENALTY_PORTION, loanSchedule.get(2).get("penaltyChargesDue"));
-        assertEquals(PENALTY_PORTION, loanSchedule.get(2).get("penaltyChargesOutstanding"));
-        assertEquals(PENALTY_PORTION + FEE_PORTION, loanSchedule.get(2).get("totalDueForPeriod"));
-        assertEquals(PENALTY_PORTION + FEE_PORTION, loanSchedule.get(2).get("totalOutstandingForPeriod"));
-        assertEquals(LocalDate.of(2011, 4, 6), LocalDate.of((int) ((List) loanSchedule.get(2).get("dueDate")).get(0),
-                (int) ((List) loanSchedule.get(2).get("dueDate")).get(1), (int) ((List) loanSchedule.get(2).get("dueDate")).get(2)));
+        assertEquals(FEE_PORTION, feeChargesDue(loanSchedule, 2));
+        assertEquals(FEE_PORTION, feeChargesOutstanding(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION, penaltyChargesDue(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION, penaltyChargesOutstanding(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION + FEE_PORTION, totalDueForPeriod(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION + FEE_PORTION, totalOutstandingForPeriod(loanSchedule, 2));
+        assertEquals(LocalDate.of(2011, 4, 6), loanSchedule.get(2).getDueDate());
 
-        targetDate = LocalDate.of(2011, 4, 7);
-        final String penaltyCharge2AddedDate = DATE_FORMATTER.format(targetDate);
-        Integer penalty2LoanChargeId = this.loanTransactionHelper.addChargesForLoan(loanID,
-                LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flatSpecifiedDueDateNext),
-                        penaltyCharge2AddedDate, String.valueOf(NEXT_PENALTY_PORTION)));
+        final String penaltyCharge2AddedDate = "07 April 2011";
+        addChargesForLoan(loanID,
+                LoanRequestBuilders.addLoanCharge(flatSpecifiedDueDateNext, NEXT_PENALTY_PORTION, penaltyCharge2AddedDate));
 
-        loanSchedule = this.loanTransactionHelper.getLoanRepaymentSchedule(requestSpec, responseSpec, loanID);
+        loanSchedule = getRepaymentSchedule(loanID);
         assertEquals(3, loanSchedule.size());
-        assertEquals(FEE_PORTION, loanSchedule.get(2).get("feeChargesDue"));
-        assertEquals(FEE_PORTION, loanSchedule.get(2).get("feeChargesOutstanding"));
-        assertEquals(PENALTY_PORTION + NEXT_PENALTY_PORTION, loanSchedule.get(2).get("penaltyChargesDue"));
-        assertEquals(PENALTY_PORTION + NEXT_PENALTY_PORTION, loanSchedule.get(2).get("penaltyChargesOutstanding"));
-        assertEquals(PENALTY_PORTION + FEE_PORTION + NEXT_PENALTY_PORTION, loanSchedule.get(2).get("totalDueForPeriod"));
-        assertEquals(PENALTY_PORTION + FEE_PORTION + NEXT_PENALTY_PORTION, loanSchedule.get(2).get("totalOutstandingForPeriod"));
-        assertEquals(LocalDate.of(2011, 4, 7), LocalDate.of((int) ((List) loanSchedule.get(2).get("dueDate")).get(0),
-                (int) ((List) loanSchedule.get(2).get("dueDate")).get(1), (int) ((List) loanSchedule.get(2).get("dueDate")).get(2)));
+        assertEquals(FEE_PORTION, feeChargesDue(loanSchedule, 2));
+        assertEquals(FEE_PORTION, feeChargesOutstanding(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION + NEXT_PENALTY_PORTION, penaltyChargesDue(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION + NEXT_PENALTY_PORTION, penaltyChargesOutstanding(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION + FEE_PORTION + NEXT_PENALTY_PORTION, totalDueForPeriod(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION + FEE_PORTION + NEXT_PENALTY_PORTION, totalOutstandingForPeriod(loanSchedule, 2));
+        assertEquals(LocalDate.of(2011, 4, 7), loanSchedule.get(2).getDueDate());
 
-        targetDate = LocalDate.of(2011, 4, 8);
-        final String feeCharge2AddedDate = DATE_FORMATTER.format(targetDate);
-        Integer fee2LoanChargeId = this.loanTransactionHelper.addChargesForLoan(loanID, LoanTransactionHelper
-                .getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flatNext), feeCharge2AddedDate, String.valueOf(NEXT_FEE_PORTION)));
+        final String feeCharge2AddedDate = "08 April 2011";
+        addChargesForLoan(loanID, LoanRequestBuilders.addLoanCharge(flatNext, NEXT_FEE_PORTION, feeCharge2AddedDate));
 
-        loanSchedule = this.loanTransactionHelper.getLoanRepaymentSchedule(requestSpec, responseSpec, loanID);
+        loanSchedule = getRepaymentSchedule(loanID);
         assertEquals(3, loanSchedule.size());
-        assertEquals(FEE_PORTION + NEXT_FEE_PORTION, loanSchedule.get(2).get("feeChargesDue"));
-        assertEquals(FEE_PORTION + NEXT_FEE_PORTION, loanSchedule.get(2).get("feeChargesOutstanding"));
-        assertEquals(PENALTY_PORTION + NEXT_PENALTY_PORTION, loanSchedule.get(2).get("penaltyChargesDue"));
-        assertEquals(PENALTY_PORTION + NEXT_PENALTY_PORTION, loanSchedule.get(2).get("penaltyChargesOutstanding"));
-        assertEquals(PENALTY_PORTION + FEE_PORTION + NEXT_PENALTY_PORTION + NEXT_FEE_PORTION, loanSchedule.get(2).get("totalDueForPeriod"));
-        assertEquals(PENALTY_PORTION + FEE_PORTION + NEXT_PENALTY_PORTION + NEXT_FEE_PORTION,
-                loanSchedule.get(2).get("totalOutstandingForPeriod"));
-        assertEquals(LocalDate.of(2011, 4, 8), LocalDate.of((int) ((List) loanSchedule.get(2).get("dueDate")).get(0),
-                (int) ((List) loanSchedule.get(2).get("dueDate")).get(1), (int) ((List) loanSchedule.get(2).get("dueDate")).get(2)));
+        assertEquals(FEE_PORTION + NEXT_FEE_PORTION, feeChargesDue(loanSchedule, 2));
+        assertEquals(FEE_PORTION + NEXT_FEE_PORTION, feeChargesOutstanding(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION + NEXT_PENALTY_PORTION, penaltyChargesDue(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION + NEXT_PENALTY_PORTION, penaltyChargesOutstanding(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION + FEE_PORTION + NEXT_PENALTY_PORTION + NEXT_FEE_PORTION, totalDueForPeriod(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION + FEE_PORTION + NEXT_PENALTY_PORTION + NEXT_FEE_PORTION, totalOutstandingForPeriod(loanSchedule, 2));
+        assertEquals(LocalDate.of(2011, 4, 8), loanSchedule.get(2).getDueDate());
 
-        runOnDateStr = penaltyCharge2AddedDate;
-        runOnDate = LocalDate.of(2011, 4, 7);
-        PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting(runOnDateStr);
-        this.loanTransactionHelper.checkAccrualTransactionForRepayment(runOnDate, 0.0f, FEE_PORTION, NEXT_PENALTY_PORTION, loanID);
+        runPeriodicAccrualAccounting(penaltyCharge2AddedDate);
+        checkAccrualTransactionForRepayment(LocalDate.of(2011, 4, 7), 0.0, FEE_PORTION, NEXT_PENALTY_PORTION, loanID);
     }
 
     @Test
     public void reopenClosedLoan() {
-        final Account assetAccount = this.accountHelper.createAssetAccount();
-        final Account incomeAccount = this.accountHelper.createIncomeAccount();
-        final Account expenseAccount = this.accountHelper.createExpenseAccount();
-        final Account overpaymentAccount = this.accountHelper.createLiabilityAccount();
+        final Long loanProductID = createLoanProduct(
+                noInterestPeriodicAccrualProduct(LP_PRINCIPAL, 1, LoanTestData.RepaymentFrequencyType.MONTHS_L, 1));
 
-        final Integer loanProductID = createLoanProductWithPeriodicAccrualAccountingNoInterest(assetAccount, incomeAccount, expenseAccount,
-                overpaymentAccount);
+        final Long clientID = createClient(DATE_OF_JOINING);
 
-        final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec, DATE_OF_JOINING);
+        final Long loanID = applyForNoInterestLoan(clientID, loanProductID);
 
-        final Integer loanID = applyForLoanApplication(clientID, loanProductID, "0");
+        final double PENALTY_PORTION = 100.0;
 
-        final float FEE_PORTION = 50.0f;
-        final float PENALTY_PORTION = 100.0f;
-        final float NEXT_FEE_PORTION = 55.0f;
-        final float NEXT_PENALTY_PORTION = 105.0f;
+        Long flatSpecifiedDueDate = chargesHelper.createLoanSpecifiedDueDatePenalty(PENALTY_PORTION).getResourceId();
 
-        Integer flat = ChargesHelper.createCharges(requestSpec, responseSpec,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, String.valueOf(FEE_PORTION), false));
-        Integer flatSpecifiedDueDate = ChargesHelper.createCharges(requestSpec, responseSpec, ChargesHelper
-                .getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, String.valueOf(PENALTY_PORTION), true));
+        assertTrue(getLoanDetails(loanID).getStatus().getPendingApproval());
 
-        Integer flatNext = ChargesHelper.createCharges(requestSpec, responseSpec, ChargesHelper
-                .getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, String.valueOf(NEXT_FEE_PORTION), false));
-        Integer flatSpecifiedDueDateNext = ChargesHelper.createCharges(requestSpec, responseSpec, ChargesHelper
-                .getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, String.valueOf(NEXT_PENALTY_PORTION), true));
+        approveLoan(loanID, LoanRequestBuilders.approveLoan(LP_PRINCIPAL, EXPECTED_DISBURSAL_DATE));
+        assertTrue(getLoanDetails(loanID).getStatus().getWaitingForDisbursal());
 
-        HashMap<String, Object> loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+        disburseLoan(loanID, LoanRequestBuilders.disburseLoan(LP_PRINCIPAL, EXPECTED_DISBURSAL_DATE));
+        assertTrue(getLoanDetails(loanID).getStatus().getActive());
 
-        loanStatusHashMap = this.loanTransactionHelper.approveLoan(EXPECTED_DISBURSAL_DATE, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-        LoanStatusChecker.verifyLoanIsWaitingForDisbursal(loanStatusHashMap);
-
-        LocalDate targetDate = LocalDate.of(2011, 3, 4);
-        final String loanDisbursementDate = DATE_FORMATTER.format(targetDate);
-
-        String loanDetails = this.loanTransactionHelper.getLoanDetails(requestSpec, responseSpec, loanID);
-        loanStatusHashMap = this.loanTransactionHelper.disburseLoanWithNetDisbursalAmount(loanDisbursementDate, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-
-        ArrayList<HashMap> loanSchedule = this.loanTransactionHelper.getLoanRepaymentSchedule(requestSpec, responseSpec, loanID);
+        List<GetLoansLoanIdRepaymentPeriod> loanSchedule = getRepaymentSchedule(loanID);
         assertEquals(2, loanSchedule.size());
-        assertEquals(0, loanSchedule.get(1).get("feeChargesDue"));
-        assertEquals(0, loanSchedule.get(1).get("feeChargesOutstanding"));
-        assertEquals(0, loanSchedule.get(1).get("penaltyChargesDue"));
-        assertEquals(0, loanSchedule.get(1).get("penaltyChargesOutstanding"));
-        assertEquals(10000.0f, loanSchedule.get(1).get("totalDueForPeriod"));
-        assertEquals(10000.0f, loanSchedule.get(1).get("totalOutstandingForPeriod"));
+        assertEquals(0.0, feeChargesDue(loanSchedule, 1));
+        assertEquals(0.0, feeChargesOutstanding(loanSchedule, 1));
+        assertEquals(0.0, penaltyChargesDue(loanSchedule, 1));
+        assertEquals(0.0, penaltyChargesOutstanding(loanSchedule, 1));
+        assertEquals(10000.0, totalDueForPeriod(loanSchedule, 1));
+        assertEquals(10000.0, totalOutstandingForPeriod(loanSchedule, 1));
 
-        targetDate = LocalDate.of(2011, 3, 10);
-        String repaymentDateStr = DATE_FORMATTER.format(targetDate);
-        loanTransactionHelper.makeRepayment(repaymentDateStr, 10000.0f, loanID);
+        makeRepayment("10 March 2011", 10000.0f, loanID);
+        assertTrue(getLoanDetails(loanID).getStatus().getClosedObligationsMet());
 
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
-        LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
+        final String penaltyCharge1AddedDate = "13 April 2011";
+        Long penalty1LoanChargeId = addChargesForLoan(loanID,
+                LoanRequestBuilders.addLoanCharge(flatSpecifiedDueDate, PENALTY_PORTION, penaltyCharge1AddedDate)).getResourceId();
 
-        targetDate = LocalDate.of(2011, 4, 13);
-        final String penaltyCharge1AddedDate = DATE_FORMATTER.format(targetDate);
-        Integer penalty1LoanChargeId = this.loanTransactionHelper.addChargesForLoan(loanID,
-                LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flatSpecifiedDueDate), penaltyCharge1AddedDate,
-                        String.valueOf(PENALTY_PORTION)));
+        assertTrue(getLoanDetails(loanID).getStatus().getActive());
 
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-
-        loanSchedule = this.loanTransactionHelper.getLoanRepaymentSchedule(requestSpec, responseSpec, loanID);
+        loanSchedule = getRepaymentSchedule(loanID);
         assertEquals(3, loanSchedule.size());
-        assertEquals(0, loanSchedule.get(2).get("feeChargesDue"));
-        assertEquals(0, loanSchedule.get(2).get("feeChargesOutstanding"));
-        assertEquals(PENALTY_PORTION, loanSchedule.get(2).get("penaltyChargesDue"));
-        assertEquals(PENALTY_PORTION, loanSchedule.get(2).get("penaltyChargesOutstanding"));
-        assertEquals(PENALTY_PORTION, loanSchedule.get(2).get("totalDueForPeriod"));
-        assertEquals(PENALTY_PORTION, loanSchedule.get(2).get("totalOutstandingForPeriod"));
-        assertEquals(LocalDate.of(2011, 4, 13), LocalDate.of((int) ((List) loanSchedule.get(2).get("dueDate")).get(0),
-                (int) ((List) loanSchedule.get(2).get("dueDate")).get(1), (int) ((List) loanSchedule.get(2).get("dueDate")).get(2)));
+        assertEquals(0.0, feeChargesDue(loanSchedule, 2));
+        assertEquals(0.0, feeChargesOutstanding(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION, penaltyChargesDue(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION, penaltyChargesOutstanding(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION, totalDueForPeriod(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION, totalOutstandingForPeriod(loanSchedule, 2));
+        assertEquals(LocalDate.of(2011, 4, 13), loanSchedule.get(2).getDueDate());
 
-        targetDate = LocalDate.of(2011, 4, 14);
-        String runOnDateStr = DATE_FORMATTER.format(targetDate);
-        PeriodicAccrualAccountingHelper.runPeriodicAccrualAccounting(runOnDateStr);
-
+        runPeriodicAccrualAccounting("14 April 2011");
         // Transaction date will be the due date of the instalment (in case of N+1 scenario)
-        this.loanTransactionHelper.checkAccrualTransactionForRepayment(LocalDate.of(2011, 4, 13), 0.0f, 0.0f, PENALTY_PORTION, loanID);
+        checkAccrualTransactionForRepayment(LocalDate.of(2011, 4, 13), 0.0, 0.0, PENALTY_PORTION, loanID);
 
-        loanTransactionHelper.waiveChargesForLoan(loanID, penalty1LoanChargeId,
-                LoanTransactionHelper.getWaiveChargeJSON(String.valueOf(2)));
+        waiveLoanCharge(loanID, penalty1LoanChargeId, 2);
 
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
-        LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
+        assertTrue(getLoanDetails(loanID).getStatus().getClosedObligationsMet());
 
-        loanSchedule = this.loanTransactionHelper.getLoanRepaymentSchedule(requestSpec, responseSpec, loanID);
+        loanSchedule = getRepaymentSchedule(loanID);
         assertEquals(3, loanSchedule.size());
-        assertEquals(0, loanSchedule.get(2).get("feeChargesDue"));
-        assertEquals(0, loanSchedule.get(2).get("feeChargesOutstanding"));
-        assertEquals(PENALTY_PORTION, loanSchedule.get(2).get("penaltyChargesDue"));
-        assertEquals(0.0f, loanSchedule.get(2).get("penaltyChargesOutstanding"));
-        assertEquals(PENALTY_PORTION, loanSchedule.get(2).get("penaltyChargesWaived"));
-        assertEquals(PENALTY_PORTION, loanSchedule.get(2).get("totalDueForPeriod"));
-        assertEquals(0.0f, loanSchedule.get(2).get("totalOutstandingForPeriod"));
-        assertEquals(PENALTY_PORTION, loanSchedule.get(2).get("totalWaivedForPeriod"));
-        assertEquals(LocalDate.of(2011, 4, 13), LocalDate.of((int) ((List) loanSchedule.get(2).get("dueDate")).get(0),
-                (int) ((List) loanSchedule.get(2).get("dueDate")).get(1), (int) ((List) loanSchedule.get(2).get("dueDate")).get(2)));
+        assertEquals(0.0, feeChargesDue(loanSchedule, 2));
+        assertEquals(0.0, feeChargesOutstanding(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION, penaltyChargesDue(loanSchedule, 2));
+        assertEquals(0.0, penaltyChargesOutstanding(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION, penaltyChargesWaived(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION, totalDueForPeriod(loanSchedule, 2));
+        assertEquals(0.0, totalOutstandingForPeriod(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION, totalWaivedForPeriod(loanSchedule, 2));
+        assertEquals(LocalDate.of(2011, 4, 13), loanSchedule.get(2).getDueDate());
 
-        targetDate = LocalDate.of(2011, 4, 14);
-        String penaltyCharge2AddedDate = DATE_FORMATTER.format(targetDate);
-        Integer penalty2LoanChargeId = this.loanTransactionHelper.addChargesForLoan(loanID,
-                LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(flatSpecifiedDueDate), penaltyCharge2AddedDate,
-                        String.valueOf(PENALTY_PORTION)));
+        final String penaltyCharge2AddedDate = "14 April 2011";
+        Long penalty2LoanChargeId = addChargesForLoan(loanID,
+                LoanRequestBuilders.addLoanCharge(flatSpecifiedDueDate, PENALTY_PORTION, penaltyCharge2AddedDate)).getResourceId();
 
-        loanSchedule = this.loanTransactionHelper.getLoanRepaymentSchedule(requestSpec, responseSpec, loanID);
+        loanSchedule = getRepaymentSchedule(loanID);
         assertEquals(3, loanSchedule.size());
-        assertEquals(0, loanSchedule.get(2).get("feeChargesDue"));
-        assertEquals(0, loanSchedule.get(2).get("feeChargesOutstanding"));
-        assertEquals(PENALTY_PORTION + PENALTY_PORTION, loanSchedule.get(2).get("penaltyChargesDue"));
-        assertEquals(PENALTY_PORTION, loanSchedule.get(2).get("penaltyChargesOutstanding"));
-        assertEquals(PENALTY_PORTION, loanSchedule.get(2).get("penaltyChargesWaived"));
-        assertEquals(PENALTY_PORTION + PENALTY_PORTION, loanSchedule.get(2).get("totalDueForPeriod"));
-        assertEquals(PENALTY_PORTION, loanSchedule.get(2).get("totalOutstandingForPeriod"));
-        assertEquals(PENALTY_PORTION, loanSchedule.get(2).get("totalWaivedForPeriod"));
-        assertEquals(LocalDate.of(2011, 4, 14), LocalDate.of((int) ((List) loanSchedule.get(2).get("dueDate")).get(0),
-                (int) ((List) loanSchedule.get(2).get("dueDate")).get(1), (int) ((List) loanSchedule.get(2).get("dueDate")).get(2)));
+        assertEquals(0.0, feeChargesDue(loanSchedule, 2));
+        assertEquals(0.0, feeChargesOutstanding(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION + PENALTY_PORTION, penaltyChargesDue(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION, penaltyChargesOutstanding(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION, penaltyChargesWaived(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION + PENALTY_PORTION, totalDueForPeriod(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION, totalOutstandingForPeriod(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION, totalWaivedForPeriod(loanSchedule, 2));
+        assertEquals(LocalDate.of(2011, 4, 14), loanSchedule.get(2).getDueDate());
 
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+        assertTrue(getLoanDetails(loanID).getStatus().getActive());
 
-        targetDate = LocalDate.of(2011, 4, 15);
-        repaymentDateStr = DATE_FORMATTER.format(targetDate);
-        loanTransactionHelper.makeRepayment(repaymentDateStr, PENALTY_PORTION, loanID);
+        makeRepayment("15 April 2011", (float) PENALTY_PORTION, loanID);
 
-        loanSchedule = this.loanTransactionHelper.getLoanRepaymentSchedule(requestSpec, responseSpec, loanID);
+        loanSchedule = getRepaymentSchedule(loanID);
         assertEquals(3, loanSchedule.size());
-        assertEquals(0, loanSchedule.get(2).get("feeChargesDue"));
-        assertEquals(0, loanSchedule.get(2).get("feeChargesOutstanding"));
-        assertEquals(PENALTY_PORTION + PENALTY_PORTION, loanSchedule.get(2).get("penaltyChargesDue"));
-        assertEquals(0.0f, loanSchedule.get(2).get("penaltyChargesOutstanding"));
-        assertEquals(PENALTY_PORTION, loanSchedule.get(2).get("penaltyChargesWaived"));
-        assertEquals(PENALTY_PORTION, loanSchedule.get(2).get("penaltyChargesPaid"));
-        assertEquals(PENALTY_PORTION + PENALTY_PORTION, loanSchedule.get(2).get("totalDueForPeriod"));
-        assertEquals(0.0f, loanSchedule.get(2).get("totalOutstandingForPeriod"));
-        assertEquals(PENALTY_PORTION, loanSchedule.get(2).get("totalWaivedForPeriod"));
+        assertEquals(0.0, feeChargesDue(loanSchedule, 2));
+        assertEquals(0.0, feeChargesOutstanding(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION + PENALTY_PORTION, penaltyChargesDue(loanSchedule, 2));
+        assertEquals(0.0, penaltyChargesOutstanding(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION, penaltyChargesWaived(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION, penaltyChargesPaid(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION + PENALTY_PORTION, totalDueForPeriod(loanSchedule, 2));
+        assertEquals(0.0, totalOutstandingForPeriod(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION, totalWaivedForPeriod(loanSchedule, 2));
         // Might need to change if refund should update the due date of N+1 instalment
-        assertEquals(LocalDate.of(2011, 4, 14), LocalDate.of((int) ((List) loanSchedule.get(2).get("dueDate")).get(0),
-                (int) ((List) loanSchedule.get(2).get("dueDate")).get(1), (int) ((List) loanSchedule.get(2).get("dueDate")).get(2)));
+        assertEquals(LocalDate.of(2011, 4, 14), loanSchedule.get(2).getDueDate());
 
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
-        LoanStatusChecker.verifyLoanAccountIsClosed(loanStatusHashMap);
+        assertTrue(getLoanDetails(loanID).getStatus().getClosedObligationsMet());
 
-        loanTransactionHelper.loanChargeRefund(penalty2LoanChargeId, null, PENALTY_PORTION, null, loanID, "resourceId");
+        loanChargeRefund(loanID, penalty2LoanChargeId, PENALTY_PORTION);
 
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
-        LoanStatusChecker.verifyLoanAccountIsOverPaid(loanStatusHashMap);
+        assertTrue(getLoanDetails(loanID).getStatus().getOverpaid());
 
-        loanSchedule = this.loanTransactionHelper.getLoanRepaymentSchedule(requestSpec, responseSpec, loanID);
+        loanSchedule = getRepaymentSchedule(loanID);
         assertEquals(3, loanSchedule.size());
-        assertEquals(0, loanSchedule.get(2).get("feeChargesDue"));
-        assertEquals(0, loanSchedule.get(2).get("feeChargesOutstanding"));
-        assertEquals(PENALTY_PORTION + PENALTY_PORTION, loanSchedule.get(2).get("penaltyChargesDue"));
-        assertEquals(0.0f, loanSchedule.get(2).get("penaltyChargesOutstanding"));
-        assertEquals(PENALTY_PORTION, loanSchedule.get(2).get("penaltyChargesWaived"));
-        assertEquals(PENALTY_PORTION, loanSchedule.get(2).get("penaltyChargesPaid"));
-        assertEquals(PENALTY_PORTION + PENALTY_PORTION, loanSchedule.get(2).get("totalDueForPeriod"));
-        assertEquals(0.0f, loanSchedule.get(2).get("totalOutstandingForPeriod"));
-        assertEquals(PENALTY_PORTION, loanSchedule.get(2).get("totalWaivedForPeriod"));
+        assertEquals(0.0, feeChargesDue(loanSchedule, 2));
+        assertEquals(0.0, feeChargesOutstanding(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION + PENALTY_PORTION, penaltyChargesDue(loanSchedule, 2));
+        assertEquals(0.0, penaltyChargesOutstanding(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION, penaltyChargesWaived(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION, penaltyChargesPaid(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION + PENALTY_PORTION, totalDueForPeriod(loanSchedule, 2));
+        assertEquals(0.0, totalOutstandingForPeriod(loanSchedule, 2));
+        assertEquals(PENALTY_PORTION, totalWaivedForPeriod(loanSchedule, 2));
         // Might need to change if refund should update the due date of N+1 instalment
-        assertEquals(LocalDate.of(2011, 4, 14), LocalDate.of((int) ((List) loanSchedule.get(2).get("dueDate")).get(0),
-                (int) ((List) loanSchedule.get(2).get("dueDate")).get(1), (int) ((List) loanSchedule.get(2).get("dueDate")).get(2)));
+        assertEquals(LocalDate.of(2011, 4, 14), loanSchedule.get(2).getDueDate());
     }
 
     @Test
@@ -433,72 +294,62 @@ public class LoanSpecificDueDateChargeAfterMaturityTest extends BaseLoanIntegrat
         try {
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
-            BUSINESS_DATE_HELPER.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("01 September 2023").dateFormat(DATETIME_PATTERN).locale("en"));
+            updateBusinessDate("01 September 2023");
 
-            PostChargesResponse penaltyCharge = CHARGES_HELPER.createCharges(new ChargeRequest().penalty(true).amount(10.0)
-                    .chargeCalculationType(ChargeCalculationType.FLAT.getValue())
-                    .chargeTimeType(ChargeTimeType.SPECIFIED_DUE_DATE.getValue()).chargePaymentMode(ChargePaymentMode.REGULAR.getValue())
-                    .currencyCode("USD").name(Utils.randomStringGenerator("PENALTY_" + Calendar.getInstance().getTimeInMillis(), 5))
-                    .chargeAppliesTo(1).locale("en").active(true));
+            PostChargesResponse penaltyCharge = chargesHelper.createLoanSpecifiedDueDatePenalty(10.0);
 
-            final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId, 1000L, 30, 30, 1,
-                    BigDecimal.ZERO, "01 September 2023", "01 September 2023");
+            final PostLoansResponse loanResponse = applyForLoanApplication(clientId, commonLoanProductId, 1000L, 30, 30, 1, BigDecimal.ZERO,
+                    "01 September 2023", "01 September 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 September 2023").locale("en"));
+            approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 September 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 September 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(1000)).locale("en"));
+            disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 September 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1000.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, 1000.0, 0.0, 1000.0, 0.0, 0.0);
             validateLoanTransaction(loanDetails, 0, 1000.0, 0.0, 0.0, 1000.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            BUSINESS_DATE_HELPER.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("01 October 2023").dateFormat(DATETIME_PATTERN).locale("en"));
+            updateBusinessDate("01 October 2023");
 
-            PostLoansLoanIdTransactionsResponse repaymentTransaction = loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(),
+            PostLoansLoanIdTransactionsResponse repaymentTransaction = makeLoanRepayment(loanResponse.getLoanId(),
                     new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate("01 October 2023").locale("en")
                             .transactionAmount(1000.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 1000.0, 0.0, 1000.0, null);
             validateRepaymentPeriod(loanDetails, 1, 1000.0, 1000.0, 0.0, 0.0, 0.0);
             validateLoanTransaction(loanDetails, 1, 1000.0, 1000.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getClosedObligationsMet());
 
-            BUSINESS_DATE_HELPER.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("04 October 2023").dateFormat(DATETIME_PATTERN).locale("en"));
+            updateBusinessDate("04 October 2023");
 
-            loanTransactionHelper.makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("04 October 2023").locale("en").transactionAmount(1000.0));
+            makeMerchantIssuedRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("04 October 2023").locale("en").transactionAmount(1000.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 1000.0, 0.0, 1000.0, 1000.0);
             validateRepaymentPeriod(loanDetails, 1, 1000.0, 1000.0, 0.0, 0.0, 0.0);
             validateLoanTransaction(loanDetails, 2, 1000.0, 0.0, 1000.0, 0.0);
             assertTrue(loanDetails.getStatus().getOverpaid());
 
-            loanTransactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), repaymentTransaction.getResourceId(),
+            reverseLoanTransaction(loanResponse.getLoanId(), repaymentTransaction.getResourceId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("04 October 2023")
                             .transactionAmount(0.0).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 1000.0, 0.0, 1000.0, null);
             validateRepaymentPeriod(loanDetails, 1, 1000.0, 1000.0, 0.0, 0.0, 1000.0);
             validateLoanTransaction(loanDetails, 2, 1000.0, 1000.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getClosedObligationsMet());
 
-            PostLoansLoanIdChargesResponse penaltyLoanChargeResult = loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdChargesRequest().chargeId(penaltyCharge.getResourceId()).dateFormat(DATETIME_PATTERN).locale("en")
-                            .amount(10.0).dueDate("04 October 2023"));
+            addChargesForLoan(loanResponse.getLoanId(), new PostLoansLoanIdChargesRequest().chargeId(penaltyCharge.getResourceId())
+                    .dateFormat(DATETIME_PATTERN).locale("en").amount(10.0).dueDate("04 October 2023"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 10.0, 1000.0, 0.0, 1000.0, null);
             validateRepaymentPeriod(loanDetails, 1, 1000.0, 1000.0, 0.0, 0.0, 1000.0);
             validateRepaymentPeriod(loanDetails, 2, 0.0, 0.0, 0.0, 10.0, 0.0, 10.0, 0.0, 0.0);
@@ -509,53 +360,109 @@ public class LoanSpecificDueDateChargeAfterMaturityTest extends BaseLoanIntegrat
         }
     }
 
-    private Integer applyForLoanApplication(final Integer clientID, final Integer loanProductID, String interestRate) {
-        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
-        final String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal(LP_PRINCIPAL.toString())
-                .withLoanTermFrequency(LOAN_TERM_FREQUENCY).withLoanTermFrequencyAsMonths().withNumberOfRepayments(LP_REPAYMENTS)
-                .withRepaymentEveryAfter(LP_REPAYMENT_PERIOD).withRepaymentFrequencyTypeAsMonths().withInterestRatePerPeriod(interestRate)
-                .withInterestTypeAsFlatBalance().withAmortizationTypeAsEqualPrincipalPayments()
-                .withInterestCalculationPeriodTypeSameAsRepaymentPeriod().withExpectedDisbursementDate(EXPECTED_DISBURSAL_DATE)
-                .withSubmittedOnDate(LOAN_APPLICATION_SUBMISSION_DATE).withLoanType(INDIVIDUAL_LOAN)
-                .build(clientID.toString(), loanProductID.toString(), null);
-        return this.loanTransactionHelper.getLoanId(loanApplicationJSON);
+    private PostLoanProductsRequest noInterestPeriodicAccrualProduct(double principal, int repaymentEvery, long repaymentFrequencyType,
+            int numberOfRepayments) {
+        return create4Period1MonthLongWithoutInterestProduct(STRATEGY)//
+                .minPrincipal(principal)//
+                .principal(principal)//
+                .numberOfRepayments(numberOfRepayments)//
+                .repaymentEvery(repaymentEvery)//
+                .repaymentFrequencyType(repaymentFrequencyType)//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_PRINCIPAL);
     }
 
-    private Integer createLoanProductWithPeriodicAccrualAccountingNoInterest(final Account... accounts) {
-        LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-        final String loanProductJSON = new LoanProductTestBuilder().withPrincipal(LP_PRINCIPAL.toString()).withRepaymentTypeAsMonth()
-                .withRepaymentAfterEvery(LP_REPAYMENT_PERIOD).withNumberOfRepayments(LP_REPAYMENTS).withRepaymentTypeAsMonth()
-                .withinterestRatePerPeriod("0").withInterestRateFrequencyTypeAsMonths().withAmortizationTypeAsEqualPrincipalPayment()
-                .withInterestTypeAsFlat().withAccountingRulePeriodicAccrual(accounts).withDaysInMonth("30").withDaysInYear("365")
-                .withMoratorium("0", "0").build(null);
-        return this.loanTransactionHelper.getLoanProductId(loanProductJSON);
+    private Long applyForNoInterestLoan(final Long clientId, final Long loanProductID) {
+        return applyForLoan(new PostLoansRequest().clientId(clientId).productId(loanProductID).principal(BigDecimal.valueOf(LP_PRINCIPAL))//
+                .loanTermFrequency(1).loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .numberOfRepayments(1).repaymentEvery(1).repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .interestRatePerPeriod(BigDecimal.ZERO).interestType(LoanTestData.InterestType.FLAT)//
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_PRINCIPAL).expectedDisbursementDate(EXPECTED_DISBURSAL_DATE)//
+                .submittedOnDate(LOAN_APPLICATION_SUBMISSION_DATE).transactionProcessingStrategyCode(STRATEGY).loanType("individual")//
+                .dateFormat(DATETIME_PATTERN).locale("en"));
     }
 
-    private static Integer createLoanProduct(final String principal, final String repaymentAfterEvery, final String numberOfRepayments,
-            final Account... accounts) {
-        LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-        final String loanProductJSON = new LoanProductTestBuilder().withMinPrincipal(principal).withPrincipal(principal)
-                .withRepaymentTypeAsDays().withRepaymentAfterEvery(repaymentAfterEvery).withNumberOfRepayments(numberOfRepayments)
-                .withinterestRatePerPeriod("0").withInterestRateFrequencyTypeAsMonths()
-                .withRepaymentStrategy(
-                        LoanProductTestBuilder.DUE_PENALTY_FEE_INTEREST_PRINCIPAL_IN_ADVANCE_PRINCIPAL_PENALTY_FEE_INTEREST_STRATEGY)
-                .withAmortizationTypeAsEqualPrincipalPayment().withInterestTypeAsFlat().withAccountingRulePeriodicAccrual(accounts)
-                .withDaysInMonth("30").withDaysInYear("365").withMoratorium("0", "0").build(null);
-        return loanTransactionHelper.getLoanProductId(loanProductJSON);
-    }
-
-    private static PostLoansResponse applyForLoanApplication(final Long clientId, final Integer loanProductId, final Long principal,
+    private PostLoansResponse applyForLoanApplication(final Long clientId, final Long loanProductId, final Long principal,
             final int loanTermFrequency, final int repaymentAfterEvery, final int numberOfRepayments, final BigDecimal interestRate,
             final String expectedDisbursementDate, final String submittedOnDate) {
-        LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
-        return loanTransactionHelper.applyLoan(new PostLoansRequest().clientId(clientId).productId(loanProductId.longValue())
-                .expectedDisbursementDate(expectedDisbursementDate).dateFormat(DATETIME_PATTERN)
-                .transactionProcessingStrategyCode(
-                        LoanProductTestBuilder.DUE_PENALTY_FEE_INTEREST_PRINCIPAL_IN_ADVANCE_PRINCIPAL_PENALTY_FEE_INTEREST_STRATEGY)
-                .locale("en").submittedOnDate(submittedOnDate).amortizationType(1).interestRatePerPeriod(interestRate)
-                .interestCalculationPeriodType(1).interestType(0).repaymentFrequencyType(0).repaymentEvery(repaymentAfterEvery)
-                .repaymentFrequencyType(0).numberOfRepayments(numberOfRepayments).loanTermFrequency(loanTermFrequency)
-                .loanTermFrequencyType(0).principal(BigDecimal.valueOf(principal)).loanType("individual"));
+        return loanHelper.applyForLoan(new PostLoansRequest().clientId(clientId).productId(loanProductId)
+                .expectedDisbursementDate(expectedDisbursementDate).dateFormat(DATETIME_PATTERN).transactionProcessingStrategyCode(STRATEGY)
+                .locale("en").submittedOnDate(submittedOnDate).amortizationType(LoanTestData.AmortizationType.EQUAL_INSTALLMENTS)
+                .interestRatePerPeriod(interestRate)
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.SAME_AS_REPAYMENT_PERIOD)
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE).repaymentEvery(repaymentAfterEvery)
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.DAYS).numberOfRepayments(numberOfRepayments)
+                .loanTermFrequency(loanTermFrequency).loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.DAYS)
+                .principal(BigDecimal.valueOf(principal)).loanType("individual"));
+    }
+
+    private List<GetLoansLoanIdRepaymentPeriod> getRepaymentSchedule(Long loanId) {
+        return getLoanDetails(loanId).getRepaymentSchedule().getPeriods();
+    }
+
+    private void checkAccrualTransactionForRepayment(final LocalDate transactionDate, final double interestPortion, final double feePortion,
+            final double penaltyPortion, final Long loanId) {
+        boolean isTransactionFound = false;
+        for (GetLoansLoanIdTransactions transaction : getLoanDetails(loanId).getTransactions()) {
+            if (Boolean.TRUE.equals(transaction.getType().getAccrual()) && transactionDate.equals(transaction.getDate())) {
+                isTransactionFound = true;
+                assertEquals(interestPortion, Utils.getDoubleValue(transaction.getInterestPortion()), "Mismatch in transaction amounts");
+                assertEquals(feePortion, Utils.getDoubleValue(transaction.getFeeChargesPortion()), "Mismatch in transaction amounts");
+                assertEquals(penaltyPortion, Utils.getDoubleValue(transaction.getPenaltyChargesPortion()),
+                        "Mismatch in transaction amounts");
+                break;
+            }
+        }
+        assertTrue(isTransactionFound, "No Accrual entries are posted");
+    }
+
+    private void noAccrualTransactionForRepayment(final Long loanId) {
+        for (GetLoansLoanIdTransactions transaction : getLoanDetails(loanId).getTransactions()) {
+            assertFalse(Boolean.TRUE.equals(transaction.getType().getAccrual()), "Accrual entries are posted!");
+        }
+    }
+
+    private void loanChargeRefund(final Long loanId, final Long loanChargeId, final double amount) {
+        ok(() -> fineractClient().loanTransactions().handleCommandsLoanTransaction(loanId,
+                new PostLoansLoanIdTransactionsRequest().locale("en").dateFormat(DATETIME_PATTERN).loanChargeId(loanChargeId)
+                        .transactionAmount(amount).note("Loancharge Refund Made!!!"),
+                "chargeRefund"));
+    }
+
+    private static double feeChargesDue(List<GetLoansLoanIdRepaymentPeriod> schedule, int index) {
+        return Utils.getDoubleValue(schedule.get(index).getFeeChargesDue());
+    }
+
+    private static double feeChargesOutstanding(List<GetLoansLoanIdRepaymentPeriod> schedule, int index) {
+        return Utils.getDoubleValue(schedule.get(index).getFeeChargesOutstanding());
+    }
+
+    private static double penaltyChargesDue(List<GetLoansLoanIdRepaymentPeriod> schedule, int index) {
+        return Utils.getDoubleValue(schedule.get(index).getPenaltyChargesDue());
+    }
+
+    private static double penaltyChargesOutstanding(List<GetLoansLoanIdRepaymentPeriod> schedule, int index) {
+        return Utils.getDoubleValue(schedule.get(index).getPenaltyChargesOutstanding());
+    }
+
+    private static double penaltyChargesWaived(List<GetLoansLoanIdRepaymentPeriod> schedule, int index) {
+        return Utils.getDoubleValue(schedule.get(index).getPenaltyChargesWaived());
+    }
+
+    private static double penaltyChargesPaid(List<GetLoansLoanIdRepaymentPeriod> schedule, int index) {
+        return Utils.getDoubleValue(schedule.get(index).getPenaltyChargesPaid());
+    }
+
+    private static double totalDueForPeriod(List<GetLoansLoanIdRepaymentPeriod> schedule, int index) {
+        return Utils.getDoubleValue(schedule.get(index).getTotalDueForPeriod());
+    }
+
+    private static double totalOutstandingForPeriod(List<GetLoansLoanIdRepaymentPeriod> schedule, int index) {
+        return Utils.getDoubleValue(schedule.get(index).getTotalOutstandingForPeriod());
+    }
+
+    private static double totalWaivedForPeriod(List<GetLoansLoanIdRepaymentPeriod> schedule, int index) {
+        return Utils.getDoubleValue(schedule.get(index).getTotalWaivedForPeriod());
     }
 
     private static void validateLoanTransaction(GetLoansLoanIdResponse loanDetails, int index, double transactionAmount,

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanTransactionAccrualActivityPostingTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanTransactionAccrualActivityPostingTest.java
@@ -18,20 +18,15 @@
  */
 package org.apache.fineract.integrationtests;
 
-import static org.apache.fineract.integrationtests.common.funds.FundsResourceHandler.createFund;
 import static org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY;
 import static org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder.DEFAULT_STRATEGY;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.fineract.client.models.AdvancedPaymentData;
 import org.apache.fineract.client.models.AllowAttributeOverrides;
@@ -42,22 +37,23 @@ import org.apache.fineract.client.models.GetLoansLoanIdStatus;
 import org.apache.fineract.client.models.LoanProductChargeData;
 import org.apache.fineract.client.models.LoanProductChargeToGLAccountMapper;
 import org.apache.fineract.client.models.PostChargesResponse;
-import org.apache.fineract.client.models.PostClientsResponse;
 import org.apache.fineract.client.models.PostLoanProductsRequest;
 import org.apache.fineract.client.models.PostLoanProductsResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdChargesRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdChargesResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdRequest;
+import org.apache.fineract.client.models.PostLoansLoanIdTransactionsResponse;
 import org.apache.fineract.client.models.PostLoansRequest;
 import org.apache.fineract.client.models.PostLoansResponse;
-import org.apache.fineract.integrationtests.common.BusinessStepHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.SchedulerJobHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignBusinessStepHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignDelinquencyHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignFundHelper;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.DaysInMonthType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.DaysInYearType;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.apache.fineract.integrationtests.common.products.DelinquencyBucketsHelper;
-import org.apache.fineract.integrationtests.inlinecob.InlineLoanCOBHelper;
 import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
 import org.apache.fineract.portfolio.charge.domain.ChargePaymentMode;
 import org.apache.fineract.portfolio.charge.domain.ChargeTimeType;
@@ -70,35 +66,37 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrationTest {
+public class LoanTransactionAccrualActivityPostingTest extends FeignLoanTestBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(LoanTransactionAccrualActivityPostingTest.class);
-    private static final String DATETIME_PATTERN = "dd MMMM yyyy";
-    private static ResponseSpecification responseSpec;
-    private static RequestSpecification requestSpec;
-    private static LoanTransactionHelper loanTransactionHelper;
-    private static PostClientsResponse client;
-    private static ChargesHelper chargesHelper;
-    private static InlineLoanCOBHelper inlineLoanCOBHelper;
-    private static BusinessStepHelper businessStepHelper;
+    private static Long clientId;
 
     @BeforeAll
-    public static void setup() {
-        Utils.initializeRESTAssured();
-        requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        requestSpec.header("Fineract-Platform-TenantId", "default");
-        responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-        ClientHelper clientHelper = new ClientHelper(requestSpec, responseSpec);
-        chargesHelper = new ChargesHelper();
-        client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
-        inlineLoanCOBHelper = new InlineLoanCOBHelper(requestSpec, responseSpec);
-        businessStepHelper = new BusinessStepHelper();
+    public static void setupTest() {
+        clientId = clientHelper.createClient();
         // setup COB Business Steps to prevent test failing due other integration test configurations
-        businessStepHelper.updateSteps("LOAN_CLOSE_OF_BUSINESS", "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION",
-                "CHECK_LOAN_REPAYMENT_DUE", "CHECK_LOAN_REPAYMENT_OVERDUE", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
+        new FeignBusinessStepHelper(FineractFeignClientHelper.getFineractFeignClient()).updateSteps("LOAN_CLOSE_OF_BUSINESS",
+                "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION", "CHECK_LOAN_REPAYMENT_DUE",
+                "CHECK_LOAN_REPAYMENT_OVERDUE", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
                 "EXTERNAL_ASSET_OWNER_TRANSFER", "ACCRUAL_ACTIVITY_POSTING");
+    }
+
+    // Mirrors the original test's repayment (unique external id) so multi-disburse reverse-replay behaves identically.
+    @Override
+    protected Long addRepaymentForLoan(Long loanId, Double amount, String date) {
+        return addRepayment(loanId, LoanRequestBuilders.repayLoan(amount, date).externalId(UUID.randomUUID().toString()));
+    }
+
+    private PostLoansLoanIdTransactionsResponse makeLoanRepayment(String date, float amount, Integer loanId) {
+        return makeLoanRepayment(loanId.longValue(), "repayment", date, (double) amount);
+    }
+
+    private PostLoansLoanIdTransactionsResponse makeLoanRepayment(String command, String date, float amount, Integer loanId) {
+        return makeLoanRepayment(loanId.longValue(), command, date, (double) amount);
+    }
+
+    private void reverseRepayment(Integer loanId, Integer transactionId, String date) {
+        reverseLoanTransaction(loanId.longValue(), transactionId.longValue(), date);
     }
 
     /**
@@ -114,24 +112,24 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
     @Test
     public void testInterestBearingProgressiveNoInterestRecalculationReopenDueReverseRepayment1() {
         runAt("17 January 2025", () -> {
-            final PostLoanProductsResponse loanProductsResponse = loanProductHelper.createLoanProduct(create4IProgressive() //
+            final PostLoanProductsResponse loanProductsResponse = loanHelper.createLoanProduct(create4IProgressive() //
                     .description("Interest bearing Progressive Loan USD, Accrual Activity Posting, NO InterestRecalculation") //
                     .enableAccrualActivityPosting(true) //
                     .daysInMonthType(DaysInMonthType.ACTUAL) //
                     .daysInYearType(DaysInYearType.ACTUAL) //
                     .isInterestRecalculationEnabled(false));//
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applyLP2ProgressiveLoanRequest(client.getClientId(),
-                    loanProductsResponse.getResourceId(), "17 August 2024", 450.0, 25.0, 6, null));
+            PostLoansResponse postLoansResponse = loanHelper.applyForLoan(
+                    applyLP2ProgressiveLoanRequest(clientId, loanProductsResponse.getResourceId(), "17 August 2024", 450.0, 25.0, 6, null));
             Long loanId = postLoansResponse.getLoanId();
             Assertions.assertNotNull(loanId);
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(450.0, "17 August 2024"));
+            approveLoan(loanId, approveLoanRequest(450.0, "17 August 2024"));
             disburseLoan(loanId, BigDecimal.valueOf(450.0), "17 August 2024");
             verifyTransactions(loanId, //
                     transaction(450.0, "Disbursement", "17 August 2024") //
             );
-            Long repaymentId = loanTransactionHelper.makeLoanRepayment("17 January 2025", 600.0f, loanId.intValue()).getResourceId();
+            Long repaymentId = makeLoanRepayment("17 January 2025", 600.0f, loanId.intValue()).getResourceId();
             Assertions.assertNotNull(repaymentId);
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getOverpaid);
             verifyTransactions(loanId, //
                     transaction(450.0, "Disbursement", "17 August 2024"), //
@@ -142,8 +140,8 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
                     transaction(6.48, "Accrual Activity", "17 November 2024"), //
                     transaction(4.75, "Accrual Activity", "17 December 2024"), //
                     transaction(4.99, "Accrual Activity", "17 January 2025")); //
-            loanTransactionHelper.reverseRepayment(loanId.intValue(), repaymentId.intValue(), "17 January 2025");
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            reverseRepayment(loanId.intValue(), repaymentId.intValue(), "17 January 2025");
+            loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getActive);
             verifyTransactions(loanId, transaction(450.0, "Disbursement", "17 August 2024"), //
                     transaction(33.52, "Accrual", "17 January 2025"), //
@@ -168,24 +166,24 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
     @Test
     public void testInterestBearingProgressiveInterestRecalculationReopenDueReverseRepayment() {
         runAt("17 January 2025", () -> {
-            final PostLoanProductsResponse loanProductsResponse = loanProductHelper.createLoanProduct(create4IProgressive() //
+            final PostLoanProductsResponse loanProductsResponse = loanHelper.createLoanProduct(create4IProgressive() //
                     .description("Interest bearing Progressive Loan USD, Accrual Activity Posting, NO InterestRecalculation") //
                     .enableAccrualActivityPosting(true) //
                     .daysInMonthType(DaysInMonthType.ACTUAL) //
                     .daysInYearType(DaysInYearType.ACTUAL) //
                     .isInterestRecalculationEnabled(false));//
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applyLP2ProgressiveLoanRequest(client.getClientId(),
-                    loanProductsResponse.getResourceId(), "17 August 2024", 450.0, 25.0, 6, null));
+            PostLoansResponse postLoansResponse = loanHelper.applyForLoan(
+                    applyLP2ProgressiveLoanRequest(clientId, loanProductsResponse.getResourceId(), "17 August 2024", 450.0, 25.0, 6, null));
             Long loanId = postLoansResponse.getLoanId();
             Assertions.assertNotNull(loanId);
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(450.0, "17 August 2024"));
+            approveLoan(loanId, approveLoanRequest(450.0, "17 August 2024"));
             disburseLoan(loanId, BigDecimal.valueOf(450.0), "17 August 2024");
             verifyTransactions(loanId, //
                     transaction(450.0, "Disbursement", "17 August 2024") //
             );
-            Long repaymentId = loanTransactionHelper.makeLoanRepayment("17 January 2025", 600.0f, loanId.intValue()).getResourceId();
+            Long repaymentId = makeLoanRepayment("17 January 2025", 600.0f, loanId.intValue()).getResourceId();
             Assertions.assertNotNull(repaymentId);
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getOverpaid);
             verifyTransactions(loanId, //
                     transaction(450.0, "Disbursement", "17 August 2024"), //
@@ -196,9 +194,9 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
                     transaction(6.48, "Accrual Activity", "17 November 2024"), //
                     transaction(4.75, "Accrual Activity", "17 December 2024"), //
                     transaction(4.99, "Accrual Activity", "17 January 2025")); //
-            loanTransactionHelper.reverseRepayment(loanId.intValue(), repaymentId.intValue(), "17 January 2025");
+            reverseRepayment(loanId.intValue(), repaymentId.intValue(), "17 January 2025");
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getActive);
             verifyTransactions(loanId, transaction(450.0, "Disbursement", "17 August 2024"), //
                     transaction(33.52, "Accrual", "17 January 2025"), //
@@ -223,24 +221,24 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
     @Test
     public void testInterestBearingProgressiveNoInterestRecalculationReopenDueReverseRepayment1b() {
         runAt("18 January 2025", () -> {
-            final PostLoanProductsResponse loanProductsResponse = loanProductHelper.createLoanProduct(create4IProgressive() //
+            final PostLoanProductsResponse loanProductsResponse = loanHelper.createLoanProduct(create4IProgressive() //
                     .description("Interest bearing Progressive Loan USD, Accrual Activity Posting, NO InterestRecalculation") //
                     .enableAccrualActivityPosting(true) //
                     .daysInMonthType(DaysInMonthType.ACTUAL) //
                     .daysInYearType(DaysInYearType.ACTUAL) //
                     .isInterestRecalculationEnabled(false));//
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applyLP2ProgressiveLoanRequest(client.getClientId(),
-                    loanProductsResponse.getResourceId(), "17 August 2024", 450.0, 25.0, 6, null));
+            PostLoansResponse postLoansResponse = loanHelper.applyForLoan(
+                    applyLP2ProgressiveLoanRequest(clientId, loanProductsResponse.getResourceId(), "17 August 2024", 450.0, 25.0, 6, null));
             Long loanId = postLoansResponse.getLoanId();
             Assertions.assertNotNull(loanId);
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(450.0, "17 August 2024"));
+            approveLoan(loanId, approveLoanRequest(450.0, "17 August 2024"));
             disburseLoan(loanId, BigDecimal.valueOf(450.0), "17 August 2024");
             verifyTransactions(loanId, //
                     transaction(450.0, "Disbursement", "17 August 2024") //
             );
-            Long repaymentId = loanTransactionHelper.makeLoanRepayment("17 January 2025", 600.0f, loanId.intValue()).getResourceId();
+            Long repaymentId = makeLoanRepayment("17 January 2025", 600.0f, loanId.intValue()).getResourceId();
             Assertions.assertNotNull(repaymentId);
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getOverpaid);
             verifyTransactions(loanId, //
                     transaction(450.0, "Disbursement", "17 August 2024"), //
@@ -251,8 +249,8 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
                     transaction(6.48, "Accrual Activity", "17 November 2024"), //
                     transaction(4.75, "Accrual Activity", "17 December 2024"), //
                     transaction(4.99, "Accrual Activity", "17 January 2025")); //
-            loanTransactionHelper.reverseRepayment(loanId.intValue(), repaymentId.intValue(), "17 January 2025");
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            reverseRepayment(loanId.intValue(), repaymentId.intValue(), "17 January 2025");
+            loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getActive);
             verifyTransactions(loanId, transaction(450.0, "Disbursement", "17 August 2024"), //
                     transaction(33.52, "Accrual", "18 January 2025"), //
@@ -268,25 +266,25 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
     @Test
     public void testAccrualActivityPostingAndReversalsInterestBearingProgressiveInterestRecalculationMerchantIssuedRefund() {
         runAt("17 January 2025", () -> {
-            final PostLoanProductsResponse loanProductsResponse = loanProductHelper.createLoanProduct(create4IProgressive() //
+            final PostLoanProductsResponse loanProductsResponse = loanHelper.createLoanProduct(create4IProgressive() //
                     .description("Interest bearing Progressive Loan USD, Accrual Activity Posting, InterestRecalculation") //
                     .enableAccrualActivityPosting(true) //
                     .currencyCode("USD") //
                     .daysInMonthType(DaysInMonthType.ACTUAL) //
                     .daysInYearType(DaysInYearType.ACTUAL) //
                     .isInterestRecalculationEnabled(true));//
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applyLP2ProgressiveLoanRequest(client.getClientId(),
-                    loanProductsResponse.getResourceId(), "17 August 2024", 450.0, 25.0, 6, null));
+            PostLoansResponse postLoansResponse = loanHelper.applyForLoan(
+                    applyLP2ProgressiveLoanRequest(clientId, loanProductsResponse.getResourceId(), "17 August 2024", 450.0, 25.0, 6, null));
             Long loanId = postLoansResponse.getLoanId();
             Assertions.assertNotNull(loanId);
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(450.0, "17 August 2024"));
+            approveLoan(loanId, approveLoanRequest(450.0, "17 August 2024"));
             disburseLoan(loanId, BigDecimal.valueOf(450.0), "17 August 2024");
             verifyTransactions(loanId, //
                     transaction(450.0, "Disbursement", "17 August 2024") //
             );
-            Long repaymentId = loanTransactionHelper.makeLoanRepayment("17 January 2025", 497.04f, loanId.intValue()).getResourceId();
+            Long repaymentId = makeLoanRepayment("17 January 2025", 497.04f, loanId.intValue()).getResourceId();
             Assertions.assertNotNull(repaymentId);
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getClosedObligationsMet);
             verifyTransactions(loanId, //
                     transaction(450.0, "Disbursement", "17 August 2024"), //
@@ -297,8 +295,8 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
                     transaction(9.53, "Accrual Activity", "17 November 2024"), //
                     transaction(9.22, "Accrual Activity", "17 December 2024"), //
                     transaction(9.54, "Accrual Activity", "17 January 2025")); //
-            loanTransactionHelper.makeLoanRepayment("MerchantIssuedRefund", "17 August 2024", 450.0f, loanId.intValue()).getResourceId();
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            makeLoanRepayment("MerchantIssuedRefund", "17 August 2024", 450.0f, loanId.intValue()).getResourceId();
+            loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getOverpaid);
             verifyTransactions(loanId, transaction(450.0, "Disbursement", "17 August 2024"), //
                     transaction(450.0, "Merchant Issued Refund", "17 August 2024"), //
@@ -320,25 +318,25 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
     @Test
     public void testInterestBearingProgressiveNoInterestRecalculationReopenDueReverseRepayment2b() {
         runAt("17 January 2025", () -> {
-            final PostLoanProductsResponse loanProductsResponse = loanProductHelper.createLoanProduct(create4IProgressive() //
+            final PostLoanProductsResponse loanProductsResponse = loanHelper.createLoanProduct(create4IProgressive() //
                     .description("Interest bearing Progressive Loan USD, Accrual Activity Posting, NO InterestRecalculation") //
                     .enableAccrualActivityPosting(true) //
                     .currencyCode("USD") //
                     .daysInMonthType(DaysInMonthType.ACTUAL) //
                     .daysInYearType(DaysInYearType.ACTUAL) //
                     .isInterestRecalculationEnabled(false));//
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applyLP2ProgressiveLoanRequest(client.getClientId(),
-                    loanProductsResponse.getResourceId(), "17 August 2024", 450.0, 25.0, 6, null));
+            PostLoansResponse postLoansResponse = loanHelper.applyForLoan(
+                    applyLP2ProgressiveLoanRequest(clientId, loanProductsResponse.getResourceId(), "17 August 2024", 450.0, 25.0, 6, null));
             Long loanId = postLoansResponse.getLoanId();
             Assertions.assertNotNull(loanId);
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(450.0, "17 August 2024"));
+            approveLoan(loanId, approveLoanRequest(450.0, "17 August 2024"));
             disburseLoan(loanId, BigDecimal.valueOf(450.0), "17 August 2024");
             verifyTransactions(loanId, //
                     transaction(450.0, "Disbursement", "17 August 2024") //
             );
-            Long repaymentId = loanTransactionHelper.makeLoanRepayment("17 January 2025", 483.52f, loanId.intValue()).getResourceId();
+            Long repaymentId = makeLoanRepayment("17 January 2025", 483.52f, loanId.intValue()).getResourceId();
             Assertions.assertNotNull(repaymentId);
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getClosedObligationsMet);
             verifyTransactions(loanId, //
                     transaction(450.0, "Disbursement", "17 August 2024"), //
@@ -350,7 +348,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
                     transaction(4.75, "Accrual Activity", "17 December 2024"), //
                     transaction(4.99, "Accrual Activity", "17 January 2025")); //
             addCharge(loanId, false, 15.0, "15 January 2025");
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getActive);
             verifyTransactions(loanId, transaction(450.0, "Disbursement", "17 August 2024"), //
                     transaction(33.52, "Accrual", "17 January 2025"), //
@@ -374,25 +372,25 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
     @Test
     public void testInterestBearingProgressiveNoInterestRecalculationReopenDueReverseRepayment2c() {
         runAt("18 January 2025", () -> {
-            final PostLoanProductsResponse loanProductsResponse = loanProductHelper.createLoanProduct(create4IProgressive() //
+            final PostLoanProductsResponse loanProductsResponse = loanHelper.createLoanProduct(create4IProgressive() //
                     .description("Interest bearing Progressive Loan USD, Accrual Activity Posting, NO InterestRecalculation") //
                     .enableAccrualActivityPosting(true) //
                     .currencyCode("USD") //
                     .daysInMonthType(DaysInMonthType.ACTUAL) //
                     .daysInYearType(DaysInYearType.ACTUAL) //
                     .isInterestRecalculationEnabled(false));//
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applyLP2ProgressiveLoanRequest(client.getClientId(),
-                    loanProductsResponse.getResourceId(), "17 August 2024", 450.0, 25.0, 6, null));
+            PostLoansResponse postLoansResponse = loanHelper.applyForLoan(
+                    applyLP2ProgressiveLoanRequest(clientId, loanProductsResponse.getResourceId(), "17 August 2024", 450.0, 25.0, 6, null));
             Long loanId = postLoansResponse.getLoanId();
             Assertions.assertNotNull(loanId);
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(450.0, "17 August 2024"));
+            approveLoan(loanId, approveLoanRequest(450.0, "17 August 2024"));
             disburseLoan(loanId, BigDecimal.valueOf(450.0), "17 August 2024");
             verifyTransactions(loanId, //
                     transaction(450.0, "Disbursement", "17 August 2024") //
             );
-            Long repaymentId = loanTransactionHelper.makeLoanRepayment("17 January 2025", 483.52f, loanId.intValue()).getResourceId();
+            Long repaymentId = makeLoanRepayment("17 January 2025", 483.52f, loanId.intValue()).getResourceId();
             Assertions.assertNotNull(repaymentId);
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getClosedObligationsMet);
             verifyTransactions(loanId, //
                     transaction(450.0, "Disbursement", "17 August 2024"), //
@@ -404,7 +402,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
                     transaction(4.75, "Accrual Activity", "17 December 2024"), //
                     transaction(4.99, "Accrual Activity", "17 January 2025")); //
             addCharge(loanId, false, 15.0, "15 January 2025");
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getActive);
             verifyTransactions(loanId, transaction(450.0, "Disbursement", "17 August 2024"), //
                     transaction(33.52, "Accrual", "18 January 2025"), //
@@ -442,14 +440,13 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         runAt(creationBusinessDay, () -> {
 
             Long localLoanProductId = createLoanProductAccountingAccrualPeriodicWithInterest();
-            loanId.set(applyForLoanApplicationWithInterest(client.getClientId(), localLoanProductId, BigDecimal.valueOf(40000),
-                    disbursementDay));
+            loanId.set(applyForLoanApplicationWithInterest(clientId, localLoanProductId, BigDecimal.valueOf(40000), disbursementDay));
 
-            loanTransactionHelper.approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
-                    .dateFormat(DATETIME_PATTERN).approvedOnDate(disbursementDay).locale("en"));
+            approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
+                    .approvedOnDate(disbursementDay).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
             chargePenalty(loanId.get(), 30.0, repaymentPeriod1DueDate);
             chargePenalty(loanId.get(), 50.0, repaymentPeriod2DueDate);
@@ -458,13 +455,13 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
 
         });
         runAt(repaymentPeriod1OneDayBeforeCloseDate, () -> {
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.get()));
+            executeInlineCOB(List.of(loanId.get()));
             verifyTransactions(loanId.get(), //
                     transaction(1000.0, "Disbursement", disbursementDay, 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
                     transaction(19.35, "Accrual", "31 January 2023", 0, 0, 19.35, 0, 0, 0.0, 0.0));
         });
         runAt(repaymentPeriod1CloseDate, () -> {
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.get()));
+            executeInlineCOB(List.of(loanId.get()));
             verifyTransactions(loanId.get(), //
                     transaction(1000.0, "Disbursement", disbursementDay, 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
                     transaction(19.35, "Accrual", "31 January 2023", 0, 0, 19.35, 0, 0, 0.0, 0.0),
@@ -473,7 +470,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
 
         });
         runAt(repaymentPeriod1OneDayAfterCloseDate, () -> {
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.get()));
+            executeInlineCOB(List.of(loanId.get()));
             verifyTransactions(loanId.get(), //
                     transaction(1000.0, "Disbursement", disbursementDay, 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
                     transaction(19.35, "Accrual", "31 January 2023", 0, 0, 19.35, 0, 0, 0.0, 0.0),
@@ -512,14 +509,13 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         runAt(creationBusinessDay, () -> {
 
             Long localLoanProductId = createLoanProductAccountingAccrualPeriodicWithInterest();
-            loanId.set(applyForLoanApplicationWithInterest(client.getClientId(), localLoanProductId, BigDecimal.valueOf(40000),
-                    disbursementDay));
+            loanId.set(applyForLoanApplicationWithInterest(clientId, localLoanProductId, BigDecimal.valueOf(40000), disbursementDay));
 
-            loanTransactionHelper.approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
-                    .dateFormat(DATETIME_PATTERN).approvedOnDate(disbursementDay).locale("en"));
+            approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
+                    .approvedOnDate(disbursementDay).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
             chargePenalty(loanId.get(), 30.0, repaymentPeriod1DueDate);
             chargePenalty(loanId.get(), 50.0, repaymentPeriod2DueDate);
@@ -528,19 +524,19 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
 
         });
         runAt(repaymentPeriod1OneDayBeforeCloseDate, () -> {
-            SchedulerJobHelper.executeAndAwaitJob("Accrual Activity Posting");
+            schedulerHelper.executeAndAwaitJob("Accrual Activity Posting");
             verifyTransactions(loanId.get(), //
                     transaction(1000.0, "Disbursement", disbursementDay, 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
         });
         runAt(repaymentPeriod1CloseDate, () -> {
-            SchedulerJobHelper.executeAndAwaitJob("Accrual Activity Posting");
+            schedulerHelper.executeAndAwaitJob("Accrual Activity Posting");
 
             verifyTransactions(loanId.get(), //
                     transaction(1000.0, "Disbursement", disbursementDay, 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
                     transaction(90.0, "Accrual Activity", "01 February 2023", 0, 0, 20.0, 40.0, 30.0, 0.0, 0.0));
         });
         runAt(repaymentPeriod1OneDayAfterCloseDate, () -> {
-            SchedulerJobHelper.executeAndAwaitJob("Accrual Activity Posting");
+            schedulerHelper.executeAndAwaitJob("Accrual Activity Posting");
             verifyTransactions(loanId.get(), //
                     transaction(1000.0, "Disbursement", disbursementDay, 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
                     transaction(90.0, "Accrual Activity", "01 February 2023", 0, 0, 20.0, 40.0, 30.0, 0.0, 0.0));
@@ -573,20 +569,18 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
 
             Long localLoanProductId = createLoanProductAccountingAccrualPeriodicWithInterest();
 
-            loanId1.set(applyForLoanApplicationWithInterest(client.getClientId(), localLoanProductId, BigDecimal.valueOf(40000),
-                    disbursementDay));
-            loanId2.set(applyForLoanApplicationWithInterest(client.getClientId(), localLoanProductId, BigDecimal.valueOf(40000),
-                    disbursementDay));
+            loanId1.set(applyForLoanApplicationWithInterest(clientId, localLoanProductId, BigDecimal.valueOf(40000), disbursementDay));
+            loanId2.set(applyForLoanApplicationWithInterest(clientId, localLoanProductId, BigDecimal.valueOf(40000), disbursementDay));
 
-            loanTransactionHelper.approveLoan(loanId1.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+            approveLoan(loanId1.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
                     .dateFormat(DATETIME_PATTERN).approvedOnDate(disbursementDay).locale("en"));
-            loanTransactionHelper.approveLoan(loanId2.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+            approveLoan(loanId2.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
                     .dateFormat(DATETIME_PATTERN).approvedOnDate(disbursementDay).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanId1.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
-            loanTransactionHelper.disburseLoan(loanId2.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanId1.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanId2.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
             chargePenalty(loanId1.get(), 30.0, repaymentPeriod1DueDate);
             chargeFee(loanId1.get(), 40.0, repaymentPeriod1DueDate);
@@ -596,7 +590,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
 
         });
         runAt(repaymentPeriod1CloseDate, () -> {
-            SchedulerJobHelper.executeAndAwaitJob("Accrual Activity Posting");
+            schedulerHelper.executeAndAwaitJob("Accrual Activity Posting");
 
             verifyTransactions(loanId1.get(), //
                     transaction(1000.0, "Disbursement", disbursementDay, 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
@@ -631,14 +625,13 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         runAt(creationBusinessDay, () -> {
 
             Long localLoanProductId = createLoanProductAccountingAccrualPeriodicWithInterest();
-            loanId.set(applyForLoanApplicationWithInterest(client.getClientId(), localLoanProductId, BigDecimal.valueOf(40000),
-                    disbursementDay));
+            loanId.set(applyForLoanApplicationWithInterest(clientId, localLoanProductId, BigDecimal.valueOf(40000), disbursementDay));
 
-            loanTransactionHelper.approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
-                    .dateFormat(DATETIME_PATTERN).approvedOnDate(disbursementDay).locale("en"));
+            approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
+                    .approvedOnDate(disbursementDay).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
             addRepaymentForLoan(loanId.get(), 50.0, "10 January 2023");
             verifyTransactions(loanId.get(), //
@@ -647,7 +640,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
 
         });
         runAt(repaymentPeriod1CloseDate, () -> {
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.get()));
+            executeInlineCOB(List.of(loanId.get()));
             verifyTransactions(loanId.get(), //
                     transaction(1000.0, "Disbursement", disbursementDay, 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
                     transaction(20.0, "Accrual", "01 February 2023", 0, 0, 20, 0, 0, 0.0, 0.0),
@@ -713,14 +706,14 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         AtomicReference<Long> loanId = new AtomicReference<>();
         runAt(creationBusinessDay, () -> {
             Long localLoanProductId = createLoanProductAccountingAccrualPeriodicAdvancedPaymentAllocation();
-            loanId.set(applyForLoanApplicationAdvancedPaymentAllocation(client.getClientId(), localLoanProductId, BigDecimal.valueOf(40000),
+            loanId.set(applyForLoanApplicationAdvancedPaymentAllocation(clientId, localLoanProductId, BigDecimal.valueOf(40000),
                     disbursementDay, BigDecimal.ZERO));
 
-            loanTransactionHelper.approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
-                    .dateFormat(DATETIME_PATTERN).approvedOnDate(disbursementDay).locale("en"));
+            approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
+                    .approvedOnDate(disbursementDay).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(1000)).locale("en"));
 
             chargePenalty(loanId.get(), 20.0, chargeDueDate1st);
 
@@ -731,7 +724,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
 
         });
         runAt(repaymentPeriod1CloseDate, () -> {
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.get()));
+            executeInlineCOB(List.of(loanId.get()));
             verifyTransactions(loanId.get(), //
                     transaction(1000, "Disbursement", disbursementDay, 1000, 0, 0, 0, 0, 0, 0),
                     transaction(20, "Accrual", "01 February 2023", 0, 0, 0, 0, 20, 0, 0),
@@ -791,14 +784,14 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         runAt(creationBusinessDay, () -> {
 
             Long localLoanProductId = createLoanProductAccountingAccrualPeriodicAdvancedPaymentAllocation();
-            loanId.set(applyForLoanApplicationAdvancedPaymentAllocation(client.getClientId(), localLoanProductId, BigDecimal.valueOf(40000),
+            loanId.set(applyForLoanApplicationAdvancedPaymentAllocation(clientId, localLoanProductId, BigDecimal.valueOf(40000),
                     disbursementDay, BigDecimal.ZERO));
 
-            loanTransactionHelper.approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
-                    .dateFormat(DATETIME_PATTERN).approvedOnDate(disbursementDay).locale("en"));
+            approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
+                    .approvedOnDate(disbursementDay).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
             chargePenalty(loanId.get(), 20.0, chargeDueDate1st);
 
@@ -807,7 +800,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
 
         });
         runAt(repaymentPeriod1CloseDate, () -> {
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.get()));
+            executeInlineCOB(List.of(loanId.get()));
             verifyTransactions(loanId.get(), //
                     transaction(1000.0, "Disbursement", disbursementDay, 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
                     transaction(20.0, "Accrual", "01 February 2023", 0, 0, 0, 0, 20, 0.0, 0.0),
@@ -843,14 +836,14 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         AtomicReference<Long> repaymentId = new AtomicReference<>();
         runAt(creationBusinessDay, () -> {
             Long localLoanProductId = createLoanProductAccountingAccrualPeriodicAdvancedPaymentAllocation();
-            loanId.set(applyForLoanApplicationAdvancedPaymentAllocation(client.getClientId(), localLoanProductId, BigDecimal.valueOf(40000),
+            loanId.set(applyForLoanApplicationAdvancedPaymentAllocation(clientId, localLoanProductId, BigDecimal.valueOf(40000),
                     disbursementDay, BigDecimal.ZERO));
 
-            loanTransactionHelper.approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
-                    .dateFormat(DATETIME_PATTERN).approvedOnDate(disbursementDay).locale("en"));
+            approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
+                    .approvedOnDate(disbursementDay).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
             chargePenalty(loanId.get(), 30.0, repaymentPeriod1DueDate);
             chargeFee(loanId.get(), 40.0, repaymentPeriod1DueDate);
@@ -866,7 +859,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         });
         runAt(repaymentPeriod1CloseDate, () -> {
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.get()));
+            executeInlineCOB(List.of(loanId.get()));
 
             verifyTransactions(loanId.get(),
                     transaction(1000.0, "Disbursement", disbursementDay, 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false), //
@@ -874,7 +867,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
                     transaction(70.0, "Accrual", repaymentDate1, 0.0, 0.0, 0.0, 40.0, 30.0, 0.0, 0.0, false), //
                     transaction(70.0, "Accrual Activity", repaymentDate1, 0.0, 0.0, 0.0, 40.0, 30.0, 0.0, 0.0, false)); //
 
-            loanTransactionHelper.reverseRepayment(loanId.get().intValue(), repaymentId.get().intValue(), repaymentDate1);
+            reverseRepayment(loanId.get().intValue(), repaymentId.get().intValue(), repaymentDate1);
 
             verifyTransactions(loanId.get(),
                     transaction(1000.0, "Disbursement", disbursementDay, 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false), //
@@ -895,14 +888,13 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         AtomicReference<Long> repaymentId = new AtomicReference<>();
         runAt(creationBusinessDay, () -> {
             Long localLoanProductId = createLoanProductAccountingAccrualPeriodicWithInterest();
-            loanId.set(applyForLoanApplicationWithInterest(client.getClientId(), localLoanProductId, BigDecimal.valueOf(40000),
-                    disbursementDay));
+            loanId.set(applyForLoanApplicationWithInterest(clientId, localLoanProductId, BigDecimal.valueOf(40000), disbursementDay));
 
-            loanTransactionHelper.approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
-                    .dateFormat(DATETIME_PATTERN).approvedOnDate(disbursementDay).locale("en"));
+            approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
+                    .approvedOnDate(disbursementDay).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
             chargePenalty(loanId.get(), 30.0, repaymentPeriod1DueDate);
             chargeFee(loanId.get(), 40.0, repaymentPeriod1DueDate);
@@ -918,7 +910,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         });
         runAt(repaymentPeriod1CloseDate, () -> {
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.get()));
+            executeInlineCOB(List.of(loanId.get()));
 
             verifyTransactions(loanId.get(),
                     transaction(1000.0, "Disbursement", disbursementDay, 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false), //
@@ -926,7 +918,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
                     transaction(150.0, "Accrual", repaymentDate1, 0.0, 0.0, 80.0, 40.0, 30.0, 0.0, 0.0, false), //
                     transaction(150.0, "Accrual Activity", repaymentDate1, 0.0, 0.0, 80.0, 40.0, 30.0, 0.0, 0.0, false)); //
 
-            loanTransactionHelper.reverseRepayment(loanId.get().intValue(), repaymentId.get().intValue(), repaymentDate1);
+            reverseRepayment(loanId.get().intValue(), repaymentId.get().intValue(), repaymentDate1);
 
             verifyTransactions(loanId.get(),
                     transaction(1000.0, "Disbursement", disbursementDay, 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false), //
@@ -948,14 +940,14 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         runAt(creationBusinessDay, () -> {
             Long localLoanProductId = createLoanProductAccountingAccrualPeriodicAdvancedPaymentAllocation(true);
 
-            loanId.set(applyForLoanApplicationAdvancedPaymentAllocation(client.getClientId(), localLoanProductId, BigDecimal.valueOf(40000),
+            loanId.set(applyForLoanApplicationAdvancedPaymentAllocation(clientId, localLoanProductId, BigDecimal.valueOf(40000),
                     disbursementDay, disbursementDay2, BigDecimal.ZERO));
 
-            loanTransactionHelper.approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
-                    .dateFormat(DATETIME_PATTERN).approvedOnDate(disbursementDay).locale("en"));
+            approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
+                    .approvedOnDate(disbursementDay).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
 
             chargePenalty(loanId.get(), 30.0, repaymentPeriod1DueDate);
             chargeFee(loanId.get(), 40.0, repaymentPeriod1DueDate);
@@ -971,8 +963,8 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         });
         runAt(disbursementDay2, () -> {
 
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay2)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay2).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
 
             verifyTransactions(loanId.get(),
                     transaction(500.0, "Disbursement", disbursementDay, 500.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false), //
@@ -983,7 +975,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         });
         runAt(repaymentPeriod1CloseDate, () -> {
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.get()));
+            executeInlineCOB(List.of(loanId.get()));
 
             verifyTransactions(loanId.get(),
                     transaction(500.0, "Disbursement", disbursementDay, 500.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false), //
@@ -1007,14 +999,14 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         runAt(creationBusinessDay, () -> {
             Long localLoanProductId = createLoanProductAccountingAccrualPeriodicAdvancedPaymentAllocation(true);
 
-            loanId.set(applyForLoanApplicationAdvancedPaymentAllocation(client.getClientId(), localLoanProductId, BigDecimal.valueOf(40000),
+            loanId.set(applyForLoanApplicationAdvancedPaymentAllocation(clientId, localLoanProductId, BigDecimal.valueOf(40000),
                     disbursementDay, disbursementDay2, BigDecimal.ZERO));
 
-            loanTransactionHelper.approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
-                    .dateFormat(DATETIME_PATTERN).approvedOnDate(disbursementDay).locale("en"));
+            approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
+                    .approvedOnDate(disbursementDay).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
 
             chargePenalty(loanId.get(), 30.0, repaymentPeriod1DueDate);
             chargeFee(loanId.get(), 40.0, repaymentPeriod1DueDate);
@@ -1029,15 +1021,15 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         });
         runAt(repaymentPeriod1CloseDate, () -> {
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.get()));
+            executeInlineCOB(List.of(loanId.get()));
 
             verifyTransactions(loanId.get(), transaction(650.0, "Repayment", repaymentDate1, 0.0, 500.0, 0.0, 40.0, 30.0, 0.0, 80.0, false), //
                     transaction(70.0, "Accrual", repaymentDate1, 0.0, 0.0, 0.0, 40.0, 30.0, 0.0, 0.0, false), //
                     transaction(70.0, "Accrual Activity", repaymentDate1, 0.0, 0.0, 0.0, 40.0, 30.0, 0.0, 0.0, false), //
                     transaction(500.0, "Disbursement", disbursementDay, 500.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false)); //
 
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay2)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay2).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
 
             verifyTransactions(loanId.get(), transaction(650.0, "Repayment", repaymentDate1, 0.0, 500.0, 0.0, 40.0, 30.0, 0.0, 80.0, false), //
                     transaction(500.0, "Disbursement", disbursementDay2, 420.0, 0.0, 0.0, 0.0, 0.0, 0.0, 80.0, false), //
@@ -1059,14 +1051,14 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         AtomicReference<Long> loanId = new AtomicReference<>();
         runAt(creationBusinessDay, () -> {
             Long localLoanProductId = createLoanProductAccountingAccrualPeriodicWithInterest(true);
-            loanId.set(applyForLoanApplicationWithInterest(client.getClientId(), localLoanProductId, BigDecimal.valueOf(40000),
-                    disbursementDay, disbursementDay2));
+            loanId.set(applyForLoanApplicationWithInterest(clientId, localLoanProductId, BigDecimal.valueOf(40000), disbursementDay,
+                    disbursementDay2));
 
-            loanTransactionHelper.approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
-                    .dateFormat(DATETIME_PATTERN).approvedOnDate(disbursementDay).locale("en"));
+            approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
+                    .approvedOnDate(disbursementDay).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
 
             chargePenalty(loanId.get(), 30.0, repaymentPeriod1DueDate);
             chargeFee(loanId.get(), 40.0, repaymentPeriod1DueDate);
@@ -1080,15 +1072,15 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         });
         runAt(repaymentPeriod1CloseDate, () -> {
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.get()));
+            executeInlineCOB(List.of(loanId.get()));
 
             verifyTransactions(loanId.get(), transaction(94.9, "Accrual", repaymentDate1, 0.0, 0.0, 24.9, 40.0, 30.0, 0.0, 0.0, false), //
                     transaction(94.9, "Accrual Activity", repaymentDate1, 0.0, 0.0, 24.9, 40.0, 30.0, 0.0, 0.0, false), //
                     transaction(650.0, "Repayment", repaymentDate1, 0.0, 500.0, 24.9, 40.0, 30.0, 0.0, 55.1, false), //
                     transaction(500.0, "Disbursement", disbursementDay, 500.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false)); //
 
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay2)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay2).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
 
             verifyTransactions(loanId.get(),
                     transaction(500.0, "Disbursement", disbursementDay, 500.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false), //
@@ -1112,13 +1104,13 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         AtomicReference<Long> loanId = new AtomicReference<>();
         runAt(creationBusinessDay, () -> {
             Long localLoanProductId = createLoanProductAccountingAccrualPeriodicAdvancedPaymentAllocation(true);
-            loanId.set(applyForLoanApplicationAdvancedPaymentAllocation(client.getClientId(), localLoanProductId, BigDecimal.valueOf(1000),
+            loanId.set(applyForLoanApplicationAdvancedPaymentAllocation(clientId, localLoanProductId, BigDecimal.valueOf(1000),
                     disbursementDay, disbursementDay2, BigDecimal.ZERO));
-            loanTransactionHelper.approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
-                    .dateFormat(DATETIME_PATTERN).approvedOnDate(disbursementDay).locale("en"));
+            approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
+                    .approvedOnDate(disbursementDay).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
             chargePenalty(loanId.get(), 30.0, repaymentPeriod1DueDate);
             chargeFee(loanId.get(), 40.0, repaymentPeriod1DueDate);
 
@@ -1131,15 +1123,15 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         });
         runAt(repaymentPeriod1CloseDate, () -> {
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.get()));
+            executeInlineCOB(List.of(loanId.get()));
 
             verifyTransactions(loanId.get(), transaction(500.0, "Disbursement", disbursementDay, 500.0, 0, 0, 0, 0, 0, 0, false),
-                    transaction(570, "Repayment", repaymentDate1, 0.0, 500.0, 0, 40.0, 30.0, 0, 0, true),
+                    transaction(570, "Repayment", repaymentDate1, 0.0, 500.0, 0, 40.0, 30.0, 0, 0, false),
                     transaction(70.0, "Accrual", repaymentDate1, 0, 0, 0.0, 40.0, 30.0, 0, 0, false),
                     transaction(70.0, "Accrual Activity", repaymentDate1, 0, 0, 0.0, 40.0, 30.0, 0, 0, false));
 
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay2)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay2).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
 
             verifyTransactions(loanId.get(), transaction(500.0, "Disbursement", disbursementDay, 500.0, 0, 0, 0, 0, 0, 0, false),
                     transaction(570, "Repayment", repaymentDate1, 0.0, 500.0, 0, 40.0, 30.0, 0, 0, false),
@@ -1149,7 +1141,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         });
         runAt(repaymentPeriod2CloseDate, () -> {
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.get()));
+            executeInlineCOB(List.of(loanId.get()));
 
             verifyTransactions(loanId.get(), transaction(500.0, "Disbursement", disbursementDay, 500.0, 0, 0, 0, 0, 0, 0, false),
                     transaction(570.0, "Repayment", repaymentDate1, 0.0, 500.0, 0, 40.0, 30.0, 0, 0, false),
@@ -1172,13 +1164,13 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         AtomicReference<Long> loanId = new AtomicReference<>();
         runAt(creationBusinessDay, () -> {
             Long localLoanProductId = createLoanProductAccountingAccrualPeriodicWithInterest(true);
-            loanId.set(applyForLoanApplicationWithInterest(client.getClientId(), localLoanProductId, BigDecimal.valueOf(40000),
-                    disbursementDay, disbursementDay2));
-            loanTransactionHelper.approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
-                    .dateFormat(DATETIME_PATTERN).approvedOnDate(disbursementDay).locale("en"));
+            loanId.set(applyForLoanApplicationWithInterest(clientId, localLoanProductId, BigDecimal.valueOf(40000), disbursementDay,
+                    disbursementDay2));
+            approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
+                    .approvedOnDate(disbursementDay).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
             chargePenalty(loanId.get(), 30.0, repaymentPeriod1DueDate);
             chargeFee(loanId.get(), 40.0, repaymentPeriod1DueDate);
             addRepaymentForLoan(loanId.get(), 650.0, repaymentDate1);
@@ -1189,15 +1181,15 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
                     transaction(500.0, "Disbursement", disbursementDay, 500.0, 0, 0, 0, 0, 0, 0, false));
         });
         runAt(repaymentPeriod1CloseDate, () -> {
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.get()));
+            executeInlineCOB(List.of(loanId.get()));
             verifyTransactions(loanId.get(),
                     transaction(650.0, "Repayment", repaymentDate1, 0.0, 500.0, 24.9, 40.0, 30.0, 0.0, 55.1, false), //
                     transaction(94.90, "Accrual Activity", repaymentDate1, 0.0, 0.0, 24.9, 40.0, 30.0, 0.0, 0.0, false),
                     transaction(94.90, "Accrual", repaymentDate1, 0.0, 0.0, 24.9, 40.0, 30.0, 0.0, 0.0, false), //
                     transaction(500.0, "Disbursement", disbursementDay, 500.0, 0, 0, 0, 0, 0, 0, false) //
             );
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay2)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay2).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
             verifyTransactions(loanId.get(),
                     transaction(500.0, "Disbursement", disbursementDay2, 453.79, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false), //
                     transaction(650.0, "Repayment", repaymentDate1, 0.0, 546.21, 33.79, 40.0, 30.0, 0.0, 0.0, false), //
@@ -1206,7 +1198,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
             );
         });
         runAt(repaymentPeriod2CloseDate, () -> {
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.get()));
+            executeInlineCOB(List.of(loanId.get()));
             verifyTransactions(loanId.get(),
                     transaction(500.0, "Disbursement", disbursementDay2, 453.79, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false), //
                     transaction(650.0, "Repayment", repaymentDate1, 0.0, 546.21, 33.79, 40.0, 30.0, 0.0, 0.0, false), //
@@ -1223,8 +1215,8 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
 
     public void createInterestBearingProgressiveNoInterestRecalculationAutoDownPayment25percentLoanProductIfNotExists() {
         if (interestBearingProgressiveLoanProductId == null) {
-            final PostLoanProductsResponse loanProductsResponse = loanProductHelper.createLoanProduct(create4IProgressive()
-                    .currencyCode("USD").enableAccrualActivityPosting(true).enableDownPayment(true)
+            final PostLoanProductsResponse loanProductsResponse = loanHelper.createLoanProduct(create4IProgressive().currencyCode("USD")
+                    .enableAccrualActivityPosting(true).enableDownPayment(true)
                     .disbursedAmountPercentageForDownPayment(BigDecimal.valueOf(25.0)).enableAutoRepaymentForDownPayment(true)
                     .currencyCode("USD").daysInMonthType(DaysInMonthType.ACTUAL).daysInYearType(DaysInYearType.ACTUAL)
                     .isInterestRecalculationEnabled(false).description(
@@ -1245,12 +1237,12 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         createInterestBearingProgressiveNoInterestRecalculationAutoDownPayment25percentLoanProductIfNotExists();
         AtomicReference<Long> loanIdRef = new AtomicReference<>(null);
         runAt("1 January 2024", () -> {
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applyLP2ProgressiveLoanRequest(client.getClientId(),
+            PostLoansResponse postLoansResponse = loanHelper.applyForLoan(applyLP2ProgressiveLoanRequest(clientId,
                     interestBearingProgressiveLoanProductId, "01 January 2024", 400.0, 9.99, 6, null));
             Long loanId = postLoansResponse.getLoanId();
             Assertions.assertNotNull(loanId);
             loanIdRef.set(loanId);
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(400.0, "01 January 2024"));
+            approveLoan(loanId, approveLoanRequest(400.0, "01 January 2024"));
             disburseLoan(loanId, BigDecimal.valueOf(400.0), "01 January 2024");
             verifyTransactions(loanId, //
                     transaction(400.0, "Disbursement", "01 January 2024"), //
@@ -1259,15 +1251,15 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         });
         runAt("2 January 2024", () -> {
             Long loanId = loanIdRef.get();
-            Long repaymentId = loanTransactionHelper.makeLoanRepayment("02 January 2024", 370.0f, loanId.intValue()).getResourceId();
+            Long repaymentId = makeLoanRepayment("02 January 2024", 370.0f, loanId.intValue()).getResourceId();
             Assertions.assertNotNull(repaymentId);
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getOverpaid);
 
             verifyTransactions(loanId, transaction(400.0, "Disbursement", "01 January 2024"),
                     transaction(100.0, "Down Payment", "01 January 2024"), transaction(8.76, "Accrual", "02 January 2024"),
                     transaction(8.76, "Accrual Activity", "02 January 2024"), transaction(370.0, "Repayment", "02 January 2024"));
-            loanTransactionHelper.reverseRepayment(loanId.intValue(), repaymentId.intValue(), "02 January 2024");
+            reverseRepayment(loanId.intValue(), repaymentId.intValue(), "02 January 2024");
         });
     }
 
@@ -1282,27 +1274,27 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
     public void testInterestBearingProgressiveNoInterestRecalculationAutoDownPayment25percentReopenDueReverseRepayment2() {
         createInterestBearingProgressiveNoInterestRecalculationAutoDownPayment25percentLoanProductIfNotExists();
         runAt("1 January 2024", () -> {
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applyLP2ProgressiveLoanRequest(client.getClientId(),
+            PostLoansResponse postLoansResponse = loanHelper.applyForLoan(applyLP2ProgressiveLoanRequest(clientId,
                     interestBearingProgressiveLoanProductId, "01 January 2024", 400.0, 9.99, 6, null));
             Long loanId = postLoansResponse.getLoanId();
             Assertions.assertNotNull(loanId);
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(400.0, "01 January 2024"));
+            approveLoan(loanId, approveLoanRequest(400.0, "01 January 2024"));
             disburseLoan(loanId, BigDecimal.valueOf(400.0), "01 January 2024");
             verifyTransactions(loanId, //
                     transaction(400.0, "Disbursement", "01 January 2024"), //
                     transaction(100.0, "Down Payment", "01 January 2024") //
             );
-            Long repaymentId = loanTransactionHelper.makeLoanRepayment("01 January 2024", 370.0f, loanId.intValue()).getResourceId();
+            Long repaymentId = makeLoanRepayment("01 January 2024", 370.0f, loanId.intValue()).getResourceId();
             Assertions.assertNotNull(repaymentId);
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getOverpaid);
 
             verifyTransactions(loanId, transaction(400.0, "Disbursement", "01 January 2024"),
                     transaction(100.0, "Down Payment", "01 January 2024"), transaction(8.76, "Accrual", "01 January 2024"),
                     transaction(8.76, "Accrual Activity", "01 January 2024"), transaction(370.0, "Repayment", "01 January 2024"));
 
-            loanTransactionHelper.reverseRepayment(loanId.intValue(), repaymentId.intValue(), "01 January 2024");
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            reverseRepayment(loanId.intValue(), repaymentId.intValue(), "01 January 2024");
+            loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getActive);
             verifyTransactions(loanId, transaction(400.0, "Disbursement", "01 January 2024"),
                     transaction(100.0, "Down Payment", "01 January 2024"), transaction(8.76, "Accrual", "01 January 2024"),
@@ -1322,27 +1314,27 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
     public void testInterestBearingProgressiveNoInterestRecalculationAutoDownPayment25percentReopenDueReverseRepayment3() {
         createInterestBearingProgressiveNoInterestRecalculationAutoDownPayment25percentLoanProductIfNotExists();
         runAt("1 January 2024", () -> {
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applyLP2ProgressiveLoanRequest(client.getClientId(),
+            PostLoansResponse postLoansResponse = loanHelper.applyForLoan(applyLP2ProgressiveLoanRequest(clientId,
                     interestBearingProgressiveLoanProductId, "01 January 2024", 400.0, 9.99, 6, null));
             Long loanId = postLoansResponse.getLoanId();
             Assertions.assertNotNull(loanId);
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(400.0, "01 January 2024"));
+            approveLoan(loanId, approveLoanRequest(400.0, "01 January 2024"));
             disburseLoan(loanId, BigDecimal.valueOf(400.0), "01 January 2024");
             verifyTransactions(loanId, //
                     transaction(400.0, "Disbursement", "01 January 2024"), //
                     transaction(100.0, "Down Payment", "01 January 2024") //
             );
             addCharge(loanId, false, 30.0, "01 January 2024");
-            Long repaymentId = loanTransactionHelper.makeLoanRepayment("01 January 2024", 370.0f, loanId.intValue()).getResourceId();
+            Long repaymentId = makeLoanRepayment("01 January 2024", 370.0f, loanId.intValue()).getResourceId();
             Assertions.assertNotNull(repaymentId);
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getOverpaid);
 
             verifyTransactions(loanId, transaction(400.0, "Disbursement", "01 January 2024"),
                     transaction(100.0, "Down Payment", "01 January 2024"), transaction(38.76, "Accrual", "01 January 2024"),
                     transaction(38.76, "Accrual Activity", "01 January 2024"), transaction(370.0, "Repayment", "01 January 2024"));
-            loanTransactionHelper.reverseRepayment(loanId.intValue(), repaymentId.intValue(), "01 January 2024");
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            reverseRepayment(loanId.intValue(), repaymentId.intValue(), "01 January 2024");
+            loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getActive);
             verifyTransactions(loanId, transaction(400.0, "Disbursement", "01 January 2024"),
                     transaction(100.0, "Down Payment", "01 January 2024"), transaction(38.76, "Accrual", "01 January 2024"),
@@ -1359,23 +1351,23 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         final String creationBusinessDay = "15 January 2023";
         AtomicReference<Long> loanId = new AtomicReference<>();
         runAt(creationBusinessDay, () -> {
-            Long localLoanProductId = loanTransactionHelper
+            Long localLoanProductId = loanHelper
                     .createLoanProduct(loanProductsRequestInterestDecliningBalanceDailyRecalculationCompoundingNoneAccrualActivity())
                     .getResourceId();
-            loanId.set(applyForLoanApplication(client.getClientId(), localLoanProductId, BigDecimal.valueOf(1000), disbursementDay));
-            loanTransactionHelper.approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
-                    .dateFormat(DATETIME_PATTERN).approvedOnDate(disbursementDay).locale("en"));
+            loanId.set(applyForLoanApplication(clientId, localLoanProductId, BigDecimal.valueOf(1000), disbursementDay));
+            approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
+                    .approvedOnDate(disbursementDay).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
         });
         runAt(repaymentPeriod1CloseDate, () -> {
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.get()));
+            executeInlineCOB(List.of(loanId.get()));
             verifyTransactions(loanId.get(),
                     transaction(1.64, "Accrual", repaymentPeriod1DueDate, 0.0, 0.0, 1.64, 0.0, 0.0, 0.0, 0.0, false), //
                     transaction(1.64, "Accrual Activity", repaymentPeriod1DueDate, 0.0, 0.0, 1.64, 0.0, 0.0, 0.0, 0.0, false), //
                     transaction(1000.0, "Disbursement", disbursementDay, 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false));
-            loanTransactionHelper.makeLoanRepayment(repaymentDate1, 150.0F, loanId.get().intValue());
+            makeLoanRepayment(repaymentDate1, 150.0F, loanId.get().intValue());
 
             verifyTransactions(loanId.get(),
                     transaction(150.0, "Repayment", repaymentDate1, 851.52, 148.48, 1.52, 0.0, 0.0, 0.0, 0.0, false), //
@@ -1391,24 +1383,24 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         AtomicReference<Long> loanId = new AtomicReference<>();
         runAt(disbursementDay, () -> {
             Long localLoanProductId = createLoanProductAccountingAccrualPeriodicAdvancedPaymentAllocationInterestRecalculation(true);
-            loanId.set(applyForLoanApplicationAdvancedPaymentAllocation(client.getClientId(), localLoanProductId, BigDecimal.valueOf(800),
+            loanId.set(applyForLoanApplicationAdvancedPaymentAllocation(clientId, localLoanProductId, BigDecimal.valueOf(800),
                     disbursementDay, disbursementDay, BigDecimal.valueOf(0.3)));
 
-            loanTransactionHelper.approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(800))
-                    .dateFormat(DATETIME_PATTERN).approvedOnDate(disbursementDay).locale("en"));
+            approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(800)).dateFormat(DATETIME_PATTERN)
+                    .approvedOnDate(disbursementDay).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(800.0)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(800.0)).locale("en"));
         });
 
         runAt("02 February 2025", () -> {
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.get()));
+            executeInlineCOB(List.of(loanId.get()));
             verifyTransactions(loanId.get(),
                     transaction(10.60, "Accrual Activity", "01 February 2025", 0.0, 0.0, 10.60, 0.0, 0.0, 0.0, 0.0, false), //
                     transaction(10.60, "Accrual", "01 February 2025", 0.0, 0.0, 10.60, 0.0, 0.0, 0.0, 0.0, false), //
                     transaction(800.0, "Disbursement", disbursementDay, 800.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false));
 
-            loanTransactionHelper.makeLoanRepayment("31 January 2025", 900.0F, loanId.get().intValue());
+            makeLoanRepayment("31 January 2025", 900.0F, loanId.get().intValue());
 
             verifyTransactions(loanId.get(),
                     transaction(0.34, "Accrual Adjustment", "02 February 2025", 0.0, 0.0, 0.34, 0.0, 0.0, 0.0, 0.0, false), //
@@ -1433,14 +1425,15 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
 
         List<GetLoanPaymentChannelToFundSourceMappings> paymentChannelToFundSourceMappings = new ArrayList<>();
         GetLoanPaymentChannelToFundSourceMappings loanPaymentChannelToFundSourceMappings = new GetLoanPaymentChannelToFundSourceMappings();
-        loanPaymentChannelToFundSourceMappings.fundSourceAccountId(fundSource.getAccountID().longValue());
+        loanPaymentChannelToFundSourceMappings.fundSourceAccountId(getAccounts().getFundSource().getAccountID().longValue());
         loanPaymentChannelToFundSourceMappings.paymentTypeId(1L);
         paymentChannelToFundSourceMappings.add(loanPaymentChannelToFundSourceMappings);
 
-        final Integer fundId = createFund(requestSpec, responseSpec);
+        final Long fundId = new FeignFundHelper(FineractFeignClientHelper.getFineractFeignClient()).createFund().getResourceId();
         Assertions.assertNotNull(fundId);
 
-        final Long delinquencyBucketId = DelinquencyBucketsHelper.createDefaultBucket();
+        final Long delinquencyBucketId = new FeignDelinquencyHelper(FineractFeignClientHelper.getFineractFeignClient())
+                .createDefaultBucket();
         Assertions.assertNotNull(delinquencyBucketId);
 
         return new PostLoanProductsRequest()//
@@ -1504,27 +1497,27 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
                 .charges(charges)//
                 .accountingRule(3)//
 
-                .fundSourceAccountId(suspenseAccount.getAccountID().longValue())//
-                .loanPortfolioAccountId(loansReceivableAccount.getAccountID().longValue())//
-                .transfersInSuspenseAccountId(suspenseAccount.getAccountID().longValue())//
-                .interestOnLoanAccountId(interestIncomeAccount.getAccountID().longValue())//
-                .incomeFromFeeAccountId(feeIncomeAccount.getAccountID().longValue())//
-                .incomeFromPenaltyAccountId(penaltyIncomeAccount.getAccountID().longValue())//
-                .incomeFromRecoveryAccountId(recoveriesAccount.getAccountID().longValue())//
-                .writeOffAccountId(writtenOffAccount.getAccountID().longValue())//
-                .overpaymentLiabilityAccountId(overpaymentAccount.getAccountID().longValue())//
-                .receivableInterestAccountId(interestReceivableAccount.getAccountID().longValue())//
-                .receivableFeeAccountId(feeReceivableAccount.getAccountID().longValue())//
-                .receivablePenaltyAccountId(penaltyReceivableAccount.getAccountID().longValue())//
-                .goodwillCreditAccountId(goodwillExpenseAccount.getAccountID().longValue())//
-                .incomeFromGoodwillCreditInterestAccountId(interestIncomeChargeOffAccount.getAccountID().longValue())//
-                .incomeFromGoodwillCreditFeesAccountId(feeChargeOffAccount.getAccountID().longValue())//
-                .incomeFromGoodwillCreditPenaltyAccountId(feeChargeOffAccount.getAccountID().longValue())//
-                .incomeFromChargeOffInterestAccountId(interestIncomeChargeOffAccount.getAccountID().longValue())//
-                .incomeFromChargeOffFeesAccountId(feeChargeOffAccount.getAccountID().longValue())//
-                .chargeOffExpenseAccountId(chargeOffExpenseAccount.getAccountID().longValue())//
-                .chargeOffFraudExpenseAccountId(chargeOffFraudExpenseAccount.getAccountID().longValue())//
-                .incomeFromChargeOffPenaltyAccountId(penaltyChargeOffAccount.getAccountID().longValue())//
+                .fundSourceAccountId(getAccounts().getSuspenseAccount().getAccountID().longValue())//
+                .loanPortfolioAccountId(getAccounts().getLoansReceivableAccount().getAccountID().longValue())//
+                .transfersInSuspenseAccountId(getAccounts().getSuspenseAccount().getAccountID().longValue())//
+                .interestOnLoanAccountId(getAccounts().getInterestIncomeAccount().getAccountID().longValue())//
+                .incomeFromFeeAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())//
+                .incomeFromPenaltyAccountId(getAccounts().getPenaltyIncomeAccount().getAccountID().longValue())//
+                .incomeFromRecoveryAccountId(getAccounts().getRecoveriesAccount().getAccountID().longValue())//
+                .writeOffAccountId(getAccounts().getWrittenOffAccount().getAccountID().longValue())//
+                .overpaymentLiabilityAccountId(getAccounts().getOverpaymentAccount().getAccountID().longValue())//
+                .receivableInterestAccountId(getAccounts().getInterestReceivableAccount().getAccountID().longValue())//
+                .receivableFeeAccountId(getAccounts().getFeeReceivableAccount().getAccountID().longValue())//
+                .receivablePenaltyAccountId(getAccounts().getPenaltyReceivableAccount().getAccountID().longValue())//
+                .goodwillCreditAccountId(getAccounts().getGoodwillExpenseAccount().getAccountID().longValue())//
+                .incomeFromGoodwillCreditInterestAccountId(getAccounts().getInterestIncomeChargeOffAccount().getAccountID().longValue())//
+                .incomeFromGoodwillCreditFeesAccountId(getAccounts().getFeeChargeOffAccount().getAccountID().longValue())//
+                .incomeFromGoodwillCreditPenaltyAccountId(getAccounts().getFeeChargeOffAccount().getAccountID().longValue())//
+                .incomeFromChargeOffInterestAccountId(getAccounts().getInterestIncomeChargeOffAccount().getAccountID().longValue())//
+                .incomeFromChargeOffFeesAccountId(getAccounts().getFeeChargeOffAccount().getAccountID().longValue())//
+                .chargeOffExpenseAccountId(getAccounts().getChargeOffExpenseAccount().getAccountID().longValue())//
+                .chargeOffFraudExpenseAccountId(getAccounts().getChargeOffFraudExpenseAccount().getAccountID().longValue())//
+                .incomeFromChargeOffPenaltyAccountId(getAccounts().getPenaltyChargeOffAccount().getAccountID().longValue())//
 
                 .dateFormat("dd MMMM yyyy")//
                 .locale("en")//
@@ -1546,28 +1539,26 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
 
     private void chargeFee(Long loanId, Double amount, String dueDate) {
         LOG.info("Charge FEE amount {} dueDate {}", amount, dueDate);
-        PostChargesResponse feeCharge = chargesHelper.createCharges(new ChargeRequest().penalty(false).amount(9.0)
+        PostChargesResponse feeCharge = chargesHelper.createCharge(new ChargeRequest().penalty(false).amount(9.0)
                 .chargeCalculationType(ChargeCalculationType.FLAT.getValue()).chargeTimeType(ChargeTimeType.SPECIFIED_DUE_DATE.getValue())
                 .chargePaymentMode(ChargePaymentMode.REGULAR.getValue()).currencyCode("USD")
                 .name(Utils.randomStringGenerator("FEE_" + Calendar.getInstance().getTimeInMillis(), 5)).chargeAppliesTo(1).locale("en")
                 .active(true));
-        PostLoansLoanIdChargesResponse feeLoanChargeResult = loanTransactionHelper.addChargesForLoan(loanId,
-                new PostLoansLoanIdChargesRequest().chargeId(feeCharge.getResourceId()).dateFormat(DATETIME_PATTERN).locale("en")
-                        .amount(amount).dueDate(dueDate));
+        PostLoansLoanIdChargesResponse feeLoanChargeResult = addChargesForLoan(loanId, new PostLoansLoanIdChargesRequest()
+                .chargeId(feeCharge.getResourceId()).dateFormat(DATETIME_PATTERN).locale("en").amount(amount).dueDate(dueDate));
         assertNotNull(feeLoanChargeResult);
         assertNotNull(feeLoanChargeResult.getResourceId());
     }
 
     private void chargePenalty(Long loanId, Double amount, String dueDate) {
         LOG.info("Charge PENALTY amount {} dueDate {}", amount, dueDate);
-        PostChargesResponse penaltyCharge = chargesHelper.createCharges(new ChargeRequest().penalty(true).amount(10.0)
+        PostChargesResponse penaltyCharge = chargesHelper.createCharge(new ChargeRequest().penalty(true).amount(10.0)
                 .chargeCalculationType(ChargeCalculationType.FLAT.getValue()).chargeTimeType(ChargeTimeType.SPECIFIED_DUE_DATE.getValue())
                 .chargePaymentMode(ChargePaymentMode.REGULAR.getValue()).currencyCode("USD")
                 .name(Utils.randomStringGenerator("PENALTY_" + Calendar.getInstance().getTimeInMillis(), 5)).chargeAppliesTo(1).locale("en")
                 .active(true));
-        PostLoansLoanIdChargesResponse penaltyLoanChargeResult = loanTransactionHelper.addChargesForLoan(loanId,
-                new PostLoansLoanIdChargesRequest().chargeId(penaltyCharge.getResourceId()).dateFormat(DATETIME_PATTERN).locale("en")
-                        .amount(amount).dueDate(dueDate));
+        PostLoansLoanIdChargesResponse penaltyLoanChargeResult = addChargesForLoan(loanId, new PostLoansLoanIdChargesRequest()
+                .chargeId(penaltyCharge.getResourceId()).dateFormat(DATETIME_PATTERN).locale("en").amount(amount).dueDate(dueDate));
         assertNotNull(penaltyLoanChargeResult);
         assertNotNull(penaltyLoanChargeResult.getResourceId());
     }
@@ -1579,7 +1570,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
     private Long createLoanProductAccountingAccrualPeriodicWithInterest(boolean isMultiDisburse) {
         String name = Utils.uniqueRandomStringGenerator("LOAN_PRODUCT_", 6);
         String shortName = Utils.uniqueRandomStringGenerator("", 4);
-        Long resourceId = loanTransactionHelper.createLoanProduct(new PostLoanProductsRequest().name(name).shortName(shortName)
+        Long resourceId = loanHelper.createLoanProduct(new PostLoanProductsRequest().name(name).shortName(shortName)
                 .multiDisburseLoan(isMultiDisburse).maxTrancheCount(isMultiDisburse ? 2 : 1).interestType(isMultiDisburse ? 0 : 1)
                 .interestCalculationPeriodType(isMultiDisburse ? 0 : 1).disallowExpectedDisbursements(isMultiDisburse)
                 .description("Test loan description").currencyCode("USD").digitsAfterDecimal(2).daysInYearType(1).daysInMonthType(1)
@@ -1588,71 +1579,70 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
                 .numberOfRepayments(4).repaymentFrequencyType(2L).interestRatePerPeriod(2.0).repaymentEvery(1).minPrincipal(100.0)
                 .principal(1000.0).maxPrincipal(10000000.0).amortizationType(1).dateFormat("dd MMMM yyyy")
                 .transactionProcessingStrategyCode(DEFAULT_STRATEGY).accountingRule(3).enableAccrualActivityPosting(true)
-                .fundSourceAccountId(fundSource.getAccountID().longValue())//
-                .loanPortfolioAccountId(loansReceivableAccount.getAccountID().longValue())//
-                .transfersInSuspenseAccountId(suspenseAccount.getAccountID().longValue())//
-                .interestOnLoanAccountId(interestIncomeAccount.getAccountID().longValue())//
-                .incomeFromFeeAccountId(feeIncomeAccount.getAccountID().longValue())//
-                .incomeFromPenaltyAccountId(feeIncomeAccount.getAccountID().longValue())//
-                .incomeFromRecoveryAccountId(recoveriesAccount.getAccountID().longValue())//
-                .writeOffAccountId(writtenOffAccount.getAccountID().longValue())//
-                .overpaymentLiabilityAccountId(overpaymentAccount.getAccountID().longValue())//
-                .receivableInterestAccountId(interestReceivableAccount.getAccountID().longValue())//
-                .receivableFeeAccountId(feeReceivableAccount.getAccountID().longValue())//
-                .receivablePenaltyAccountId(penaltyReceivableAccount.getAccountID().longValue())//
-                .goodwillCreditAccountId(goodwillExpenseAccount.getAccountID().longValue())//
-                .incomeFromGoodwillCreditInterestAccountId(goodwillIncomeAccount.getAccountID().longValue())//
-                .incomeFromGoodwillCreditFeesAccountId(goodwillIncomeAccount.getAccountID().longValue())//
-                .incomeFromGoodwillCreditPenaltyAccountId(goodwillIncomeAccount.getAccountID().longValue())//
-                .incomeFromChargeOffInterestAccountId(interestIncomeChargeOffAccount.getAccountID().longValue())//
-                .incomeFromChargeOffFeesAccountId(feeChargeOffAccount.getAccountID().longValue())//
-                .chargeOffExpenseAccountId(chargeOffExpenseAccount.getAccountID().longValue())//
-                .chargeOffFraudExpenseAccountId(chargeOffFraudExpenseAccount.getAccountID().longValue())//
-                .incomeFromChargeOffPenaltyAccountId(penaltyChargeOffAccount.getAccountID().longValue())//
+                .fundSourceAccountId(getAccounts().getFundSource().getAccountID().longValue())//
+                .loanPortfolioAccountId(getAccounts().getLoansReceivableAccount().getAccountID().longValue())//
+                .transfersInSuspenseAccountId(getAccounts().getSuspenseAccount().getAccountID().longValue())//
+                .interestOnLoanAccountId(getAccounts().getInterestIncomeAccount().getAccountID().longValue())//
+                .incomeFromFeeAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())//
+                .incomeFromPenaltyAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())//
+                .incomeFromRecoveryAccountId(getAccounts().getRecoveriesAccount().getAccountID().longValue())//
+                .writeOffAccountId(getAccounts().getWrittenOffAccount().getAccountID().longValue())//
+                .overpaymentLiabilityAccountId(getAccounts().getOverpaymentAccount().getAccountID().longValue())//
+                .receivableInterestAccountId(getAccounts().getInterestReceivableAccount().getAccountID().longValue())//
+                .receivableFeeAccountId(getAccounts().getFeeReceivableAccount().getAccountID().longValue())//
+                .receivablePenaltyAccountId(getAccounts().getPenaltyReceivableAccount().getAccountID().longValue())//
+                .goodwillCreditAccountId(getAccounts().getGoodwillExpenseAccount().getAccountID().longValue())//
+                .incomeFromGoodwillCreditInterestAccountId(getAccounts().getGoodwillIncomeAccount().getAccountID().longValue())//
+                .incomeFromGoodwillCreditFeesAccountId(getAccounts().getGoodwillIncomeAccount().getAccountID().longValue())//
+                .incomeFromGoodwillCreditPenaltyAccountId(getAccounts().getGoodwillIncomeAccount().getAccountID().longValue())//
+                .incomeFromChargeOffInterestAccountId(getAccounts().getInterestIncomeChargeOffAccount().getAccountID().longValue())//
+                .incomeFromChargeOffFeesAccountId(getAccounts().getFeeChargeOffAccount().getAccountID().longValue())//
+                .chargeOffExpenseAccountId(getAccounts().getChargeOffExpenseAccount().getAccountID().longValue())//
+                .chargeOffFraudExpenseAccountId(getAccounts().getChargeOffFraudExpenseAccount().getAccountID().longValue())//
+                .incomeFromChargeOffPenaltyAccountId(getAccounts().getPenaltyChargeOffAccount().getAccountID().longValue())//
         ).getResourceId();
         LOG.info("Test Loan Product With Interest Id {} isMultiDisburse {} http://localhost:4200/#/products/loan-products/{1}/general",
                 resourceId, isMultiDisburse);
         return resourceId;
     }
 
-    private static Long applyForLoanApplication(final Long clientID, final Long loanProductID, BigDecimal principal,
+    private static Long applyForLoanApplication(final Long clientId, final Long loanProductID, BigDecimal principal,
             String applicationDisbursementDate) {
         final PostLoansRequest loanRequest = new PostLoansRequest() //
                 .locale("en_GB").dateFormat("dd MMMM yyyy").expectedDisbursementDate(applicationDisbursementDate)
                 .submittedOnDate(applicationDisbursementDate).interestCalculationPeriodType(0).repaymentFrequencyType(0).repaymentEvery(30)
                 .principal(BigDecimal.valueOf(1000)).loanTermFrequency(120).loanTermFrequencyType(0)
                 .transactionProcessingStrategyCode(DEFAULT_STRATEGY).interestType(0).loanType("individual").numberOfRepayments(4)
-                .amortizationType(1).interestRatePerPeriod(BigDecimal.valueOf(2)).clientId(clientID).productId(loanProductID);
-        Long loanId = loanTransactionHelper.applyLoan(loanRequest).getLoanId();
-        LOG.info("Test Loan http://localhost:4200/#/clients/{}/loans-accounts/{}/transactions", client.getClientId(), loanId);
+                .amortizationType(1).interestRatePerPeriod(BigDecimal.valueOf(2)).clientId(clientId).productId(loanProductID);
+        Long loanId = loanHelper.applyForLoan(loanRequest).getLoanId();
+        LOG.info("Test Loan http://localhost:4200/#/clients/{}/loans-accounts/{}/transactions", clientId, loanId);
         return loanId;
     }
 
-    private static Long applyForLoanApplicationWithInterest(final Long clientID, final Long loanProductID, BigDecimal principal,
+    private static Long applyForLoanApplicationWithInterest(final Long clientId, final Long loanProductID, BigDecimal principal,
             String applicationDisbursementDate) {
         final PostLoansRequest loanRequest = new PostLoansRequest() //
                 .loanTermFrequency(4).locale("en_GB").loanTermFrequencyType(2).numberOfRepayments(4).repaymentFrequencyType(2)
                 .interestRatePerPeriod(BigDecimal.valueOf(2)).repaymentEvery(1).principal(principal).amortizationType(1).interestType(1)
                 .interestCalculationPeriodType(1).dateFormat("dd MMMM yyyy").transactionProcessingStrategyCode(DEFAULT_STRATEGY)
                 .loanType("individual").expectedDisbursementDate(applicationDisbursementDate).submittedOnDate(applicationDisbursementDate)
-                .clientId(clientID).productId(loanProductID);
-        Long loanId = loanTransactionHelper.applyLoan(loanRequest).getLoanId();
-        LOG.info("Test Loan with Interest Id {2} http://localhost:4200/#/clients/{}/loans-accounts/{}/transactions", client.getClientId(),
-                loanId);
+                .clientId(clientId).productId(loanProductID);
+        Long loanId = loanHelper.applyForLoan(loanRequest).getLoanId();
+        LOG.info("Test Loan with Interest Id {2} http://localhost:4200/#/clients/{}/loans-accounts/{}/transactions", clientId, loanId);
         return loanId;
     }
 
-    private static Long applyForLoanApplicationWithInterest(final Long clientID, final Long loanProductID, BigDecimal principal,
+    private static Long applyForLoanApplicationWithInterest(final Long clientId, final Long loanProductID, BigDecimal principal,
             String applicationDisbursementDate, String applicationDisbursementDate2) {
         final PostLoansRequest loanRequest = new PostLoansRequest() //
                 .loanTermFrequency(4).locale("en_GB").loanTermFrequencyType(2).numberOfRepayments(4).repaymentFrequencyType(2)
                 .interestRatePerPeriod(BigDecimal.valueOf(2)).repaymentEvery(1).principal(principal).amortizationType(1).interestType(0)
                 .interestCalculationPeriodType(0).dateFormat("dd MMMM yyyy").transactionProcessingStrategyCode(DEFAULT_STRATEGY)
                 .loanType("individual").submittedOnDate(applicationDisbursementDate).expectedDisbursementDate(applicationDisbursementDate2)
-                .clientId(clientID).productId(loanProductID);
-        Long loanId = loanTransactionHelper.applyLoan(loanRequest).getLoanId();
+                .clientId(clientId).productId(loanProductID);
+        Long loanId = loanHelper.applyForLoan(loanRequest).getLoanId();
         LOG.info("Test Loan with Interest Id MultiDisbursed {2} http://localhost:4200/#/clients/{}/loans-accounts/{}/transactions",
-                client.getClientId(), loanId);
+                clientId, loanId);
         return loanId;
     }
 
@@ -1661,7 +1651,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
     }
 
     private Long createLoanProductAccountingAccrualPeriodicAdvancedPaymentAllocation(boolean isMultiDisburse) {
-        Long resourceId = loanTransactionHelper
+        Long resourceId = loanHelper
                 .createLoanProduct(loanProductAccountingAccrualAdvanvedPaymentAllocationAccrualActivity(isMultiDisburse)).getResourceId();
         LOG.info("Test Progressive Loan Product Id {} isMultiDisburse {} http://localhost:4200/#/products/loan-products/{1}/general",
                 resourceId, isMultiDisburse);
@@ -1682,61 +1672,59 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
                 .interestRateFrequencyType(1).dateFormat("dd MMMM yyyy")
                 .transactionProcessingStrategyCode(ADVANCED_PAYMENT_ALLOCATION_STRATEGY).paymentAllocation(List.of(defaultAllocation))
                 .accountingRule(3).isInterestRecalculationEnabled(false).enableAccrualActivityPosting(true)
-                .fundSourceAccountId(fundSource.getAccountID().longValue())//
-                .loanPortfolioAccountId(loansReceivableAccount.getAccountID().longValue())//
-                .transfersInSuspenseAccountId(suspenseAccount.getAccountID().longValue())//
-                .interestOnLoanAccountId(interestIncomeAccount.getAccountID().longValue())//
-                .incomeFromFeeAccountId(feeIncomeAccount.getAccountID().longValue())//
-                .incomeFromPenaltyAccountId(feeIncomeAccount.getAccountID().longValue())//
-                .incomeFromRecoveryAccountId(recoveriesAccount.getAccountID().longValue())//
-                .writeOffAccountId(writtenOffAccount.getAccountID().longValue())//
-                .overpaymentLiabilityAccountId(overpaymentAccount.getAccountID().longValue())//
-                .receivableInterestAccountId(interestReceivableAccount.getAccountID().longValue())//
-                .receivableFeeAccountId(feeReceivableAccount.getAccountID().longValue())//
-                .receivablePenaltyAccountId(penaltyReceivableAccount.getAccountID().longValue())//
-                .goodwillCreditAccountId(goodwillExpenseAccount.getAccountID().longValue())//
-                .incomeFromGoodwillCreditInterestAccountId(goodwillIncomeAccount.getAccountID().longValue())//
-                .incomeFromGoodwillCreditFeesAccountId(goodwillIncomeAccount.getAccountID().longValue())//
-                .incomeFromGoodwillCreditPenaltyAccountId(goodwillIncomeAccount.getAccountID().longValue())//
-                .incomeFromChargeOffInterestAccountId(interestIncomeChargeOffAccount.getAccountID().longValue())//
-                .incomeFromChargeOffFeesAccountId(feeChargeOffAccount.getAccountID().longValue())//
-                .chargeOffExpenseAccountId(chargeOffExpenseAccount.getAccountID().longValue())//
-                .chargeOffFraudExpenseAccountId(chargeOffFraudExpenseAccount.getAccountID().longValue())//
-                .incomeFromChargeOffPenaltyAccountId(penaltyChargeOffAccount.getAccountID().longValue());//
+                .fundSourceAccountId(getAccounts().getFundSource().getAccountID().longValue())//
+                .loanPortfolioAccountId(getAccounts().getLoansReceivableAccount().getAccountID().longValue())//
+                .transfersInSuspenseAccountId(getAccounts().getSuspenseAccount().getAccountID().longValue())//
+                .interestOnLoanAccountId(getAccounts().getInterestIncomeAccount().getAccountID().longValue())//
+                .incomeFromFeeAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())//
+                .incomeFromPenaltyAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())//
+                .incomeFromRecoveryAccountId(getAccounts().getRecoveriesAccount().getAccountID().longValue())//
+                .writeOffAccountId(getAccounts().getWrittenOffAccount().getAccountID().longValue())//
+                .overpaymentLiabilityAccountId(getAccounts().getOverpaymentAccount().getAccountID().longValue())//
+                .receivableInterestAccountId(getAccounts().getInterestReceivableAccount().getAccountID().longValue())//
+                .receivableFeeAccountId(getAccounts().getFeeReceivableAccount().getAccountID().longValue())//
+                .receivablePenaltyAccountId(getAccounts().getPenaltyReceivableAccount().getAccountID().longValue())//
+                .goodwillCreditAccountId(getAccounts().getGoodwillExpenseAccount().getAccountID().longValue())//
+                .incomeFromGoodwillCreditInterestAccountId(getAccounts().getGoodwillIncomeAccount().getAccountID().longValue())//
+                .incomeFromGoodwillCreditFeesAccountId(getAccounts().getGoodwillIncomeAccount().getAccountID().longValue())//
+                .incomeFromGoodwillCreditPenaltyAccountId(getAccounts().getGoodwillIncomeAccount().getAccountID().longValue())//
+                .incomeFromChargeOffInterestAccountId(getAccounts().getInterestIncomeChargeOffAccount().getAccountID().longValue())//
+                .incomeFromChargeOffFeesAccountId(getAccounts().getFeeChargeOffAccount().getAccountID().longValue())//
+                .chargeOffExpenseAccountId(getAccounts().getChargeOffExpenseAccount().getAccountID().longValue())//
+                .chargeOffFraudExpenseAccountId(getAccounts().getChargeOffFraudExpenseAccount().getAccountID().longValue())//
+                .incomeFromChargeOffPenaltyAccountId(getAccounts().getPenaltyChargeOffAccount().getAccountID().longValue());//
     }
 
     private Long createLoanProductAccountingAccrualPeriodicAdvancedPaymentAllocationInterestRecalculation(boolean isMultiDisburse) {
-        Long resourceId = loanTransactionHelper
-                .createLoanProduct(loanProductAccountingAccrualAdvanvedPaymentAllocationAccrualActivity(isMultiDisburse) //
-                        .interestRatePerPeriod(10.0) //
-                        .isInterestRecalculationEnabled(true)//
-                        .preClosureInterestCalculationStrategy(1) // TILL_PRE_CLOSE_DATE
-                        .rescheduleStrategyMethod(4) // ADJUST_LAST_UNPAID_PERIOD
-                        .interestRecalculationCompoundingMethod(0) // NONE
-                        .recalculationRestFrequencyType(2) // DAILY
-                        .recalculationRestFrequencyInterval(1)//
-                ).getResourceId();
+        Long resourceId = loanHelper.createLoanProduct(loanProductAccountingAccrualAdvanvedPaymentAllocationAccrualActivity(isMultiDisburse) //
+                .interestRatePerPeriod(10.0) //
+                .isInterestRecalculationEnabled(true)//
+                .preClosureInterestCalculationStrategy(1) // TILL_PRE_CLOSE_DATE
+                .rescheduleStrategyMethod(4) // ADJUST_LAST_UNPAID_PERIOD
+                .interestRecalculationCompoundingMethod(0) // NONE
+                .recalculationRestFrequencyType(2) // DAILY
+                .recalculationRestFrequencyInterval(1)//
+        ).getResourceId();
         LOG.info("Test Progressive Loan Product Id {} isMultiDisburse {} http://localhost:4200/#/products/loan-products/{1}/general",
                 resourceId, isMultiDisburse);
         return resourceId;
     }
 
-    private static Long applyForLoanApplicationAdvancedPaymentAllocation(final Long clientID, final Long loanProductID,
+    private static Long applyForLoanApplicationAdvancedPaymentAllocation(final Long clientId, final Long loanProductID,
             BigDecimal principal, String applicationDisbursementDate, BigDecimal interestRatePerPeriod) {
         final PostLoansRequest loanRequest = new PostLoansRequest() //
                 .loanTermFrequency(4).locale("en_GB").loanTermFrequencyType(2).numberOfRepayments(4).repaymentFrequencyType(2)
                 .repaymentEvery(1).principal(principal).amortizationType(1).interestType(0).interestRatePerPeriod(interestRatePerPeriod)
                 .interestCalculationPeriodType(1).dateFormat("dd MMMM yyyy")
                 .transactionProcessingStrategyCode(ADVANCED_PAYMENT_ALLOCATION_STRATEGY).loanType("individual")
-                .expectedDisbursementDate(applicationDisbursementDate).submittedOnDate(applicationDisbursementDate).clientId(clientID)
+                .expectedDisbursementDate(applicationDisbursementDate).submittedOnDate(applicationDisbursementDate).clientId(clientId)
                 .productId(loanProductID);
-        Long loanId = loanTransactionHelper.applyLoan(loanRequest).getLoanId();
-        LOG.info("Test Progressive Loan Id {2} http://localhost:4200/#/clients/{}/loans-accounts/{}/transactions", client.getClientId(),
-                loanId);
+        Long loanId = loanHelper.applyForLoan(loanRequest).getLoanId();
+        LOG.info("Test Progressive Loan Id {2} http://localhost:4200/#/clients/{}/loans-accounts/{}/transactions", clientId, loanId);
         return loanId;
     }
 
-    private static Long applyForLoanApplicationAdvancedPaymentAllocation(final Long clientID, final Long loanProductID,
+    private static Long applyForLoanApplicationAdvancedPaymentAllocation(final Long clientId, final Long loanProductID,
             BigDecimal principal, String applicationDisbursementDate, String applicationDisbursementDate2,
             BigDecimal interestRatePerPeriod) {
         final PostLoansRequest loanRequest = new PostLoansRequest() //
@@ -1744,11 +1732,11 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
                 .repaymentEvery(1).principal(principal).amortizationType(1).interestType(0).interestRatePerPeriod(interestRatePerPeriod)
                 .interestCalculationPeriodType(0).dateFormat("dd MMMM yyyy")
                 .transactionProcessingStrategyCode(ADVANCED_PAYMENT_ALLOCATION_STRATEGY).loanType("individual")
-                .submittedOnDate(applicationDisbursementDate).clientId(clientID).expectedDisbursementDate(applicationDisbursementDate2)
+                .submittedOnDate(applicationDisbursementDate).clientId(clientId).expectedDisbursementDate(applicationDisbursementDate2)
                 .productId(loanProductID);
-        Long loanId = loanTransactionHelper.applyLoan(loanRequest).getLoanId();
-        LOG.info("Test Progressive Loan Multi Disbursed Id {2} http://localhost:4200/#/clients/{}/loans-accounts/{}/transactions",
-                client.getClientId(), loanId);
+        Long loanId = loanHelper.applyForLoan(loanRequest).getLoanId();
+        LOG.info("Test Progressive Loan Multi Disbursed Id {2} http://localhost:4200/#/clients/{}/loans-accounts/{}/transactions", clientId,
+                loanId);
         return loanId;
     }
 

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanTransactionAccrualActivityPostingTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanTransactionAccrualActivityPostingTest.java
@@ -18,20 +18,15 @@
  */
 package org.apache.fineract.integrationtests;
 
-import static org.apache.fineract.integrationtests.common.funds.FundsResourceHandler.createFund;
 import static org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY;
 import static org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder.DEFAULT_STRATEGY;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.fineract.client.models.AdvancedPaymentData;
 import org.apache.fineract.client.models.AllowAttributeOverrides;
@@ -42,22 +37,23 @@ import org.apache.fineract.client.models.GetLoansLoanIdStatus;
 import org.apache.fineract.client.models.LoanProductChargeData;
 import org.apache.fineract.client.models.LoanProductChargeToGLAccountMapper;
 import org.apache.fineract.client.models.PostChargesResponse;
-import org.apache.fineract.client.models.PostClientsResponse;
 import org.apache.fineract.client.models.PostLoanProductsRequest;
 import org.apache.fineract.client.models.PostLoanProductsResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdChargesRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdChargesResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdRequest;
+import org.apache.fineract.client.models.PostLoansLoanIdTransactionsResponse;
 import org.apache.fineract.client.models.PostLoansRequest;
 import org.apache.fineract.client.models.PostLoansResponse;
-import org.apache.fineract.integrationtests.common.BusinessStepHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.SchedulerJobHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignBusinessStepHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignDelinquencyHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignFundHelper;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.DaysInMonthType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.DaysInYearType;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.apache.fineract.integrationtests.common.products.DelinquencyBucketsHelper;
-import org.apache.fineract.integrationtests.inlinecob.InlineLoanCOBHelper;
 import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
 import org.apache.fineract.portfolio.charge.domain.ChargePaymentMode;
 import org.apache.fineract.portfolio.charge.domain.ChargeTimeType;
@@ -70,37 +66,37 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrationTest {
+public class LoanTransactionAccrualActivityPostingTest extends FeignLoanTestBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(LoanTransactionAccrualActivityPostingTest.class);
-    private static final String DATETIME_PATTERN = "dd MMMM yyyy";
-    private static ResponseSpecification responseSpec;
-    private static RequestSpecification requestSpec;
-    private static LoanTransactionHelper loanTransactionHelper;
-    private static PostClientsResponse client;
-    private static ChargesHelper chargesHelper;
-    private static InlineLoanCOBHelper inlineLoanCOBHelper;
-    private static BusinessStepHelper businessStepHelper;
-    private static SchedulerJobHelper schedulerJobHelper;
+    private static Long clientId;
 
     @BeforeAll
-    public static void setup() {
-        Utils.initializeRESTAssured();
-        requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        requestSpec.header("Fineract-Platform-TenantId", "default");
-        responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-        schedulerJobHelper = new SchedulerJobHelper(requestSpec);
-        ClientHelper clientHelper = new ClientHelper(requestSpec, responseSpec);
-        chargesHelper = new ChargesHelper();
-        client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
-        inlineLoanCOBHelper = new InlineLoanCOBHelper(requestSpec, responseSpec);
-        businessStepHelper = new BusinessStepHelper();
+    public static void setupTest() {
+        clientId = clientHelper.createClient();
         // setup COB Business Steps to prevent test failing due other integration test configurations
-        businessStepHelper.updateSteps("LOAN_CLOSE_OF_BUSINESS", "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION",
-                "CHECK_LOAN_REPAYMENT_DUE", "CHECK_LOAN_REPAYMENT_OVERDUE", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
+        new FeignBusinessStepHelper(FineractFeignClientHelper.getFineractFeignClient()).updateSteps("LOAN_CLOSE_OF_BUSINESS",
+                "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION", "CHECK_LOAN_REPAYMENT_DUE",
+                "CHECK_LOAN_REPAYMENT_OVERDUE", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
                 "EXTERNAL_ASSET_OWNER_TRANSFER", "ACCRUAL_ACTIVITY_POSTING");
+    }
+
+    // Mirrors the original test's repayment (unique external id) so multi-disburse reverse-replay behaves identically.
+    @Override
+    protected Long addRepaymentForLoan(Long loanId, Double amount, String date) {
+        return addRepayment(loanId, LoanRequestBuilders.repayLoan(amount, date).externalId(UUID.randomUUID().toString()));
+    }
+
+    private PostLoansLoanIdTransactionsResponse makeLoanRepayment(String date, float amount, Integer loanId) {
+        return makeLoanRepayment(loanId.longValue(), "repayment", date, (double) amount);
+    }
+
+    private PostLoansLoanIdTransactionsResponse makeLoanRepayment(String command, String date, float amount, Integer loanId) {
+        return makeLoanRepayment(loanId.longValue(), command, date, (double) amount);
+    }
+
+    private void reverseRepayment(Integer loanId, Integer transactionId, String date) {
+        reverseLoanTransaction(loanId.longValue(), transactionId.longValue(), date);
     }
 
     /**
@@ -116,24 +112,24 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
     @Test
     public void testInterestBearingProgressiveNoInterestRecalculationReopenDueReverseRepayment1() {
         runAt("17 January 2025", () -> {
-            final PostLoanProductsResponse loanProductsResponse = loanProductHelper.createLoanProduct(create4IProgressive() //
+            final PostLoanProductsResponse loanProductsResponse = loanHelper.createLoanProduct(create4IProgressive() //
                     .description("Interest bearing Progressive Loan USD, Accrual Activity Posting, NO InterestRecalculation") //
                     .enableAccrualActivityPosting(true) //
                     .daysInMonthType(DaysInMonthType.ACTUAL) //
                     .daysInYearType(DaysInYearType.ACTUAL) //
                     .isInterestRecalculationEnabled(false));//
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applyLP2ProgressiveLoanRequest(client.getClientId(),
-                    loanProductsResponse.getResourceId(), "17 August 2024", 450.0, 25.0, 6, null));
+            PostLoansResponse postLoansResponse = loanHelper.applyForLoan(
+                    applyLP2ProgressiveLoanRequest(clientId, loanProductsResponse.getResourceId(), "17 August 2024", 450.0, 25.0, 6, null));
             Long loanId = postLoansResponse.getLoanId();
             Assertions.assertNotNull(loanId);
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(450.0, "17 August 2024"));
+            approveLoan(loanId, approveLoanRequest(450.0, "17 August 2024"));
             disburseLoan(loanId, BigDecimal.valueOf(450.0), "17 August 2024");
             verifyTransactions(loanId, //
                     transaction(450.0, "Disbursement", "17 August 2024") //
             );
-            Long repaymentId = loanTransactionHelper.makeLoanRepayment("17 January 2025", 600.0f, loanId.intValue()).getResourceId();
+            Long repaymentId = makeLoanRepayment("17 January 2025", 600.0f, loanId.intValue()).getResourceId();
             Assertions.assertNotNull(repaymentId);
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getOverpaid);
             verifyTransactions(loanId, //
                     transaction(450.0, "Disbursement", "17 August 2024"), //
@@ -144,8 +140,8 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
                     transaction(6.48, "Accrual Activity", "17 November 2024"), //
                     transaction(4.75, "Accrual Activity", "17 December 2024"), //
                     transaction(4.99, "Accrual Activity", "17 January 2025")); //
-            loanTransactionHelper.reverseRepayment(loanId.intValue(), repaymentId.intValue(), "17 January 2025");
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            reverseRepayment(loanId.intValue(), repaymentId.intValue(), "17 January 2025");
+            loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getActive);
             verifyTransactions(loanId, transaction(450.0, "Disbursement", "17 August 2024"), //
                     transaction(33.52, "Accrual", "17 January 2025"), //
@@ -170,24 +166,24 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
     @Test
     public void testInterestBearingProgressiveInterestRecalculationReopenDueReverseRepayment() {
         runAt("17 January 2025", () -> {
-            final PostLoanProductsResponse loanProductsResponse = loanProductHelper.createLoanProduct(create4IProgressive() //
+            final PostLoanProductsResponse loanProductsResponse = loanHelper.createLoanProduct(create4IProgressive() //
                     .description("Interest bearing Progressive Loan USD, Accrual Activity Posting, NO InterestRecalculation") //
                     .enableAccrualActivityPosting(true) //
                     .daysInMonthType(DaysInMonthType.ACTUAL) //
                     .daysInYearType(DaysInYearType.ACTUAL) //
                     .isInterestRecalculationEnabled(false));//
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applyLP2ProgressiveLoanRequest(client.getClientId(),
-                    loanProductsResponse.getResourceId(), "17 August 2024", 450.0, 25.0, 6, null));
+            PostLoansResponse postLoansResponse = loanHelper.applyForLoan(
+                    applyLP2ProgressiveLoanRequest(clientId, loanProductsResponse.getResourceId(), "17 August 2024", 450.0, 25.0, 6, null));
             Long loanId = postLoansResponse.getLoanId();
             Assertions.assertNotNull(loanId);
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(450.0, "17 August 2024"));
+            approveLoan(loanId, approveLoanRequest(450.0, "17 August 2024"));
             disburseLoan(loanId, BigDecimal.valueOf(450.0), "17 August 2024");
             verifyTransactions(loanId, //
                     transaction(450.0, "Disbursement", "17 August 2024") //
             );
-            Long repaymentId = loanTransactionHelper.makeLoanRepayment("17 January 2025", 600.0f, loanId.intValue()).getResourceId();
+            Long repaymentId = makeLoanRepayment("17 January 2025", 600.0f, loanId.intValue()).getResourceId();
             Assertions.assertNotNull(repaymentId);
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getOverpaid);
             verifyTransactions(loanId, //
                     transaction(450.0, "Disbursement", "17 August 2024"), //
@@ -198,9 +194,9 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
                     transaction(6.48, "Accrual Activity", "17 November 2024"), //
                     transaction(4.75, "Accrual Activity", "17 December 2024"), //
                     transaction(4.99, "Accrual Activity", "17 January 2025")); //
-            loanTransactionHelper.reverseRepayment(loanId.intValue(), repaymentId.intValue(), "17 January 2025");
+            reverseRepayment(loanId.intValue(), repaymentId.intValue(), "17 January 2025");
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getActive);
             verifyTransactions(loanId, transaction(450.0, "Disbursement", "17 August 2024"), //
                     transaction(33.52, "Accrual", "17 January 2025"), //
@@ -225,24 +221,24 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
     @Test
     public void testInterestBearingProgressiveNoInterestRecalculationReopenDueReverseRepayment1b() {
         runAt("18 January 2025", () -> {
-            final PostLoanProductsResponse loanProductsResponse = loanProductHelper.createLoanProduct(create4IProgressive() //
+            final PostLoanProductsResponse loanProductsResponse = loanHelper.createLoanProduct(create4IProgressive() //
                     .description("Interest bearing Progressive Loan USD, Accrual Activity Posting, NO InterestRecalculation") //
                     .enableAccrualActivityPosting(true) //
                     .daysInMonthType(DaysInMonthType.ACTUAL) //
                     .daysInYearType(DaysInYearType.ACTUAL) //
                     .isInterestRecalculationEnabled(false));//
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applyLP2ProgressiveLoanRequest(client.getClientId(),
-                    loanProductsResponse.getResourceId(), "17 August 2024", 450.0, 25.0, 6, null));
+            PostLoansResponse postLoansResponse = loanHelper.applyForLoan(
+                    applyLP2ProgressiveLoanRequest(clientId, loanProductsResponse.getResourceId(), "17 August 2024", 450.0, 25.0, 6, null));
             Long loanId = postLoansResponse.getLoanId();
             Assertions.assertNotNull(loanId);
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(450.0, "17 August 2024"));
+            approveLoan(loanId, approveLoanRequest(450.0, "17 August 2024"));
             disburseLoan(loanId, BigDecimal.valueOf(450.0), "17 August 2024");
             verifyTransactions(loanId, //
                     transaction(450.0, "Disbursement", "17 August 2024") //
             );
-            Long repaymentId = loanTransactionHelper.makeLoanRepayment("17 January 2025", 600.0f, loanId.intValue()).getResourceId();
+            Long repaymentId = makeLoanRepayment("17 January 2025", 600.0f, loanId.intValue()).getResourceId();
             Assertions.assertNotNull(repaymentId);
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getOverpaid);
             verifyTransactions(loanId, //
                     transaction(450.0, "Disbursement", "17 August 2024"), //
@@ -253,8 +249,8 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
                     transaction(6.48, "Accrual Activity", "17 November 2024"), //
                     transaction(4.75, "Accrual Activity", "17 December 2024"), //
                     transaction(4.99, "Accrual Activity", "17 January 2025")); //
-            loanTransactionHelper.reverseRepayment(loanId.intValue(), repaymentId.intValue(), "17 January 2025");
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            reverseRepayment(loanId.intValue(), repaymentId.intValue(), "17 January 2025");
+            loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getActive);
             verifyTransactions(loanId, transaction(450.0, "Disbursement", "17 August 2024"), //
                     transaction(33.52, "Accrual", "18 January 2025"), //
@@ -270,25 +266,25 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
     @Test
     public void testAccrualActivityPostingAndReversalsInterestBearingProgressiveInterestRecalculationMerchantIssuedRefund() {
         runAt("17 January 2025", () -> {
-            final PostLoanProductsResponse loanProductsResponse = loanProductHelper.createLoanProduct(create4IProgressive() //
+            final PostLoanProductsResponse loanProductsResponse = loanHelper.createLoanProduct(create4IProgressive() //
                     .description("Interest bearing Progressive Loan USD, Accrual Activity Posting, InterestRecalculation") //
                     .enableAccrualActivityPosting(true) //
                     .currencyCode("USD") //
                     .daysInMonthType(DaysInMonthType.ACTUAL) //
                     .daysInYearType(DaysInYearType.ACTUAL) //
                     .isInterestRecalculationEnabled(true));//
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applyLP2ProgressiveLoanRequest(client.getClientId(),
-                    loanProductsResponse.getResourceId(), "17 August 2024", 450.0, 25.0, 6, null));
+            PostLoansResponse postLoansResponse = loanHelper.applyForLoan(
+                    applyLP2ProgressiveLoanRequest(clientId, loanProductsResponse.getResourceId(), "17 August 2024", 450.0, 25.0, 6, null));
             Long loanId = postLoansResponse.getLoanId();
             Assertions.assertNotNull(loanId);
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(450.0, "17 August 2024"));
+            approveLoan(loanId, approveLoanRequest(450.0, "17 August 2024"));
             disburseLoan(loanId, BigDecimal.valueOf(450.0), "17 August 2024");
             verifyTransactions(loanId, //
                     transaction(450.0, "Disbursement", "17 August 2024") //
             );
-            Long repaymentId = loanTransactionHelper.makeLoanRepayment("17 January 2025", 497.04f, loanId.intValue()).getResourceId();
+            Long repaymentId = makeLoanRepayment("17 January 2025", 497.04f, loanId.intValue()).getResourceId();
             Assertions.assertNotNull(repaymentId);
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getClosedObligationsMet);
             verifyTransactions(loanId, //
                     transaction(450.0, "Disbursement", "17 August 2024"), //
@@ -299,8 +295,8 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
                     transaction(9.53, "Accrual Activity", "17 November 2024"), //
                     transaction(9.22, "Accrual Activity", "17 December 2024"), //
                     transaction(9.54, "Accrual Activity", "17 January 2025")); //
-            loanTransactionHelper.makeLoanRepayment("MerchantIssuedRefund", "17 August 2024", 450.0f, loanId.intValue()).getResourceId();
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            makeLoanRepayment("MerchantIssuedRefund", "17 August 2024", 450.0f, loanId.intValue()).getResourceId();
+            loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getOverpaid);
             verifyTransactions(loanId, transaction(450.0, "Disbursement", "17 August 2024"), //
                     transaction(450.0, "Merchant Issued Refund", "17 August 2024"), //
@@ -322,25 +318,25 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
     @Test
     public void testInterestBearingProgressiveNoInterestRecalculationReopenDueReverseRepayment2b() {
         runAt("17 January 2025", () -> {
-            final PostLoanProductsResponse loanProductsResponse = loanProductHelper.createLoanProduct(create4IProgressive() //
+            final PostLoanProductsResponse loanProductsResponse = loanHelper.createLoanProduct(create4IProgressive() //
                     .description("Interest bearing Progressive Loan USD, Accrual Activity Posting, NO InterestRecalculation") //
                     .enableAccrualActivityPosting(true) //
                     .currencyCode("USD") //
                     .daysInMonthType(DaysInMonthType.ACTUAL) //
                     .daysInYearType(DaysInYearType.ACTUAL) //
                     .isInterestRecalculationEnabled(false));//
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applyLP2ProgressiveLoanRequest(client.getClientId(),
-                    loanProductsResponse.getResourceId(), "17 August 2024", 450.0, 25.0, 6, null));
+            PostLoansResponse postLoansResponse = loanHelper.applyForLoan(
+                    applyLP2ProgressiveLoanRequest(clientId, loanProductsResponse.getResourceId(), "17 August 2024", 450.0, 25.0, 6, null));
             Long loanId = postLoansResponse.getLoanId();
             Assertions.assertNotNull(loanId);
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(450.0, "17 August 2024"));
+            approveLoan(loanId, approveLoanRequest(450.0, "17 August 2024"));
             disburseLoan(loanId, BigDecimal.valueOf(450.0), "17 August 2024");
             verifyTransactions(loanId, //
                     transaction(450.0, "Disbursement", "17 August 2024") //
             );
-            Long repaymentId = loanTransactionHelper.makeLoanRepayment("17 January 2025", 483.52f, loanId.intValue()).getResourceId();
+            Long repaymentId = makeLoanRepayment("17 January 2025", 483.52f, loanId.intValue()).getResourceId();
             Assertions.assertNotNull(repaymentId);
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getClosedObligationsMet);
             verifyTransactions(loanId, //
                     transaction(450.0, "Disbursement", "17 August 2024"), //
@@ -352,7 +348,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
                     transaction(4.75, "Accrual Activity", "17 December 2024"), //
                     transaction(4.99, "Accrual Activity", "17 January 2025")); //
             addCharge(loanId, false, 15.0, "15 January 2025");
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getActive);
             verifyTransactions(loanId, transaction(450.0, "Disbursement", "17 August 2024"), //
                     transaction(33.52, "Accrual", "17 January 2025"), //
@@ -376,25 +372,25 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
     @Test
     public void testInterestBearingProgressiveNoInterestRecalculationReopenDueReverseRepayment2c() {
         runAt("18 January 2025", () -> {
-            final PostLoanProductsResponse loanProductsResponse = loanProductHelper.createLoanProduct(create4IProgressive() //
+            final PostLoanProductsResponse loanProductsResponse = loanHelper.createLoanProduct(create4IProgressive() //
                     .description("Interest bearing Progressive Loan USD, Accrual Activity Posting, NO InterestRecalculation") //
                     .enableAccrualActivityPosting(true) //
                     .currencyCode("USD") //
                     .daysInMonthType(DaysInMonthType.ACTUAL) //
                     .daysInYearType(DaysInYearType.ACTUAL) //
                     .isInterestRecalculationEnabled(false));//
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applyLP2ProgressiveLoanRequest(client.getClientId(),
-                    loanProductsResponse.getResourceId(), "17 August 2024", 450.0, 25.0, 6, null));
+            PostLoansResponse postLoansResponse = loanHelper.applyForLoan(
+                    applyLP2ProgressiveLoanRequest(clientId, loanProductsResponse.getResourceId(), "17 August 2024", 450.0, 25.0, 6, null));
             Long loanId = postLoansResponse.getLoanId();
             Assertions.assertNotNull(loanId);
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(450.0, "17 August 2024"));
+            approveLoan(loanId, approveLoanRequest(450.0, "17 August 2024"));
             disburseLoan(loanId, BigDecimal.valueOf(450.0), "17 August 2024");
             verifyTransactions(loanId, //
                     transaction(450.0, "Disbursement", "17 August 2024") //
             );
-            Long repaymentId = loanTransactionHelper.makeLoanRepayment("17 January 2025", 483.52f, loanId.intValue()).getResourceId();
+            Long repaymentId = makeLoanRepayment("17 January 2025", 483.52f, loanId.intValue()).getResourceId();
             Assertions.assertNotNull(repaymentId);
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getClosedObligationsMet);
             verifyTransactions(loanId, //
                     transaction(450.0, "Disbursement", "17 August 2024"), //
@@ -406,7 +402,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
                     transaction(4.75, "Accrual Activity", "17 December 2024"), //
                     transaction(4.99, "Accrual Activity", "17 January 2025")); //
             addCharge(loanId, false, 15.0, "15 January 2025");
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getActive);
             verifyTransactions(loanId, transaction(450.0, "Disbursement", "17 August 2024"), //
                     transaction(33.52, "Accrual", "18 January 2025"), //
@@ -444,14 +440,13 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         runAt(creationBusinessDay, () -> {
 
             Long localLoanProductId = createLoanProductAccountingAccrualPeriodicWithInterest();
-            loanId.set(applyForLoanApplicationWithInterest(client.getClientId(), localLoanProductId, BigDecimal.valueOf(40000),
-                    disbursementDay));
+            loanId.set(applyForLoanApplicationWithInterest(clientId, localLoanProductId, BigDecimal.valueOf(40000), disbursementDay));
 
-            loanTransactionHelper.approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
-                    .dateFormat(DATETIME_PATTERN).approvedOnDate(disbursementDay).locale("en"));
+            approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
+                    .approvedOnDate(disbursementDay).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
             chargePenalty(loanId.get(), 30.0, repaymentPeriod1DueDate);
             chargePenalty(loanId.get(), 50.0, repaymentPeriod2DueDate);
@@ -460,13 +455,13 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
 
         });
         runAt(repaymentPeriod1OneDayBeforeCloseDate, () -> {
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.get()));
+            executeInlineCOB(List.of(loanId.get()));
             verifyTransactions(loanId.get(), //
                     transaction(1000.0, "Disbursement", disbursementDay, 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
                     transaction(19.35, "Accrual", "31 January 2023", 0, 0, 19.35, 0, 0, 0.0, 0.0));
         });
         runAt(repaymentPeriod1CloseDate, () -> {
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.get()));
+            executeInlineCOB(List.of(loanId.get()));
             verifyTransactions(loanId.get(), //
                     transaction(1000.0, "Disbursement", disbursementDay, 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
                     transaction(19.35, "Accrual", "31 January 2023", 0, 0, 19.35, 0, 0, 0.0, 0.0),
@@ -475,7 +470,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
 
         });
         runAt(repaymentPeriod1OneDayAfterCloseDate, () -> {
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.get()));
+            executeInlineCOB(List.of(loanId.get()));
             verifyTransactions(loanId.get(), //
                     transaction(1000.0, "Disbursement", disbursementDay, 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
                     transaction(19.35, "Accrual", "31 January 2023", 0, 0, 19.35, 0, 0, 0.0, 0.0),
@@ -514,14 +509,13 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         runAt(creationBusinessDay, () -> {
 
             Long localLoanProductId = createLoanProductAccountingAccrualPeriodicWithInterest();
-            loanId.set(applyForLoanApplicationWithInterest(client.getClientId(), localLoanProductId, BigDecimal.valueOf(40000),
-                    disbursementDay));
+            loanId.set(applyForLoanApplicationWithInterest(clientId, localLoanProductId, BigDecimal.valueOf(40000), disbursementDay));
 
-            loanTransactionHelper.approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
-                    .dateFormat(DATETIME_PATTERN).approvedOnDate(disbursementDay).locale("en"));
+            approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
+                    .approvedOnDate(disbursementDay).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
             chargePenalty(loanId.get(), 30.0, repaymentPeriod1DueDate);
             chargePenalty(loanId.get(), 50.0, repaymentPeriod2DueDate);
@@ -530,19 +524,19 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
 
         });
         runAt(repaymentPeriod1OneDayBeforeCloseDate, () -> {
-            schedulerJobHelper.executeAndAwaitJob("Accrual Activity Posting");
+            schedulerHelper.executeAndAwaitJob("Accrual Activity Posting");
             verifyTransactions(loanId.get(), //
                     transaction(1000.0, "Disbursement", disbursementDay, 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
         });
         runAt(repaymentPeriod1CloseDate, () -> {
-            schedulerJobHelper.executeAndAwaitJob("Accrual Activity Posting");
+            schedulerHelper.executeAndAwaitJob("Accrual Activity Posting");
 
             verifyTransactions(loanId.get(), //
                     transaction(1000.0, "Disbursement", disbursementDay, 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
                     transaction(90.0, "Accrual Activity", "01 February 2023", 0, 0, 20.0, 40.0, 30.0, 0.0, 0.0));
         });
         runAt(repaymentPeriod1OneDayAfterCloseDate, () -> {
-            schedulerJobHelper.executeAndAwaitJob("Accrual Activity Posting");
+            schedulerHelper.executeAndAwaitJob("Accrual Activity Posting");
             verifyTransactions(loanId.get(), //
                     transaction(1000.0, "Disbursement", disbursementDay, 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
                     transaction(90.0, "Accrual Activity", "01 February 2023", 0, 0, 20.0, 40.0, 30.0, 0.0, 0.0));
@@ -575,20 +569,18 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
 
             Long localLoanProductId = createLoanProductAccountingAccrualPeriodicWithInterest();
 
-            loanId1.set(applyForLoanApplicationWithInterest(client.getClientId(), localLoanProductId, BigDecimal.valueOf(40000),
-                    disbursementDay));
-            loanId2.set(applyForLoanApplicationWithInterest(client.getClientId(), localLoanProductId, BigDecimal.valueOf(40000),
-                    disbursementDay));
+            loanId1.set(applyForLoanApplicationWithInterest(clientId, localLoanProductId, BigDecimal.valueOf(40000), disbursementDay));
+            loanId2.set(applyForLoanApplicationWithInterest(clientId, localLoanProductId, BigDecimal.valueOf(40000), disbursementDay));
 
-            loanTransactionHelper.approveLoan(loanId1.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+            approveLoan(loanId1.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
                     .dateFormat(DATETIME_PATTERN).approvedOnDate(disbursementDay).locale("en"));
-            loanTransactionHelper.approveLoan(loanId2.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+            approveLoan(loanId2.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
                     .dateFormat(DATETIME_PATTERN).approvedOnDate(disbursementDay).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanId1.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
-            loanTransactionHelper.disburseLoan(loanId2.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanId1.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanId2.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
             chargePenalty(loanId1.get(), 30.0, repaymentPeriod1DueDate);
             chargeFee(loanId1.get(), 40.0, repaymentPeriod1DueDate);
@@ -598,7 +590,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
 
         });
         runAt(repaymentPeriod1CloseDate, () -> {
-            schedulerJobHelper.executeAndAwaitJob("Accrual Activity Posting");
+            schedulerHelper.executeAndAwaitJob("Accrual Activity Posting");
 
             verifyTransactions(loanId1.get(), //
                     transaction(1000.0, "Disbursement", disbursementDay, 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
@@ -633,14 +625,13 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         runAt(creationBusinessDay, () -> {
 
             Long localLoanProductId = createLoanProductAccountingAccrualPeriodicWithInterest();
-            loanId.set(applyForLoanApplicationWithInterest(client.getClientId(), localLoanProductId, BigDecimal.valueOf(40000),
-                    disbursementDay));
+            loanId.set(applyForLoanApplicationWithInterest(clientId, localLoanProductId, BigDecimal.valueOf(40000), disbursementDay));
 
-            loanTransactionHelper.approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
-                    .dateFormat(DATETIME_PATTERN).approvedOnDate(disbursementDay).locale("en"));
+            approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
+                    .approvedOnDate(disbursementDay).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
             addRepaymentForLoan(loanId.get(), 50.0, "10 January 2023");
             verifyTransactions(loanId.get(), //
@@ -649,7 +640,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
 
         });
         runAt(repaymentPeriod1CloseDate, () -> {
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.get()));
+            executeInlineCOB(List.of(loanId.get()));
             verifyTransactions(loanId.get(), //
                     transaction(1000.0, "Disbursement", disbursementDay, 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
                     transaction(20.0, "Accrual", "01 February 2023", 0, 0, 20, 0, 0, 0.0, 0.0),
@@ -715,14 +706,14 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         AtomicReference<Long> loanId = new AtomicReference<>();
         runAt(creationBusinessDay, () -> {
             Long localLoanProductId = createLoanProductAccountingAccrualPeriodicAdvancedPaymentAllocation();
-            loanId.set(applyForLoanApplicationAdvancedPaymentAllocation(client.getClientId(), localLoanProductId, BigDecimal.valueOf(40000),
+            loanId.set(applyForLoanApplicationAdvancedPaymentAllocation(clientId, localLoanProductId, BigDecimal.valueOf(40000),
                     disbursementDay, BigDecimal.ZERO));
 
-            loanTransactionHelper.approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
-                    .dateFormat(DATETIME_PATTERN).approvedOnDate(disbursementDay).locale("en"));
+            approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
+                    .approvedOnDate(disbursementDay).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(1000)).locale("en"));
 
             chargePenalty(loanId.get(), 20.0, chargeDueDate1st);
 
@@ -733,7 +724,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
 
         });
         runAt(repaymentPeriod1CloseDate, () -> {
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.get()));
+            executeInlineCOB(List.of(loanId.get()));
             verifyTransactions(loanId.get(), //
                     transaction(1000, "Disbursement", disbursementDay, 1000, 0, 0, 0, 0, 0, 0),
                     transaction(20, "Accrual", "01 February 2023", 0, 0, 0, 0, 20, 0, 0),
@@ -793,14 +784,14 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         runAt(creationBusinessDay, () -> {
 
             Long localLoanProductId = createLoanProductAccountingAccrualPeriodicAdvancedPaymentAllocation();
-            loanId.set(applyForLoanApplicationAdvancedPaymentAllocation(client.getClientId(), localLoanProductId, BigDecimal.valueOf(40000),
+            loanId.set(applyForLoanApplicationAdvancedPaymentAllocation(clientId, localLoanProductId, BigDecimal.valueOf(40000),
                     disbursementDay, BigDecimal.ZERO));
 
-            loanTransactionHelper.approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
-                    .dateFormat(DATETIME_PATTERN).approvedOnDate(disbursementDay).locale("en"));
+            approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
+                    .approvedOnDate(disbursementDay).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
             chargePenalty(loanId.get(), 20.0, chargeDueDate1st);
 
@@ -809,7 +800,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
 
         });
         runAt(repaymentPeriod1CloseDate, () -> {
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.get()));
+            executeInlineCOB(List.of(loanId.get()));
             verifyTransactions(loanId.get(), //
                     transaction(1000.0, "Disbursement", disbursementDay, 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
                     transaction(20.0, "Accrual", "01 February 2023", 0, 0, 0, 0, 20, 0.0, 0.0),
@@ -845,14 +836,14 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         AtomicReference<Long> repaymentId = new AtomicReference<>();
         runAt(creationBusinessDay, () -> {
             Long localLoanProductId = createLoanProductAccountingAccrualPeriodicAdvancedPaymentAllocation();
-            loanId.set(applyForLoanApplicationAdvancedPaymentAllocation(client.getClientId(), localLoanProductId, BigDecimal.valueOf(40000),
+            loanId.set(applyForLoanApplicationAdvancedPaymentAllocation(clientId, localLoanProductId, BigDecimal.valueOf(40000),
                     disbursementDay, BigDecimal.ZERO));
 
-            loanTransactionHelper.approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
-                    .dateFormat(DATETIME_PATTERN).approvedOnDate(disbursementDay).locale("en"));
+            approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
+                    .approvedOnDate(disbursementDay).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
             chargePenalty(loanId.get(), 30.0, repaymentPeriod1DueDate);
             chargeFee(loanId.get(), 40.0, repaymentPeriod1DueDate);
@@ -868,7 +859,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         });
         runAt(repaymentPeriod1CloseDate, () -> {
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.get()));
+            executeInlineCOB(List.of(loanId.get()));
 
             verifyTransactions(loanId.get(),
                     transaction(1000.0, "Disbursement", disbursementDay, 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false), //
@@ -876,7 +867,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
                     transaction(70.0, "Accrual", repaymentDate1, 0.0, 0.0, 0.0, 40.0, 30.0, 0.0, 0.0, false), //
                     transaction(70.0, "Accrual Activity", repaymentDate1, 0.0, 0.0, 0.0, 40.0, 30.0, 0.0, 0.0, false)); //
 
-            loanTransactionHelper.reverseRepayment(loanId.get().intValue(), repaymentId.get().intValue(), repaymentDate1);
+            reverseRepayment(loanId.get().intValue(), repaymentId.get().intValue(), repaymentDate1);
 
             verifyTransactions(loanId.get(),
                     transaction(1000.0, "Disbursement", disbursementDay, 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false), //
@@ -897,14 +888,13 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         AtomicReference<Long> repaymentId = new AtomicReference<>();
         runAt(creationBusinessDay, () -> {
             Long localLoanProductId = createLoanProductAccountingAccrualPeriodicWithInterest();
-            loanId.set(applyForLoanApplicationWithInterest(client.getClientId(), localLoanProductId, BigDecimal.valueOf(40000),
-                    disbursementDay));
+            loanId.set(applyForLoanApplicationWithInterest(clientId, localLoanProductId, BigDecimal.valueOf(40000), disbursementDay));
 
-            loanTransactionHelper.approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
-                    .dateFormat(DATETIME_PATTERN).approvedOnDate(disbursementDay).locale("en"));
+            approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
+                    .approvedOnDate(disbursementDay).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
             chargePenalty(loanId.get(), 30.0, repaymentPeriod1DueDate);
             chargeFee(loanId.get(), 40.0, repaymentPeriod1DueDate);
@@ -920,7 +910,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         });
         runAt(repaymentPeriod1CloseDate, () -> {
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.get()));
+            executeInlineCOB(List.of(loanId.get()));
 
             verifyTransactions(loanId.get(),
                     transaction(1000.0, "Disbursement", disbursementDay, 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false), //
@@ -928,7 +918,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
                     transaction(150.0, "Accrual", repaymentDate1, 0.0, 0.0, 80.0, 40.0, 30.0, 0.0, 0.0, false), //
                     transaction(150.0, "Accrual Activity", repaymentDate1, 0.0, 0.0, 80.0, 40.0, 30.0, 0.0, 0.0, false)); //
 
-            loanTransactionHelper.reverseRepayment(loanId.get().intValue(), repaymentId.get().intValue(), repaymentDate1);
+            reverseRepayment(loanId.get().intValue(), repaymentId.get().intValue(), repaymentDate1);
 
             verifyTransactions(loanId.get(),
                     transaction(1000.0, "Disbursement", disbursementDay, 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false), //
@@ -950,14 +940,14 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         runAt(creationBusinessDay, () -> {
             Long localLoanProductId = createLoanProductAccountingAccrualPeriodicAdvancedPaymentAllocation(true);
 
-            loanId.set(applyForLoanApplicationAdvancedPaymentAllocation(client.getClientId(), localLoanProductId, BigDecimal.valueOf(40000),
+            loanId.set(applyForLoanApplicationAdvancedPaymentAllocation(clientId, localLoanProductId, BigDecimal.valueOf(40000),
                     disbursementDay, disbursementDay2, BigDecimal.ZERO));
 
-            loanTransactionHelper.approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
-                    .dateFormat(DATETIME_PATTERN).approvedOnDate(disbursementDay).locale("en"));
+            approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
+                    .approvedOnDate(disbursementDay).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
 
             chargePenalty(loanId.get(), 30.0, repaymentPeriod1DueDate);
             chargeFee(loanId.get(), 40.0, repaymentPeriod1DueDate);
@@ -973,8 +963,8 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         });
         runAt(disbursementDay2, () -> {
 
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay2)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay2).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
 
             verifyTransactions(loanId.get(),
                     transaction(500.0, "Disbursement", disbursementDay, 500.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false), //
@@ -985,7 +975,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         });
         runAt(repaymentPeriod1CloseDate, () -> {
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.get()));
+            executeInlineCOB(List.of(loanId.get()));
 
             verifyTransactions(loanId.get(),
                     transaction(500.0, "Disbursement", disbursementDay, 500.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false), //
@@ -1009,14 +999,14 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         runAt(creationBusinessDay, () -> {
             Long localLoanProductId = createLoanProductAccountingAccrualPeriodicAdvancedPaymentAllocation(true);
 
-            loanId.set(applyForLoanApplicationAdvancedPaymentAllocation(client.getClientId(), localLoanProductId, BigDecimal.valueOf(40000),
+            loanId.set(applyForLoanApplicationAdvancedPaymentAllocation(clientId, localLoanProductId, BigDecimal.valueOf(40000),
                     disbursementDay, disbursementDay2, BigDecimal.ZERO));
 
-            loanTransactionHelper.approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
-                    .dateFormat(DATETIME_PATTERN).approvedOnDate(disbursementDay).locale("en"));
+            approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
+                    .approvedOnDate(disbursementDay).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
 
             chargePenalty(loanId.get(), 30.0, repaymentPeriod1DueDate);
             chargeFee(loanId.get(), 40.0, repaymentPeriod1DueDate);
@@ -1031,15 +1021,15 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         });
         runAt(repaymentPeriod1CloseDate, () -> {
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.get()));
+            executeInlineCOB(List.of(loanId.get()));
 
             verifyTransactions(loanId.get(), transaction(650.0, "Repayment", repaymentDate1, 0.0, 500.0, 0.0, 40.0, 30.0, 0.0, 80.0, false), //
                     transaction(70.0, "Accrual", repaymentDate1, 0.0, 0.0, 0.0, 40.0, 30.0, 0.0, 0.0, false), //
                     transaction(70.0, "Accrual Activity", repaymentDate1, 0.0, 0.0, 0.0, 40.0, 30.0, 0.0, 0.0, false), //
                     transaction(500.0, "Disbursement", disbursementDay, 500.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false)); //
 
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay2)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay2).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
 
             verifyTransactions(loanId.get(), transaction(650.0, "Repayment", repaymentDate1, 0.0, 500.0, 0.0, 40.0, 30.0, 0.0, 80.0, false), //
                     transaction(500.0, "Disbursement", disbursementDay2, 420.0, 0.0, 0.0, 0.0, 0.0, 0.0, 80.0, false), //
@@ -1061,14 +1051,14 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         AtomicReference<Long> loanId = new AtomicReference<>();
         runAt(creationBusinessDay, () -> {
             Long localLoanProductId = createLoanProductAccountingAccrualPeriodicWithInterest(true);
-            loanId.set(applyForLoanApplicationWithInterest(client.getClientId(), localLoanProductId, BigDecimal.valueOf(40000),
-                    disbursementDay, disbursementDay2));
+            loanId.set(applyForLoanApplicationWithInterest(clientId, localLoanProductId, BigDecimal.valueOf(40000), disbursementDay,
+                    disbursementDay2));
 
-            loanTransactionHelper.approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
-                    .dateFormat(DATETIME_PATTERN).approvedOnDate(disbursementDay).locale("en"));
+            approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
+                    .approvedOnDate(disbursementDay).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
 
             chargePenalty(loanId.get(), 30.0, repaymentPeriod1DueDate);
             chargeFee(loanId.get(), 40.0, repaymentPeriod1DueDate);
@@ -1082,15 +1072,15 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         });
         runAt(repaymentPeriod1CloseDate, () -> {
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.get()));
+            executeInlineCOB(List.of(loanId.get()));
 
             verifyTransactions(loanId.get(), transaction(94.9, "Accrual", repaymentDate1, 0.0, 0.0, 24.9, 40.0, 30.0, 0.0, 0.0, false), //
                     transaction(94.9, "Accrual Activity", repaymentDate1, 0.0, 0.0, 24.9, 40.0, 30.0, 0.0, 0.0, false), //
                     transaction(650.0, "Repayment", repaymentDate1, 0.0, 500.0, 24.9, 40.0, 30.0, 0.0, 55.1, false), //
                     transaction(500.0, "Disbursement", disbursementDay, 500.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false)); //
 
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay2)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay2).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
 
             verifyTransactions(loanId.get(),
                     transaction(500.0, "Disbursement", disbursementDay, 500.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false), //
@@ -1114,13 +1104,13 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         AtomicReference<Long> loanId = new AtomicReference<>();
         runAt(creationBusinessDay, () -> {
             Long localLoanProductId = createLoanProductAccountingAccrualPeriodicAdvancedPaymentAllocation(true);
-            loanId.set(applyForLoanApplicationAdvancedPaymentAllocation(client.getClientId(), localLoanProductId, BigDecimal.valueOf(1000),
+            loanId.set(applyForLoanApplicationAdvancedPaymentAllocation(clientId, localLoanProductId, BigDecimal.valueOf(1000),
                     disbursementDay, disbursementDay2, BigDecimal.ZERO));
-            loanTransactionHelper.approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
-                    .dateFormat(DATETIME_PATTERN).approvedOnDate(disbursementDay).locale("en"));
+            approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
+                    .approvedOnDate(disbursementDay).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
             chargePenalty(loanId.get(), 30.0, repaymentPeriod1DueDate);
             chargeFee(loanId.get(), 40.0, repaymentPeriod1DueDate);
 
@@ -1133,15 +1123,15 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         });
         runAt(repaymentPeriod1CloseDate, () -> {
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.get()));
+            executeInlineCOB(List.of(loanId.get()));
 
             verifyTransactions(loanId.get(), transaction(500.0, "Disbursement", disbursementDay, 500.0, 0, 0, 0, 0, 0, 0, false),
-                    transaction(570, "Repayment", repaymentDate1, 0.0, 500.0, 0, 40.0, 30.0, 0, 0, true),
+                    transaction(570, "Repayment", repaymentDate1, 0.0, 500.0, 0, 40.0, 30.0, 0, 0, false),
                     transaction(70.0, "Accrual", repaymentDate1, 0, 0, 0.0, 40.0, 30.0, 0, 0, false),
                     transaction(70.0, "Accrual Activity", repaymentDate1, 0, 0, 0.0, 40.0, 30.0, 0, 0, false));
 
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay2)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay2).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
 
             verifyTransactions(loanId.get(), transaction(500.0, "Disbursement", disbursementDay, 500.0, 0, 0, 0, 0, 0, 0, false),
                     transaction(570, "Repayment", repaymentDate1, 0.0, 500.0, 0, 40.0, 30.0, 0, 0, false),
@@ -1151,7 +1141,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         });
         runAt(repaymentPeriod2CloseDate, () -> {
 
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.get()));
+            executeInlineCOB(List.of(loanId.get()));
 
             verifyTransactions(loanId.get(), transaction(500.0, "Disbursement", disbursementDay, 500.0, 0, 0, 0, 0, 0, 0, false),
                     transaction(570.0, "Repayment", repaymentDate1, 0.0, 500.0, 0, 40.0, 30.0, 0, 0, false),
@@ -1174,13 +1164,13 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         AtomicReference<Long> loanId = new AtomicReference<>();
         runAt(creationBusinessDay, () -> {
             Long localLoanProductId = createLoanProductAccountingAccrualPeriodicWithInterest(true);
-            loanId.set(applyForLoanApplicationWithInterest(client.getClientId(), localLoanProductId, BigDecimal.valueOf(40000),
-                    disbursementDay, disbursementDay2));
-            loanTransactionHelper.approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
-                    .dateFormat(DATETIME_PATTERN).approvedOnDate(disbursementDay).locale("en"));
+            loanId.set(applyForLoanApplicationWithInterest(clientId, localLoanProductId, BigDecimal.valueOf(40000), disbursementDay,
+                    disbursementDay2));
+            approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
+                    .approvedOnDate(disbursementDay).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
             chargePenalty(loanId.get(), 30.0, repaymentPeriod1DueDate);
             chargeFee(loanId.get(), 40.0, repaymentPeriod1DueDate);
             addRepaymentForLoan(loanId.get(), 650.0, repaymentDate1);
@@ -1191,15 +1181,15 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
                     transaction(500.0, "Disbursement", disbursementDay, 500.0, 0, 0, 0, 0, 0, 0, false));
         });
         runAt(repaymentPeriod1CloseDate, () -> {
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.get()));
+            executeInlineCOB(List.of(loanId.get()));
             verifyTransactions(loanId.get(),
                     transaction(650.0, "Repayment", repaymentDate1, 0.0, 500.0, 24.9, 40.0, 30.0, 0.0, 55.1, false), //
                     transaction(94.90, "Accrual Activity", repaymentDate1, 0.0, 0.0, 24.9, 40.0, 30.0, 0.0, 0.0, false),
                     transaction(94.90, "Accrual", repaymentDate1, 0.0, 0.0, 24.9, 40.0, 30.0, 0.0, 0.0, false), //
                     transaction(500.0, "Disbursement", disbursementDay, 500.0, 0, 0, 0, 0, 0, 0, false) //
             );
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay2)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay2).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(500.0)).locale("en"));
             verifyTransactions(loanId.get(),
                     transaction(500.0, "Disbursement", disbursementDay2, 453.79, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false), //
                     transaction(650.0, "Repayment", repaymentDate1, 0.0, 546.21, 33.79, 40.0, 30.0, 0.0, 0.0, false), //
@@ -1208,7 +1198,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
             );
         });
         runAt(repaymentPeriod2CloseDate, () -> {
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.get()));
+            executeInlineCOB(List.of(loanId.get()));
             verifyTransactions(loanId.get(),
                     transaction(500.0, "Disbursement", disbursementDay2, 453.79, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false), //
                     transaction(650.0, "Repayment", repaymentDate1, 0.0, 546.21, 33.79, 40.0, 30.0, 0.0, 0.0, false), //
@@ -1225,8 +1215,8 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
 
     public void createInterestBearingProgressiveNoInterestRecalculationAutoDownPayment25percentLoanProductIfNotExists() {
         if (interestBearingProgressiveLoanProductId == null) {
-            final PostLoanProductsResponse loanProductsResponse = loanProductHelper.createLoanProduct(create4IProgressive()
-                    .currencyCode("USD").enableAccrualActivityPosting(true).enableDownPayment(true)
+            final PostLoanProductsResponse loanProductsResponse = loanHelper.createLoanProduct(create4IProgressive().currencyCode("USD")
+                    .enableAccrualActivityPosting(true).enableDownPayment(true)
                     .disbursedAmountPercentageForDownPayment(BigDecimal.valueOf(25.0)).enableAutoRepaymentForDownPayment(true)
                     .currencyCode("USD").daysInMonthType(DaysInMonthType.ACTUAL).daysInYearType(DaysInYearType.ACTUAL)
                     .isInterestRecalculationEnabled(false).description(
@@ -1247,12 +1237,12 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         createInterestBearingProgressiveNoInterestRecalculationAutoDownPayment25percentLoanProductIfNotExists();
         AtomicReference<Long> loanIdRef = new AtomicReference<>(null);
         runAt("1 January 2024", () -> {
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applyLP2ProgressiveLoanRequest(client.getClientId(),
+            PostLoansResponse postLoansResponse = loanHelper.applyForLoan(applyLP2ProgressiveLoanRequest(clientId,
                     interestBearingProgressiveLoanProductId, "01 January 2024", 400.0, 9.99, 6, null));
             Long loanId = postLoansResponse.getLoanId();
             Assertions.assertNotNull(loanId);
             loanIdRef.set(loanId);
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(400.0, "01 January 2024"));
+            approveLoan(loanId, approveLoanRequest(400.0, "01 January 2024"));
             disburseLoan(loanId, BigDecimal.valueOf(400.0), "01 January 2024");
             verifyTransactions(loanId, //
                     transaction(400.0, "Disbursement", "01 January 2024"), //
@@ -1261,15 +1251,15 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         });
         runAt("2 January 2024", () -> {
             Long loanId = loanIdRef.get();
-            Long repaymentId = loanTransactionHelper.makeLoanRepayment("02 January 2024", 370.0f, loanId.intValue()).getResourceId();
+            Long repaymentId = makeLoanRepayment("02 January 2024", 370.0f, loanId.intValue()).getResourceId();
             Assertions.assertNotNull(repaymentId);
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getOverpaid);
 
             verifyTransactions(loanId, transaction(400.0, "Disbursement", "01 January 2024"),
                     transaction(100.0, "Down Payment", "01 January 2024"), transaction(8.76, "Accrual", "02 January 2024"),
                     transaction(8.76, "Accrual Activity", "02 January 2024"), transaction(370.0, "Repayment", "02 January 2024"));
-            loanTransactionHelper.reverseRepayment(loanId.intValue(), repaymentId.intValue(), "02 January 2024");
+            reverseRepayment(loanId.intValue(), repaymentId.intValue(), "02 January 2024");
         });
     }
 
@@ -1284,27 +1274,27 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
     public void testInterestBearingProgressiveNoInterestRecalculationAutoDownPayment25percentReopenDueReverseRepayment2() {
         createInterestBearingProgressiveNoInterestRecalculationAutoDownPayment25percentLoanProductIfNotExists();
         runAt("1 January 2024", () -> {
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applyLP2ProgressiveLoanRequest(client.getClientId(),
+            PostLoansResponse postLoansResponse = loanHelper.applyForLoan(applyLP2ProgressiveLoanRequest(clientId,
                     interestBearingProgressiveLoanProductId, "01 January 2024", 400.0, 9.99, 6, null));
             Long loanId = postLoansResponse.getLoanId();
             Assertions.assertNotNull(loanId);
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(400.0, "01 January 2024"));
+            approveLoan(loanId, approveLoanRequest(400.0, "01 January 2024"));
             disburseLoan(loanId, BigDecimal.valueOf(400.0), "01 January 2024");
             verifyTransactions(loanId, //
                     transaction(400.0, "Disbursement", "01 January 2024"), //
                     transaction(100.0, "Down Payment", "01 January 2024") //
             );
-            Long repaymentId = loanTransactionHelper.makeLoanRepayment("01 January 2024", 370.0f, loanId.intValue()).getResourceId();
+            Long repaymentId = makeLoanRepayment("01 January 2024", 370.0f, loanId.intValue()).getResourceId();
             Assertions.assertNotNull(repaymentId);
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getOverpaid);
 
             verifyTransactions(loanId, transaction(400.0, "Disbursement", "01 January 2024"),
                     transaction(100.0, "Down Payment", "01 January 2024"), transaction(8.76, "Accrual", "01 January 2024"),
                     transaction(8.76, "Accrual Activity", "01 January 2024"), transaction(370.0, "Repayment", "01 January 2024"));
 
-            loanTransactionHelper.reverseRepayment(loanId.intValue(), repaymentId.intValue(), "01 January 2024");
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            reverseRepayment(loanId.intValue(), repaymentId.intValue(), "01 January 2024");
+            loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getActive);
             verifyTransactions(loanId, transaction(400.0, "Disbursement", "01 January 2024"),
                     transaction(100.0, "Down Payment", "01 January 2024"), transaction(8.76, "Accrual", "01 January 2024"),
@@ -1324,27 +1314,27 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
     public void testInterestBearingProgressiveNoInterestRecalculationAutoDownPayment25percentReopenDueReverseRepayment3() {
         createInterestBearingProgressiveNoInterestRecalculationAutoDownPayment25percentLoanProductIfNotExists();
         runAt("1 January 2024", () -> {
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applyLP2ProgressiveLoanRequest(client.getClientId(),
+            PostLoansResponse postLoansResponse = loanHelper.applyForLoan(applyLP2ProgressiveLoanRequest(clientId,
                     interestBearingProgressiveLoanProductId, "01 January 2024", 400.0, 9.99, 6, null));
             Long loanId = postLoansResponse.getLoanId();
             Assertions.assertNotNull(loanId);
-            loanTransactionHelper.approveLoan(loanId, approveLoanRequest(400.0, "01 January 2024"));
+            approveLoan(loanId, approveLoanRequest(400.0, "01 January 2024"));
             disburseLoan(loanId, BigDecimal.valueOf(400.0), "01 January 2024");
             verifyTransactions(loanId, //
                     transaction(400.0, "Disbursement", "01 January 2024"), //
                     transaction(100.0, "Down Payment", "01 January 2024") //
             );
             addCharge(loanId, false, 30.0, "01 January 2024");
-            Long repaymentId = loanTransactionHelper.makeLoanRepayment("01 January 2024", 370.0f, loanId.intValue()).getResourceId();
+            Long repaymentId = makeLoanRepayment("01 January 2024", 370.0f, loanId.intValue()).getResourceId();
             Assertions.assertNotNull(repaymentId);
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getOverpaid);
 
             verifyTransactions(loanId, transaction(400.0, "Disbursement", "01 January 2024"),
                     transaction(100.0, "Down Payment", "01 January 2024"), transaction(38.76, "Accrual", "01 January 2024"),
                     transaction(38.76, "Accrual Activity", "01 January 2024"), transaction(370.0, "Repayment", "01 January 2024"));
-            loanTransactionHelper.reverseRepayment(loanId.intValue(), repaymentId.intValue(), "01 January 2024");
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            reverseRepayment(loanId.intValue(), repaymentId.intValue(), "01 January 2024");
+            loanDetails = getLoanDetails(loanId);
             verifyLoanStatus(loanDetails, GetLoansLoanIdStatus::getActive);
             verifyTransactions(loanId, transaction(400.0, "Disbursement", "01 January 2024"),
                     transaction(100.0, "Down Payment", "01 January 2024"), transaction(38.76, "Accrual", "01 January 2024"),
@@ -1361,23 +1351,23 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         final String creationBusinessDay = "15 January 2023";
         AtomicReference<Long> loanId = new AtomicReference<>();
         runAt(creationBusinessDay, () -> {
-            Long localLoanProductId = loanTransactionHelper
+            Long localLoanProductId = loanHelper
                     .createLoanProduct(loanProductsRequestInterestDecliningBalanceDailyRecalculationCompoundingNoneAccrualActivity())
                     .getResourceId();
-            loanId.set(applyForLoanApplication(client.getClientId(), localLoanProductId, BigDecimal.valueOf(1000), disbursementDay));
-            loanTransactionHelper.approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
-                    .dateFormat(DATETIME_PATTERN).approvedOnDate(disbursementDay).locale("en"));
+            loanId.set(applyForLoanApplication(clientId, localLoanProductId, BigDecimal.valueOf(1000), disbursementDay));
+            approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
+                    .approvedOnDate(disbursementDay).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
         });
         runAt(repaymentPeriod1CloseDate, () -> {
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.get()));
+            executeInlineCOB(List.of(loanId.get()));
             verifyTransactions(loanId.get(),
                     transaction(1.64, "Accrual", repaymentPeriod1DueDate, 0.0, 0.0, 1.64, 0.0, 0.0, 0.0, 0.0, false), //
                     transaction(1.64, "Accrual Activity", repaymentPeriod1DueDate, 0.0, 0.0, 1.64, 0.0, 0.0, 0.0, 0.0, false), //
                     transaction(1000.0, "Disbursement", disbursementDay, 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false));
-            loanTransactionHelper.makeLoanRepayment(repaymentDate1, 150.0F, loanId.get().intValue());
+            makeLoanRepayment(repaymentDate1, 150.0F, loanId.get().intValue());
 
             verifyTransactions(loanId.get(),
                     transaction(150.0, "Repayment", repaymentDate1, 851.52, 148.48, 1.52, 0.0, 0.0, 0.0, 0.0, false), //
@@ -1393,24 +1383,24 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
         AtomicReference<Long> loanId = new AtomicReference<>();
         runAt(disbursementDay, () -> {
             Long localLoanProductId = createLoanProductAccountingAccrualPeriodicAdvancedPaymentAllocationInterestRecalculation(true);
-            loanId.set(applyForLoanApplicationAdvancedPaymentAllocation(client.getClientId(), localLoanProductId, BigDecimal.valueOf(800),
+            loanId.set(applyForLoanApplicationAdvancedPaymentAllocation(clientId, localLoanProductId, BigDecimal.valueOf(800),
                     disbursementDay, disbursementDay, BigDecimal.valueOf(0.3)));
 
-            loanTransactionHelper.approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(800))
-                    .dateFormat(DATETIME_PATTERN).approvedOnDate(disbursementDay).locale("en"));
+            approveLoan(loanId.get(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(800)).dateFormat(DATETIME_PATTERN)
+                    .approvedOnDate(disbursementDay).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(800.0)).locale("en"));
+            disburseLoan(loanId.get(), new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(800.0)).locale("en"));
         });
 
         runAt("02 February 2025", () -> {
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanId.get()));
+            executeInlineCOB(List.of(loanId.get()));
             verifyTransactions(loanId.get(),
                     transaction(10.60, "Accrual Activity", "01 February 2025", 0.0, 0.0, 10.60, 0.0, 0.0, 0.0, 0.0, false), //
                     transaction(10.60, "Accrual", "01 February 2025", 0.0, 0.0, 10.60, 0.0, 0.0, 0.0, 0.0, false), //
                     transaction(800.0, "Disbursement", disbursementDay, 800.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false));
 
-            loanTransactionHelper.makeLoanRepayment("31 January 2025", 900.0F, loanId.get().intValue());
+            makeLoanRepayment("31 January 2025", 900.0F, loanId.get().intValue());
 
             verifyTransactions(loanId.get(),
                     transaction(0.34, "Accrual Adjustment", "02 February 2025", 0.0, 0.0, 0.34, 0.0, 0.0, 0.0, 0.0, false), //
@@ -1435,14 +1425,15 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
 
         List<GetLoanPaymentChannelToFundSourceMappings> paymentChannelToFundSourceMappings = new ArrayList<>();
         GetLoanPaymentChannelToFundSourceMappings loanPaymentChannelToFundSourceMappings = new GetLoanPaymentChannelToFundSourceMappings();
-        loanPaymentChannelToFundSourceMappings.fundSourceAccountId(fundSource.getAccountID().longValue());
+        loanPaymentChannelToFundSourceMappings.fundSourceAccountId(getAccounts().getFundSource().getAccountID().longValue());
         loanPaymentChannelToFundSourceMappings.paymentTypeId(1L);
         paymentChannelToFundSourceMappings.add(loanPaymentChannelToFundSourceMappings);
 
-        final Integer fundId = createFund(requestSpec, responseSpec);
+        final Long fundId = new FeignFundHelper(FineractFeignClientHelper.getFineractFeignClient()).createFund().getResourceId();
         Assertions.assertNotNull(fundId);
 
-        final Long delinquencyBucketId = DelinquencyBucketsHelper.createDefaultBucket();
+        final Long delinquencyBucketId = new FeignDelinquencyHelper(FineractFeignClientHelper.getFineractFeignClient())
+                .createDefaultBucket();
         Assertions.assertNotNull(delinquencyBucketId);
 
         return new PostLoanProductsRequest()//
@@ -1506,27 +1497,27 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
                 .charges(charges)//
                 .accountingRule(3)//
 
-                .fundSourceAccountId(suspenseAccount.getAccountID().longValue())//
-                .loanPortfolioAccountId(loansReceivableAccount.getAccountID().longValue())//
-                .transfersInSuspenseAccountId(suspenseAccount.getAccountID().longValue())//
-                .interestOnLoanAccountId(interestIncomeAccount.getAccountID().longValue())//
-                .incomeFromFeeAccountId(feeIncomeAccount.getAccountID().longValue())//
-                .incomeFromPenaltyAccountId(penaltyIncomeAccount.getAccountID().longValue())//
-                .incomeFromRecoveryAccountId(recoveriesAccount.getAccountID().longValue())//
-                .writeOffAccountId(writtenOffAccount.getAccountID().longValue())//
-                .overpaymentLiabilityAccountId(overpaymentAccount.getAccountID().longValue())//
-                .receivableInterestAccountId(interestReceivableAccount.getAccountID().longValue())//
-                .receivableFeeAccountId(feeReceivableAccount.getAccountID().longValue())//
-                .receivablePenaltyAccountId(penaltyReceivableAccount.getAccountID().longValue())//
-                .goodwillCreditAccountId(goodwillExpenseAccount.getAccountID().longValue())//
-                .incomeFromGoodwillCreditInterestAccountId(interestIncomeChargeOffAccount.getAccountID().longValue())//
-                .incomeFromGoodwillCreditFeesAccountId(feeChargeOffAccount.getAccountID().longValue())//
-                .incomeFromGoodwillCreditPenaltyAccountId(feeChargeOffAccount.getAccountID().longValue())//
-                .incomeFromChargeOffInterestAccountId(interestIncomeChargeOffAccount.getAccountID().longValue())//
-                .incomeFromChargeOffFeesAccountId(feeChargeOffAccount.getAccountID().longValue())//
-                .chargeOffExpenseAccountId(chargeOffExpenseAccount.getAccountID().longValue())//
-                .chargeOffFraudExpenseAccountId(chargeOffFraudExpenseAccount.getAccountID().longValue())//
-                .incomeFromChargeOffPenaltyAccountId(penaltyChargeOffAccount.getAccountID().longValue())//
+                .fundSourceAccountId(getAccounts().getSuspenseAccount().getAccountID().longValue())//
+                .loanPortfolioAccountId(getAccounts().getLoansReceivableAccount().getAccountID().longValue())//
+                .transfersInSuspenseAccountId(getAccounts().getSuspenseAccount().getAccountID().longValue())//
+                .interestOnLoanAccountId(getAccounts().getInterestIncomeAccount().getAccountID().longValue())//
+                .incomeFromFeeAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())//
+                .incomeFromPenaltyAccountId(getAccounts().getPenaltyIncomeAccount().getAccountID().longValue())//
+                .incomeFromRecoveryAccountId(getAccounts().getRecoveriesAccount().getAccountID().longValue())//
+                .writeOffAccountId(getAccounts().getWrittenOffAccount().getAccountID().longValue())//
+                .overpaymentLiabilityAccountId(getAccounts().getOverpaymentAccount().getAccountID().longValue())//
+                .receivableInterestAccountId(getAccounts().getInterestReceivableAccount().getAccountID().longValue())//
+                .receivableFeeAccountId(getAccounts().getFeeReceivableAccount().getAccountID().longValue())//
+                .receivablePenaltyAccountId(getAccounts().getPenaltyReceivableAccount().getAccountID().longValue())//
+                .goodwillCreditAccountId(getAccounts().getGoodwillExpenseAccount().getAccountID().longValue())//
+                .incomeFromGoodwillCreditInterestAccountId(getAccounts().getInterestIncomeChargeOffAccount().getAccountID().longValue())//
+                .incomeFromGoodwillCreditFeesAccountId(getAccounts().getFeeChargeOffAccount().getAccountID().longValue())//
+                .incomeFromGoodwillCreditPenaltyAccountId(getAccounts().getFeeChargeOffAccount().getAccountID().longValue())//
+                .incomeFromChargeOffInterestAccountId(getAccounts().getInterestIncomeChargeOffAccount().getAccountID().longValue())//
+                .incomeFromChargeOffFeesAccountId(getAccounts().getFeeChargeOffAccount().getAccountID().longValue())//
+                .chargeOffExpenseAccountId(getAccounts().getChargeOffExpenseAccount().getAccountID().longValue())//
+                .chargeOffFraudExpenseAccountId(getAccounts().getChargeOffFraudExpenseAccount().getAccountID().longValue())//
+                .incomeFromChargeOffPenaltyAccountId(getAccounts().getPenaltyChargeOffAccount().getAccountID().longValue())//
 
                 .dateFormat("dd MMMM yyyy")//
                 .locale("en")//
@@ -1548,28 +1539,26 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
 
     private void chargeFee(Long loanId, Double amount, String dueDate) {
         LOG.info("Charge FEE amount {} dueDate {}", amount, dueDate);
-        PostChargesResponse feeCharge = chargesHelper.createCharges(new ChargeRequest().penalty(false).amount(9.0)
+        PostChargesResponse feeCharge = chargesHelper.createCharge(new ChargeRequest().penalty(false).amount(9.0)
                 .chargeCalculationType(ChargeCalculationType.FLAT.getValue()).chargeTimeType(ChargeTimeType.SPECIFIED_DUE_DATE.getValue())
                 .chargePaymentMode(ChargePaymentMode.REGULAR.getValue()).currencyCode("USD")
                 .name(Utils.randomStringGenerator("FEE_" + Calendar.getInstance().getTimeInMillis(), 5)).chargeAppliesTo(1).locale("en")
                 .active(true));
-        PostLoansLoanIdChargesResponse feeLoanChargeResult = loanTransactionHelper.addChargesForLoan(loanId,
-                new PostLoansLoanIdChargesRequest().chargeId(feeCharge.getResourceId()).dateFormat(DATETIME_PATTERN).locale("en")
-                        .amount(amount).dueDate(dueDate));
+        PostLoansLoanIdChargesResponse feeLoanChargeResult = addChargesForLoan(loanId, new PostLoansLoanIdChargesRequest()
+                .chargeId(feeCharge.getResourceId()).dateFormat(DATETIME_PATTERN).locale("en").amount(amount).dueDate(dueDate));
         assertNotNull(feeLoanChargeResult);
         assertNotNull(feeLoanChargeResult.getResourceId());
     }
 
     private void chargePenalty(Long loanId, Double amount, String dueDate) {
         LOG.info("Charge PENALTY amount {} dueDate {}", amount, dueDate);
-        PostChargesResponse penaltyCharge = chargesHelper.createCharges(new ChargeRequest().penalty(true).amount(10.0)
+        PostChargesResponse penaltyCharge = chargesHelper.createCharge(new ChargeRequest().penalty(true).amount(10.0)
                 .chargeCalculationType(ChargeCalculationType.FLAT.getValue()).chargeTimeType(ChargeTimeType.SPECIFIED_DUE_DATE.getValue())
                 .chargePaymentMode(ChargePaymentMode.REGULAR.getValue()).currencyCode("USD")
                 .name(Utils.randomStringGenerator("PENALTY_" + Calendar.getInstance().getTimeInMillis(), 5)).chargeAppliesTo(1).locale("en")
                 .active(true));
-        PostLoansLoanIdChargesResponse penaltyLoanChargeResult = loanTransactionHelper.addChargesForLoan(loanId,
-                new PostLoansLoanIdChargesRequest().chargeId(penaltyCharge.getResourceId()).dateFormat(DATETIME_PATTERN).locale("en")
-                        .amount(amount).dueDate(dueDate));
+        PostLoansLoanIdChargesResponse penaltyLoanChargeResult = addChargesForLoan(loanId, new PostLoansLoanIdChargesRequest()
+                .chargeId(penaltyCharge.getResourceId()).dateFormat(DATETIME_PATTERN).locale("en").amount(amount).dueDate(dueDate));
         assertNotNull(penaltyLoanChargeResult);
         assertNotNull(penaltyLoanChargeResult.getResourceId());
     }
@@ -1581,7 +1570,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
     private Long createLoanProductAccountingAccrualPeriodicWithInterest(boolean isMultiDisburse) {
         String name = Utils.uniqueRandomStringGenerator("LOAN_PRODUCT_", 6);
         String shortName = Utils.uniqueRandomStringGenerator("", 4);
-        Long resourceId = loanTransactionHelper.createLoanProduct(new PostLoanProductsRequest().name(name).shortName(shortName)
+        Long resourceId = loanHelper.createLoanProduct(new PostLoanProductsRequest().name(name).shortName(shortName)
                 .multiDisburseLoan(isMultiDisburse).maxTrancheCount(isMultiDisburse ? 2 : 1).interestType(isMultiDisburse ? 0 : 1)
                 .interestCalculationPeriodType(isMultiDisburse ? 0 : 1).disallowExpectedDisbursements(isMultiDisburse)
                 .description("Test loan description").currencyCode("USD").digitsAfterDecimal(2).daysInYearType(1).daysInMonthType(1)
@@ -1590,71 +1579,70 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
                 .numberOfRepayments(4).repaymentFrequencyType(2L).interestRatePerPeriod(2.0).repaymentEvery(1).minPrincipal(100.0)
                 .principal(1000.0).maxPrincipal(10000000.0).amortizationType(1).dateFormat("dd MMMM yyyy")
                 .transactionProcessingStrategyCode(DEFAULT_STRATEGY).accountingRule(3).enableAccrualActivityPosting(true)
-                .fundSourceAccountId(fundSource.getAccountID().longValue())//
-                .loanPortfolioAccountId(loansReceivableAccount.getAccountID().longValue())//
-                .transfersInSuspenseAccountId(suspenseAccount.getAccountID().longValue())//
-                .interestOnLoanAccountId(interestIncomeAccount.getAccountID().longValue())//
-                .incomeFromFeeAccountId(feeIncomeAccount.getAccountID().longValue())//
-                .incomeFromPenaltyAccountId(feeIncomeAccount.getAccountID().longValue())//
-                .incomeFromRecoveryAccountId(recoveriesAccount.getAccountID().longValue())//
-                .writeOffAccountId(writtenOffAccount.getAccountID().longValue())//
-                .overpaymentLiabilityAccountId(overpaymentAccount.getAccountID().longValue())//
-                .receivableInterestAccountId(interestReceivableAccount.getAccountID().longValue())//
-                .receivableFeeAccountId(feeReceivableAccount.getAccountID().longValue())//
-                .receivablePenaltyAccountId(penaltyReceivableAccount.getAccountID().longValue())//
-                .goodwillCreditAccountId(goodwillExpenseAccount.getAccountID().longValue())//
-                .incomeFromGoodwillCreditInterestAccountId(goodwillIncomeAccount.getAccountID().longValue())//
-                .incomeFromGoodwillCreditFeesAccountId(goodwillIncomeAccount.getAccountID().longValue())//
-                .incomeFromGoodwillCreditPenaltyAccountId(goodwillIncomeAccount.getAccountID().longValue())//
-                .incomeFromChargeOffInterestAccountId(interestIncomeChargeOffAccount.getAccountID().longValue())//
-                .incomeFromChargeOffFeesAccountId(feeChargeOffAccount.getAccountID().longValue())//
-                .chargeOffExpenseAccountId(chargeOffExpenseAccount.getAccountID().longValue())//
-                .chargeOffFraudExpenseAccountId(chargeOffFraudExpenseAccount.getAccountID().longValue())//
-                .incomeFromChargeOffPenaltyAccountId(penaltyChargeOffAccount.getAccountID().longValue())//
+                .fundSourceAccountId(getAccounts().getFundSource().getAccountID().longValue())//
+                .loanPortfolioAccountId(getAccounts().getLoansReceivableAccount().getAccountID().longValue())//
+                .transfersInSuspenseAccountId(getAccounts().getSuspenseAccount().getAccountID().longValue())//
+                .interestOnLoanAccountId(getAccounts().getInterestIncomeAccount().getAccountID().longValue())//
+                .incomeFromFeeAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())//
+                .incomeFromPenaltyAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())//
+                .incomeFromRecoveryAccountId(getAccounts().getRecoveriesAccount().getAccountID().longValue())//
+                .writeOffAccountId(getAccounts().getWrittenOffAccount().getAccountID().longValue())//
+                .overpaymentLiabilityAccountId(getAccounts().getOverpaymentAccount().getAccountID().longValue())//
+                .receivableInterestAccountId(getAccounts().getInterestReceivableAccount().getAccountID().longValue())//
+                .receivableFeeAccountId(getAccounts().getFeeReceivableAccount().getAccountID().longValue())//
+                .receivablePenaltyAccountId(getAccounts().getPenaltyReceivableAccount().getAccountID().longValue())//
+                .goodwillCreditAccountId(getAccounts().getGoodwillExpenseAccount().getAccountID().longValue())//
+                .incomeFromGoodwillCreditInterestAccountId(getAccounts().getGoodwillIncomeAccount().getAccountID().longValue())//
+                .incomeFromGoodwillCreditFeesAccountId(getAccounts().getGoodwillIncomeAccount().getAccountID().longValue())//
+                .incomeFromGoodwillCreditPenaltyAccountId(getAccounts().getGoodwillIncomeAccount().getAccountID().longValue())//
+                .incomeFromChargeOffInterestAccountId(getAccounts().getInterestIncomeChargeOffAccount().getAccountID().longValue())//
+                .incomeFromChargeOffFeesAccountId(getAccounts().getFeeChargeOffAccount().getAccountID().longValue())//
+                .chargeOffExpenseAccountId(getAccounts().getChargeOffExpenseAccount().getAccountID().longValue())//
+                .chargeOffFraudExpenseAccountId(getAccounts().getChargeOffFraudExpenseAccount().getAccountID().longValue())//
+                .incomeFromChargeOffPenaltyAccountId(getAccounts().getPenaltyChargeOffAccount().getAccountID().longValue())//
         ).getResourceId();
         LOG.info("Test Loan Product With Interest Id {} isMultiDisburse {} http://localhost:4200/#/products/loan-products/{1}/general",
                 resourceId, isMultiDisburse);
         return resourceId;
     }
 
-    private static Long applyForLoanApplication(final Long clientID, final Long loanProductID, BigDecimal principal,
+    private static Long applyForLoanApplication(final Long clientId, final Long loanProductID, BigDecimal principal,
             String applicationDisbursementDate) {
         final PostLoansRequest loanRequest = new PostLoansRequest() //
                 .locale("en_GB").dateFormat("dd MMMM yyyy").expectedDisbursementDate(applicationDisbursementDate)
                 .submittedOnDate(applicationDisbursementDate).interestCalculationPeriodType(0).repaymentFrequencyType(0).repaymentEvery(30)
                 .principal(BigDecimal.valueOf(1000)).loanTermFrequency(120).loanTermFrequencyType(0)
                 .transactionProcessingStrategyCode(DEFAULT_STRATEGY).interestType(0).loanType("individual").numberOfRepayments(4)
-                .amortizationType(1).interestRatePerPeriod(BigDecimal.valueOf(2)).clientId(clientID).productId(loanProductID);
-        Long loanId = loanTransactionHelper.applyLoan(loanRequest).getLoanId();
-        LOG.info("Test Loan http://localhost:4200/#/clients/{}/loans-accounts/{}/transactions", client.getClientId(), loanId);
+                .amortizationType(1).interestRatePerPeriod(BigDecimal.valueOf(2)).clientId(clientId).productId(loanProductID);
+        Long loanId = loanHelper.applyForLoan(loanRequest).getLoanId();
+        LOG.info("Test Loan http://localhost:4200/#/clients/{}/loans-accounts/{}/transactions", clientId, loanId);
         return loanId;
     }
 
-    private static Long applyForLoanApplicationWithInterest(final Long clientID, final Long loanProductID, BigDecimal principal,
+    private static Long applyForLoanApplicationWithInterest(final Long clientId, final Long loanProductID, BigDecimal principal,
             String applicationDisbursementDate) {
         final PostLoansRequest loanRequest = new PostLoansRequest() //
                 .loanTermFrequency(4).locale("en_GB").loanTermFrequencyType(2).numberOfRepayments(4).repaymentFrequencyType(2)
                 .interestRatePerPeriod(BigDecimal.valueOf(2)).repaymentEvery(1).principal(principal).amortizationType(1).interestType(1)
                 .interestCalculationPeriodType(1).dateFormat("dd MMMM yyyy").transactionProcessingStrategyCode(DEFAULT_STRATEGY)
                 .loanType("individual").expectedDisbursementDate(applicationDisbursementDate).submittedOnDate(applicationDisbursementDate)
-                .clientId(clientID).productId(loanProductID);
-        Long loanId = loanTransactionHelper.applyLoan(loanRequest).getLoanId();
-        LOG.info("Test Loan with Interest Id {2} http://localhost:4200/#/clients/{}/loans-accounts/{}/transactions", client.getClientId(),
-                loanId);
+                .clientId(clientId).productId(loanProductID);
+        Long loanId = loanHelper.applyForLoan(loanRequest).getLoanId();
+        LOG.info("Test Loan with Interest Id {2} http://localhost:4200/#/clients/{}/loans-accounts/{}/transactions", clientId, loanId);
         return loanId;
     }
 
-    private static Long applyForLoanApplicationWithInterest(final Long clientID, final Long loanProductID, BigDecimal principal,
+    private static Long applyForLoanApplicationWithInterest(final Long clientId, final Long loanProductID, BigDecimal principal,
             String applicationDisbursementDate, String applicationDisbursementDate2) {
         final PostLoansRequest loanRequest = new PostLoansRequest() //
                 .loanTermFrequency(4).locale("en_GB").loanTermFrequencyType(2).numberOfRepayments(4).repaymentFrequencyType(2)
                 .interestRatePerPeriod(BigDecimal.valueOf(2)).repaymentEvery(1).principal(principal).amortizationType(1).interestType(0)
                 .interestCalculationPeriodType(0).dateFormat("dd MMMM yyyy").transactionProcessingStrategyCode(DEFAULT_STRATEGY)
                 .loanType("individual").submittedOnDate(applicationDisbursementDate).expectedDisbursementDate(applicationDisbursementDate2)
-                .clientId(clientID).productId(loanProductID);
-        Long loanId = loanTransactionHelper.applyLoan(loanRequest).getLoanId();
+                .clientId(clientId).productId(loanProductID);
+        Long loanId = loanHelper.applyForLoan(loanRequest).getLoanId();
         LOG.info("Test Loan with Interest Id MultiDisbursed {2} http://localhost:4200/#/clients/{}/loans-accounts/{}/transactions",
-                client.getClientId(), loanId);
+                clientId, loanId);
         return loanId;
     }
 
@@ -1663,7 +1651,7 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
     }
 
     private Long createLoanProductAccountingAccrualPeriodicAdvancedPaymentAllocation(boolean isMultiDisburse) {
-        Long resourceId = loanTransactionHelper
+        Long resourceId = loanHelper
                 .createLoanProduct(loanProductAccountingAccrualAdvanvedPaymentAllocationAccrualActivity(isMultiDisburse)).getResourceId();
         LOG.info("Test Progressive Loan Product Id {} isMultiDisburse {} http://localhost:4200/#/products/loan-products/{1}/general",
                 resourceId, isMultiDisburse);
@@ -1684,61 +1672,59 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
                 .interestRateFrequencyType(1).dateFormat("dd MMMM yyyy")
                 .transactionProcessingStrategyCode(ADVANCED_PAYMENT_ALLOCATION_STRATEGY).paymentAllocation(List.of(defaultAllocation))
                 .accountingRule(3).isInterestRecalculationEnabled(false).enableAccrualActivityPosting(true)
-                .fundSourceAccountId(fundSource.getAccountID().longValue())//
-                .loanPortfolioAccountId(loansReceivableAccount.getAccountID().longValue())//
-                .transfersInSuspenseAccountId(suspenseAccount.getAccountID().longValue())//
-                .interestOnLoanAccountId(interestIncomeAccount.getAccountID().longValue())//
-                .incomeFromFeeAccountId(feeIncomeAccount.getAccountID().longValue())//
-                .incomeFromPenaltyAccountId(feeIncomeAccount.getAccountID().longValue())//
-                .incomeFromRecoveryAccountId(recoveriesAccount.getAccountID().longValue())//
-                .writeOffAccountId(writtenOffAccount.getAccountID().longValue())//
-                .overpaymentLiabilityAccountId(overpaymentAccount.getAccountID().longValue())//
-                .receivableInterestAccountId(interestReceivableAccount.getAccountID().longValue())//
-                .receivableFeeAccountId(feeReceivableAccount.getAccountID().longValue())//
-                .receivablePenaltyAccountId(penaltyReceivableAccount.getAccountID().longValue())//
-                .goodwillCreditAccountId(goodwillExpenseAccount.getAccountID().longValue())//
-                .incomeFromGoodwillCreditInterestAccountId(goodwillIncomeAccount.getAccountID().longValue())//
-                .incomeFromGoodwillCreditFeesAccountId(goodwillIncomeAccount.getAccountID().longValue())//
-                .incomeFromGoodwillCreditPenaltyAccountId(goodwillIncomeAccount.getAccountID().longValue())//
-                .incomeFromChargeOffInterestAccountId(interestIncomeChargeOffAccount.getAccountID().longValue())//
-                .incomeFromChargeOffFeesAccountId(feeChargeOffAccount.getAccountID().longValue())//
-                .chargeOffExpenseAccountId(chargeOffExpenseAccount.getAccountID().longValue())//
-                .chargeOffFraudExpenseAccountId(chargeOffFraudExpenseAccount.getAccountID().longValue())//
-                .incomeFromChargeOffPenaltyAccountId(penaltyChargeOffAccount.getAccountID().longValue());//
+                .fundSourceAccountId(getAccounts().getFundSource().getAccountID().longValue())//
+                .loanPortfolioAccountId(getAccounts().getLoansReceivableAccount().getAccountID().longValue())//
+                .transfersInSuspenseAccountId(getAccounts().getSuspenseAccount().getAccountID().longValue())//
+                .interestOnLoanAccountId(getAccounts().getInterestIncomeAccount().getAccountID().longValue())//
+                .incomeFromFeeAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())//
+                .incomeFromPenaltyAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())//
+                .incomeFromRecoveryAccountId(getAccounts().getRecoveriesAccount().getAccountID().longValue())//
+                .writeOffAccountId(getAccounts().getWrittenOffAccount().getAccountID().longValue())//
+                .overpaymentLiabilityAccountId(getAccounts().getOverpaymentAccount().getAccountID().longValue())//
+                .receivableInterestAccountId(getAccounts().getInterestReceivableAccount().getAccountID().longValue())//
+                .receivableFeeAccountId(getAccounts().getFeeReceivableAccount().getAccountID().longValue())//
+                .receivablePenaltyAccountId(getAccounts().getPenaltyReceivableAccount().getAccountID().longValue())//
+                .goodwillCreditAccountId(getAccounts().getGoodwillExpenseAccount().getAccountID().longValue())//
+                .incomeFromGoodwillCreditInterestAccountId(getAccounts().getGoodwillIncomeAccount().getAccountID().longValue())//
+                .incomeFromGoodwillCreditFeesAccountId(getAccounts().getGoodwillIncomeAccount().getAccountID().longValue())//
+                .incomeFromGoodwillCreditPenaltyAccountId(getAccounts().getGoodwillIncomeAccount().getAccountID().longValue())//
+                .incomeFromChargeOffInterestAccountId(getAccounts().getInterestIncomeChargeOffAccount().getAccountID().longValue())//
+                .incomeFromChargeOffFeesAccountId(getAccounts().getFeeChargeOffAccount().getAccountID().longValue())//
+                .chargeOffExpenseAccountId(getAccounts().getChargeOffExpenseAccount().getAccountID().longValue())//
+                .chargeOffFraudExpenseAccountId(getAccounts().getChargeOffFraudExpenseAccount().getAccountID().longValue())//
+                .incomeFromChargeOffPenaltyAccountId(getAccounts().getPenaltyChargeOffAccount().getAccountID().longValue());//
     }
 
     private Long createLoanProductAccountingAccrualPeriodicAdvancedPaymentAllocationInterestRecalculation(boolean isMultiDisburse) {
-        Long resourceId = loanTransactionHelper
-                .createLoanProduct(loanProductAccountingAccrualAdvanvedPaymentAllocationAccrualActivity(isMultiDisburse) //
-                        .interestRatePerPeriod(10.0) //
-                        .isInterestRecalculationEnabled(true)//
-                        .preClosureInterestCalculationStrategy(1) // TILL_PRE_CLOSE_DATE
-                        .rescheduleStrategyMethod(4) // ADJUST_LAST_UNPAID_PERIOD
-                        .interestRecalculationCompoundingMethod(0) // NONE
-                        .recalculationRestFrequencyType(2) // DAILY
-                        .recalculationRestFrequencyInterval(1)//
-                ).getResourceId();
+        Long resourceId = loanHelper.createLoanProduct(loanProductAccountingAccrualAdvanvedPaymentAllocationAccrualActivity(isMultiDisburse) //
+                .interestRatePerPeriod(10.0) //
+                .isInterestRecalculationEnabled(true)//
+                .preClosureInterestCalculationStrategy(1) // TILL_PRE_CLOSE_DATE
+                .rescheduleStrategyMethod(4) // ADJUST_LAST_UNPAID_PERIOD
+                .interestRecalculationCompoundingMethod(0) // NONE
+                .recalculationRestFrequencyType(2) // DAILY
+                .recalculationRestFrequencyInterval(1)//
+        ).getResourceId();
         LOG.info("Test Progressive Loan Product Id {} isMultiDisburse {} http://localhost:4200/#/products/loan-products/{1}/general",
                 resourceId, isMultiDisburse);
         return resourceId;
     }
 
-    private static Long applyForLoanApplicationAdvancedPaymentAllocation(final Long clientID, final Long loanProductID,
+    private static Long applyForLoanApplicationAdvancedPaymentAllocation(final Long clientId, final Long loanProductID,
             BigDecimal principal, String applicationDisbursementDate, BigDecimal interestRatePerPeriod) {
         final PostLoansRequest loanRequest = new PostLoansRequest() //
                 .loanTermFrequency(4).locale("en_GB").loanTermFrequencyType(2).numberOfRepayments(4).repaymentFrequencyType(2)
                 .repaymentEvery(1).principal(principal).amortizationType(1).interestType(0).interestRatePerPeriod(interestRatePerPeriod)
                 .interestCalculationPeriodType(1).dateFormat("dd MMMM yyyy")
                 .transactionProcessingStrategyCode(ADVANCED_PAYMENT_ALLOCATION_STRATEGY).loanType("individual")
-                .expectedDisbursementDate(applicationDisbursementDate).submittedOnDate(applicationDisbursementDate).clientId(clientID)
+                .expectedDisbursementDate(applicationDisbursementDate).submittedOnDate(applicationDisbursementDate).clientId(clientId)
                 .productId(loanProductID);
-        Long loanId = loanTransactionHelper.applyLoan(loanRequest).getLoanId();
-        LOG.info("Test Progressive Loan Id {2} http://localhost:4200/#/clients/{}/loans-accounts/{}/transactions", client.getClientId(),
-                loanId);
+        Long loanId = loanHelper.applyForLoan(loanRequest).getLoanId();
+        LOG.info("Test Progressive Loan Id {2} http://localhost:4200/#/clients/{}/loans-accounts/{}/transactions", clientId, loanId);
         return loanId;
     }
 
-    private static Long applyForLoanApplicationAdvancedPaymentAllocation(final Long clientID, final Long loanProductID,
+    private static Long applyForLoanApplicationAdvancedPaymentAllocation(final Long clientId, final Long loanProductID,
             BigDecimal principal, String applicationDisbursementDate, String applicationDisbursementDate2,
             BigDecimal interestRatePerPeriod) {
         final PostLoansRequest loanRequest = new PostLoansRequest() //
@@ -1746,11 +1732,11 @@ public class LoanTransactionAccrualActivityPostingTest extends BaseLoanIntegrati
                 .repaymentEvery(1).principal(principal).amortizationType(1).interestType(0).interestRatePerPeriod(interestRatePerPeriod)
                 .interestCalculationPeriodType(0).dateFormat("dd MMMM yyyy")
                 .transactionProcessingStrategyCode(ADVANCED_PAYMENT_ALLOCATION_STRATEGY).loanType("individual")
-                .submittedOnDate(applicationDisbursementDate).clientId(clientID).expectedDisbursementDate(applicationDisbursementDate2)
+                .submittedOnDate(applicationDisbursementDate).clientId(clientId).expectedDisbursementDate(applicationDisbursementDate2)
                 .productId(loanProductID);
-        Long loanId = loanTransactionHelper.applyLoan(loanRequest).getLoanId();
-        LOG.info("Test Progressive Loan Multi Disbursed Id {2} http://localhost:4200/#/clients/{}/loans-accounts/{}/transactions",
-                client.getClientId(), loanId);
+        Long loanId = loanHelper.applyForLoan(loanRequest).getLoanId();
+        LOG.info("Test Progressive Loan Multi Disbursed Id {2} http://localhost:4200/#/clients/{}/loans-accounts/{}/transactions", clientId,
+                loanId);
         return loanId;
     }
 

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanTransactionInterestPaymentWaiverTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanTransactionInterestPaymentWaiverTest.java
@@ -18,41 +18,33 @@
  */
 package org.apache.fineract.integrationtests;
 
-import static com.jayway.jsonpath.internal.path.PathCompiler.fail;
-import static org.apache.fineract.integrationtests.BaseLoanIntegrationTest.TransactionProcessingStrategyCode.ADVANCED_PAYMENT_ALLOCATION_STRATEGY;
+import static org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.TransactionProcessingStrategyCode.ADVANCED_PAYMENT_ALLOCATION_STRATEGY;
 import static org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder.DEFAULT_STRATEGY;
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
+import static org.apache.http.HttpStatus.SC_FORBIDDEN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.gson.Gson;
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import org.apache.fineract.batch.command.internal.CreateTransactionLoanCommandStrategy;
-import org.apache.fineract.batch.domain.BatchRequest;
-import org.apache.fineract.batch.domain.BatchResponse;
-import org.apache.fineract.client.models.AdvancedPaymentData;
-import org.apache.fineract.client.models.BusinessDateUpdateRequest;
-import org.apache.fineract.client.models.ChargeRequest;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
+import org.apache.fineract.client.models.BatchRequest;
+import org.apache.fineract.client.models.BatchResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdLoanChargeData;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdTransactionsTransactionIdResponse;
 import org.apache.fineract.client.models.PostChargesResponse;
 import org.apache.fineract.client.models.PostClientsResponse;
 import org.apache.fineract.client.models.PostLoanProductsRequest;
-import org.apache.fineract.client.models.PostLoanProductsResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdChargesRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdChargesResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdRequest;
@@ -61,65 +53,47 @@ import org.apache.fineract.client.models.PostLoansLoanIdTransactionsResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsTransactionIdRequest;
 import org.apache.fineract.client.models.PostLoansRequest;
 import org.apache.fineract.client.models.PostLoansResponse;
-import org.apache.fineract.integrationtests.common.BatchHelper;
-import org.apache.fineract.integrationtests.common.BusinessDateHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignBatchHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignCollateralHelper;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.AmortizationType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.DaysInMonthType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.DaysInYearCustomStrategy;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.DaysInYearType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestCalculationPeriodType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.RepaymentFrequencyType;
 import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.CollateralManagementHelper;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.common.accounting.Account;
-import org.apache.fineract.integrationtests.common.accounting.AccountHelper;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
 import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.apache.fineract.integrationtests.common.system.CodeHelper;
-import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
-import org.apache.fineract.portfolio.charge.domain.ChargePaymentMode;
-import org.apache.fineract.portfolio.charge.domain.ChargeTimeType;
-import org.apache.fineract.portfolio.loanaccount.domain.transactionprocessor.impl.AdvancedPaymentScheduleTransactionProcessor;
-import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleProcessingType;
-import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleType;
-import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegrationTest {
+public class LoanTransactionInterestPaymentWaiverTest extends FeignLoanTestBase {
 
-    private static final Logger LOG = LoggerFactory.getLogger(AdvancedPaymentAllocationLoanRepaymentScheduleTest.class);
-    private static final String DATETIME_PATTERN = "dd MMMM yyyy";
-    private static ResponseSpecification responseSpec;
-    private static RequestSpecification requestSpec;
-    private static BusinessDateHelper businessDateHelper;
-    private static LoanTransactionHelper loanTransactionHelper;
-    private static AccountHelper accountHelper;
-    private static Integer commonLoanProductId;
-    private static PostClientsResponse client;
-    private static ChargesHelper chargesHelper;
+    private static final Logger LOG = LoggerFactory.getLogger(LoanTransactionInterestPaymentWaiverTest.class);
     private static final Gson GSON = new Gson();
+    private static final String HORIZONTAL = "HORIZONTAL";
+    private static final String VERTICAL = "VERTICAL";
+    private static Long commonLoanProductId;
+    private static PostClientsResponse client;
+
+    private final FeignBatchHelper batchHelper = new FeignBatchHelper(FineractFeignClientHelper.getFineractFeignClient());
+    private final FeignCollateralHelper collateralHelper = new FeignCollateralHelper(FineractFeignClientHelper.getFineractFeignClient());
 
     @BeforeAll
-    public static void setup() {
-        Utils.initializeRESTAssured();
-        requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        requestSpec.header("Fineract-Platform-TenantId", "default");
-        responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-        businessDateHelper = new BusinessDateHelper();
-        accountHelper = new AccountHelper(requestSpec, responseSpec);
-        ClientHelper clientHelper = new ClientHelper(requestSpec, responseSpec);
-        chargesHelper = new ChargesHelper();
-
-        final Account assetAccount = accountHelper.createAssetAccount();
-        final Account incomeAccount = accountHelper.createIncomeAccount();
-        final Account expenseAccount = accountHelper.createExpenseAccount();
-        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-
-        commonLoanProductId = createLoanProduct("500", "15", "4", true, "25", true, LoanScheduleType.PROGRESSIVE,
-                LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
+    public static void setupTestData() {
         client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+    }
+
+    private Long commonLoanProductId() {
+        if (commonLoanProductId == null) {
+            commonLoanProductId = createLoanProduct(500.0, 15, 4, true, "25", true, HORIZONTAL);
+        }
+        return commonLoanProductId;
     }
 
     @Test
@@ -132,12 +106,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
 
             LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-            PostLoanProductsResponse loanProductResponse = loanProductHelper
-                    .createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
-                            .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()));
+            Long loanProductId = createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
+                    .loanScheduleType("PROGRESSIVE"));
 
-            Long loanId = applyAndApproveLoanProgressiveAdvancedPaymentAllocationStrategyMonthlyRepayments(clientId,
-                    loanProductResponse.getResourceId(), numberOfRepayments, loanDisbursementDate, amount, null);
+            Long loanId = applyAndApproveLoanProgressiveAdvancedPaymentAllocationStrategyMonthlyRepayments(clientId, loanProductId,
+                    numberOfRepayments, loanDisbursementDate, amount, null);
 
             verifyRepaymentSchedule(loanId, //
                     installment(1000.0, null, "01 January 2023"), //
@@ -147,8 +120,8 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     installment(250.0, false, "01 May 2023") //
             );
 
-            loanTransactionHelper.disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2023")
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2023").dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
             verifyTransactions(loanId, //
                     transaction(1000.0, "Disbursement", "01 January 2023", 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
@@ -191,12 +164,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
 
             LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-            PostLoanProductsResponse loanProductResponse = loanProductHelper
-                    .createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
-                            .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()));
+            Long loanProductId = createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
+                    .loanScheduleType("PROGRESSIVE"));
 
-            Long loanId = applyAndApproveLoanProgressiveAdvancedPaymentAllocationStrategyMonthlyRepayments(clientId,
-                    loanProductResponse.getResourceId(), numberOfRepayments, loanDisbursementDate, amount, null);
+            Long loanId = applyAndApproveLoanProgressiveAdvancedPaymentAllocationStrategyMonthlyRepayments(clientId, loanProductId,
+                    numberOfRepayments, loanDisbursementDate, amount, null);
 
             verifyRepaymentSchedule(loanId, //
                     installment(1000.0, null, "01 January 2023"), //
@@ -206,14 +178,22 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     installment(250.0, false, "01 May 2023") //
             );
 
+            // loan should be active - LoanDownPaymentTransactionValidator raises a data-validation error here
             // loan should be active
-            assertThrows(Exception.class, () -> addInterestPaymentWaiverForLoan(loanId, 250.0, "2 January 2023"));
+            CallFailedRuntimeException notActive = assertThrows(CallFailedRuntimeException.class,
+                    () -> addInterestPaymentWaiverForLoan(loanId, 250.0, "2 January 2023"));
+            assertEquals(SC_BAD_REQUEST, notActive.getStatus());
+            assertTrue(notActive.getResponseBody().contains("error.msg.loan.must.be.active.fully.paid.or.overpaid"));
 
-            loanTransactionHelper.disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2023")
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2023").dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
+            // transaction cant be made before disbursement - InvalidLoanStateTransitionException maps to 403
             // transaction cant be made before disbursement
-            assertThrows(Exception.class, () -> addInterestPaymentWaiverForLoan(loanId, 250.0, "30 December 2022"));
+            CallFailedRuntimeException beforeDisbursement = assertThrows(CallFailedRuntimeException.class,
+                    () -> addInterestPaymentWaiverForLoan(loanId, 250.0, "30 December 2022"));
+            assertEquals(SC_FORBIDDEN, beforeDisbursement.getStatus());
+            assertTrue(beforeDisbursement.getResponseBody().contains("cannot.be.before.disbursement.date"));
         });
     }
 
@@ -227,13 +207,12 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
 
             LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-            PostLoanProductsResponse loanProductResponse = loanProductHelper
-                    .createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
-                            .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()));
+            Long loanProductId = createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
+                    .loanScheduleType("PROGRESSIVE"));
 
             String loanExternalIdStr = UUID.randomUUID().toString();
-            Long loanId = applyAndApproveLoanProgressiveAdvancedPaymentAllocationStrategyMonthlyRepayments(clientId,
-                    loanProductResponse.getResourceId(), numberOfRepayments, loanDisbursementDate, amount, loanExternalIdStr);
+            Long loanId = applyAndApproveLoanProgressiveAdvancedPaymentAllocationStrategyMonthlyRepayments(clientId, loanProductId,
+                    numberOfRepayments, loanDisbursementDate, amount, loanExternalIdStr);
 
             verifyRepaymentSchedule(loanId, //
                     installment(1000.0, null, "01 January 2023"), //
@@ -243,26 +222,24 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     installment(250.0, false, "01 May 2023") //
             );
 
-            loanTransactionHelper.disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2023")
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2023").dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
             verifyTransactions(loanId, //
                     transaction(1000.0, "Disbursement", "01 January 2023", 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
 
             // Check whether the provided external id was retrieved
             String transactionExternalIdStr = UUID.randomUUID().toString();
-            final PostLoansLoanIdTransactionsResponse interestPaymentWaiverResultWithExternalId = loanTransactionHelper
-                    .makeGoodwillCredit(loanExternalIdStr, new PostLoansLoanIdTransactionsRequest().dateFormat("dd MMMM yyyy")
-                            .transactionDate("03 January 2023").locale("en").transactionAmount(5.0).externalId(transactionExternalIdStr));
+            final PostLoansLoanIdTransactionsResponse interestPaymentWaiverResultWithExternalId = makeGoodwillCredit(loanExternalIdStr,
+                    new PostLoansLoanIdTransactionsRequest().dateFormat("dd MMMM yyyy").transactionDate("03 January 2023").locale("en")
+                            .transactionAmount(5.0).externalId(transactionExternalIdStr));
             assertEquals(transactionExternalIdStr, interestPaymentWaiverResultWithExternalId.getResourceExternalId());
 
-            GetLoansLoanIdTransactionsTransactionIdResponse response = loanTransactionHelper.getLoanTransactionDetails(loanId,
-                    transactionExternalIdStr);
+            GetLoansLoanIdTransactionsTransactionIdResponse response = getLoanTransactionDetails(loanId, transactionExternalIdStr);
             assertEquals(transactionExternalIdStr, response.getExternalId());
-            response = loanTransactionHelper.getLoanTransactionDetails(loanExternalIdStr,
-                    interestPaymentWaiverResultWithExternalId.getResourceId());
+            response = getLoanTransactionDetails(loanExternalIdStr, interestPaymentWaiverResultWithExternalId.getResourceId());
             assertEquals(transactionExternalIdStr, response.getExternalId());
-            response = loanTransactionHelper.getLoanTransactionDetails(loanExternalIdStr, transactionExternalIdStr);
+            response = getLoanTransactionDetails(loanExternalIdStr, transactionExternalIdStr);
             assertEquals(transactionExternalIdStr, response.getExternalId());
         });
     }
@@ -277,12 +254,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
 
             LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-            PostLoanProductsResponse loanProductResponse = loanProductHelper
-                    .createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
-                            .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()));
+            Long loanProductId = createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
+                    .loanScheduleType("PROGRESSIVE"));
 
-            Long loanId = applyAndApproveLoanProgressiveAdvancedPaymentAllocationStrategyMonthlyRepayments(clientId,
-                    loanProductResponse.getResourceId(), numberOfRepayments, loanDisbursementDate, amount, null);
+            Long loanId = applyAndApproveLoanProgressiveAdvancedPaymentAllocationStrategyMonthlyRepayments(clientId, loanProductId,
+                    numberOfRepayments, loanDisbursementDate, amount, null);
 
             verifyRepaymentSchedule(loanId, //
                     installment(1000.0, null, "01 January 2023"), //
@@ -292,8 +268,8 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     installment(250.0, false, "01 May 2023") //
             );
 
-            loanTransactionHelper.disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2023")
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2023").dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
             verifyTransactions(loanId, //
                     transaction(1000.0, "Disbursement", "01 January 2023", 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
@@ -314,7 +290,7 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     installment(250.0, false, "01 May 2023") //
             );
 
-            loanTransactionHelper.reverseRepayment(Math.toIntExact(loanId), Math.toIntExact(repayment1TransactionId), "2 January 2023");
+            reverseRepayment(loanId, repayment1TransactionId, "2 January 2023");
 
             verifyTransactions(loanId, //
                     transaction(1000.0, "Disbursement", "01 January 2023", 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
@@ -341,12 +317,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
 
             LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-            PostLoanProductsResponse loanProductResponse = loanProductHelper
-                    .createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
-                            .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()));
+            Long loanProductId = createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
+                    .loanScheduleType("PROGRESSIVE"));
 
-            Long loanId = applyAndApproveLoanProgressiveAdvancedPaymentAllocationStrategyMonthlyRepayments(clientId,
-                    loanProductResponse.getResourceId(), numberOfRepayments, loanDisbursementDate, amount, null);
+            Long loanId = applyAndApproveLoanProgressiveAdvancedPaymentAllocationStrategyMonthlyRepayments(clientId, loanProductId,
+                    numberOfRepayments, loanDisbursementDate, amount, null);
 
             verifyRepaymentSchedule(loanId, //
                     installment(1000.0, null, "01 January 2023"), //
@@ -356,8 +331,8 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     installment(250.0, false, "01 May 2023") //
             );
 
-            loanTransactionHelper.disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2023")
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2023").dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
             verifyTransactions(loanId, //
                     transaction(1000.0, "Disbursement", "01 January 2023", 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
@@ -402,14 +377,14 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
         PostLoansRequest applicationRequest = applyLoanRequestProgressiveAdvancedPaymentAllocationStrategyMonthlyRepayments(clientId,
                 loanProductId, externalLoanId, amount, numberOfRepayments, loanDisbursementDate);
 
-        PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+        PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
         Long loanId = loanResponse.getLoanId();
 
         assertNotNull(loanId);
 
-        loanTransactionHelper.approveLoan(loanId, new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(amount))
-                .dateFormat(DATETIME_PATTERN).approvedOnDate(loanDisbursementDate).locale("en"));
+        approveLoan(loanId, new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(amount)).dateFormat(DATETIME_PATTERN)
+                .approvedOnDate(loanDisbursementDate).locale("en"));
 
         return loanId;
     }
@@ -418,9 +393,8 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             String loanExternalId, double amount, Integer numberOfRepayments, String loanDisbursementDate) {
         PostLoansRequest postLoansRequest = new PostLoansRequest().clientId(clientId).productId(loanId)
                 .submittedOnDate(loanDisbursementDate).expectedDisbursementDate(loanDisbursementDate).dateFormat(DATETIME_PATTERN)
-                .locale("en").loanType("individual")
-                .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).amortizationType(1)
-                .interestRatePerPeriod(BigDecimal.ZERO).interestCalculationPeriodType(1).interestType(0)
+                .locale("en").loanType("individual").transactionProcessingStrategyCode(ADVANCED_PAYMENT_ALLOCATION_STRATEGY)
+                .amortizationType(1).interestRatePerPeriod(BigDecimal.ZERO).interestCalculationPeriodType(1).interestType(0)
                 .maxOutstandingLoanBalance(BigDecimal.valueOf(amount)).principal(BigDecimal.valueOf(amount))
                 .loanTermFrequencyType(RepaymentFrequencyType.MONTHS).loanTermFrequency(numberOfRepayments)
                 .repaymentFrequencyType(RepaymentFrequencyType.MONTHS).repaymentEvery(1).numberOfRepayments(numberOfRepayments);
@@ -439,18 +413,16 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
     public void testInterestPaymentWaiverUC3() {
         runAt("15 February 2023", () -> {
 
-            final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
+            final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId(),
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -459,10 +431,10 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             validateLoanTransaction(loanDetails, 1, 125.0, 125.0, 0.0, 375.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeInterestPaymentWaiver(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(150.0));
+            makeInterestPaymentWaiver(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("16 January 2023").locale("en").transactionAmount(150.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 225.0, 275.0, 225.0, 275.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -471,10 +443,10 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             validateLoanTransaction(loanDetails, 2, 150.0, 150.0, 0.0, 225.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(125.0));
+            makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("31 January 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 100.0, 400.0, 100.0, 400.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -483,10 +455,10 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             validateLoanTransaction(loanDetails, 3, 125.0, 125.0, 0.0, 100.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("15 February 2023").locale("en").transactionAmount(125.0));
+            makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("15 February 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, 25.0);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -507,18 +479,16 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
     public void testInterestPaymentWaiverUC12() {
         runAt("15 February 2023", () -> {
 
-            final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
+            final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId(),
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -527,10 +497,10 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             validateLoanTransaction(loanDetails, 1, 125.0, 125.0, 0.0, 375.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeInterestPaymentWaiver(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("08 January 2023").locale("en").transactionAmount(200.0));
+            makeInterestPaymentWaiver(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("08 January 2023").locale("en").transactionAmount(200.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 175.0, 325.0, 175.0, 325.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -539,10 +509,10 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             validateLoanTransaction(loanDetails, 2, 200.0, 200.0, 0.0, 175.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(125.0));
+            makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("16 January 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 50.0, 450.0, 50.0, 450.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -551,10 +521,10 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             validateLoanTransaction(loanDetails, 3, 125.0, 125.0, 0.0, 50.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(50.0));
+            makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("31 January 2023").locale("en").transactionAmount(50.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -575,18 +545,16 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
     public void testInterestPaymentWaiverUC13() {
         runAt("15 February 2023", () -> {
 
-            final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
+            final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId(),
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -595,10 +563,10 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             validateLoanTransaction(loanDetails, 1, 125.0, 125.0, 0.0, 375.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeInterestPaymentWaiver(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("08 January 2023").locale("en").transactionAmount(200.0));
+            makeInterestPaymentWaiver(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("08 January 2023").locale("en").transactionAmount(200.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 175.0, 325.0, 175.0, 325.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -607,10 +575,10 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             validateLoanTransaction(loanDetails, 2, 200.0, 200.0, 0.0, 175.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(125.0));
+            makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("16 January 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 50.0, 450.0, 50.0, 450.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -619,10 +587,10 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             validateLoanTransaction(loanDetails, 3, 125.0, 125.0, 0.0, 50.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(50.0));
+            makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("31 January 2023").locale("en").transactionAmount(50.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -644,23 +612,21 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
     public void testInterestPaymentWaiverUC15() {
         runAt("15 February 2023", () -> {
 
-            final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
+            final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId(),
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
-            loanTransactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(1).getId(),
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanResponse.getLoanId());
+            reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(1).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("01 January 2023")
                             .transactionAmount(0.0).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 500.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -668,10 +634,10 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             validateRepaymentPeriod(loanDetails, 4, 125.0, 0.0, 125.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeInterestPaymentWaiver(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("15 January 2023").locale("en").transactionAmount(200.0));
+            makeInterestPaymentWaiver(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("15 January 2023").locale("en").transactionAmount(200.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 300.0, 200.0, 300.0, 200.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -680,9 +646,9 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             validateLoanTransaction(loanDetails, 2, 200.0, 200.0, 0.0, 300.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(125.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("16 January 2023").locale("en").transactionAmount(125.0));
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 175.0, 325.0, 175.0, 325.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -691,9 +657,9 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             validateLoanTransaction(loanDetails, 3, 125.0, 125.0, 0.0, 175.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(125.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("31 January 2023").locale("en").transactionAmount(125.0));
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 50.0, 450.0, 50.0, 450.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -702,9 +668,9 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             validateLoanTransaction(loanDetails, 4, 125.0, 125.0, 0.0, 50.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("15 February 2023").locale("en").transactionAmount(50.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("15 February 2023").locale("en").transactionAmount(50.0));
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -726,18 +692,16 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
     public void testInterestPaymentWaiverUC17c() {
         runAt("15 February 2023", () -> {
 
-            final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
+            final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId(),
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -746,10 +710,10 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             validateLoanTransaction(loanDetails, 1, 125.0, 125.0, 0.0, 375.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeInterestPaymentWaiver(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("08 January 2023").locale("en").transactionAmount(500.0));
+            makeInterestPaymentWaiver(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("08 January 2023").locale("en").transactionAmount(500.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, 125.0);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -758,9 +722,9 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             validateLoanTransaction(loanDetails, 2, 500.0, 375.0, 125.0, 0.0);
             assertTrue(loanDetails.getStatus().getOverpaid());
 
-            loanTransactionHelper.makeCreditBalanceRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("09 January 2023").locale("en").transactionAmount(125.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            makeCreditBalanceRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("09 January 2023").locale("en").transactionAmount(125.0));
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -775,8 +739,6 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
      * Tests successful run of batch Interest Payment Waiver for loans. 200(OK) status is returned for successful
      * responses. It first creates a new loan, approves and disburses the loan. Then a Interest Payment Waiver request
      * is made
-     *
-     * @see CreateTransactionLoanCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusForBatchInterestPaymentWaiver() {
@@ -792,16 +754,15 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                 .withInterestTypeAsDecliningBalance() //
                 .currencyDetails("0", "100").build(null);
 
-        final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(requestSpec, responseSpec, clientID);
+        final Long clientId = createClient();
+        assertNotNull(clientId);
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(requestSpec, responseSpec);
-        Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(requestSpec, responseSpec, clientID.toString(),
-                collateralId);
-        Assertions.assertNotNull(clientCollateralId);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
+        assertNotNull(collateralId);
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientId, collateralId).getResourceId();
+        assertNotNull(clientCollateralId);
 
-        final Integer productId = new LoanTransactionHelper(requestSpec, responseSpec).getLoanProductId(loanProductJSON);
+        final Integer productId = getLoanProductId(loanProductJSON);
 
         final Long createActiveClientRequestId = 4730L;
         final Long applyLoanRequestId = createActiveClientRequestId + 1;
@@ -809,21 +770,44 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
         final Long disburseLoanRequestId = approveLoanRequestId + 1;
         final Long interestPaymentWaiverRequestId = disburseLoanRequestId + 1;
 
+        final String applyAndApproveDate = dateTimeFormatter.format(LocalDate.now(Utils.getZoneIdOfTenant()).minusDays(10));
+        final String disburseDate = dateTimeFormatter.format(LocalDate.now(Utils.getZoneIdOfTenant()).minusDays(8));
+        final String waiverDate = dateTimeFormatter.format(LocalDate.now(Utils.getZoneIdOfTenant()));
+
         // Create a createClient Request
-        final BatchRequest br1 = BatchHelper.createActiveClientRequest(createActiveClientRequestId, "");
+        final BatchRequest br1 = new BatchRequest().requestId(createActiveClientRequestId).relativeUrl("v1/clients").method("POST")
+                .body("{ \"officeId\": 1, \"legalFormId\":1, \"firstname\": \"Petra\", \"lastname\": \"Yton\"," + "\"externalId\": \"\","
+                        + "  \"dateFormat\": \"dd MMMM yyyy\", \"locale\": \"en\","
+                        + "\"active\": true, \"activationDate\": \"04 March 2010\", \"submittedOnDate\": \"04 March 2010\"}");
 
         // Create a ApplyLoan Request
-        final BatchRequest br2 = BatchHelper.applyLoanRequest(applyLoanRequestId, createActiveClientRequestId, productId,
-                clientCollateralId);
+        final BatchRequest br2 = new BatchRequest().requestId(applyLoanRequestId).relativeUrl("v1/loans").method("POST")
+                .reference(createActiveClientRequestId)
+                .body("{\"dateFormat\": \"dd MMMM yyyy\", \"locale\": \"en_GB\", \"clientId\": \"$.clientId\"," + "\"productId\": "
+                        + productId + ", \"principal\": \"10,000.00\", \"loanTermFrequency\": 10,"
+                        + "\"loanTermFrequencyType\": 2, \"loanType\": \"individual\", \"numberOfRepayments\": 10,"
+                        + "\"repaymentEvery\": 1, \"repaymentFrequencyType\": 2, \"interestRatePerPeriod\": 10,"
+                        + "\"amortizationType\": 1, \"interestType\": 0, \"interestCalculationPeriodType\": 1,"
+                        + "\"transactionProcessingStrategyCode\": \"mifos-standard-strategy\", \"expectedDisbursementDate\": \""
+                        + applyAndApproveDate + "\"," + "\"collateral\": [{\"clientCollateralId\": \"" + clientCollateralId
+                        + "\", \"quantity\": \"1\"}]," + "\"submittedOnDate\": \"" + applyAndApproveDate + "\"}");
 
         // Create a approveLoan Request
-        final BatchRequest br3 = BatchHelper.approveLoanRequest(approveLoanRequestId, applyLoanRequestId);
+        final BatchRequest br3 = new BatchRequest().requestId(approveLoanRequestId).relativeUrl("v1/loans/$.loanId?command=approve")
+                .reference(applyLoanRequestId).method("POST")
+                .body("{\"locale\": \"en\", \"dateFormat\": \"dd MMMM yyyy\", \"approvedOnDate\": \"" + applyAndApproveDate + "\","
+                        + "\"note\": \"Loan approval note\", \"expectedDisbursementDate\": \"" + applyAndApproveDate + "\"}");
 
         // Create a disburseLoan Request
-        final BatchRequest br4 = BatchHelper.disburseLoanRequest(disburseLoanRequestId, approveLoanRequestId);
+        final BatchRequest br4 = new BatchRequest().requestId(disburseLoanRequestId).relativeUrl("v1/loans/$.loanId?command=disburse")
+                .reference(approveLoanRequestId).method("POST")
+                .body("{\"locale\": \"en\", \"dateFormat\": \"dd MMMM yyyy\", \"actualDisbursementDate\": \"" + disburseDate + "\"}");
 
         // Create a Interest Payment Waiver request.
-        final BatchRequest br5 = BatchHelper.interestPaymentWaiverRequest(interestPaymentWaiverRequestId, disburseLoanRequestId, "500");
+        final BatchRequest br5 = new BatchRequest().requestId(interestPaymentWaiverRequestId)
+                .relativeUrl("v1/loans/$.loanId/transactions?command=interestPaymentWaiver").reference(disburseLoanRequestId).method("POST")
+                .body("{\"locale\": \"en\", \"dateFormat\": \"dd MMMM yyyy\", " + "\"transactionDate\": \"" + waiverDate
+                        + "\",  \"transactionAmount\": 500, \"note\":null}");
 
         final List<BatchRequest> batchRequests = new ArrayList<>();
 
@@ -833,12 +817,9 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
         batchRequests.add(br4);
         batchRequests.add(br5);
 
-        final String batchRequestStr = BatchHelper.toJsonString(batchRequests);
+        final List<BatchResponse> response = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        final List<BatchResponse> response = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(requestSpec, responseSpec,
-                batchRequestStr);
-
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(4).getStatusCode(), "Verify Status Code 200 for Goodwill credit");
+        assertEquals(200, response.get(4).getStatusCode(), "Verify Status Code 200 for interest payment waiver");
     }
 
     // PW UC112: Advanced payment allocation, horizontal repayment processing
@@ -854,24 +835,17 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
     public void testInterestPaymentWaiverUC112() {
         runAt("01 September 2023", () -> {
 
-            final Account assetAccount = accountHelper.createAssetAccount();
-            final Account incomeAccount = accountHelper.createIncomeAccount();
-            final Account expenseAccount = accountHelper.createExpenseAccount();
-            final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
-                    LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
+            Long localLoanProductId = createLoanProduct(1000.0, 15, 3, true, "25", false, HORIZONTAL);
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId,
                     BigDecimal.valueOf(1000.0), 45, 15, 3, BigDecimal.ZERO, "01 September 2023", "01 September 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 September 2023").locale("en"));
+            approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 September 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 September 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 September 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1000.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -880,12 +854,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             assertTrue(loanDetails.getStatus().getActive());
 
             // Add Charge Penalty
-            Integer penalty = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "20", true));
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "17 October 2023", "20"));
+            Long penalty = chargesHelper.createLoanSpecifiedDueDatePenalty(20.0).getResourceId();
+            addChargesForLoan(loanResponse.getLoanId(), new PostLoansLoanIdChargesRequest().chargeId(penalty).amount(20.0)
+                    .dueDate("17 October 2023").dateFormat(DATETIME_PATTERN).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1020.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -895,9 +868,9 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("01 September 2023").locale("en").transactionAmount(250.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("01 September 2023").locale("en").transactionAmount(250.0));
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 770.0, 250.0, 750.0, 250.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -907,12 +880,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            businessDateHelper.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("2023.09.16").dateFormat("yyyy.MM.dd").locale("en"));
+            updateBusinessDate("16 September 2023");
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("16 September 2023").locale("en").transactionAmount(250.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("16 September 2023").locale("en").transactionAmount(250.0));
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 520.0, 500.0, 500.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 250.0, 0.0, 0.0, 0.0);
@@ -922,14 +894,14 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "17 September 2023", "20"));
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "16 October 2023", "20"));
+            addChargesForLoan(loanResponse.getLoanId(), new PostLoansLoanIdChargesRequest().chargeId(penalty).amount(20.0)
+                    .dueDate("17 September 2023").dateFormat(DATETIME_PATTERN).locale("en"));
+            addChargesForLoan(loanResponse.getLoanId(), new PostLoansLoanIdChargesRequest().chargeId(penalty).amount(20.0)
+                    .dueDate("16 October 2023").dateFormat(DATETIME_PATTERN).locale("en"));
 
-            loanTransactionHelper.makeInterestPaymentWaiver(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("16 September 2023").locale("en").transactionAmount(50.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            makeInterestPaymentWaiver(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("16 September 2023").locale("en").transactionAmount(50.0));
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 510.0, 550.0, 490.0, 510.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 250.0, 0.0, 0.0, 0.0);
@@ -960,25 +932,17 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
     public void testInterestPaymentWaiverUC113() {
         runAt("01 September 2023", () -> {
 
-            final Account assetAccount = accountHelper.createAssetAccount();
-            final Account incomeAccount = accountHelper.createIncomeAccount();
-            final Account expenseAccount = accountHelper.createExpenseAccount();
-            final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
-                    LoanScheduleProcessingType.VERTICAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
+            Long localLoanProductId = createLoanProduct(1000.0, 15, 3, true, "25", false, VERTICAL);
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId,
-                    BigDecimal.valueOf(1000.0), 45, 15, 3, BigDecimal.ZERO, "01 September 2023", "01 September 2023",
-                    LoanScheduleProcessingType.VERTICAL);
+                    BigDecimal.valueOf(1000.0), 45, 15, 3, BigDecimal.ZERO, "01 September 2023", "01 September 2023", VERTICAL);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 September 2023").locale("en"));
+            approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 September 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 September 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 September 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1000.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -987,12 +951,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             assertTrue(loanDetails.getStatus().getActive());
 
             // Add Charge Penalty
-            Integer penalty = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "20", true));
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "17 October 2023", "20"));
+            Long penalty = chargesHelper.createLoanSpecifiedDueDatePenalty(20.0).getResourceId();
+            addChargesForLoan(loanResponse.getLoanId(), new PostLoansLoanIdChargesRequest().chargeId(penalty).amount(20.0)
+                    .dueDate("17 October 2023").dateFormat(DATETIME_PATTERN).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1020.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -1002,9 +965,9 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("01 September 2023").locale("en").transactionAmount(250.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("01 September 2023").locale("en").transactionAmount(250.0));
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 770.0, 250.0, 750.0, 250.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -1014,12 +977,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            businessDateHelper.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("2023.09.16").dateFormat("yyyy.MM.dd").locale("en"));
+            updateBusinessDate("16 September 2023");
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("16 September 2023").locale("en").transactionAmount(250.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("16 September 2023").locale("en").transactionAmount(250.0));
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 520.0, 500.0, 500.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 250.0, 0.0, 0.0, 0.0);
@@ -1029,14 +991,14 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "17 September 2023", "20"));
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "16 October 2023", "20"));
+            addChargesForLoan(loanResponse.getLoanId(), new PostLoansLoanIdChargesRequest().chargeId(penalty).amount(20.0)
+                    .dueDate("17 September 2023").dateFormat(DATETIME_PATTERN).locale("en"));
+            addChargesForLoan(loanResponse.getLoanId(), new PostLoansLoanIdChargesRequest().chargeId(penalty).amount(20.0)
+                    .dueDate("16 October 2023").dateFormat(DATETIME_PATTERN).locale("en"));
 
-            loanTransactionHelper.makeInterestPaymentWaiver(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("16 September 2023").locale("en").transactionAmount(50.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            makeInterestPaymentWaiver(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("16 September 2023").locale("en").transactionAmount(50.0));
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 510.0, 550.0, 500.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 250.0, 0.0, 0.0, 0.0);
@@ -1066,6 +1028,14 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
     public void testAccounting() {
         runAt("15 May 2023", () -> {
 
+            final Account fundSource = getAccounts().getFundSource();
+            final Account loansReceivableAccount = getAccounts().getLoansReceivableAccount();
+            final Account interestReceivableAccount = getAccounts().getInterestReceivableAccount();
+            final Account feeReceivableAccount = getAccounts().getFeeReceivableAccount();
+            final Account penaltyReceivableAccount = getAccounts().getPenaltyReceivableAccount();
+            final Account interestIncomeAccount = getAccounts().getInterestIncomeAccount();
+            final Account overpaymentAccount = getAccounts().getOverpaymentAccount();
+
             final String disbursementDay = "01 January 2023";
             final String repaymentPeriod1DueDate = "01 February 2023";
             final String repaymentPeriod2DueDate = "01 March 2023";
@@ -1076,18 +1046,18 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             final Long loanId = applyForLoanApplicationWithInterest(client.getClientId(), localLoanProductId, BigDecimal.valueOf(40000),
                     disbursementDay);
 
-            loanTransactionHelper.approveLoan(loanId, new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
-                    .dateFormat(DATETIME_PATTERN).approvedOnDate(disbursementDay).locale("en"));
+            approveLoan(loanId, new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
+                    .approvedOnDate(disbursementDay).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
             chargePenalty(loanId, 30.0, repaymentPeriod1DueDate);
             chargePenalty(loanId, 50.0, repaymentPeriod2DueDate);
             chargeFee(loanId, 40.0, repaymentPeriod1DueDate);
             chargeFee(loanId, 60.0, repaymentPeriod3DueDate);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 1260.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 250.0, 0.0, 250.0, 40.0, 0.0, 40.0, 30.0, 0.0, 30.0, 20.0,
                     0.0, 20.0, 0.0, 0.0);
@@ -1100,11 +1070,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             assertTrue(loanDetails.getStatus().getActive());
 
             // transaction 1
-            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr1 = loanTransactionHelper.makeInterestPaymentWaiver(loanId,
+            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr1 = makeInterestPaymentWaiver(loanId,
                     new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate(repaymentPeriod1DueDate)
                             .locale("en").transactionAmount(340.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 920.0, 340.0, 750.0, 250.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 250.0, 250.0, 0.0, 40.0, 40.0, 0.0, 30.0, 30.0, 0.0, 20.0,
                     20.0, 0.0, 0.0, 0.0);
@@ -1131,11 +1101,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     journalEntry(340.0, interestIncomeAccount, "DEBIT"));
 
             // transaction 2
-            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr2 = loanTransactionHelper.makeInterestPaymentWaiver(loanId,
+            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr2 = makeInterestPaymentWaiver(loanId,
                     new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate(repaymentPeriod2DueDate)
                             .locale("en").transactionAmount(320.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 600.0, 660.0, 500.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 250.0, 250.0, 0.0, 40.0, 40.0, 0.0, 30.0, 30.0, 0.0, 20.0,
                     20.0, 0.0, 0.0, 0.0);
@@ -1165,11 +1135,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     journalEntry(340.0, interestIncomeAccount, "DEBIT"));
 
             // transaction 3
-            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr3 = loanTransactionHelper.makeInterestPaymentWaiver(loanId,
+            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr3 = makeInterestPaymentWaiver(loanId,
                     new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate(repaymentPeriod3DueDate)
                             .locale("en").transactionAmount(330.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 270.0, 990.0, 250.0, 750.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 250.0, 250.0, 0.0, 40.0, 40.0, 0.0, 30.0, 30.0, 0.0, 20.0,
                     20.0, 0.0, 0.0, 0.0);
@@ -1203,11 +1173,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     journalEntry(330.0, interestIncomeAccount, "DEBIT"));
 
             // transaction 4 + overpayment
-            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr4 = loanTransactionHelper.makeInterestPaymentWaiver(loanId,
+            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr4 = makeInterestPaymentWaiver(loanId,
                     new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate(repaymentPeriod4DueDate)
                             .locale("en").transactionAmount(350.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 0.0, 1260.0, 0.0, 1000.0, 80.0);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 250.0, 250.0, 0.0, 40.0, 40.0, 0.0, 30.0, 30.0, 0.0, 20.0,
                     20.0, 0.0, 0.0, 0.0);
@@ -1227,11 +1197,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     journalEntry(350.0, interestIncomeAccount, "DEBIT"));
 
             // reverse transaction 4
-            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr4Reverse = loanTransactionHelper.reverseLoanTransaction(loanId,
+            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr4Reverse = reverseLoanTransaction(loanId,
                     interestPaymentWaiverTr4.getResourceId(), new PostLoansLoanIdTransactionsTransactionIdRequest()
                             .dateFormat(DATETIME_PATTERN).transactionDate(repaymentPeriod4DueDate).transactionAmount(0.0).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 270.0, 990.0, 250.0, 750.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 250.0, 250.0, 0.0, 40.0, 40.0, 0.0, 30.0, 30.0, 0.0, 20.0,
                     20.0, 0.0, 0.0, 0.0);
@@ -1253,11 +1223,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     journalEntry(350.0, interestIncomeAccount, "DEBIT"));
 
             // reverse transaction 3
-            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr3Reverse = loanTransactionHelper.reverseLoanTransaction(loanId,
+            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr3Reverse = reverseLoanTransaction(loanId,
                     interestPaymentWaiverTr3.getResourceId(), new PostLoansLoanIdTransactionsTransactionIdRequest()
                             .dateFormat(DATETIME_PATTERN).transactionDate(repaymentPeriod3DueDate).transactionAmount(0.0).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 600.0, 660.0, 500.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 250.0, 250.0, 0.0, 40.0, 40.0, 0.0, 30.0, 30.0, 0.0, 20.0,
                     20.0, 0.0, 0.0, 0.0);
@@ -1280,11 +1250,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     journalEntry(330.0, interestIncomeAccount, "CREDIT"));
 
             // reverse transaction 2
-            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr2Reverse = loanTransactionHelper.reverseLoanTransaction(loanId,
+            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr2Reverse = reverseLoanTransaction(loanId,
                     interestPaymentWaiverTr2.getResourceId(), new PostLoansLoanIdTransactionsTransactionIdRequest()
                             .dateFormat(DATETIME_PATTERN).transactionDate(repaymentPeriod2DueDate).transactionAmount(0.0).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 920.0, 340.0, 750.0, 250.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 250.0, 250.0, 0.0, 40.0, 40.0, 0.0, 30.0, 30.0, 0.0, 20.0,
                     20.0, 0.0, 0.0, 0.0);
@@ -1307,11 +1277,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     journalEntry(320.0, interestIncomeAccount, "CREDIT"));
 
             // reverse transaction 1
-            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr1Reverse = loanTransactionHelper.reverseLoanTransaction(loanId,
+            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr1Reverse = reverseLoanTransaction(loanId,
                     interestPaymentWaiverTr1.getResourceId(), new PostLoansLoanIdTransactionsTransactionIdRequest()
                             .dateFormat(DATETIME_PATTERN).transactionDate(repaymentPeriod1DueDate).transactionAmount(0.0).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 1260.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 250.0, 0.0, 250.0, 40.0, 0.0, 40.0, 30.0, 0.0, 30.0, 20.0,
                     0.0, 20.0, 0.0, 0.0);
@@ -1351,6 +1321,10 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
     public void testInterestPaymentWaiverTransactionAccountingAccuralForInterestPenaltyFeeOverpaymentChargeOFFLoan() {
         runAt("2 January 2023", () -> {
 
+            final Account interestIncomeAccount = getAccounts().getInterestIncomeAccount();
+            final Account interestIncomeChargeOffAccount = getAccounts().getInterestIncomeChargeOffAccount();
+            final Account overpaymentAccount = getAccounts().getOverpaymentAccount();
+
             final String disbursementDay = "01 January 2023";
             final String repaymentPeriod1DueDate = "01 February 2023";
             final String repaymentPeriod2DueDate = "01 March 2023";
@@ -1361,11 +1335,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             final Long loanId = applyForLoanApplicationWithInterest(client.getClientId(), localLoanProductId, BigDecimal.valueOf(40000),
                     disbursementDay);
 
-            loanTransactionHelper.approveLoan(loanId, new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
-                    .dateFormat(DATETIME_PATTERN).approvedOnDate(disbursementDay).locale("en"));
+            approveLoan(loanId, new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
+                    .approvedOnDate(disbursementDay).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
             chargePenalty(loanId, 30.0, repaymentPeriod1DueDate);
             chargePenalty(loanId, 50.0, repaymentPeriod2DueDate);
@@ -1375,15 +1349,14 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             // Charge-OFF loan
             String randomText = Utils.randomStringGenerator("en", 5) + Utils.randomNumberGenerator(6)
                     + Utils.randomStringGenerator("is", 5);
-            Integer chargeOffReasonId = CodeHelper.createChargeOffCodeValue(requestSpec, responseSpec, randomText, 1);
+            Long chargeOffReasonId = codeHelper.createChargeOffCodeValue(randomText, 1);
             String transactionExternalId = UUID.randomUUID().toString();
-            PostLoansLoanIdTransactionsResponse chargeOffTransaction = loanTransactionHelper.chargeOffLoan(loanId,
-                    new PostLoansLoanIdTransactionsRequest().transactionDate("2 January 2023").locale("en").dateFormat("dd MMMM yyyy")
-                            .externalId(transactionExternalId).chargeOffReasonId((long) chargeOffReasonId));
+            chargeOffLoan(loanId, new PostLoansLoanIdTransactionsRequest().transactionDate("2 January 2023").locale("en")
+                    .dateFormat("dd MMMM yyyy").externalId(transactionExternalId).chargeOffReasonId(chargeOffReasonId));
 
             updateBusinessDate("15 May 2023");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 1260.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 250.0, 0.0, 250.0, 40.0, 0.0, 40.0, 30.0, 0.0, 30.0, 20.0,
                     0.0, 20.0, 0.0, 0.0);
@@ -1396,11 +1369,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             assertTrue(loanDetails.getStatus().getActive());
 
             // transaction 1
-            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr1 = loanTransactionHelper.makeInterestPaymentWaiver(loanId,
+            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr1 = makeInterestPaymentWaiver(loanId,
                     new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate(repaymentPeriod1DueDate)
                             .locale("en").transactionAmount(340.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 920.0, 340.0, 750.0, 250.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 250.0, 250.0, 0.0, 40.0, 40.0, 0.0, 30.0, 30.0, 0.0, 20.0,
                     20.0, 0.0, 0.0, 0.0);
@@ -1416,11 +1389,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     journalEntry(340.0, interestIncomeAccount, "DEBIT"));
 
             // transaction 2
-            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr2 = loanTransactionHelper.makeInterestPaymentWaiver(loanId,
+            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr2 = makeInterestPaymentWaiver(loanId,
                     new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate(repaymentPeriod2DueDate)
                             .locale("en").transactionAmount(320.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 600.0, 660.0, 500.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 250.0, 250.0, 0.0, 40.0, 40.0, 0.0, 30.0, 30.0, 0.0, 20.0,
                     20.0, 0.0, 0.0, 0.0);
@@ -1436,11 +1409,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     journalEntry(320.0, interestIncomeAccount, "DEBIT"));
 
             // transaction 3
-            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr3 = loanTransactionHelper.makeInterestPaymentWaiver(loanId,
+            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr3 = makeInterestPaymentWaiver(loanId,
                     new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate(repaymentPeriod3DueDate)
                             .locale("en").transactionAmount(330.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 270.0, 990.0, 250.0, 750.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 250.0, 250.0, 0.0, 40.0, 40.0, 0.0, 30.0, 30.0, 0.0, 20.0,
                     20.0, 0.0, 0.0, 0.0);
@@ -1456,11 +1429,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     journalEntry(330.0, interestIncomeAccount, "DEBIT"));
 
             // transaction 4 + overpayment
-            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr4 = loanTransactionHelper.makeInterestPaymentWaiver(loanId,
+            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr4 = makeInterestPaymentWaiver(loanId,
                     new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate(repaymentPeriod4DueDate)
                             .locale("en").transactionAmount(350.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 0.0, 1260.0, 0.0, 1000.0, 80.0);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 250.0, 250.0, 0.0, 40.0, 40.0, 0.0, 30.0, 30.0, 0.0, 20.0,
                     20.0, 0.0, 0.0, 0.0);
@@ -1479,11 +1452,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     journalEntry(350.0, interestIncomeAccount, "DEBIT"));
 
             // reverse transaction 4
-            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr4Reverse = loanTransactionHelper.reverseLoanTransaction(loanId,
+            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr4Reverse = reverseLoanTransaction(loanId,
                     interestPaymentWaiverTr4.getResourceId(), new PostLoansLoanIdTransactionsTransactionIdRequest()
                             .dateFormat(DATETIME_PATTERN).transactionDate(repaymentPeriod4DueDate).transactionAmount(0.0).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 270.0, 990.0, 250.0, 750.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 250.0, 250.0, 0.0, 40.0, 40.0, 0.0, 30.0, 30.0, 0.0, 20.0,
                     20.0, 0.0, 0.0, 0.0);
@@ -1504,11 +1477,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     journalEntry(350.0, interestIncomeAccount, "CREDIT"));
 
             // reverse transaction 3
-            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr3Reverse = loanTransactionHelper.reverseLoanTransaction(loanId,
+            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr3Reverse = reverseLoanTransaction(loanId,
                     interestPaymentWaiverTr3.getResourceId(), new PostLoansLoanIdTransactionsTransactionIdRequest()
                             .dateFormat(DATETIME_PATTERN).transactionDate(repaymentPeriod3DueDate).transactionAmount(0.0).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 600.0, 660.0, 500.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 250.0, 250.0, 0.0, 40.0, 40.0, 0.0, 30.0, 30.0, 0.0, 20.0,
                     20.0, 0.0, 0.0, 0.0);
@@ -1527,11 +1500,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     journalEntry(330.0, interestIncomeAccount, "CREDIT"));
 
             // reverse transaction 2
-            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr2Reverse = loanTransactionHelper.reverseLoanTransaction(loanId,
+            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr2Reverse = reverseLoanTransaction(loanId,
                     interestPaymentWaiverTr2.getResourceId(), new PostLoansLoanIdTransactionsTransactionIdRequest()
                             .dateFormat(DATETIME_PATTERN).transactionDate(repaymentPeriod2DueDate).transactionAmount(0.0).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 920.0, 340.0, 750.0, 250.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 250.0, 250.0, 0.0, 40.0, 40.0, 0.0, 30.0, 30.0, 0.0, 20.0,
                     20.0, 0.0, 0.0, 0.0);
@@ -1550,11 +1523,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     journalEntry(320.0, interestIncomeAccount, "CREDIT"));
 
             // reverse transaction 1
-            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr1Reverse = loanTransactionHelper.reverseLoanTransaction(loanId,
+            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr1Reverse = reverseLoanTransaction(loanId,
                     interestPaymentWaiverTr1.getResourceId(), new PostLoansLoanIdTransactionsTransactionIdRequest()
                             .dateFormat(DATETIME_PATTERN).transactionDate(repaymentPeriod1DueDate).transactionAmount(0.0).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 1260.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 250.0, 0.0, 250.0, 40.0, 0.0, 40.0, 30.0, 0.0, 30.0, 20.0,
                     0.0, 20.0, 0.0, 0.0);
@@ -1584,12 +1557,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
 
             LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-            PostLoanProductsResponse loanProductResponse = loanProductHelper
-                    .createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
-                            .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()));
+            Long loanProductId = createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
+                    .loanScheduleType("PROGRESSIVE"));
 
-            Long loanId = applyAndApproveLoanProgressiveAdvancedPaymentAllocationStrategyMonthlyRepayments(clientId,
-                    loanProductResponse.getResourceId(), numberOfRepayments, loanDisbursementDate, amount, null);
+            Long loanId = applyAndApproveLoanProgressiveAdvancedPaymentAllocationStrategyMonthlyRepayments(clientId, loanProductId,
+                    numberOfRepayments, loanDisbursementDate, amount, null);
 
             verifyRepaymentSchedule(loanId, //
                     installment(1000.0, null, "01 January 2023"), //
@@ -1599,8 +1571,8 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     installment(250.0, false, "01 May 2023") //
             );
 
-            loanTransactionHelper.disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2023")
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2023").dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
             // loan should be active
             Long transactionId = addInterestPaymentWaiverForLoan(loanId, 250.0, "2 January 2023");
@@ -1609,8 +1581,7 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     transaction(1000.0, "Disbursement", "01 January 2023", 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
                     transaction(250.0, "Interest Payment Waiver", "02 January 2023", 750.0, 250.0, 0.0, 0.0, 0, 0.0, 0.0));
 
-            loanTransactionHelper.adjustLoanTransaction(loanId, transactionId, new PostLoansLoanIdTransactionsTransactionIdRequest()
-                    .transactionAmount(200.0).dateFormat(DATETIME_PATTERN).transactionDate("3 January 2023").locale("en"));
+            transactionHelper.adjustLoanTransaction(loanId, transactionId, "3 January 2023", 200.0);
 
             verifyTransactions(loanId, //
                     transaction(1000.0, "Disbursement", "01 January 2023", 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
@@ -1626,8 +1597,7 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
 
         runAt("01 January 2025", () -> {
             PostLoanProductsRequest loanProductRequest = create4IProgressiveWithChargeOffBehaviour();
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductRequest);
-            Long loanProductId = loanProductResponse.getResourceId();
+            Long loanProductId = createLoanProduct(loanProductRequest);
             assertNotNull(loanProductId);
 
             PostClientsResponse clientResponse = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
@@ -1677,8 +1647,7 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             batchRequests.add(waiverRequest);
             batchRequests.add(getRequest);
 
-            List<BatchResponse> responses = BatchHelper.postBatchRequestsWithEnclosingTransaction(requestSpec, responseSpec,
-                    BatchHelper.toJsonString(batchRequests));
+            List<BatchResponse> responses = batchHelper.executeEnclosingTransaction(batchRequests);
 
             assertEquals(2, responses.size());
 
@@ -1724,8 +1693,7 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
     public void testInterestPaymentWaiverBackbookBatchExternalId() {
         runAt("01 January 2025", () -> {
             PostLoanProductsRequest loanProductRequest = create4IProgressiveWithChargeOffBehaviour();
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductRequest);
-            Long loanProductId = loanProductResponse.getResourceId();
+            Long loanProductId = createLoanProduct(loanProductRequest);
             assertNotNull(loanProductId);
 
             PostClientsResponse clientResponse = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
@@ -1742,9 +1710,9 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
 
             disburseLoan(loanId, BigDecimal.valueOf(431.98), "18 January 2022");
 
-            loanTransactionHelper.makeLoanRepayment("28 February 2022", 19.83f, loanId.intValue());
-            PostLoansLoanIdTransactionsResponse txn2 = loanTransactionHelper.makeLoanRepayment("18 March 2022", 19.83f, loanId.intValue());
-            loanTransactionHelper.reverseRepayment(loanId.intValue(), txn2.getResourceId().intValue(), "18 March 2022");
+            makeLoanRepayment(loanId, "repayment", "28 February 2022", 19.83);
+            PostLoansLoanIdTransactionsResponse txn2 = makeLoanRepayment(loanId, "repayment", "18 March 2022", 19.83);
+            reverseRepayment(loanId, txn2.getResourceId(), "18 March 2022");
 
             Long chargeOffTxnId = chargeOffLoan(loanId, "16 September 2022");
             assertNotNull(chargeOffTxnId);
@@ -1772,8 +1740,7 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             batchRequests.add(waiverRequest);
             batchRequests.add(getRequest);
 
-            List<BatchResponse> responses = BatchHelper.postBatchRequestsWithEnclosingTransaction(requestSpec, responseSpec,
-                    BatchHelper.toJsonString(batchRequests));
+            List<BatchResponse> responses = batchHelper.executeEnclosingTransaction(batchRequests);
 
             assertEquals(2, responses.size());
 
@@ -1809,8 +1776,7 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
 
         runAt("18 January 2022", () -> {
             PostLoanProductsRequest loanProductRequest = create4IProgressiveWithChargeOffBehaviour();
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductRequest);
-            Long loanProductId = loanProductResponse.getResourceId();
+            Long loanProductId = createLoanProduct(loanProductRequest);
             assertNotNull(loanProductId);
 
             PostClientsResponse clientResponse = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
@@ -1834,22 +1800,22 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
         String loanExternalId = loanExternalIdContainer[0];
 
         runAt("28 February 2022", () -> {
-            loanTransactionHelper.makeLoanRepayment("28 February 2022", 19.83f, loanId.intValue());
+            makeLoanRepayment(loanId, "repayment", "28 February 2022", 19.83);
         });
 
         runAt("18 March 2022", () -> {
-            PostLoansLoanIdTransactionsResponse txn = loanTransactionHelper.makeLoanRepayment("18 March 2022", 19.83f, loanId.intValue());
-            loanTransactionHelper.reverseRepayment(loanId.intValue(), txn.getResourceId().intValue(), "18 March 2022");
+            PostLoansLoanIdTransactionsResponse txn = makeLoanRepayment(loanId, "repayment", "18 March 2022", 19.83);
+            reverseRepayment(loanId, txn.getResourceId(), "18 March 2022");
         });
 
         runAt("31 March 2022", () -> {
-            PostLoansLoanIdTransactionsResponse txn = loanTransactionHelper.makeLoanRepayment("31 March 2022", 19.83f, loanId.intValue());
-            loanTransactionHelper.reverseRepayment(loanId.intValue(), txn.getResourceId().intValue(), "31 March 2022");
+            PostLoansLoanIdTransactionsResponse txn = makeLoanRepayment(loanId, "repayment", "31 March 2022", 19.83);
+            reverseRepayment(loanId, txn.getResourceId(), "31 March 2022");
         });
 
         runAt("18 April 2022", () -> {
-            PostLoansLoanIdTransactionsResponse txn = loanTransactionHelper.makeLoanRepayment("18 April 2022", 39.66f, loanId.intValue());
-            loanTransactionHelper.reverseRepayment(loanId.intValue(), txn.getResourceId().intValue(), "18 April 2022");
+            PostLoansLoanIdTransactionsResponse txn = makeLoanRepayment(loanId, "repayment", "18 April 2022", 39.66);
+            reverseRepayment(loanId, txn.getResourceId(), "18 April 2022");
         });
 
         runAt("16 September 2022", () -> {
@@ -1881,8 +1847,7 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             batchRequests.add(waiverRequest);
             batchRequests.add(getRequest);
 
-            List<BatchResponse> responses = BatchHelper.postBatchRequestsWithEnclosingTransaction(requestSpec, responseSpec,
-                    BatchHelper.toJsonString(batchRequests));
+            List<BatchResponse> responses = batchHelper.executeEnclosingTransaction(batchRequests);
 
             assertEquals(2, responses.size());
 
@@ -1915,8 +1880,7 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
     public void testInterestPaymentWaiverProductionScenarioBatchExternalId() {
         runAt("01 January 2025", () -> {
             PostLoanProductsRequest loanProductRequest = create4IProgressiveWithChargeOffBehaviour();
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductRequest);
-            Long loanProductId = loanProductResponse.getResourceId();
+            Long loanProductId = createLoanProduct(loanProductRequest);
             assertNotNull(loanProductId);
 
             PostClientsResponse clientResponse = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
@@ -1933,28 +1897,28 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
 
             disburseLoan(loanId, BigDecimal.valueOf(431.98), "18 January 2022");
 
-            loanTransactionHelper.makeLoanRepayment("28 February 2022", 19.83f, loanId.intValue());
+            makeLoanRepayment(loanId, "repayment", "28 February 2022", 19.83);
 
-            PostLoansLoanIdTransactionsResponse txn2 = loanTransactionHelper.makeLoanRepayment("18 March 2022", 19.83f, loanId.intValue());
-            loanTransactionHelper.reverseRepayment(loanId.intValue(), txn2.getResourceId().intValue(), "18 March 2022");
+            PostLoansLoanIdTransactionsResponse txn2 = makeLoanRepayment(loanId, "repayment", "18 March 2022", 19.83);
+            reverseRepayment(loanId, txn2.getResourceId(), "18 March 2022");
 
-            PostLoansLoanIdTransactionsResponse txn3 = loanTransactionHelper.makeLoanRepayment("31 March 2022", 19.83f, loanId.intValue());
-            loanTransactionHelper.reverseRepayment(loanId.intValue(), txn3.getResourceId().intValue(), "31 March 2022");
+            PostLoansLoanIdTransactionsResponse txn3 = makeLoanRepayment(loanId, "repayment", "31 March 2022", 19.83);
+            reverseRepayment(loanId, txn3.getResourceId(), "31 March 2022");
 
-            PostLoansLoanIdTransactionsResponse txn4 = loanTransactionHelper.makeLoanRepayment("18 April 2022", 39.66f, loanId.intValue());
-            loanTransactionHelper.reverseRepayment(loanId.intValue(), txn4.getResourceId().intValue(), "18 April 2022");
+            PostLoansLoanIdTransactionsResponse txn4 = makeLoanRepayment(loanId, "repayment", "18 April 2022", 39.66);
+            reverseRepayment(loanId, txn4.getResourceId(), "18 April 2022");
 
-            PostLoansLoanIdTransactionsResponse txn5 = loanTransactionHelper.makeLoanRepayment("18 May 2022", 59.49f, loanId.intValue());
-            loanTransactionHelper.reverseRepayment(loanId.intValue(), txn5.getResourceId().intValue(), "18 May 2022");
+            PostLoansLoanIdTransactionsResponse txn5 = makeLoanRepayment(loanId, "repayment", "18 May 2022", 59.49);
+            reverseRepayment(loanId, txn5.getResourceId(), "18 May 2022");
 
-            PostLoansLoanIdTransactionsResponse txn6 = loanTransactionHelper.makeLoanRepayment("18 June 2022", 64.83f, loanId.intValue());
-            loanTransactionHelper.reverseRepayment(loanId.intValue(), txn6.getResourceId().intValue(), "18 June 2022");
+            PostLoansLoanIdTransactionsResponse txn6 = makeLoanRepayment(loanId, "repayment", "18 June 2022", 64.83);
+            reverseRepayment(loanId, txn6.getResourceId(), "18 June 2022");
 
-            PostLoansLoanIdTransactionsResponse txn7 = loanTransactionHelper.makeLoanRepayment("18 July 2022", 65.32f, loanId.intValue());
-            loanTransactionHelper.reverseRepayment(loanId.intValue(), txn7.getResourceId().intValue(), "18 July 2022");
+            PostLoansLoanIdTransactionsResponse txn7 = makeLoanRepayment(loanId, "repayment", "18 July 2022", 65.32);
+            reverseRepayment(loanId, txn7.getResourceId(), "18 July 2022");
 
-            PostLoansLoanIdTransactionsResponse txn8 = loanTransactionHelper.makeLoanRepayment("18 August 2022", 65.83f, loanId.intValue());
-            loanTransactionHelper.reverseRepayment(loanId.intValue(), txn8.getResourceId().intValue(), "18 August 2022");
+            PostLoansLoanIdTransactionsResponse txn8 = makeLoanRepayment(loanId, "repayment", "18 August 2022", 65.83);
+            reverseRepayment(loanId, txn8.getResourceId(), "18 August 2022");
 
             Long chargeOffTxnId = chargeOffLoan(loanId, "16 September 2022");
             assertNotNull(chargeOffTxnId);
@@ -1982,8 +1946,7 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             batchRequests.add(waiverRequest);
             batchRequests.add(getRequest);
 
-            List<BatchResponse> responses = BatchHelper.postBatchRequestsWithEnclosingTransaction(requestSpec, responseSpec,
-                    BatchHelper.toJsonString(batchRequests));
+            List<BatchResponse> responses = batchHelper.executeEnclosingTransaction(batchRequests);
 
             if (responses.size() != 2) {
                 fail("Batch API returned " + responses.size() + " responses instead of 2.");
@@ -2036,27 +1999,17 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
     }
 
     private void chargeFee(Long loanId, Double amount, String dueDate) {
-        PostChargesResponse feeCharge = chargesHelper.createCharges(new ChargeRequest().penalty(false).amount(9.0)
-                .chargeCalculationType(ChargeCalculationType.FLAT.getValue()).chargeTimeType(ChargeTimeType.SPECIFIED_DUE_DATE.getValue())
-                .chargePaymentMode(ChargePaymentMode.REGULAR.getValue()).currencyCode("USD")
-                .name(Utils.randomStringGenerator("FEE_" + Calendar.getInstance().getTimeInMillis(), 5)).chargeAppliesTo(1).locale("en")
-                .active(true));
-        PostLoansLoanIdChargesResponse feeLoanChargeResult = loanTransactionHelper.addChargesForLoan(loanId,
-                new PostLoansLoanIdChargesRequest().chargeId(feeCharge.getResourceId()).dateFormat(DATETIME_PATTERN).locale("en")
-                        .amount(amount).dueDate(dueDate));
+        PostChargesResponse feeCharge = chargesHelper.createLoanSpecifiedDueDateCharge(9.0);
+        PostLoansLoanIdChargesResponse feeLoanChargeResult = addChargesForLoan(loanId, new PostLoansLoanIdChargesRequest()
+                .chargeId(feeCharge.getResourceId()).dateFormat(DATETIME_PATTERN).locale("en").amount(amount).dueDate(dueDate));
         assertNotNull(feeLoanChargeResult);
         assertNotNull(feeLoanChargeResult.getResourceId());
     }
 
     private void chargePenalty(Long loanId, Double amount, String dueDate) {
-        PostChargesResponse penaltyCharge = chargesHelper.createCharges(new ChargeRequest().penalty(true).amount(10.0)
-                .chargeCalculationType(ChargeCalculationType.FLAT.getValue()).chargeTimeType(ChargeTimeType.SPECIFIED_DUE_DATE.getValue())
-                .chargePaymentMode(ChargePaymentMode.REGULAR.getValue()).currencyCode("USD")
-                .name(Utils.randomStringGenerator("PENALTY_" + Calendar.getInstance().getTimeInMillis(), 5)).chargeAppliesTo(1).locale("en")
-                .active(true));
-        PostLoansLoanIdChargesResponse penaltyLoanChargeResult = loanTransactionHelper.addChargesForLoan(loanId,
-                new PostLoansLoanIdChargesRequest().chargeId(penaltyCharge.getResourceId()).dateFormat(DATETIME_PATTERN).locale("en")
-                        .amount(amount).dueDate(dueDate));
+        PostChargesResponse penaltyCharge = chargesHelper.createLoanSpecifiedDueDatePenalty(10.0);
+        PostLoansLoanIdChargesResponse penaltyLoanChargeResult = addChargesForLoan(loanId, new PostLoansLoanIdChargesRequest()
+                .chargeId(penaltyCharge.getResourceId()).dateFormat(DATETIME_PATTERN).locale("en").amount(amount).dueDate(dueDate));
         assertNotNull(penaltyLoanChargeResult);
         assertNotNull(penaltyLoanChargeResult.getResourceId());
     }
@@ -2065,38 +2018,38 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
         LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
         String name = Utils.uniqueRandomStringGenerator("LOAN_PRODUCT_", 6);
         String shortName = Utils.uniqueRandomStringGenerator("", 4);
-        return loanTransactionHelper.createLoanProduct(new PostLoanProductsRequest().name(name).shortName(shortName)
-                .description("Test loan description").currencyCode("USD").digitsAfterDecimal(2).daysInYearType(1).daysInMonthType(1)
-                .interestRecalculationCompoundingMethod(0).recalculationRestFrequencyType(1).rescheduleStrategyMethod(1)
-                .recalculationRestFrequencyInterval(0).isInterestRecalculationEnabled(false).interestRateFrequencyType(2).locale("en_GB")
-                .numberOfRepayments(4).repaymentFrequencyType(2L).interestRatePerPeriod(2.0).repaymentEvery(1).minPrincipal(100.0)
-                .principal(1000.0).maxPrincipal(10000000.0).amortizationType(1).interestType(1).interestCalculationPeriodType(1)
-                .dateFormat("dd MMMM yyyy").transactionProcessingStrategyCode(DEFAULT_STRATEGY).accountingRule(3)
-                .fundSourceAccountId(fundSource.getAccountID().longValue())//
-                .loanPortfolioAccountId(loansReceivableAccount.getAccountID().longValue())//
-                .transfersInSuspenseAccountId(suspenseAccount.getAccountID().longValue())//
-                .interestOnLoanAccountId(interestIncomeAccount.getAccountID().longValue())//
-                .incomeFromFeeAccountId(feeIncomeAccount.getAccountID().longValue())//
-                .incomeFromPenaltyAccountId(feeIncomeAccount.getAccountID().longValue())//
-                .incomeFromRecoveryAccountId(recoveriesAccount.getAccountID().longValue())//
-                .writeOffAccountId(writtenOffAccount.getAccountID().longValue())//
-                .overpaymentLiabilityAccountId(overpaymentAccount.getAccountID().longValue())//
-                .receivableInterestAccountId(interestReceivableAccount.getAccountID().longValue())//
-                .receivableFeeAccountId(feeReceivableAccount.getAccountID().longValue())//
-                .receivablePenaltyAccountId(penaltyReceivableAccount.getAccountID().longValue())//
-                .goodwillCreditAccountId(goodwillExpenseAccount.getAccountID().longValue())//
-                .incomeFromGoodwillCreditInterestAccountId(goodwillIncomeAccount.getAccountID().longValue())//
-                .incomeFromGoodwillCreditFeesAccountId(goodwillIncomeAccount.getAccountID().longValue())//
-                .incomeFromGoodwillCreditPenaltyAccountId(goodwillIncomeAccount.getAccountID().longValue())//
-                .incomeFromChargeOffInterestAccountId(interestIncomeChargeOffAccount.getAccountID().longValue())//
-                .incomeFromChargeOffFeesAccountId(feeChargeOffAccount.getAccountID().longValue())//
-                .chargeOffExpenseAccountId(chargeOffExpenseAccount.getAccountID().longValue())//
-                .chargeOffFraudExpenseAccountId(chargeOffFraudExpenseAccount.getAccountID().longValue())//
-                .incomeFromChargeOffPenaltyAccountId(penaltyChargeOffAccount.getAccountID().longValue())//
-        ).getResourceId();
+        return createLoanProduct(new PostLoanProductsRequest().name(name).shortName(shortName).description("Test loan description")
+                .currencyCode("USD").digitsAfterDecimal(2).daysInYearType(1).daysInMonthType(1).interestRecalculationCompoundingMethod(0)
+                .recalculationRestFrequencyType(1).rescheduleStrategyMethod(1).recalculationRestFrequencyInterval(0)
+                .isInterestRecalculationEnabled(false).interestRateFrequencyType(2).locale("en_GB").numberOfRepayments(4)
+                .repaymentFrequencyType(2L).interestRatePerPeriod(2.0).repaymentEvery(1).minPrincipal(100.0).principal(1000.0)
+                .maxPrincipal(10000000.0).amortizationType(1).interestType(1).interestCalculationPeriodType(1).dateFormat("dd MMMM yyyy")
+                .transactionProcessingStrategyCode(DEFAULT_STRATEGY).accountingRule(3)
+                .fundSourceAccountId(getAccounts().getFundSource().getAccountID().longValue())//
+                .loanPortfolioAccountId(getAccounts().getLoansReceivableAccount().getAccountID().longValue())//
+                .transfersInSuspenseAccountId(getAccounts().getSuspenseAccount().getAccountID().longValue())//
+                .interestOnLoanAccountId(getAccounts().getInterestIncomeAccount().getAccountID().longValue())//
+                .incomeFromFeeAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())//
+                .incomeFromPenaltyAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())//
+                .incomeFromRecoveryAccountId(getAccounts().getRecoveriesAccount().getAccountID().longValue())//
+                .writeOffAccountId(getAccounts().getWrittenOffAccount().getAccountID().longValue())//
+                .overpaymentLiabilityAccountId(getAccounts().getOverpaymentAccount().getAccountID().longValue())//
+                .receivableInterestAccountId(getAccounts().getInterestReceivableAccount().getAccountID().longValue())//
+                .receivableFeeAccountId(getAccounts().getFeeReceivableAccount().getAccountID().longValue())//
+                .receivablePenaltyAccountId(getAccounts().getPenaltyReceivableAccount().getAccountID().longValue())//
+                .goodwillCreditAccountId(getAccounts().getGoodwillExpenseAccount().getAccountID().longValue())//
+                .incomeFromGoodwillCreditInterestAccountId(getAccounts().getGoodwillIncomeAccount().getAccountID().longValue())//
+                .incomeFromGoodwillCreditFeesAccountId(getAccounts().getGoodwillIncomeAccount().getAccountID().longValue())//
+                .incomeFromGoodwillCreditPenaltyAccountId(getAccounts().getGoodwillIncomeAccount().getAccountID().longValue())//
+                .incomeFromChargeOffInterestAccountId(getAccounts().getInterestIncomeChargeOffAccount().getAccountID().longValue())//
+                .incomeFromChargeOffFeesAccountId(getAccounts().getFeeChargeOffAccount().getAccountID().longValue())//
+                .chargeOffExpenseAccountId(getAccounts().getChargeOffExpenseAccount().getAccountID().longValue())//
+                .chargeOffFraudExpenseAccountId(getAccounts().getChargeOffFraudExpenseAccount().getAccountID().longValue())//
+                .incomeFromChargeOffPenaltyAccountId(getAccounts().getPenaltyChargeOffAccount().getAccountID().longValue())//
+        );
     }
 
-    private static Long applyForLoanApplicationWithInterest(final Long clientID, final Long loanProductID, BigDecimal principal,
+    private Long applyForLoanApplicationWithInterest(final Long clientID, final Long loanProductID, BigDecimal principal,
             String applicationDisbursementDate) {
         LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
         final PostLoansRequest loanRequest = new PostLoansRequest() //
@@ -2105,62 +2058,53 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                 .interestCalculationPeriodType(1).dateFormat("dd MMMM yyyy").transactionProcessingStrategyCode(DEFAULT_STRATEGY)
                 .loanType("individual").expectedDisbursementDate(applicationDisbursementDate).submittedOnDate(applicationDisbursementDate)
                 .clientId(clientID).productId(loanProductID);
-        return loanTransactionHelper.applyLoan(loanRequest).getLoanId();
+        return applyForLoan(loanRequest);
     }
 
-    private static Integer createLoanProduct(final String principal, final String repaymentAfterEvery, final String numberOfRepayments,
-            boolean downPaymentEnabled, String downPaymentPercentage, boolean autoPayForDownPayment, LoanScheduleType loanScheduleType,
-            LoanScheduleProcessingType loanScheduleProcessingType, final Account... accounts) {
-        AdvancedPaymentData defaultAllocation = createDefaultPaymentAllocation();
-        AdvancedPaymentData goodwillCreditAllocation = createPaymentAllocation("GOODWILL_CREDIT", "LAST_INSTALLMENT");
-        AdvancedPaymentData interestPaymentWaiver = createPaymentAllocation("INTEREST_PAYMENT_WAIVER", "LAST_INSTALLMENT");
-        AdvancedPaymentData merchantIssuedRefundAllocation = createPaymentAllocation("MERCHANT_ISSUED_REFUND", "REAMORTIZATION");
-        AdvancedPaymentData payoutRefundAllocation = createPaymentAllocation("PAYOUT_REFUND", "NEXT_INSTALLMENT");
+    private Long createLoanProduct(final double principal, final int repaymentAfterEvery, final int numberOfRepayments,
+            boolean downPaymentEnabled, String downPaymentPercentage, boolean autoPayForDownPayment, String loanScheduleProcessingType) {
         LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-        final String loanProductJSON = new LoanProductTestBuilder().withMinPrincipal(principal).withPrincipal(principal)
-                .withRepaymentTypeAsDays().withRepaymentAfterEvery(repaymentAfterEvery).withNumberOfRepayments(numberOfRepayments)
-                .withEnableDownPayment(downPaymentEnabled, downPaymentPercentage, autoPayForDownPayment).withinterestRatePerPeriod("0")
-                .withInterestRateFrequencyTypeAsMonths()
-                .withRepaymentStrategy(AdvancedPaymentScheduleTransactionProcessor.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)
-                .withAmortizationTypeAsEqualPrincipalPayment().withInterestTypeAsFlat().withAccountingRulePeriodicAccrual(accounts)
-                .addAdvancedPaymentAllocation(defaultAllocation, goodwillCreditAllocation, merchantIssuedRefundAllocation,
-                        payoutRefundAllocation, interestPaymentWaiver)
-                .withInterestCalculationPeriodTypeAsRepaymentPeriod(true).withInterestTypeAsDecliningBalance().withMultiDisburse()
-                .withDisallowExpectedDisbursements(true).withLoanScheduleType(loanScheduleType)
-                .withLoanScheduleProcessingType(loanScheduleProcessingType).withDaysInMonth("30").withDaysInYear("365")
-                .withMoratorium("0", "0").build(null);
-        return loanTransactionHelper.getLoanProductId(loanProductJSON);
+        return createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
+                .loanScheduleProcessingType(loanScheduleProcessingType).paymentAllocation(List.of(createDefaultPaymentAllocation(), //
+                        createPaymentAllocation("GOODWILL_CREDIT", "LAST_INSTALLMENT"), //
+                        createPaymentAllocation("MERCHANT_ISSUED_REFUND", "REAMORTIZATION"), //
+                        createPaymentAllocation("PAYOUT_REFUND", "NEXT_INSTALLMENT"), //
+                        createPaymentAllocation("INTEREST_PAYMENT_WAIVER", "LAST_INSTALLMENT")))
+                .principal(principal).minPrincipal(principal).repaymentEvery(repaymentAfterEvery).numberOfRepayments(numberOfRepayments)
+                .enableDownPayment(downPaymentEnabled).disbursedAmountPercentageForDownPayment(new BigDecimal(downPaymentPercentage))
+                .enableAutoRepaymentForDownPayment(autoPayForDownPayment).amortizationType(AmortizationType.EQUAL_PRINCIPAL)
+                .daysInMonthType(DaysInMonthType.DAYS_30).daysInYearType(DaysInYearType.DAYS_365).graceOnPrincipalPayment(0)
+                .graceOnInterestPayment(0));
     }
 
-    private static PostLoansResponse applyForLoanApplication(final Long clientId, final Integer loanProductId, final BigDecimal principal,
+    private PostLoansResponse applyForLoanApplication(final Long clientId, final Long loanProductId, final BigDecimal principal,
             final int loanTermFrequency, final int repaymentAfterEvery, final int numberOfRepayments, final BigDecimal interestRate,
             final String expectedDisbursementDate, final String submittedOnDate, String transactionProcessorCode,
             String loanScheduleProcessingType) {
         LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
-        return loanTransactionHelper.applyLoan(new PostLoansRequest().clientId(clientId).productId(loanProductId.longValue())
-                .expectedDisbursementDate(expectedDisbursementDate).dateFormat(DATETIME_PATTERN)
-                .transactionProcessingStrategyCode(transactionProcessorCode).locale("en").submittedOnDate(submittedOnDate)
-                .amortizationType(1).interestRatePerPeriod(interestRate).interestCalculationPeriodType(1).interestType(0)
-                .repaymentFrequencyType(0).repaymentEvery(repaymentAfterEvery).repaymentFrequencyType(0)
-                .numberOfRepayments(numberOfRepayments).loanTermFrequency(loanTermFrequency).loanTermFrequencyType(0).principal(principal)
-                .loanType("individual").loanScheduleProcessingType(loanScheduleProcessingType)
-                .maxOutstandingLoanBalance(BigDecimal.valueOf(35000)));
+        return loanHelper.applyForLoan(
+                new PostLoansRequest().clientId(clientId).productId(loanProductId).expectedDisbursementDate(expectedDisbursementDate)
+                        .dateFormat(DATETIME_PATTERN).transactionProcessingStrategyCode(transactionProcessorCode).locale("en")
+                        .submittedOnDate(submittedOnDate).amortizationType(1).interestRatePerPeriod(interestRate)
+                        .interestCalculationPeriodType(1).interestType(0).repaymentFrequencyType(0).repaymentEvery(repaymentAfterEvery)
+                        .repaymentFrequencyType(0).numberOfRepayments(numberOfRepayments).loanTermFrequency(loanTermFrequency)
+                        .loanTermFrequencyType(0).principal(principal).loanType("individual")
+                        .loanScheduleProcessingType(loanScheduleProcessingType).maxOutstandingLoanBalance(BigDecimal.valueOf(35000)));
     }
 
-    private static PostLoansResponse applyForLoanApplication(final Long clientId, final Integer loanProductId, final BigDecimal principal,
+    private PostLoansResponse applyForLoanApplication(final Long clientId, final Long loanProductId, final BigDecimal principal,
             final int loanTermFrequency, final int repaymentAfterEvery, final int numberOfRepayments, final BigDecimal interestRate,
             final String expectedDisbursementDate, final String submittedOnDate) {
         return applyForLoanApplication(clientId, loanProductId, principal, loanTermFrequency, repaymentAfterEvery, numberOfRepayments,
-                interestRate, expectedDisbursementDate, submittedOnDate, LoanScheduleProcessingType.HORIZONTAL);
+                interestRate, expectedDisbursementDate, submittedOnDate, HORIZONTAL);
     }
 
-    private static PostLoansResponse applyForLoanApplication(final Long clientId, final Integer loanProductId, final BigDecimal principal,
+    private PostLoansResponse applyForLoanApplication(final Long clientId, final Long loanProductId, final BigDecimal principal,
             final int loanTermFrequency, final int repaymentAfterEvery, final int numberOfRepayments, final BigDecimal interestRate,
-            final String expectedDisbursementDate, final String submittedOnDate, LoanScheduleProcessingType loanScheduleProcessingType) {
+            final String expectedDisbursementDate, final String submittedOnDate, String loanScheduleProcessingType) {
         LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
         return applyForLoanApplication(clientId, loanProductId, principal, loanTermFrequency, repaymentAfterEvery, numberOfRepayments,
-                interestRate, expectedDisbursementDate, submittedOnDate,
-                AdvancedPaymentScheduleTransactionProcessor.ADVANCED_PAYMENT_ALLOCATION_STRATEGY, loanScheduleProcessingType.name());
+                interestRate, expectedDisbursementDate, submittedOnDate, ADVANCED_PAYMENT_ALLOCATION_STRATEGY, loanScheduleProcessingType);
     }
 
     private static void validateLoanTransaction(GetLoansLoanIdResponse loanDetails, int index, double transactionAmount,

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanTransactionInterestPaymentWaiverTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanTransactionInterestPaymentWaiverTest.java
@@ -18,41 +18,33 @@
  */
 package org.apache.fineract.integrationtests;
 
-import static com.jayway.jsonpath.internal.path.PathCompiler.fail;
-import static org.apache.fineract.integrationtests.BaseLoanIntegrationTest.TransactionProcessingStrategyCode.ADVANCED_PAYMENT_ALLOCATION_STRATEGY;
+import static org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.TransactionProcessingStrategyCode.ADVANCED_PAYMENT_ALLOCATION_STRATEGY;
 import static org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder.DEFAULT_STRATEGY;
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
+import static org.apache.http.HttpStatus.SC_FORBIDDEN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.gson.Gson;
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import org.apache.fineract.batch.command.internal.CreateTransactionLoanCommandStrategy;
-import org.apache.fineract.batch.domain.BatchRequest;
-import org.apache.fineract.batch.domain.BatchResponse;
-import org.apache.fineract.client.models.AdvancedPaymentData;
-import org.apache.fineract.client.models.BusinessDateUpdateRequest;
-import org.apache.fineract.client.models.ChargeRequest;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
+import org.apache.fineract.client.models.BatchRequest;
+import org.apache.fineract.client.models.BatchResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdLoanChargeData;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdTransactionsTransactionIdResponse;
 import org.apache.fineract.client.models.PostChargesResponse;
 import org.apache.fineract.client.models.PostClientsResponse;
 import org.apache.fineract.client.models.PostLoanProductsRequest;
-import org.apache.fineract.client.models.PostLoanProductsResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdChargesRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdChargesResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdRequest;
@@ -61,65 +53,47 @@ import org.apache.fineract.client.models.PostLoansLoanIdTransactionsResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsTransactionIdRequest;
 import org.apache.fineract.client.models.PostLoansRequest;
 import org.apache.fineract.client.models.PostLoansResponse;
-import org.apache.fineract.integrationtests.common.BatchHelper;
-import org.apache.fineract.integrationtests.common.BusinessDateHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignBatchHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignCollateralHelper;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.AmortizationType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.DaysInMonthType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.DaysInYearCustomStrategy;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.DaysInYearType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestCalculationPeriodType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.RepaymentFrequencyType;
 import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.CollateralManagementHelper;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.common.accounting.Account;
-import org.apache.fineract.integrationtests.common.accounting.AccountHelper;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
 import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.apache.fineract.integrationtests.common.system.CodeHelper;
-import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
-import org.apache.fineract.portfolio.charge.domain.ChargePaymentMode;
-import org.apache.fineract.portfolio.charge.domain.ChargeTimeType;
-import org.apache.fineract.portfolio.loanaccount.domain.transactionprocessor.impl.AdvancedPaymentScheduleTransactionProcessor;
-import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleProcessingType;
-import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleType;
-import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegrationTest {
+public class LoanTransactionInterestPaymentWaiverTest extends FeignLoanTestBase {
 
-    private static final Logger LOG = LoggerFactory.getLogger(AdvancedPaymentAllocationLoanRepaymentScheduleTest.class);
-    private static final String DATETIME_PATTERN = "dd MMMM yyyy";
-    private static ResponseSpecification responseSpec;
-    private static RequestSpecification requestSpec;
-    private static BusinessDateHelper businessDateHelper;
-    private static LoanTransactionHelper loanTransactionHelper;
-    private static AccountHelper accountHelper;
-    private static Integer commonLoanProductId;
-    private static PostClientsResponse client;
-    private static ChargesHelper chargesHelper;
+    private static final Logger LOG = LoggerFactory.getLogger(LoanTransactionInterestPaymentWaiverTest.class);
     private static final Gson GSON = new Gson();
+    private static final String HORIZONTAL = "HORIZONTAL";
+    private static final String VERTICAL = "VERTICAL";
+    private static Long commonLoanProductId;
+    private static PostClientsResponse client;
+
+    private final FeignBatchHelper batchHelper = new FeignBatchHelper(FineractFeignClientHelper.getFineractFeignClient());
+    private final FeignCollateralHelper collateralHelper = new FeignCollateralHelper(FineractFeignClientHelper.getFineractFeignClient());
 
     @BeforeAll
-    public static void setup() {
-        Utils.initializeRESTAssured();
-        requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        requestSpec.header("Fineract-Platform-TenantId", "default");
-        responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-        businessDateHelper = new BusinessDateHelper();
-        accountHelper = new AccountHelper(requestSpec, responseSpec);
-        ClientHelper clientHelper = new ClientHelper(requestSpec, responseSpec);
-        chargesHelper = new ChargesHelper();
-
-        final Account assetAccount = accountHelper.createAssetAccount();
-        final Account incomeAccount = accountHelper.createIncomeAccount();
-        final Account expenseAccount = accountHelper.createExpenseAccount();
-        final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-
-        commonLoanProductId = createLoanProduct("500", "15", "4", true, "25", true, LoanScheduleType.PROGRESSIVE,
-                LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
+    public static void setupTestData() {
         client = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+    }
+
+    private Long commonLoanProductId() {
+        if (commonLoanProductId == null) {
+            commonLoanProductId = createLoanProduct(500.0, 15, 4, true, "25", true, HORIZONTAL);
+        }
+        return commonLoanProductId;
     }
 
     @Test
@@ -132,12 +106,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
 
             LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-            PostLoanProductsResponse loanProductResponse = loanProductHelper
-                    .createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
-                            .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()));
+            Long loanProductId = createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
+                    .loanScheduleType("PROGRESSIVE"));
 
-            Long loanId = applyAndApproveLoanProgressiveAdvancedPaymentAllocationStrategyMonthlyRepayments(clientId,
-                    loanProductResponse.getResourceId(), numberOfRepayments, loanDisbursementDate, amount, null);
+            Long loanId = applyAndApproveLoanProgressiveAdvancedPaymentAllocationStrategyMonthlyRepayments(clientId, loanProductId,
+                    numberOfRepayments, loanDisbursementDate, amount, null);
 
             verifyRepaymentSchedule(loanId, //
                     installment(1000.0, null, "01 January 2023"), //
@@ -147,8 +120,8 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     installment(250.0, false, "01 May 2023") //
             );
 
-            loanTransactionHelper.disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2023")
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2023").dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
             verifyTransactions(loanId, //
                     transaction(1000.0, "Disbursement", "01 January 2023", 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
@@ -191,12 +164,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
 
             LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-            PostLoanProductsResponse loanProductResponse = loanProductHelper
-                    .createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
-                            .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()));
+            Long loanProductId = createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
+                    .loanScheduleType("PROGRESSIVE"));
 
-            Long loanId = applyAndApproveLoanProgressiveAdvancedPaymentAllocationStrategyMonthlyRepayments(clientId,
-                    loanProductResponse.getResourceId(), numberOfRepayments, loanDisbursementDate, amount, null);
+            Long loanId = applyAndApproveLoanProgressiveAdvancedPaymentAllocationStrategyMonthlyRepayments(clientId, loanProductId,
+                    numberOfRepayments, loanDisbursementDate, amount, null);
 
             verifyRepaymentSchedule(loanId, //
                     installment(1000.0, null, "01 January 2023"), //
@@ -206,14 +178,20 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     installment(250.0, false, "01 May 2023") //
             );
 
-            // loan should be active
-            assertThrows(Exception.class, () -> addInterestPaymentWaiverForLoan(loanId, 250.0, "2 January 2023"));
+            // loan should be active - LoanDownPaymentTransactionValidator raises a data-validation error here
+            CallFailedRuntimeException notActive = assertThrows(CallFailedRuntimeException.class,
+                    () -> addInterestPaymentWaiverForLoan(loanId, 250.0, "2 January 2023"));
+            assertEquals(SC_BAD_REQUEST, notActive.getStatus());
+            assertTrue(notActive.getResponseBody().contains("error.msg.loan.must.be.active.fully.paid.or.overpaid"));
 
-            loanTransactionHelper.disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2023")
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2023").dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
-            // transaction cant be made before disbursement
-            assertThrows(Exception.class, () -> addInterestPaymentWaiverForLoan(loanId, 250.0, "30 December 2022"));
+            // transaction cant be made before disbursement - InvalidLoanStateTransitionException maps to 403
+            CallFailedRuntimeException beforeDisbursement = assertThrows(CallFailedRuntimeException.class,
+                    () -> addInterestPaymentWaiverForLoan(loanId, 250.0, "30 December 2022"));
+            assertEquals(SC_FORBIDDEN, beforeDisbursement.getStatus());
+            assertTrue(beforeDisbursement.getResponseBody().contains("cannot.be.before.disbursement.date"));
         });
     }
 
@@ -227,13 +205,12 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
 
             LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-            PostLoanProductsResponse loanProductResponse = loanProductHelper
-                    .createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
-                            .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()));
+            Long loanProductId = createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
+                    .loanScheduleType("PROGRESSIVE"));
 
             String loanExternalIdStr = UUID.randomUUID().toString();
-            Long loanId = applyAndApproveLoanProgressiveAdvancedPaymentAllocationStrategyMonthlyRepayments(clientId,
-                    loanProductResponse.getResourceId(), numberOfRepayments, loanDisbursementDate, amount, loanExternalIdStr);
+            Long loanId = applyAndApproveLoanProgressiveAdvancedPaymentAllocationStrategyMonthlyRepayments(clientId, loanProductId,
+                    numberOfRepayments, loanDisbursementDate, amount, loanExternalIdStr);
 
             verifyRepaymentSchedule(loanId, //
                     installment(1000.0, null, "01 January 2023"), //
@@ -243,26 +220,24 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     installment(250.0, false, "01 May 2023") //
             );
 
-            loanTransactionHelper.disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2023")
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2023").dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
             verifyTransactions(loanId, //
                     transaction(1000.0, "Disbursement", "01 January 2023", 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
 
             // Check whether the provided external id was retrieved
             String transactionExternalIdStr = UUID.randomUUID().toString();
-            final PostLoansLoanIdTransactionsResponse interestPaymentWaiverResultWithExternalId = loanTransactionHelper
-                    .makeGoodwillCredit(loanExternalIdStr, new PostLoansLoanIdTransactionsRequest().dateFormat("dd MMMM yyyy")
-                            .transactionDate("03 January 2023").locale("en").transactionAmount(5.0).externalId(transactionExternalIdStr));
+            final PostLoansLoanIdTransactionsResponse interestPaymentWaiverResultWithExternalId = makeGoodwillCredit(loanExternalIdStr,
+                    new PostLoansLoanIdTransactionsRequest().dateFormat("dd MMMM yyyy").transactionDate("03 January 2023").locale("en")
+                            .transactionAmount(5.0).externalId(transactionExternalIdStr));
             assertEquals(transactionExternalIdStr, interestPaymentWaiverResultWithExternalId.getResourceExternalId());
 
-            GetLoansLoanIdTransactionsTransactionIdResponse response = loanTransactionHelper.getLoanTransactionDetails(loanId,
-                    transactionExternalIdStr);
+            GetLoansLoanIdTransactionsTransactionIdResponse response = getLoanTransactionDetails(loanId, transactionExternalIdStr);
             assertEquals(transactionExternalIdStr, response.getExternalId());
-            response = loanTransactionHelper.getLoanTransactionDetails(loanExternalIdStr,
-                    interestPaymentWaiverResultWithExternalId.getResourceId());
+            response = getLoanTransactionDetails(loanExternalIdStr, interestPaymentWaiverResultWithExternalId.getResourceId());
             assertEquals(transactionExternalIdStr, response.getExternalId());
-            response = loanTransactionHelper.getLoanTransactionDetails(loanExternalIdStr, transactionExternalIdStr);
+            response = getLoanTransactionDetails(loanExternalIdStr, transactionExternalIdStr);
             assertEquals(transactionExternalIdStr, response.getExternalId());
         });
     }
@@ -277,12 +252,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
 
             LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-            PostLoanProductsResponse loanProductResponse = loanProductHelper
-                    .createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
-                            .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()));
+            Long loanProductId = createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
+                    .loanScheduleType("PROGRESSIVE"));
 
-            Long loanId = applyAndApproveLoanProgressiveAdvancedPaymentAllocationStrategyMonthlyRepayments(clientId,
-                    loanProductResponse.getResourceId(), numberOfRepayments, loanDisbursementDate, amount, null);
+            Long loanId = applyAndApproveLoanProgressiveAdvancedPaymentAllocationStrategyMonthlyRepayments(clientId, loanProductId,
+                    numberOfRepayments, loanDisbursementDate, amount, null);
 
             verifyRepaymentSchedule(loanId, //
                     installment(1000.0, null, "01 January 2023"), //
@@ -292,8 +266,8 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     installment(250.0, false, "01 May 2023") //
             );
 
-            loanTransactionHelper.disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2023")
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2023").dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
             verifyTransactions(loanId, //
                     transaction(1000.0, "Disbursement", "01 January 2023", 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
@@ -314,7 +288,7 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     installment(250.0, false, "01 May 2023") //
             );
 
-            loanTransactionHelper.reverseRepayment(Math.toIntExact(loanId), Math.toIntExact(repayment1TransactionId), "2 January 2023");
+            reverseRepayment(loanId, repayment1TransactionId, "2 January 2023");
 
             verifyTransactions(loanId, //
                     transaction(1000.0, "Disbursement", "01 January 2023", 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
@@ -341,12 +315,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
 
             LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-            PostLoanProductsResponse loanProductResponse = loanProductHelper
-                    .createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
-                            .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()));
+            Long loanProductId = createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
+                    .loanScheduleType("PROGRESSIVE"));
 
-            Long loanId = applyAndApproveLoanProgressiveAdvancedPaymentAllocationStrategyMonthlyRepayments(clientId,
-                    loanProductResponse.getResourceId(), numberOfRepayments, loanDisbursementDate, amount, null);
+            Long loanId = applyAndApproveLoanProgressiveAdvancedPaymentAllocationStrategyMonthlyRepayments(clientId, loanProductId,
+                    numberOfRepayments, loanDisbursementDate, amount, null);
 
             verifyRepaymentSchedule(loanId, //
                     installment(1000.0, null, "01 January 2023"), //
@@ -356,8 +329,8 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     installment(250.0, false, "01 May 2023") //
             );
 
-            loanTransactionHelper.disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2023")
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2023").dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
             verifyTransactions(loanId, //
                     transaction(1000.0, "Disbursement", "01 January 2023", 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
@@ -402,14 +375,14 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
         PostLoansRequest applicationRequest = applyLoanRequestProgressiveAdvancedPaymentAllocationStrategyMonthlyRepayments(clientId,
                 loanProductId, externalLoanId, amount, numberOfRepayments, loanDisbursementDate);
 
-        PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
+        PostLoansResponse loanResponse = loanHelper.applyForLoan(applicationRequest);
 
         Long loanId = loanResponse.getLoanId();
 
         assertNotNull(loanId);
 
-        loanTransactionHelper.approveLoan(loanId, new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(amount))
-                .dateFormat(DATETIME_PATTERN).approvedOnDate(loanDisbursementDate).locale("en"));
+        approveLoan(loanId, new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(amount)).dateFormat(DATETIME_PATTERN)
+                .approvedOnDate(loanDisbursementDate).locale("en"));
 
         return loanId;
     }
@@ -418,9 +391,8 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             String loanExternalId, double amount, Integer numberOfRepayments, String loanDisbursementDate) {
         PostLoansRequest postLoansRequest = new PostLoansRequest().clientId(clientId).productId(loanId)
                 .submittedOnDate(loanDisbursementDate).expectedDisbursementDate(loanDisbursementDate).dateFormat(DATETIME_PATTERN)
-                .locale("en").loanType("individual")
-                .transactionProcessingStrategyCode(LoanProductTestBuilder.ADVANCED_PAYMENT_ALLOCATION_STRATEGY).amortizationType(1)
-                .interestRatePerPeriod(BigDecimal.ZERO).interestCalculationPeriodType(1).interestType(0)
+                .locale("en").loanType("individual").transactionProcessingStrategyCode(ADVANCED_PAYMENT_ALLOCATION_STRATEGY)
+                .amortizationType(1).interestRatePerPeriod(BigDecimal.ZERO).interestCalculationPeriodType(1).interestType(0)
                 .maxOutstandingLoanBalance(BigDecimal.valueOf(amount)).principal(BigDecimal.valueOf(amount))
                 .loanTermFrequencyType(RepaymentFrequencyType.MONTHS).loanTermFrequency(numberOfRepayments)
                 .repaymentFrequencyType(RepaymentFrequencyType.MONTHS).repaymentEvery(1).numberOfRepayments(numberOfRepayments);
@@ -439,18 +411,16 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
     public void testInterestPaymentWaiverUC3() {
         runAt("15 February 2023", () -> {
 
-            final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
+            final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId(),
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -459,10 +429,10 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             validateLoanTransaction(loanDetails, 1, 125.0, 125.0, 0.0, 375.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeInterestPaymentWaiver(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(150.0));
+            makeInterestPaymentWaiver(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("16 January 2023").locale("en").transactionAmount(150.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 225.0, 275.0, 225.0, 275.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -471,10 +441,10 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             validateLoanTransaction(loanDetails, 2, 150.0, 150.0, 0.0, 225.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(125.0));
+            makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("31 January 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 100.0, 400.0, 100.0, 400.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -483,10 +453,10 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             validateLoanTransaction(loanDetails, 3, 125.0, 125.0, 0.0, 100.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("15 February 2023").locale("en").transactionAmount(125.0));
+            makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("15 February 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, 25.0);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -507,18 +477,16 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
     public void testInterestPaymentWaiverUC12() {
         runAt("15 February 2023", () -> {
 
-            final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
+            final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId(),
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -527,10 +495,10 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             validateLoanTransaction(loanDetails, 1, 125.0, 125.0, 0.0, 375.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeInterestPaymentWaiver(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("08 January 2023").locale("en").transactionAmount(200.0));
+            makeInterestPaymentWaiver(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("08 January 2023").locale("en").transactionAmount(200.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 175.0, 325.0, 175.0, 325.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -539,10 +507,10 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             validateLoanTransaction(loanDetails, 2, 200.0, 200.0, 0.0, 175.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(125.0));
+            makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("16 January 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 50.0, 450.0, 50.0, 450.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -551,10 +519,10 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             validateLoanTransaction(loanDetails, 3, 125.0, 125.0, 0.0, 50.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(50.0));
+            makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("31 January 2023").locale("en").transactionAmount(50.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -575,18 +543,16 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
     public void testInterestPaymentWaiverUC13() {
         runAt("15 February 2023", () -> {
 
-            final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
+            final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId(),
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -595,10 +561,10 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             validateLoanTransaction(loanDetails, 1, 125.0, 125.0, 0.0, 375.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeInterestPaymentWaiver(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("08 January 2023").locale("en").transactionAmount(200.0));
+            makeInterestPaymentWaiver(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("08 January 2023").locale("en").transactionAmount(200.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 175.0, 325.0, 175.0, 325.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -607,10 +573,10 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             validateLoanTransaction(loanDetails, 2, 200.0, 200.0, 0.0, 175.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(125.0));
+            makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("16 January 2023").locale("en").transactionAmount(125.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 50.0, 450.0, 50.0, 450.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -619,10 +585,10 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             validateLoanTransaction(loanDetails, 3, 125.0, 125.0, 0.0, 50.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(50.0));
+            makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("31 January 2023").locale("en").transactionAmount(50.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -644,23 +610,21 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
     public void testInterestPaymentWaiverUC15() {
         runAt("15 February 2023", () -> {
 
-            final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
+            final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId(),
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
-            loanTransactionHelper.reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(1).getId(),
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanResponse.getLoanId());
+            reverseLoanTransaction(loanResponse.getLoanId(), loanDetails.getTransactions().get(1).getId(),
                     new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).transactionDate("01 January 2023")
                             .transactionAmount(0.0).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 500.0, 0.0, 500.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 0.0, 125.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -668,10 +632,10 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             validateRepaymentPeriod(loanDetails, 4, 125.0, 0.0, 125.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeInterestPaymentWaiver(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("15 January 2023").locale("en").transactionAmount(200.0));
+            makeInterestPaymentWaiver(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("15 January 2023").locale("en").transactionAmount(200.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 300.0, 200.0, 300.0, 200.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -680,9 +644,9 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             validateLoanTransaction(loanDetails, 2, 200.0, 200.0, 0.0, 300.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("16 January 2023").locale("en").transactionAmount(125.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("16 January 2023").locale("en").transactionAmount(125.0));
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 175.0, 325.0, 175.0, 325.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -691,9 +655,9 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             validateLoanTransaction(loanDetails, 3, 125.0, 125.0, 0.0, 175.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("31 January 2023").locale("en").transactionAmount(125.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("31 January 2023").locale("en").transactionAmount(125.0));
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 50.0, 450.0, 50.0, 450.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -702,9 +666,9 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             validateLoanTransaction(loanDetails, 4, 125.0, 125.0, 0.0, 50.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("15 February 2023").locale("en").transactionAmount(50.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("15 February 2023").locale("en").transactionAmount(50.0));
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 125.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 0.0, 0.0);
@@ -726,18 +690,16 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
     public void testInterestPaymentWaiverUC17c() {
         runAt("15 February 2023", () -> {
 
-            final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId,
+            final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), commonLoanProductId(),
                     BigDecimal.valueOf(500.0), 45, 15, 3, BigDecimal.ZERO, "01 January 2023", "01 January 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 January 2023").locale("en"));
+            approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(500))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 January 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
+            disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 January 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(500.00)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 375.0, 125.0, 375.0, 125.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 0.0, 125.0, 0.0, 0.0);
@@ -746,10 +708,10 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             validateLoanTransaction(loanDetails, 1, 125.0, 125.0, 0.0, 375.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeInterestPaymentWaiver(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("08 January 2023").locale("en").transactionAmount(500.0));
+            makeInterestPaymentWaiver(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("08 January 2023").locale("en").transactionAmount(500.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, 125.0);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -758,9 +720,9 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             validateLoanTransaction(loanDetails, 2, 500.0, 375.0, 125.0, 0.0);
             assertTrue(loanDetails.getStatus().getOverpaid());
 
-            loanTransactionHelper.makeCreditBalanceRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("09 January 2023").locale("en").transactionAmount(125.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            makeCreditBalanceRefund(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("09 January 2023").locale("en").transactionAmount(125.0));
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 0.0, 500.0, 0.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, 125.0, 125.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, 125.0, 125.0, 0.0, 125.0, 0.0);
@@ -775,8 +737,6 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
      * Tests successful run of batch Interest Payment Waiver for loans. 200(OK) status is returned for successful
      * responses. It first creates a new loan, approves and disburses the loan. Then a Interest Payment Waiver request
      * is made
-     *
-     * @see CreateTransactionLoanCommandStrategy
      */
     @Test
     public void shouldReturnOkStatusForBatchInterestPaymentWaiver() {
@@ -792,16 +752,15 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                 .withInterestTypeAsDecliningBalance() //
                 .currencyDetails("0", "100").build(null);
 
-        final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec);
-        ClientHelper.verifyClientCreatedOnServer(requestSpec, responseSpec, clientID);
+        final Long clientId = createClient();
+        assertNotNull(clientId);
 
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(requestSpec, responseSpec);
-        Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(requestSpec, responseSpec, clientID.toString(),
-                collateralId);
-        Assertions.assertNotNull(clientCollateralId);
+        final Long collateralId = collateralHelper.createCollateralProduct().getResourceId();
+        assertNotNull(collateralId);
+        final Long clientCollateralId = collateralHelper.createClientCollateral(clientId, collateralId).getResourceId();
+        assertNotNull(clientCollateralId);
 
-        final Integer productId = new LoanTransactionHelper(requestSpec, responseSpec).getLoanProductId(loanProductJSON);
+        final Integer productId = getLoanProductId(loanProductJSON);
 
         final Long createActiveClientRequestId = 4730L;
         final Long applyLoanRequestId = createActiveClientRequestId + 1;
@@ -809,21 +768,44 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
         final Long disburseLoanRequestId = approveLoanRequestId + 1;
         final Long interestPaymentWaiverRequestId = disburseLoanRequestId + 1;
 
+        final String applyAndApproveDate = dateTimeFormatter.format(LocalDate.now(Utils.getZoneIdOfTenant()).minusDays(10));
+        final String disburseDate = dateTimeFormatter.format(LocalDate.now(Utils.getZoneIdOfTenant()).minusDays(8));
+        final String waiverDate = dateTimeFormatter.format(LocalDate.now(Utils.getZoneIdOfTenant()));
+
         // Create a createClient Request
-        final BatchRequest br1 = BatchHelper.createActiveClientRequest(createActiveClientRequestId, "");
+        final BatchRequest br1 = new BatchRequest().requestId(createActiveClientRequestId).relativeUrl("v1/clients").method("POST")
+                .body("{ \"officeId\": 1, \"legalFormId\":1, \"firstname\": \"Petra\", \"lastname\": \"Yton\"," + "\"externalId\": \"\","
+                        + "  \"dateFormat\": \"dd MMMM yyyy\", \"locale\": \"en\","
+                        + "\"active\": true, \"activationDate\": \"04 March 2010\", \"submittedOnDate\": \"04 March 2010\"}");
 
         // Create a ApplyLoan Request
-        final BatchRequest br2 = BatchHelper.applyLoanRequest(applyLoanRequestId, createActiveClientRequestId, productId,
-                clientCollateralId);
+        final BatchRequest br2 = new BatchRequest().requestId(applyLoanRequestId).relativeUrl("v1/loans").method("POST")
+                .reference(createActiveClientRequestId)
+                .body("{\"dateFormat\": \"dd MMMM yyyy\", \"locale\": \"en_GB\", \"clientId\": \"$.clientId\"," + "\"productId\": "
+                        + productId + ", \"principal\": \"10,000.00\", \"loanTermFrequency\": 10,"
+                        + "\"loanTermFrequencyType\": 2, \"loanType\": \"individual\", \"numberOfRepayments\": 10,"
+                        + "\"repaymentEvery\": 1, \"repaymentFrequencyType\": 2, \"interestRatePerPeriod\": 10,"
+                        + "\"amortizationType\": 1, \"interestType\": 0, \"interestCalculationPeriodType\": 1,"
+                        + "\"transactionProcessingStrategyCode\": \"mifos-standard-strategy\", \"expectedDisbursementDate\": \""
+                        + applyAndApproveDate + "\"," + "\"collateral\": [{\"clientCollateralId\": \"" + clientCollateralId
+                        + "\", \"quantity\": \"1\"}]," + "\"submittedOnDate\": \"" + applyAndApproveDate + "\"}");
 
         // Create a approveLoan Request
-        final BatchRequest br3 = BatchHelper.approveLoanRequest(approveLoanRequestId, applyLoanRequestId);
+        final BatchRequest br3 = new BatchRequest().requestId(approveLoanRequestId).relativeUrl("v1/loans/$.loanId?command=approve")
+                .reference(applyLoanRequestId).method("POST")
+                .body("{\"locale\": \"en\", \"dateFormat\": \"dd MMMM yyyy\", \"approvedOnDate\": \"" + applyAndApproveDate + "\","
+                        + "\"note\": \"Loan approval note\", \"expectedDisbursementDate\": \"" + applyAndApproveDate + "\"}");
 
         // Create a disburseLoan Request
-        final BatchRequest br4 = BatchHelper.disburseLoanRequest(disburseLoanRequestId, approveLoanRequestId);
+        final BatchRequest br4 = new BatchRequest().requestId(disburseLoanRequestId).relativeUrl("v1/loans/$.loanId?command=disburse")
+                .reference(approveLoanRequestId).method("POST")
+                .body("{\"locale\": \"en\", \"dateFormat\": \"dd MMMM yyyy\", \"actualDisbursementDate\": \"" + disburseDate + "\"}");
 
         // Create a Interest Payment Waiver request.
-        final BatchRequest br5 = BatchHelper.interestPaymentWaiverRequest(interestPaymentWaiverRequestId, disburseLoanRequestId, "500");
+        final BatchRequest br5 = new BatchRequest().requestId(interestPaymentWaiverRequestId)
+                .relativeUrl("v1/loans/$.loanId/transactions?command=interestPaymentWaiver").reference(disburseLoanRequestId).method("POST")
+                .body("{\"locale\": \"en\", \"dateFormat\": \"dd MMMM yyyy\", " + "\"transactionDate\": \"" + waiverDate
+                        + "\",  \"transactionAmount\": 500, \"note\":null}");
 
         final List<BatchRequest> batchRequests = new ArrayList<>();
 
@@ -833,12 +815,9 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
         batchRequests.add(br4);
         batchRequests.add(br5);
 
-        final String batchRequestStr = BatchHelper.toJsonString(batchRequests);
+        final List<BatchResponse> response = batchHelper.executeWithoutEnclosingTransaction(batchRequests);
 
-        final List<BatchResponse> response = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(requestSpec, responseSpec,
-                batchRequestStr);
-
-        Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(4).getStatusCode(), "Verify Status Code 200 for Goodwill credit");
+        assertEquals(200, response.get(4).getStatusCode(), "Verify Status Code 200 for interest payment waiver");
     }
 
     // PW UC112: Advanced payment allocation, horizontal repayment processing
@@ -854,24 +833,17 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
     public void testInterestPaymentWaiverUC112() {
         runAt("01 September 2023", () -> {
 
-            final Account assetAccount = accountHelper.createAssetAccount();
-            final Account incomeAccount = accountHelper.createIncomeAccount();
-            final Account expenseAccount = accountHelper.createExpenseAccount();
-            final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
-                    LoanScheduleProcessingType.HORIZONTAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
+            Long localLoanProductId = createLoanProduct(1000.0, 15, 3, true, "25", false, HORIZONTAL);
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId,
                     BigDecimal.valueOf(1000.0), 45, 15, 3, BigDecimal.ZERO, "01 September 2023", "01 September 2023");
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 September 2023").locale("en"));
+            approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 September 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 September 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 September 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1000.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -880,12 +852,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             assertTrue(loanDetails.getStatus().getActive());
 
             // Add Charge Penalty
-            Integer penalty = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "20", true));
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "17 October 2023", "20"));
+            Long penalty = chargesHelper.createLoanSpecifiedDueDatePenalty(20.0).getResourceId();
+            addChargesForLoan(loanResponse.getLoanId(), new PostLoansLoanIdChargesRequest().chargeId(penalty).amount(20.0)
+                    .dueDate("17 October 2023").dateFormat(DATETIME_PATTERN).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1020.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -895,9 +866,9 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("01 September 2023").locale("en").transactionAmount(250.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("01 September 2023").locale("en").transactionAmount(250.0));
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 770.0, 250.0, 750.0, 250.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -907,12 +878,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            businessDateHelper.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("2023.09.16").dateFormat("yyyy.MM.dd").locale("en"));
+            updateBusinessDate("16 September 2023");
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("16 September 2023").locale("en").transactionAmount(250.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("16 September 2023").locale("en").transactionAmount(250.0));
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 520.0, 500.0, 500.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 250.0, 0.0, 0.0, 0.0);
@@ -922,14 +892,14 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "17 September 2023", "20"));
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "16 October 2023", "20"));
+            addChargesForLoan(loanResponse.getLoanId(), new PostLoansLoanIdChargesRequest().chargeId(penalty).amount(20.0)
+                    .dueDate("17 September 2023").dateFormat(DATETIME_PATTERN).locale("en"));
+            addChargesForLoan(loanResponse.getLoanId(), new PostLoansLoanIdChargesRequest().chargeId(penalty).amount(20.0)
+                    .dueDate("16 October 2023").dateFormat(DATETIME_PATTERN).locale("en"));
 
-            loanTransactionHelper.makeInterestPaymentWaiver(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("16 September 2023").locale("en").transactionAmount(50.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            makeInterestPaymentWaiver(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("16 September 2023").locale("en").transactionAmount(50.0));
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 510.0, 550.0, 490.0, 510.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 250.0, 0.0, 0.0, 0.0);
@@ -960,25 +930,17 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
     public void testInterestPaymentWaiverUC113() {
         runAt("01 September 2023", () -> {
 
-            final Account assetAccount = accountHelper.createAssetAccount();
-            final Account incomeAccount = accountHelper.createIncomeAccount();
-            final Account expenseAccount = accountHelper.createExpenseAccount();
-            final Account overpaymentAccount = accountHelper.createLiabilityAccount();
-            Integer localLoanProductId = createLoanProduct("1000", "15", "3", true, "25", false, LoanScheduleType.PROGRESSIVE,
-                    LoanScheduleProcessingType.VERTICAL, assetAccount, incomeAccount, expenseAccount, overpaymentAccount);
+            Long localLoanProductId = createLoanProduct(1000.0, 15, 3, true, "25", false, VERTICAL);
             final PostLoansResponse loanResponse = applyForLoanApplication(client.getClientId(), localLoanProductId,
-                    BigDecimal.valueOf(1000.0), 45, 15, 3, BigDecimal.ZERO, "01 September 2023", "01 September 2023",
-                    LoanScheduleProcessingType.VERTICAL);
+                    BigDecimal.valueOf(1000.0), 45, 15, 3, BigDecimal.ZERO, "01 September 2023", "01 September 2023", VERTICAL);
 
-            loanTransactionHelper.approveLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
-                            .approvedOnDate("01 September 2023").locale("en"));
+            approveLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
+                    .dateFormat(DATETIME_PATTERN).approvedOnDate("01 September 2023").locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanResponse.getLoanId(),
-                    new PostLoansLoanIdRequest().actualDisbursementDate("01 September 2023").dateFormat(DATETIME_PATTERN)
-                            .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanResponse.getLoanId(), new PostLoansLoanIdRequest().actualDisbursementDate("01 September 2023")
+                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1000.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -987,12 +949,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             assertTrue(loanDetails.getStatus().getActive());
 
             // Add Charge Penalty
-            Integer penalty = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, "20", true));
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "17 October 2023", "20"));
+            Long penalty = chargesHelper.createLoanSpecifiedDueDatePenalty(20.0).getResourceId();
+            addChargesForLoan(loanResponse.getLoanId(), new PostLoansLoanIdChargesRequest().chargeId(penalty).amount(20.0)
+                    .dueDate("17 October 2023").dateFormat(DATETIME_PATTERN).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 1020.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 0.0, 250.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -1002,9 +963,9 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("01 September 2023").locale("en").transactionAmount(250.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("01 September 2023").locale("en").transactionAmount(250.0));
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 770.0, 250.0, 750.0, 250.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 0.0, 250.0, 0.0, 0.0);
@@ -1014,12 +975,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            businessDateHelper.updateBusinessDate(new BusinessDateUpdateRequest().type(BusinessDateUpdateRequest.TypeEnum.BUSINESS_DATE)
-                    .date("2023.09.16").dateFormat("yyyy.MM.dd").locale("en"));
+            updateBusinessDate("16 September 2023");
 
-            loanTransactionHelper.makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("16 September 2023").locale("en").transactionAmount(250.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            makeLoanRepayment(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("16 September 2023").locale("en").transactionAmount(250.0));
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 520.0, 500.0, 500.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 250.0, 0.0, 0.0, 0.0);
@@ -1029,14 +989,14 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     0.0, 0.0, 0.0);
             assertTrue(loanDetails.getStatus().getActive());
 
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "17 September 2023", "20"));
-            loanTransactionHelper.addChargesForLoan(loanResponse.getLoanId().intValue(),
-                    LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "16 October 2023", "20"));
+            addChargesForLoan(loanResponse.getLoanId(), new PostLoansLoanIdChargesRequest().chargeId(penalty).amount(20.0)
+                    .dueDate("17 September 2023").dateFormat(DATETIME_PATTERN).locale("en"));
+            addChargesForLoan(loanResponse.getLoanId(), new PostLoansLoanIdChargesRequest().chargeId(penalty).amount(20.0)
+                    .dueDate("16 October 2023").dateFormat(DATETIME_PATTERN).locale("en"));
 
-            loanTransactionHelper.makeInterestPaymentWaiver(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest()
-                    .dateFormat(DATETIME_PATTERN).transactionDate("16 September 2023").locale("en").transactionAmount(50.0));
-            loanDetails = loanTransactionHelper.getLoanDetails(loanResponse.getLoanId());
+            makeInterestPaymentWaiver(loanResponse.getLoanId(), new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                    .transactionDate("16 September 2023").locale("en").transactionAmount(50.0));
+            loanDetails = getLoanDetails(loanResponse.getLoanId());
             validateLoanSummaryBalances(loanDetails, 510.0, 550.0, 500.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 9, 1), 250.0, 250.0, 0.0, 0.0, 0.0);
             validateRepaymentPeriod(loanDetails, 2, LocalDate.of(2023, 9, 16), 250.0, 250.0, 0.0, 0.0, 0.0);
@@ -1066,6 +1026,14 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
     public void testAccounting() {
         runAt("15 May 2023", () -> {
 
+            final Account fundSource = getAccounts().getFundSource();
+            final Account loansReceivableAccount = getAccounts().getLoansReceivableAccount();
+            final Account interestReceivableAccount = getAccounts().getInterestReceivableAccount();
+            final Account feeReceivableAccount = getAccounts().getFeeReceivableAccount();
+            final Account penaltyReceivableAccount = getAccounts().getPenaltyReceivableAccount();
+            final Account interestIncomeAccount = getAccounts().getInterestIncomeAccount();
+            final Account overpaymentAccount = getAccounts().getOverpaymentAccount();
+
             final String disbursementDay = "01 January 2023";
             final String repaymentPeriod1DueDate = "01 February 2023";
             final String repaymentPeriod2DueDate = "01 March 2023";
@@ -1076,18 +1044,18 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             final Long loanId = applyForLoanApplicationWithInterest(client.getClientId(), localLoanProductId, BigDecimal.valueOf(40000),
                     disbursementDay);
 
-            loanTransactionHelper.approveLoan(loanId, new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
-                    .dateFormat(DATETIME_PATTERN).approvedOnDate(disbursementDay).locale("en"));
+            approveLoan(loanId, new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
+                    .approvedOnDate(disbursementDay).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
             chargePenalty(loanId, 30.0, repaymentPeriod1DueDate);
             chargePenalty(loanId, 50.0, repaymentPeriod2DueDate);
             chargeFee(loanId, 40.0, repaymentPeriod1DueDate);
             chargeFee(loanId, 60.0, repaymentPeriod3DueDate);
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 1260.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 250.0, 0.0, 250.0, 40.0, 0.0, 40.0, 30.0, 0.0, 30.0, 20.0,
                     0.0, 20.0, 0.0, 0.0);
@@ -1100,11 +1068,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             assertTrue(loanDetails.getStatus().getActive());
 
             // transaction 1
-            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr1 = loanTransactionHelper.makeInterestPaymentWaiver(loanId,
+            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr1 = makeInterestPaymentWaiver(loanId,
                     new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate(repaymentPeriod1DueDate)
                             .locale("en").transactionAmount(340.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 920.0, 340.0, 750.0, 250.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 250.0, 250.0, 0.0, 40.0, 40.0, 0.0, 30.0, 30.0, 0.0, 20.0,
                     20.0, 0.0, 0.0, 0.0);
@@ -1131,11 +1099,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     journalEntry(340.0, interestIncomeAccount, "DEBIT"));
 
             // transaction 2
-            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr2 = loanTransactionHelper.makeInterestPaymentWaiver(loanId,
+            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr2 = makeInterestPaymentWaiver(loanId,
                     new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate(repaymentPeriod2DueDate)
                             .locale("en").transactionAmount(320.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 600.0, 660.0, 500.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 250.0, 250.0, 0.0, 40.0, 40.0, 0.0, 30.0, 30.0, 0.0, 20.0,
                     20.0, 0.0, 0.0, 0.0);
@@ -1165,11 +1133,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     journalEntry(340.0, interestIncomeAccount, "DEBIT"));
 
             // transaction 3
-            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr3 = loanTransactionHelper.makeInterestPaymentWaiver(loanId,
+            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr3 = makeInterestPaymentWaiver(loanId,
                     new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate(repaymentPeriod3DueDate)
                             .locale("en").transactionAmount(330.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 270.0, 990.0, 250.0, 750.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 250.0, 250.0, 0.0, 40.0, 40.0, 0.0, 30.0, 30.0, 0.0, 20.0,
                     20.0, 0.0, 0.0, 0.0);
@@ -1203,11 +1171,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     journalEntry(330.0, interestIncomeAccount, "DEBIT"));
 
             // transaction 4 + overpayment
-            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr4 = loanTransactionHelper.makeInterestPaymentWaiver(loanId,
+            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr4 = makeInterestPaymentWaiver(loanId,
                     new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate(repaymentPeriod4DueDate)
                             .locale("en").transactionAmount(350.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 0.0, 1260.0, 0.0, 1000.0, 80.0);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 250.0, 250.0, 0.0, 40.0, 40.0, 0.0, 30.0, 30.0, 0.0, 20.0,
                     20.0, 0.0, 0.0, 0.0);
@@ -1227,11 +1195,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     journalEntry(350.0, interestIncomeAccount, "DEBIT"));
 
             // reverse transaction 4
-            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr4Reverse = loanTransactionHelper.reverseLoanTransaction(loanId,
+            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr4Reverse = reverseLoanTransaction(loanId,
                     interestPaymentWaiverTr4.getResourceId(), new PostLoansLoanIdTransactionsTransactionIdRequest()
                             .dateFormat(DATETIME_PATTERN).transactionDate(repaymentPeriod4DueDate).transactionAmount(0.0).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 270.0, 990.0, 250.0, 750.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 250.0, 250.0, 0.0, 40.0, 40.0, 0.0, 30.0, 30.0, 0.0, 20.0,
                     20.0, 0.0, 0.0, 0.0);
@@ -1253,11 +1221,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     journalEntry(350.0, interestIncomeAccount, "DEBIT"));
 
             // reverse transaction 3
-            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr3Reverse = loanTransactionHelper.reverseLoanTransaction(loanId,
+            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr3Reverse = reverseLoanTransaction(loanId,
                     interestPaymentWaiverTr3.getResourceId(), new PostLoansLoanIdTransactionsTransactionIdRequest()
                             .dateFormat(DATETIME_PATTERN).transactionDate(repaymentPeriod3DueDate).transactionAmount(0.0).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 600.0, 660.0, 500.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 250.0, 250.0, 0.0, 40.0, 40.0, 0.0, 30.0, 30.0, 0.0, 20.0,
                     20.0, 0.0, 0.0, 0.0);
@@ -1280,11 +1248,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     journalEntry(330.0, interestIncomeAccount, "CREDIT"));
 
             // reverse transaction 2
-            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr2Reverse = loanTransactionHelper.reverseLoanTransaction(loanId,
+            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr2Reverse = reverseLoanTransaction(loanId,
                     interestPaymentWaiverTr2.getResourceId(), new PostLoansLoanIdTransactionsTransactionIdRequest()
                             .dateFormat(DATETIME_PATTERN).transactionDate(repaymentPeriod2DueDate).transactionAmount(0.0).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 920.0, 340.0, 750.0, 250.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 250.0, 250.0, 0.0, 40.0, 40.0, 0.0, 30.0, 30.0, 0.0, 20.0,
                     20.0, 0.0, 0.0, 0.0);
@@ -1307,11 +1275,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     journalEntry(320.0, interestIncomeAccount, "CREDIT"));
 
             // reverse transaction 1
-            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr1Reverse = loanTransactionHelper.reverseLoanTransaction(loanId,
+            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr1Reverse = reverseLoanTransaction(loanId,
                     interestPaymentWaiverTr1.getResourceId(), new PostLoansLoanIdTransactionsTransactionIdRequest()
                             .dateFormat(DATETIME_PATTERN).transactionDate(repaymentPeriod1DueDate).transactionAmount(0.0).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 1260.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 250.0, 0.0, 250.0, 40.0, 0.0, 40.0, 30.0, 0.0, 30.0, 20.0,
                     0.0, 20.0, 0.0, 0.0);
@@ -1351,6 +1319,10 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
     public void testInterestPaymentWaiverTransactionAccountingAccuralForInterestPenaltyFeeOverpaymentChargeOFFLoan() {
         runAt("2 January 2023", () -> {
 
+            final Account interestIncomeAccount = getAccounts().getInterestIncomeAccount();
+            final Account interestIncomeChargeOffAccount = getAccounts().getInterestIncomeChargeOffAccount();
+            final Account overpaymentAccount = getAccounts().getOverpaymentAccount();
+
             final String disbursementDay = "01 January 2023";
             final String repaymentPeriod1DueDate = "01 February 2023";
             final String repaymentPeriod2DueDate = "01 March 2023";
@@ -1361,11 +1333,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             final Long loanId = applyForLoanApplicationWithInterest(client.getClientId(), localLoanProductId, BigDecimal.valueOf(40000),
                     disbursementDay);
 
-            loanTransactionHelper.approveLoan(loanId, new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000))
-                    .dateFormat(DATETIME_PATTERN).approvedOnDate(disbursementDay).locale("en"));
+            approveLoan(loanId, new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000)).dateFormat(DATETIME_PATTERN)
+                    .approvedOnDate(disbursementDay).locale("en"));
 
-            loanTransactionHelper.disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate(disbursementDay).dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
             chargePenalty(loanId, 30.0, repaymentPeriod1DueDate);
             chargePenalty(loanId, 50.0, repaymentPeriod2DueDate);
@@ -1375,15 +1347,14 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             // Charge-OFF loan
             String randomText = Utils.randomStringGenerator("en", 5) + Utils.randomNumberGenerator(6)
                     + Utils.randomStringGenerator("is", 5);
-            Integer chargeOffReasonId = CodeHelper.createChargeOffCodeValue(requestSpec, responseSpec, randomText, 1);
+            Long chargeOffReasonId = codeHelper.createChargeOffCodeValue(randomText, 1);
             String transactionExternalId = UUID.randomUUID().toString();
-            PostLoansLoanIdTransactionsResponse chargeOffTransaction = loanTransactionHelper.chargeOffLoan(loanId,
-                    new PostLoansLoanIdTransactionsRequest().transactionDate("2 January 2023").locale("en").dateFormat("dd MMMM yyyy")
-                            .externalId(transactionExternalId).chargeOffReasonId((long) chargeOffReasonId));
+            chargeOffLoan(loanId, new PostLoansLoanIdTransactionsRequest().transactionDate("2 January 2023").locale("en")
+                    .dateFormat("dd MMMM yyyy").externalId(transactionExternalId).chargeOffReasonId(chargeOffReasonId));
 
             updateBusinessDate("15 May 2023");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 1260.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 250.0, 0.0, 250.0, 40.0, 0.0, 40.0, 30.0, 0.0, 30.0, 20.0,
                     0.0, 20.0, 0.0, 0.0);
@@ -1396,11 +1367,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             assertTrue(loanDetails.getStatus().getActive());
 
             // transaction 1
-            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr1 = loanTransactionHelper.makeInterestPaymentWaiver(loanId,
+            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr1 = makeInterestPaymentWaiver(loanId,
                     new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate(repaymentPeriod1DueDate)
                             .locale("en").transactionAmount(340.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 920.0, 340.0, 750.0, 250.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 250.0, 250.0, 0.0, 40.0, 40.0, 0.0, 30.0, 30.0, 0.0, 20.0,
                     20.0, 0.0, 0.0, 0.0);
@@ -1416,11 +1387,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     journalEntry(340.0, interestIncomeAccount, "DEBIT"));
 
             // transaction 2
-            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr2 = loanTransactionHelper.makeInterestPaymentWaiver(loanId,
+            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr2 = makeInterestPaymentWaiver(loanId,
                     new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate(repaymentPeriod2DueDate)
                             .locale("en").transactionAmount(320.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 600.0, 660.0, 500.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 250.0, 250.0, 0.0, 40.0, 40.0, 0.0, 30.0, 30.0, 0.0, 20.0,
                     20.0, 0.0, 0.0, 0.0);
@@ -1436,11 +1407,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     journalEntry(320.0, interestIncomeAccount, "DEBIT"));
 
             // transaction 3
-            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr3 = loanTransactionHelper.makeInterestPaymentWaiver(loanId,
+            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr3 = makeInterestPaymentWaiver(loanId,
                     new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate(repaymentPeriod3DueDate)
                             .locale("en").transactionAmount(330.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 270.0, 990.0, 250.0, 750.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 250.0, 250.0, 0.0, 40.0, 40.0, 0.0, 30.0, 30.0, 0.0, 20.0,
                     20.0, 0.0, 0.0, 0.0);
@@ -1456,11 +1427,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     journalEntry(330.0, interestIncomeAccount, "DEBIT"));
 
             // transaction 4 + overpayment
-            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr4 = loanTransactionHelper.makeInterestPaymentWaiver(loanId,
+            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr4 = makeInterestPaymentWaiver(loanId,
                     new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).transactionDate(repaymentPeriod4DueDate)
                             .locale("en").transactionAmount(350.0));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 0.0, 1260.0, 0.0, 1000.0, 80.0);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 250.0, 250.0, 0.0, 40.0, 40.0, 0.0, 30.0, 30.0, 0.0, 20.0,
                     20.0, 0.0, 0.0, 0.0);
@@ -1479,11 +1450,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     journalEntry(350.0, interestIncomeAccount, "DEBIT"));
 
             // reverse transaction 4
-            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr4Reverse = loanTransactionHelper.reverseLoanTransaction(loanId,
+            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr4Reverse = reverseLoanTransaction(loanId,
                     interestPaymentWaiverTr4.getResourceId(), new PostLoansLoanIdTransactionsTransactionIdRequest()
                             .dateFormat(DATETIME_PATTERN).transactionDate(repaymentPeriod4DueDate).transactionAmount(0.0).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 270.0, 990.0, 250.0, 750.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 250.0, 250.0, 0.0, 40.0, 40.0, 0.0, 30.0, 30.0, 0.0, 20.0,
                     20.0, 0.0, 0.0, 0.0);
@@ -1504,11 +1475,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     journalEntry(350.0, interestIncomeAccount, "CREDIT"));
 
             // reverse transaction 3
-            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr3Reverse = loanTransactionHelper.reverseLoanTransaction(loanId,
+            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr3Reverse = reverseLoanTransaction(loanId,
                     interestPaymentWaiverTr3.getResourceId(), new PostLoansLoanIdTransactionsTransactionIdRequest()
                             .dateFormat(DATETIME_PATTERN).transactionDate(repaymentPeriod3DueDate).transactionAmount(0.0).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 600.0, 660.0, 500.0, 500.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 250.0, 250.0, 0.0, 40.0, 40.0, 0.0, 30.0, 30.0, 0.0, 20.0,
                     20.0, 0.0, 0.0, 0.0);
@@ -1527,11 +1498,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     journalEntry(330.0, interestIncomeAccount, "CREDIT"));
 
             // reverse transaction 2
-            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr2Reverse = loanTransactionHelper.reverseLoanTransaction(loanId,
+            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr2Reverse = reverseLoanTransaction(loanId,
                     interestPaymentWaiverTr2.getResourceId(), new PostLoansLoanIdTransactionsTransactionIdRequest()
                             .dateFormat(DATETIME_PATTERN).transactionDate(repaymentPeriod2DueDate).transactionAmount(0.0).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 920.0, 340.0, 750.0, 250.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 250.0, 250.0, 0.0, 40.0, 40.0, 0.0, 30.0, 30.0, 0.0, 20.0,
                     20.0, 0.0, 0.0, 0.0);
@@ -1550,11 +1521,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     journalEntry(320.0, interestIncomeAccount, "CREDIT"));
 
             // reverse transaction 1
-            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr1Reverse = loanTransactionHelper.reverseLoanTransaction(loanId,
+            PostLoansLoanIdTransactionsResponse interestPaymentWaiverTr1Reverse = reverseLoanTransaction(loanId,
                     interestPaymentWaiverTr1.getResourceId(), new PostLoansLoanIdTransactionsTransactionIdRequest()
                             .dateFormat(DATETIME_PATTERN).transactionDate(repaymentPeriod1DueDate).transactionAmount(0.0).locale("en"));
 
-            loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            loanDetails = getLoanDetails(loanId);
             validateLoanSummaryBalances(loanDetails, 1260.0, 0.0, 1000.0, 0.0, null);
             validateRepaymentPeriod(loanDetails, 1, LocalDate.of(2023, 2, 1), 250.0, 0.0, 250.0, 40.0, 0.0, 40.0, 30.0, 0.0, 30.0, 20.0,
                     0.0, 20.0, 0.0, 0.0);
@@ -1584,12 +1555,11 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
 
             LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-            PostLoanProductsResponse loanProductResponse = loanProductHelper
-                    .createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
-                            .loanScheduleType(LoanScheduleType.PROGRESSIVE.toString()));
+            Long loanProductId = createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
+                    .loanScheduleType("PROGRESSIVE"));
 
-            Long loanId = applyAndApproveLoanProgressiveAdvancedPaymentAllocationStrategyMonthlyRepayments(clientId,
-                    loanProductResponse.getResourceId(), numberOfRepayments, loanDisbursementDate, amount, null);
+            Long loanId = applyAndApproveLoanProgressiveAdvancedPaymentAllocationStrategyMonthlyRepayments(clientId, loanProductId,
+                    numberOfRepayments, loanDisbursementDate, amount, null);
 
             verifyRepaymentSchedule(loanId, //
                     installment(1000.0, null, "01 January 2023"), //
@@ -1599,8 +1569,8 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     installment(250.0, false, "01 May 2023") //
             );
 
-            loanTransactionHelper.disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2023")
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
+            disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2023").dateFormat(DATETIME_PATTERN)
+                    .transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
 
             // loan should be active
             Long transactionId = addInterestPaymentWaiverForLoan(loanId, 250.0, "2 January 2023");
@@ -1609,8 +1579,7 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                     transaction(1000.0, "Disbursement", "01 January 2023", 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
                     transaction(250.0, "Interest Payment Waiver", "02 January 2023", 750.0, 250.0, 0.0, 0.0, 0, 0.0, 0.0));
 
-            loanTransactionHelper.adjustLoanTransaction(loanId, transactionId, new PostLoansLoanIdTransactionsTransactionIdRequest()
-                    .transactionAmount(200.0).dateFormat(DATETIME_PATTERN).transactionDate("3 January 2023").locale("en"));
+            transactionHelper.adjustLoanTransaction(loanId, transactionId, "3 January 2023", 200.0);
 
             verifyTransactions(loanId, //
                     transaction(1000.0, "Disbursement", "01 January 2023", 1000.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
@@ -1626,8 +1595,7 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
 
         runAt("01 January 2025", () -> {
             PostLoanProductsRequest loanProductRequest = create4IProgressiveWithChargeOffBehaviour();
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductRequest);
-            Long loanProductId = loanProductResponse.getResourceId();
+            Long loanProductId = createLoanProduct(loanProductRequest);
             assertNotNull(loanProductId);
 
             PostClientsResponse clientResponse = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
@@ -1677,8 +1645,7 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             batchRequests.add(waiverRequest);
             batchRequests.add(getRequest);
 
-            List<BatchResponse> responses = BatchHelper.postBatchRequestsWithEnclosingTransaction(requestSpec, responseSpec,
-                    BatchHelper.toJsonString(batchRequests));
+            List<BatchResponse> responses = batchHelper.executeEnclosingTransaction(batchRequests);
 
             assertEquals(2, responses.size());
 
@@ -1724,8 +1691,7 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
     public void testInterestPaymentWaiverBackbookBatchExternalId() {
         runAt("01 January 2025", () -> {
             PostLoanProductsRequest loanProductRequest = create4IProgressiveWithChargeOffBehaviour();
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductRequest);
-            Long loanProductId = loanProductResponse.getResourceId();
+            Long loanProductId = createLoanProduct(loanProductRequest);
             assertNotNull(loanProductId);
 
             PostClientsResponse clientResponse = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
@@ -1742,9 +1708,9 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
 
             disburseLoan(loanId, BigDecimal.valueOf(431.98), "18 January 2022");
 
-            loanTransactionHelper.makeLoanRepayment("28 February 2022", 19.83f, loanId.intValue());
-            PostLoansLoanIdTransactionsResponse txn2 = loanTransactionHelper.makeLoanRepayment("18 March 2022", 19.83f, loanId.intValue());
-            loanTransactionHelper.reverseRepayment(loanId.intValue(), txn2.getResourceId().intValue(), "18 March 2022");
+            makeLoanRepayment(loanId, "repayment", "28 February 2022", 19.83);
+            PostLoansLoanIdTransactionsResponse txn2 = makeLoanRepayment(loanId, "repayment", "18 March 2022", 19.83);
+            reverseRepayment(loanId, txn2.getResourceId(), "18 March 2022");
 
             Long chargeOffTxnId = chargeOffLoan(loanId, "16 September 2022");
             assertNotNull(chargeOffTxnId);
@@ -1772,8 +1738,7 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             batchRequests.add(waiverRequest);
             batchRequests.add(getRequest);
 
-            List<BatchResponse> responses = BatchHelper.postBatchRequestsWithEnclosingTransaction(requestSpec, responseSpec,
-                    BatchHelper.toJsonString(batchRequests));
+            List<BatchResponse> responses = batchHelper.executeEnclosingTransaction(batchRequests);
 
             assertEquals(2, responses.size());
 
@@ -1809,8 +1774,7 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
 
         runAt("18 January 2022", () -> {
             PostLoanProductsRequest loanProductRequest = create4IProgressiveWithChargeOffBehaviour();
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductRequest);
-            Long loanProductId = loanProductResponse.getResourceId();
+            Long loanProductId = createLoanProduct(loanProductRequest);
             assertNotNull(loanProductId);
 
             PostClientsResponse clientResponse = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
@@ -1834,22 +1798,22 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
         String loanExternalId = loanExternalIdContainer[0];
 
         runAt("28 February 2022", () -> {
-            loanTransactionHelper.makeLoanRepayment("28 February 2022", 19.83f, loanId.intValue());
+            makeLoanRepayment(loanId, "repayment", "28 February 2022", 19.83);
         });
 
         runAt("18 March 2022", () -> {
-            PostLoansLoanIdTransactionsResponse txn = loanTransactionHelper.makeLoanRepayment("18 March 2022", 19.83f, loanId.intValue());
-            loanTransactionHelper.reverseRepayment(loanId.intValue(), txn.getResourceId().intValue(), "18 March 2022");
+            PostLoansLoanIdTransactionsResponse txn = makeLoanRepayment(loanId, "repayment", "18 March 2022", 19.83);
+            reverseRepayment(loanId, txn.getResourceId(), "18 March 2022");
         });
 
         runAt("31 March 2022", () -> {
-            PostLoansLoanIdTransactionsResponse txn = loanTransactionHelper.makeLoanRepayment("31 March 2022", 19.83f, loanId.intValue());
-            loanTransactionHelper.reverseRepayment(loanId.intValue(), txn.getResourceId().intValue(), "31 March 2022");
+            PostLoansLoanIdTransactionsResponse txn = makeLoanRepayment(loanId, "repayment", "31 March 2022", 19.83);
+            reverseRepayment(loanId, txn.getResourceId(), "31 March 2022");
         });
 
         runAt("18 April 2022", () -> {
-            PostLoansLoanIdTransactionsResponse txn = loanTransactionHelper.makeLoanRepayment("18 April 2022", 39.66f, loanId.intValue());
-            loanTransactionHelper.reverseRepayment(loanId.intValue(), txn.getResourceId().intValue(), "18 April 2022");
+            PostLoansLoanIdTransactionsResponse txn = makeLoanRepayment(loanId, "repayment", "18 April 2022", 39.66);
+            reverseRepayment(loanId, txn.getResourceId(), "18 April 2022");
         });
 
         runAt("16 September 2022", () -> {
@@ -1881,8 +1845,7 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             batchRequests.add(waiverRequest);
             batchRequests.add(getRequest);
 
-            List<BatchResponse> responses = BatchHelper.postBatchRequestsWithEnclosingTransaction(requestSpec, responseSpec,
-                    BatchHelper.toJsonString(batchRequests));
+            List<BatchResponse> responses = batchHelper.executeEnclosingTransaction(batchRequests);
 
             assertEquals(2, responses.size());
 
@@ -1915,8 +1878,7 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
     public void testInterestPaymentWaiverProductionScenarioBatchExternalId() {
         runAt("01 January 2025", () -> {
             PostLoanProductsRequest loanProductRequest = create4IProgressiveWithChargeOffBehaviour();
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductRequest);
-            Long loanProductId = loanProductResponse.getResourceId();
+            Long loanProductId = createLoanProduct(loanProductRequest);
             assertNotNull(loanProductId);
 
             PostClientsResponse clientResponse = clientHelper.createClient(ClientHelper.defaultClientCreationRequest());
@@ -1933,28 +1895,28 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
 
             disburseLoan(loanId, BigDecimal.valueOf(431.98), "18 January 2022");
 
-            loanTransactionHelper.makeLoanRepayment("28 February 2022", 19.83f, loanId.intValue());
+            makeLoanRepayment(loanId, "repayment", "28 February 2022", 19.83);
 
-            PostLoansLoanIdTransactionsResponse txn2 = loanTransactionHelper.makeLoanRepayment("18 March 2022", 19.83f, loanId.intValue());
-            loanTransactionHelper.reverseRepayment(loanId.intValue(), txn2.getResourceId().intValue(), "18 March 2022");
+            PostLoansLoanIdTransactionsResponse txn2 = makeLoanRepayment(loanId, "repayment", "18 March 2022", 19.83);
+            reverseRepayment(loanId, txn2.getResourceId(), "18 March 2022");
 
-            PostLoansLoanIdTransactionsResponse txn3 = loanTransactionHelper.makeLoanRepayment("31 March 2022", 19.83f, loanId.intValue());
-            loanTransactionHelper.reverseRepayment(loanId.intValue(), txn3.getResourceId().intValue(), "31 March 2022");
+            PostLoansLoanIdTransactionsResponse txn3 = makeLoanRepayment(loanId, "repayment", "31 March 2022", 19.83);
+            reverseRepayment(loanId, txn3.getResourceId(), "31 March 2022");
 
-            PostLoansLoanIdTransactionsResponse txn4 = loanTransactionHelper.makeLoanRepayment("18 April 2022", 39.66f, loanId.intValue());
-            loanTransactionHelper.reverseRepayment(loanId.intValue(), txn4.getResourceId().intValue(), "18 April 2022");
+            PostLoansLoanIdTransactionsResponse txn4 = makeLoanRepayment(loanId, "repayment", "18 April 2022", 39.66);
+            reverseRepayment(loanId, txn4.getResourceId(), "18 April 2022");
 
-            PostLoansLoanIdTransactionsResponse txn5 = loanTransactionHelper.makeLoanRepayment("18 May 2022", 59.49f, loanId.intValue());
-            loanTransactionHelper.reverseRepayment(loanId.intValue(), txn5.getResourceId().intValue(), "18 May 2022");
+            PostLoansLoanIdTransactionsResponse txn5 = makeLoanRepayment(loanId, "repayment", "18 May 2022", 59.49);
+            reverseRepayment(loanId, txn5.getResourceId(), "18 May 2022");
 
-            PostLoansLoanIdTransactionsResponse txn6 = loanTransactionHelper.makeLoanRepayment("18 June 2022", 64.83f, loanId.intValue());
-            loanTransactionHelper.reverseRepayment(loanId.intValue(), txn6.getResourceId().intValue(), "18 June 2022");
+            PostLoansLoanIdTransactionsResponse txn6 = makeLoanRepayment(loanId, "repayment", "18 June 2022", 64.83);
+            reverseRepayment(loanId, txn6.getResourceId(), "18 June 2022");
 
-            PostLoansLoanIdTransactionsResponse txn7 = loanTransactionHelper.makeLoanRepayment("18 July 2022", 65.32f, loanId.intValue());
-            loanTransactionHelper.reverseRepayment(loanId.intValue(), txn7.getResourceId().intValue(), "18 July 2022");
+            PostLoansLoanIdTransactionsResponse txn7 = makeLoanRepayment(loanId, "repayment", "18 July 2022", 65.32);
+            reverseRepayment(loanId, txn7.getResourceId(), "18 July 2022");
 
-            PostLoansLoanIdTransactionsResponse txn8 = loanTransactionHelper.makeLoanRepayment("18 August 2022", 65.83f, loanId.intValue());
-            loanTransactionHelper.reverseRepayment(loanId.intValue(), txn8.getResourceId().intValue(), "18 August 2022");
+            PostLoansLoanIdTransactionsResponse txn8 = makeLoanRepayment(loanId, "repayment", "18 August 2022", 65.83);
+            reverseRepayment(loanId, txn8.getResourceId(), "18 August 2022");
 
             Long chargeOffTxnId = chargeOffLoan(loanId, "16 September 2022");
             assertNotNull(chargeOffTxnId);
@@ -1982,8 +1944,7 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
             batchRequests.add(waiverRequest);
             batchRequests.add(getRequest);
 
-            List<BatchResponse> responses = BatchHelper.postBatchRequestsWithEnclosingTransaction(requestSpec, responseSpec,
-                    BatchHelper.toJsonString(batchRequests));
+            List<BatchResponse> responses = batchHelper.executeEnclosingTransaction(batchRequests);
 
             if (responses.size() != 2) {
                 fail("Batch API returned " + responses.size() + " responses instead of 2.");
@@ -2036,27 +1997,17 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
     }
 
     private void chargeFee(Long loanId, Double amount, String dueDate) {
-        PostChargesResponse feeCharge = chargesHelper.createCharges(new ChargeRequest().penalty(false).amount(9.0)
-                .chargeCalculationType(ChargeCalculationType.FLAT.getValue()).chargeTimeType(ChargeTimeType.SPECIFIED_DUE_DATE.getValue())
-                .chargePaymentMode(ChargePaymentMode.REGULAR.getValue()).currencyCode("USD")
-                .name(Utils.randomStringGenerator("FEE_" + Calendar.getInstance().getTimeInMillis(), 5)).chargeAppliesTo(1).locale("en")
-                .active(true));
-        PostLoansLoanIdChargesResponse feeLoanChargeResult = loanTransactionHelper.addChargesForLoan(loanId,
-                new PostLoansLoanIdChargesRequest().chargeId(feeCharge.getResourceId()).dateFormat(DATETIME_PATTERN).locale("en")
-                        .amount(amount).dueDate(dueDate));
+        PostChargesResponse feeCharge = chargesHelper.createLoanSpecifiedDueDateCharge(9.0);
+        PostLoansLoanIdChargesResponse feeLoanChargeResult = addChargesForLoan(loanId, new PostLoansLoanIdChargesRequest()
+                .chargeId(feeCharge.getResourceId()).dateFormat(DATETIME_PATTERN).locale("en").amount(amount).dueDate(dueDate));
         assertNotNull(feeLoanChargeResult);
         assertNotNull(feeLoanChargeResult.getResourceId());
     }
 
     private void chargePenalty(Long loanId, Double amount, String dueDate) {
-        PostChargesResponse penaltyCharge = chargesHelper.createCharges(new ChargeRequest().penalty(true).amount(10.0)
-                .chargeCalculationType(ChargeCalculationType.FLAT.getValue()).chargeTimeType(ChargeTimeType.SPECIFIED_DUE_DATE.getValue())
-                .chargePaymentMode(ChargePaymentMode.REGULAR.getValue()).currencyCode("USD")
-                .name(Utils.randomStringGenerator("PENALTY_" + Calendar.getInstance().getTimeInMillis(), 5)).chargeAppliesTo(1).locale("en")
-                .active(true));
-        PostLoansLoanIdChargesResponse penaltyLoanChargeResult = loanTransactionHelper.addChargesForLoan(loanId,
-                new PostLoansLoanIdChargesRequest().chargeId(penaltyCharge.getResourceId()).dateFormat(DATETIME_PATTERN).locale("en")
-                        .amount(amount).dueDate(dueDate));
+        PostChargesResponse penaltyCharge = chargesHelper.createLoanSpecifiedDueDatePenalty(10.0);
+        PostLoansLoanIdChargesResponse penaltyLoanChargeResult = addChargesForLoan(loanId, new PostLoansLoanIdChargesRequest()
+                .chargeId(penaltyCharge.getResourceId()).dateFormat(DATETIME_PATTERN).locale("en").amount(amount).dueDate(dueDate));
         assertNotNull(penaltyLoanChargeResult);
         assertNotNull(penaltyLoanChargeResult.getResourceId());
     }
@@ -2065,38 +2016,38 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
         LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
         String name = Utils.uniqueRandomStringGenerator("LOAN_PRODUCT_", 6);
         String shortName = Utils.uniqueRandomStringGenerator("", 4);
-        return loanTransactionHelper.createLoanProduct(new PostLoanProductsRequest().name(name).shortName(shortName)
-                .description("Test loan description").currencyCode("USD").digitsAfterDecimal(2).daysInYearType(1).daysInMonthType(1)
-                .interestRecalculationCompoundingMethod(0).recalculationRestFrequencyType(1).rescheduleStrategyMethod(1)
-                .recalculationRestFrequencyInterval(0).isInterestRecalculationEnabled(false).interestRateFrequencyType(2).locale("en_GB")
-                .numberOfRepayments(4).repaymentFrequencyType(2L).interestRatePerPeriod(2.0).repaymentEvery(1).minPrincipal(100.0)
-                .principal(1000.0).maxPrincipal(10000000.0).amortizationType(1).interestType(1).interestCalculationPeriodType(1)
-                .dateFormat("dd MMMM yyyy").transactionProcessingStrategyCode(DEFAULT_STRATEGY).accountingRule(3)
-                .fundSourceAccountId(fundSource.getAccountID().longValue())//
-                .loanPortfolioAccountId(loansReceivableAccount.getAccountID().longValue())//
-                .transfersInSuspenseAccountId(suspenseAccount.getAccountID().longValue())//
-                .interestOnLoanAccountId(interestIncomeAccount.getAccountID().longValue())//
-                .incomeFromFeeAccountId(feeIncomeAccount.getAccountID().longValue())//
-                .incomeFromPenaltyAccountId(feeIncomeAccount.getAccountID().longValue())//
-                .incomeFromRecoveryAccountId(recoveriesAccount.getAccountID().longValue())//
-                .writeOffAccountId(writtenOffAccount.getAccountID().longValue())//
-                .overpaymentLiabilityAccountId(overpaymentAccount.getAccountID().longValue())//
-                .receivableInterestAccountId(interestReceivableAccount.getAccountID().longValue())//
-                .receivableFeeAccountId(feeReceivableAccount.getAccountID().longValue())//
-                .receivablePenaltyAccountId(penaltyReceivableAccount.getAccountID().longValue())//
-                .goodwillCreditAccountId(goodwillExpenseAccount.getAccountID().longValue())//
-                .incomeFromGoodwillCreditInterestAccountId(goodwillIncomeAccount.getAccountID().longValue())//
-                .incomeFromGoodwillCreditFeesAccountId(goodwillIncomeAccount.getAccountID().longValue())//
-                .incomeFromGoodwillCreditPenaltyAccountId(goodwillIncomeAccount.getAccountID().longValue())//
-                .incomeFromChargeOffInterestAccountId(interestIncomeChargeOffAccount.getAccountID().longValue())//
-                .incomeFromChargeOffFeesAccountId(feeChargeOffAccount.getAccountID().longValue())//
-                .chargeOffExpenseAccountId(chargeOffExpenseAccount.getAccountID().longValue())//
-                .chargeOffFraudExpenseAccountId(chargeOffFraudExpenseAccount.getAccountID().longValue())//
-                .incomeFromChargeOffPenaltyAccountId(penaltyChargeOffAccount.getAccountID().longValue())//
-        ).getResourceId();
+        return createLoanProduct(new PostLoanProductsRequest().name(name).shortName(shortName).description("Test loan description")
+                .currencyCode("USD").digitsAfterDecimal(2).daysInYearType(1).daysInMonthType(1).interestRecalculationCompoundingMethod(0)
+                .recalculationRestFrequencyType(1).rescheduleStrategyMethod(1).recalculationRestFrequencyInterval(0)
+                .isInterestRecalculationEnabled(false).interestRateFrequencyType(2).locale("en_GB").numberOfRepayments(4)
+                .repaymentFrequencyType(2L).interestRatePerPeriod(2.0).repaymentEvery(1).minPrincipal(100.0).principal(1000.0)
+                .maxPrincipal(10000000.0).amortizationType(1).interestType(1).interestCalculationPeriodType(1).dateFormat("dd MMMM yyyy")
+                .transactionProcessingStrategyCode(DEFAULT_STRATEGY).accountingRule(3)
+                .fundSourceAccountId(getAccounts().getFundSource().getAccountID().longValue())//
+                .loanPortfolioAccountId(getAccounts().getLoansReceivableAccount().getAccountID().longValue())//
+                .transfersInSuspenseAccountId(getAccounts().getSuspenseAccount().getAccountID().longValue())//
+                .interestOnLoanAccountId(getAccounts().getInterestIncomeAccount().getAccountID().longValue())//
+                .incomeFromFeeAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())//
+                .incomeFromPenaltyAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())//
+                .incomeFromRecoveryAccountId(getAccounts().getRecoveriesAccount().getAccountID().longValue())//
+                .writeOffAccountId(getAccounts().getWrittenOffAccount().getAccountID().longValue())//
+                .overpaymentLiabilityAccountId(getAccounts().getOverpaymentAccount().getAccountID().longValue())//
+                .receivableInterestAccountId(getAccounts().getInterestReceivableAccount().getAccountID().longValue())//
+                .receivableFeeAccountId(getAccounts().getFeeReceivableAccount().getAccountID().longValue())//
+                .receivablePenaltyAccountId(getAccounts().getPenaltyReceivableAccount().getAccountID().longValue())//
+                .goodwillCreditAccountId(getAccounts().getGoodwillExpenseAccount().getAccountID().longValue())//
+                .incomeFromGoodwillCreditInterestAccountId(getAccounts().getGoodwillIncomeAccount().getAccountID().longValue())//
+                .incomeFromGoodwillCreditFeesAccountId(getAccounts().getGoodwillIncomeAccount().getAccountID().longValue())//
+                .incomeFromGoodwillCreditPenaltyAccountId(getAccounts().getGoodwillIncomeAccount().getAccountID().longValue())//
+                .incomeFromChargeOffInterestAccountId(getAccounts().getInterestIncomeChargeOffAccount().getAccountID().longValue())//
+                .incomeFromChargeOffFeesAccountId(getAccounts().getFeeChargeOffAccount().getAccountID().longValue())//
+                .chargeOffExpenseAccountId(getAccounts().getChargeOffExpenseAccount().getAccountID().longValue())//
+                .chargeOffFraudExpenseAccountId(getAccounts().getChargeOffFraudExpenseAccount().getAccountID().longValue())//
+                .incomeFromChargeOffPenaltyAccountId(getAccounts().getPenaltyChargeOffAccount().getAccountID().longValue())//
+        );
     }
 
-    private static Long applyForLoanApplicationWithInterest(final Long clientID, final Long loanProductID, BigDecimal principal,
+    private Long applyForLoanApplicationWithInterest(final Long clientID, final Long loanProductID, BigDecimal principal,
             String applicationDisbursementDate) {
         LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
         final PostLoansRequest loanRequest = new PostLoansRequest() //
@@ -2105,62 +2056,53 @@ public class LoanTransactionInterestPaymentWaiverTest extends BaseLoanIntegratio
                 .interestCalculationPeriodType(1).dateFormat("dd MMMM yyyy").transactionProcessingStrategyCode(DEFAULT_STRATEGY)
                 .loanType("individual").expectedDisbursementDate(applicationDisbursementDate).submittedOnDate(applicationDisbursementDate)
                 .clientId(clientID).productId(loanProductID);
-        return loanTransactionHelper.applyLoan(loanRequest).getLoanId();
+        return applyForLoan(loanRequest);
     }
 
-    private static Integer createLoanProduct(final String principal, final String repaymentAfterEvery, final String numberOfRepayments,
-            boolean downPaymentEnabled, String downPaymentPercentage, boolean autoPayForDownPayment, LoanScheduleType loanScheduleType,
-            LoanScheduleProcessingType loanScheduleProcessingType, final Account... accounts) {
-        AdvancedPaymentData defaultAllocation = createDefaultPaymentAllocation();
-        AdvancedPaymentData goodwillCreditAllocation = createPaymentAllocation("GOODWILL_CREDIT", "LAST_INSTALLMENT");
-        AdvancedPaymentData interestPaymentWaiver = createPaymentAllocation("INTEREST_PAYMENT_WAIVER", "LAST_INSTALLMENT");
-        AdvancedPaymentData merchantIssuedRefundAllocation = createPaymentAllocation("MERCHANT_ISSUED_REFUND", "REAMORTIZATION");
-        AdvancedPaymentData payoutRefundAllocation = createPaymentAllocation("PAYOUT_REFUND", "NEXT_INSTALLMENT");
+    private Long createLoanProduct(final double principal, final int repaymentAfterEvery, final int numberOfRepayments,
+            boolean downPaymentEnabled, String downPaymentPercentage, boolean autoPayForDownPayment, String loanScheduleProcessingType) {
         LOG.info("------------------------------CREATING NEW LOAN PRODUCT ---------------------------------------");
-        final String loanProductJSON = new LoanProductTestBuilder().withMinPrincipal(principal).withPrincipal(principal)
-                .withRepaymentTypeAsDays().withRepaymentAfterEvery(repaymentAfterEvery).withNumberOfRepayments(numberOfRepayments)
-                .withEnableDownPayment(downPaymentEnabled, downPaymentPercentage, autoPayForDownPayment).withinterestRatePerPeriod("0")
-                .withInterestRateFrequencyTypeAsMonths()
-                .withRepaymentStrategy(AdvancedPaymentScheduleTransactionProcessor.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)
-                .withAmortizationTypeAsEqualPrincipalPayment().withInterestTypeAsFlat().withAccountingRulePeriodicAccrual(accounts)
-                .addAdvancedPaymentAllocation(defaultAllocation, goodwillCreditAllocation, merchantIssuedRefundAllocation,
-                        payoutRefundAllocation, interestPaymentWaiver)
-                .withInterestCalculationPeriodTypeAsRepaymentPeriod(true).withInterestTypeAsDecliningBalance().withMultiDisburse()
-                .withDisallowExpectedDisbursements(true).withLoanScheduleType(loanScheduleType)
-                .withLoanScheduleProcessingType(loanScheduleProcessingType).withDaysInMonth("30").withDaysInYear("365")
-                .withMoratorium("0", "0").build(null);
-        return loanTransactionHelper.getLoanProductId(loanProductJSON);
+        return createLoanProduct(createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation()
+                .loanScheduleProcessingType(loanScheduleProcessingType).paymentAllocation(List.of(createDefaultPaymentAllocation(), //
+                        createPaymentAllocation("GOODWILL_CREDIT", "LAST_INSTALLMENT"), //
+                        createPaymentAllocation("MERCHANT_ISSUED_REFUND", "REAMORTIZATION"), //
+                        createPaymentAllocation("PAYOUT_REFUND", "NEXT_INSTALLMENT"), //
+                        createPaymentAllocation("INTEREST_PAYMENT_WAIVER", "LAST_INSTALLMENT")))
+                .principal(principal).minPrincipal(principal).repaymentEvery(repaymentAfterEvery).numberOfRepayments(numberOfRepayments)
+                .enableDownPayment(downPaymentEnabled).disbursedAmountPercentageForDownPayment(new BigDecimal(downPaymentPercentage))
+                .enableAutoRepaymentForDownPayment(autoPayForDownPayment).amortizationType(AmortizationType.EQUAL_PRINCIPAL)
+                .daysInMonthType(DaysInMonthType.DAYS_30).daysInYearType(DaysInYearType.DAYS_365).graceOnPrincipalPayment(0)
+                .graceOnInterestPayment(0));
     }
 
-    private static PostLoansResponse applyForLoanApplication(final Long clientId, final Integer loanProductId, final BigDecimal principal,
+    private PostLoansResponse applyForLoanApplication(final Long clientId, final Long loanProductId, final BigDecimal principal,
             final int loanTermFrequency, final int repaymentAfterEvery, final int numberOfRepayments, final BigDecimal interestRate,
             final String expectedDisbursementDate, final String submittedOnDate, String transactionProcessorCode,
             String loanScheduleProcessingType) {
         LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
-        return loanTransactionHelper.applyLoan(new PostLoansRequest().clientId(clientId).productId(loanProductId.longValue())
-                .expectedDisbursementDate(expectedDisbursementDate).dateFormat(DATETIME_PATTERN)
-                .transactionProcessingStrategyCode(transactionProcessorCode).locale("en").submittedOnDate(submittedOnDate)
-                .amortizationType(1).interestRatePerPeriod(interestRate).interestCalculationPeriodType(1).interestType(0)
-                .repaymentFrequencyType(0).repaymentEvery(repaymentAfterEvery).repaymentFrequencyType(0)
-                .numberOfRepayments(numberOfRepayments).loanTermFrequency(loanTermFrequency).loanTermFrequencyType(0).principal(principal)
-                .loanType("individual").loanScheduleProcessingType(loanScheduleProcessingType)
-                .maxOutstandingLoanBalance(BigDecimal.valueOf(35000)));
+        return loanHelper.applyForLoan(
+                new PostLoansRequest().clientId(clientId).productId(loanProductId).expectedDisbursementDate(expectedDisbursementDate)
+                        .dateFormat(DATETIME_PATTERN).transactionProcessingStrategyCode(transactionProcessorCode).locale("en")
+                        .submittedOnDate(submittedOnDate).amortizationType(1).interestRatePerPeriod(interestRate)
+                        .interestCalculationPeriodType(1).interestType(0).repaymentFrequencyType(0).repaymentEvery(repaymentAfterEvery)
+                        .repaymentFrequencyType(0).numberOfRepayments(numberOfRepayments).loanTermFrequency(loanTermFrequency)
+                        .loanTermFrequencyType(0).principal(principal).loanType("individual")
+                        .loanScheduleProcessingType(loanScheduleProcessingType).maxOutstandingLoanBalance(BigDecimal.valueOf(35000)));
     }
 
-    private static PostLoansResponse applyForLoanApplication(final Long clientId, final Integer loanProductId, final BigDecimal principal,
+    private PostLoansResponse applyForLoanApplication(final Long clientId, final Long loanProductId, final BigDecimal principal,
             final int loanTermFrequency, final int repaymentAfterEvery, final int numberOfRepayments, final BigDecimal interestRate,
             final String expectedDisbursementDate, final String submittedOnDate) {
         return applyForLoanApplication(clientId, loanProductId, principal, loanTermFrequency, repaymentAfterEvery, numberOfRepayments,
-                interestRate, expectedDisbursementDate, submittedOnDate, LoanScheduleProcessingType.HORIZONTAL);
+                interestRate, expectedDisbursementDate, submittedOnDate, HORIZONTAL);
     }
 
-    private static PostLoansResponse applyForLoanApplication(final Long clientId, final Integer loanProductId, final BigDecimal principal,
+    private PostLoansResponse applyForLoanApplication(final Long clientId, final Long loanProductId, final BigDecimal principal,
             final int loanTermFrequency, final int repaymentAfterEvery, final int numberOfRepayments, final BigDecimal interestRate,
-            final String expectedDisbursementDate, final String submittedOnDate, LoanScheduleProcessingType loanScheduleProcessingType) {
+            final String expectedDisbursementDate, final String submittedOnDate, String loanScheduleProcessingType) {
         LOG.info("--------------------------------APPLYING FOR LOAN APPLICATION--------------------------------");
         return applyForLoanApplication(clientId, loanProductId, principal, loanTermFrequency, repaymentAfterEvery, numberOfRepayments,
-                interestRate, expectedDisbursementDate, submittedOnDate,
-                AdvancedPaymentScheduleTransactionProcessor.ADVANCED_PAYMENT_ALLOCATION_STRATEGY, loanScheduleProcessingType.name());
+                interestRate, expectedDisbursementDate, submittedOnDate, ADVANCED_PAYMENT_ALLOCATION_STRATEGY, loanScheduleProcessingType);
     }
 
     private static void validateLoanTransaction(GetLoansLoanIdResponse loanDetails, int index, double transactionAmount,

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/SqlInjectionReportingServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/SqlInjectionReportingServiceIntegrationTest.java
@@ -18,25 +18,22 @@
  */
 package org.apache.fineract.integrationtests;
 
-import static io.restassured.RestAssured.given;
+import static org.apache.fineract.client.feign.util.FeignCalls.ok;
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
+import static org.apache.http.HttpStatus.SC_NOT_FOUND;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.response.Response;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -44,8 +41,12 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.fineract.infrastructure.security.service.SqlInjectionPreventerService;
-import org.apache.fineract.integrationtests.common.Utils;
+import org.apache.fineract.client.feign.services.ReportsApi;
+import org.apache.fineract.client.feign.services.RunReportsApi;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
+import org.apache.fineract.client.models.GetReportsResponse;
+import org.apache.fineract.client.models.PostRepostRequest;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -58,38 +59,26 @@ import org.junit.jupiter.params.provider.ValueSource;
  *
  * Tests the migration from ESAPI to native database escaping and validates that CVE-2025-5878 is fixed. Covers
  * ReadReportingServiceImpl security measures through actual API endpoints.
- *
- * @see ReadReportingServiceImpl
- * @see SqlInjectionPreventerService
  */
 @Slf4j
-public class SqlInjectionReportingServiceIntegrationTest extends BaseLoanIntegrationTest {
+public class SqlInjectionReportingServiceIntegrationTest {
 
-    private RequestSpecification requestSpec;
-    private ResponseSpecification responseSpec;
-    private ResponseSpecification createOrReadResponseSpec;
     private Long testReportId = null;
     private Long booleanReportId = null;
     private static final String TEST_REPORT_NAME = "SQL_Injection_Test_Report";
     private static final String TEST_REPORT_SQL = "SELECT 1 as test_column, 'Test Data' as test_name";
     private static final String BOOLEAN_REPORT_SQL = "SELECT (1 = 1) AS active";
+    private static final String TEST_REPORT_COLUMN = "test_column";
+    private static final String BOOLEAN_REPORT_COLUMN = "active";
+    private static final String REPORT_TYPE_TABLE = "Table";
+    private static final String REPORT_CATEGORY_CLIENT = "Client";
+    private static final String GENERIC_RESULT_SET_PARAM = "genericResultSet";
+    private static final String REPORT_TYPE_PARAM = "reportType";
     private String booleanReportName;
 
     @BeforeEach
     public void setup() {
         Locale.setDefault(Locale.ENGLISH);
-        Utils.initializeRESTAssured();
-        this.requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        this.requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        this.requestSpec.header("Fineract-Platform-TenantId", "default");
-
-        // Keep strict 200 for runreports GET assertions used in tests
-        this.responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-
-        // Creation endpoints may return 201 in some environments
-        this.createOrReadResponseSpec = new ResponseSpecBuilder()
-                .expectStatusCode(org.hamcrest.Matchers.anyOf(org.hamcrest.Matchers.is(200), org.hamcrest.Matchers.is(201))).build();
-
         // Create test report for the tests
         createTestReportIfNotExists();
     }
@@ -99,7 +88,7 @@ public class SqlInjectionReportingServiceIntegrationTest extends BaseLoanIntegra
         // Clean up test report after tests
         if (testReportId != null) {
             try {
-                deleteTestReport();
+                deleteReport(testReportId);
             } catch (Exception e) {
                 log.warn("Failed to clean up test report: {}", e.getMessage());
             } finally {
@@ -108,7 +97,7 @@ public class SqlInjectionReportingServiceIntegrationTest extends BaseLoanIntegra
         }
         if (booleanReportId != null) {
             try {
-                deleteBooleanReport();
+                deleteReport(booleanReportId);
             } catch (Exception e) {
                 log.warn("Failed to clean up boolean test report: {}", e.getMessage());
             } finally {
@@ -120,64 +109,29 @@ public class SqlInjectionReportingServiceIntegrationTest extends BaseLoanIntegra
 
     private void createTestReportIfNotExists() {
         try {
+            Long existingId = findReportIdByName(TEST_REPORT_NAME);
             // First try to get the report to see if it exists - use direct RestAssured call to handle 404
-            Response response = given().spec(requestSpec).when().get("/fineract-provider/api/v1/reports");
-
-            if (response.getStatusCode() == 200) {
-                String existingReports = response.asString();
-                if (existingReports.contains("\"reportName\":\"" + TEST_REPORT_NAME + "\"")) {
-                    log.info("Test report '{}' already exists", TEST_REPORT_NAME);
-                    // Extract the ID for cleanup
-                    try {
-                        String pattern = "\"id\":(\\d+)[^}]*\"reportName\":\"" + TEST_REPORT_NAME + "\"";
-                        java.util.regex.Pattern p = java.util.regex.Pattern.compile(pattern);
-                        java.util.regex.Matcher m = p.matcher(existingReports);
-                        if (m.find()) {
-                            testReportId = Long.parseLong(m.group(1));
-                            log.info("Found existing test report with ID: {}", testReportId);
-                        }
-                    } catch (Exception ex) {
-                        log.debug("Could not extract existing report ID");
-                    }
-                    return;
-                }
-            } else if (response.getStatusCode() == 404) {
-                log.debug("Reports endpoint returned 404 (no reports exist yet), will create report");
-            } else {
-                log.debug("Reports endpoint returned unexpected status: {}, will try to create report", response.getStatusCode());
+            if (existingId != null) {
+                testReportId = existingId;
+                log.info("Found existing test report '{}' with ID: {}", TEST_REPORT_NAME, testReportId);
+                // Extract the ID for cleanup
+                return;
             }
-        } catch (Exception e) {
-            log.debug("Report list fetch failed, will try to create report: {}", e.getMessage());
+        } catch (CallFailedRuntimeException e) {
+            log.debug("Report list fetch failed with status {}, will try to create report: {}", e.getStatus(), e.getResponseBody());
         }
-        // Create the test report
-        String reportJson = "{" + "\"reportName\": \"" + TEST_REPORT_NAME + "\"," + "\"reportType\": \"Table\","
-                + "\"reportCategory\": \"Client\"," + "\"reportSql\": \"" + TEST_REPORT_SQL + "\","
-                + "\"description\": \"Test report for SQL injection prevention tests\"," + "\"useReport\": true" + "}";
 
         try {
             // Use direct RestAssured call to handle different response codes
-            Response postResponse = given().spec(requestSpec).contentType(ContentType.JSON).body(reportJson).when()
-                    .post("/fineract-provider/api/v1/reports");
-
-            if (postResponse.getStatusCode() == 200 || postResponse.getStatusCode() == 201) {
-                String response = postResponse.asString();
+            testReportId = ok(() -> reports()
+                    .createReport(reportRequest(TEST_REPORT_NAME, TEST_REPORT_SQL, "Test report for SQL injection prevention tests")))
+                    .getResourceId();
+            if (testReportId == null) {
                 // Extract report ID from response for cleanup
-                if (response.contains("resourceId")) {
-                    String idStr = response.replaceAll(".*\"resourceId\":(\\d+).*", "$1");
-                    testReportId = Long.parseLong(idStr);
-                    log.info("Created test report with ID: {}", testReportId);
-                } else {
-                    throw new RuntimeException("Test report creation failed - no resourceId in response: " + response);
-                }
-            } else {
-                String errorResponse = postResponse.asString();
-                log.error("Report creation failed - Status: {}, Body: {}, Headers: {}", postResponse.getStatusCode(), errorResponse,
-                        postResponse.getHeaders());
-                log.error("Sent JSON: {}", reportJson);
-                throw new RuntimeException(
-                        "Test report creation failed with status " + postResponse.getStatusCode() + ": " + errorResponse);
+                throw new RuntimeException("Test report creation failed - no resourceId in the response");
             }
-        } catch (Exception e) {
+            log.info("Created test report with ID: {}", testReportId);
+        } catch (RuntimeException e) {
             // This is a critical failure - tests cannot proceed without the test report
             throw new RuntimeException(
                     "CRITICAL: Could not create test report '" + TEST_REPORT_NAME + "'. Tests cannot proceed. Error: " + e.getMessage(), e);
@@ -185,60 +139,52 @@ public class SqlInjectionReportingServiceIntegrationTest extends BaseLoanIntegra
     }
 
     private void createBooleanReport() {
-        booleanReportName = "BOOLEAN_Runreports_Test_Report_" + java.util.UUID.randomUUID();
+        booleanReportName = "BOOLEAN_Runreports_Test_Report_" + UUID.randomUUID();
 
-        String reportJson = "{" + "\"reportName\": \"" + booleanReportName + "\"," + "\"reportType\": \"Table\","
-                + "\"reportCategory\": \"Client\"," + "\"reportSql\": \"" + BOOLEAN_REPORT_SQL + "\","
-                + "\"description\": \"Test report for BOOLEAN runreports support\"," + "\"useReport\": true" + "}";
-
-        Response postResponse = given().spec(requestSpec).contentType(ContentType.JSON).body(reportJson).when()
-                .post("/fineract-provider/api/v1/reports");
-
-        if (postResponse.getStatusCode() == 200 || postResponse.getStatusCode() == 201) {
-            String response = postResponse.asString();
-            if (response.contains("resourceId")) {
-                String idStr = response.replaceAll(".*\"resourceId\":(\\d+).*", "$1");
-                booleanReportId = Long.parseLong(idStr);
-                log.info("Created BOOLEAN test report with ID: {}, name: {}", booleanReportId, booleanReportName);
-            } else {
-                throw new RuntimeException("BOOLEAN test report creation failed - no resourceId in response: " + response);
-            }
-        } else {
-            throw new RuntimeException(
-                    "BOOLEAN test report creation failed with status " + postResponse.getStatusCode() + ": " + postResponse.asString());
-        }
-    }
-
-    private void deleteTestReport() {
-        if (testReportId == null) {
-            return;
-        }
-
-        Response deleteResponse = given().spec(requestSpec).contentType(ContentType.JSON).when()
-                .delete("/fineract-provider/api/v1/reports/" + testReportId);
-
-        if (deleteResponse.getStatusCode() == 200 || deleteResponse.getStatusCode() == 204 || deleteResponse.getStatusCode() == 404) {
-            log.info("Deleted (or already absent) test report with ID: {}", testReportId);
-        } else {
-            throw new RuntimeException("Failed deleting test report with ID " + testReportId + ", status: " + deleteResponse.getStatusCode()
-                    + ", body: " + deleteResponse.asString());
-        }
-    }
-
-    private void deleteBooleanReport() {
+        booleanReportId = ok(() -> reports()
+                .createReport(reportRequest(booleanReportName, BOOLEAN_REPORT_SQL, "Test report for BOOLEAN runreports support")))
+                .getResourceId();
         if (booleanReportId == null) {
+            throw new RuntimeException("BOOLEAN test report creation failed - no resourceId in the response");
+        }
+        log.info("Created BOOLEAN test report with ID: {}, name: {}", booleanReportId, booleanReportName);
+    }
+
+    private void deleteReport(Long reportId) {
+        if (reportId == null) {
             return;
         }
-
-        Response deleteResponse = given().spec(requestSpec).contentType(ContentType.JSON).when()
-                .delete("/fineract-provider/api/v1/reports/" + booleanReportId);
-
-        if (deleteResponse.getStatusCode() == 200 || deleteResponse.getStatusCode() == 204 || deleteResponse.getStatusCode() == 404) {
-            log.info("Deleted (or already absent) BOOLEAN test report with ID: {}", booleanReportId);
-        } else {
-            throw new RuntimeException("Failed deleting BOOLEAN test report with ID " + booleanReportId + ", status: "
-                    + deleteResponse.getStatusCode() + ", body: " + deleteResponse.asString());
+        try {
+            ok(() -> reports().deleteReport(reportId));
+            log.info("Deleted test report with ID: {}", reportId);
+        } catch (CallFailedRuntimeException e) {
+            // Treat an already-absent report as successfully cleaned up. Compare the status code itself: the message
+            // embeds the request path, so a report whose id contains "404" would match a naive substring check.
+            if (e.getStatus() == SC_NOT_FOUND) {
+                log.info("Test report with ID {} already absent", reportId);
+                return;
+            }
+            throw new RuntimeException("Failed deleting test report with ID " + reportId + ", status: " + e.getStatus(), e);
         }
+    }
+
+    /** Finds a report id by exact name, or {@code null} when no report of that name exists. */
+    private static Long findReportIdByName(String reportName) {
+        return ok(() -> reports().retrieveAllReports()).stream()//
+                .filter(report -> reportName.equals(report.getReportName()))//
+                .map(GetReportsResponse::getId)//
+                .findFirst()//
+                .orElse(null);
+    }
+
+    private static PostRepostRequest reportRequest(String reportName, String reportSql, String description) {
+        return new PostRepostRequest()//
+                .reportName(reportName)//
+                .reportType(REPORT_TYPE_TABLE)//
+                .reportCategory(REPORT_CATEGORY_CLIENT)//
+                .reportSql(reportSql)//
+                .description(description)//
+                .useReport(true);
     }
 
     /**
@@ -253,18 +199,17 @@ public class SqlInjectionReportingServiceIntegrationTest extends BaseLoanIntegra
         queryParams.put("R_officeId", "1");
 
         // Test with the test report we created in setup - this MUST succeed
-        String response = Utils.performServerGet(requestSpec, responseSpec,
-                "/fineract-provider/api/v1/runreports/" + TEST_REPORT_NAME + "?genericResultSet=false&" + toQueryString(queryParams), null);
+        List<Map<String, Object>> rows = runReport(TEST_REPORT_NAME, queryParams);
 
-        assertNotNull(response);
-        assertNotEquals("", response.trim());
+        assertNotNull(rows);
+        assertFalse(rows.isEmpty(), "The report should return at least one row");
 
         // Debug: Log actual response to understand structure
-        log.info("Response from report execution: {}", response);
+        log.info("Response from report execution: {}", rows);
 
         // Verify response is valid JSON structure
-        assertTrue(response.contains("columnHeaders") || response.contains("data") || response.contains("test_column"),
-                "Response should contain expected JSON structure, but got: " + response);
+        assertTrue(rows.stream().allMatch(row -> row.containsKey(TEST_REPORT_COLUMN)),
+                "Every row should carry the report's own column, but got: " + rows);
     }
 
     /**
@@ -284,21 +229,16 @@ public class SqlInjectionReportingServiceIntegrationTest extends BaseLoanIntegra
         // This should either succeed with empty/safe results or fail with validation error
         // but NOT with SQL syntax errors
         try {
-            Utils.performServerGet(requestSpec, responseSpec, "/fineract-provider/api/v1/runreports/" + TEST_REPORT_NAME
-                    + "?genericResultSet=false&" + toQueryString(maliciousParams), null);
-
+            runReport(TEST_REPORT_NAME, maliciousParams);
             // If we get here, the SQL injection was prevented and handled safely
             log.info("SQL injection prevented - query executed safely with malicious parameters");
-        } catch (AssertionError exception) {
+        } catch (CallFailedRuntimeException exception) {
             // The response should indicate parameter validation error or safe handling
             // NOT SQL syntax errors which would indicate successful injection
-            assertFalse(exception.getMessage().toLowerCase().contains("syntax error"),
-                    "Should not get SQL syntax error, got: " + exception.getMessage());
-            assertFalse(exception.getMessage().toLowerCase().contains("you have an error in your sql"),
-                    "Should not get SQL error, got: " + exception.getMessage());
+            assertNoSqlError(exception);
             // Should be a validation error, not a 404
-            assertFalse(exception.getMessage().contains("404"), "Should not get 404 - report should exist. Got: " + exception.getMessage());
-
+            assertNotEquals(SC_NOT_FOUND, exception.getStatus(),
+                    "Should not get 404 - report should exist. Got: " + exception.getMessage());
             log.info("Got expected validation error: {}", exception.getMessage());
         }
     }
@@ -317,12 +257,11 @@ public class SqlInjectionReportingServiceIntegrationTest extends BaseLoanIntegra
 
         // Test that valid report types work through the API
         try {
-            Utils.performServerGet(requestSpec, responseSpec,
-                    "/runreports/TestReport?reportType=" + validType + "&genericResultSet=false&" + toQueryString(queryParams), null);
+            runReport("TestReport", withReportType(queryParams, validType));
             // Should get a proper response or 404 (report not found), not validation error
-        } catch (AssertionError e) {
+        } catch (CallFailedRuntimeException e) {
             // For valid types, we expect 404 (report not found), not validation errors
-            assertTrue(e.getMessage().contains("404"));
+            assertEquals(SC_NOT_FOUND, e.getStatus(), "Expected 404 for a valid report type, got: " + e.getMessage());
         }
     }
 
@@ -338,13 +277,12 @@ public class SqlInjectionReportingServiceIntegrationTest extends BaseLoanIntegra
         queryParams.put("R_officeId", "1");
 
         // These should be rejected and result in 404 (report not found) or validation error
-        AssertionError exception = assertThrows(AssertionError.class, () -> {
-            Utils.performServerGet(requestSpec, responseSpec,
-                    "/runreports/TestReport?reportType=" + invalidType + "&genericResultSet=false&" + toQueryString(queryParams), null);
-        });
+        CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
+                () -> runReport("TestReport", withReportType(queryParams, invalidType)));
 
         // Should get 404 or validation error, not SQL execution error
-        assertTrue(exception.getMessage().contains("404") || exception.getMessage().contains("validation"));
+        assertTrue(exception.getStatus() == SC_NOT_FOUND || exception.getResponseBody().toLowerCase(Locale.ROOT).contains("validation"),
+                "Expected 404 or a validation error, got: " + exception.getMessage());
         assertFalse(exception.getMessage().toLowerCase().contains("sql syntax"));
     }
 
@@ -363,20 +301,12 @@ public class SqlInjectionReportingServiceIntegrationTest extends BaseLoanIntegra
 
         // Use the real test report to ensure SQL injection prevention works with actual queries
         try {
-            String response = Utils.performServerGet(requestSpec, responseSpec,
-                    "/fineract-provider/api/v1/runreports/" + TEST_REPORT_NAME + "?genericResultSet=false&" + toQueryString(queryParams),
-                    null);
-
+            assertNotNull(runReport(TEST_REPORT_NAME, queryParams));
             // If successful, the special characters were safely escaped
-            assertNotNull(response);
             log.info("MySQL/MariaDB special characters safely escaped");
-        } catch (AssertionError e) {
+        } catch (CallFailedRuntimeException e) {
             // Should not get SQL syntax errors - only validation errors
-            assertFalse(e.getMessage().toLowerCase().contains("syntax error"),
-                    "Should not get SQL syntax error for MySQL escaping test. Got: " + e.getMessage());
-            assertFalse(e.getMessage().toLowerCase().contains("you have an error in your sql"),
-                    "Should not get SQL error. Got: " + e.getMessage());
-
+            assertNoSqlError(e);
             log.info("MySQL/MariaDB escaping prevented SQL injection with validation error");
         }
     }
@@ -397,22 +327,14 @@ public class SqlInjectionReportingServiceIntegrationTest extends BaseLoanIntegra
 
         // Use the real test report to ensure SQL injection prevention works
         try {
-            String response = Utils.performServerGet(requestSpec, responseSpec,
-                    "/fineract-provider/api/v1/runreports/" + TEST_REPORT_NAME + "?genericResultSet=false&" + toQueryString(queryParams),
-                    null);
-
+            assertNotNull(runReport(TEST_REPORT_NAME, queryParams));
             // If successful, the PostgreSQL special syntax was safely escaped
-            assertNotNull(response);
             log.info("PostgreSQL special characters and syntax safely escaped");
-        } catch (AssertionError e) {
+        } catch (CallFailedRuntimeException e) {
             // Should not get SQL syntax errors - only validation errors
-            assertFalse(e.getMessage().toLowerCase().contains("syntax error"),
-                    "Should not get SQL syntax error for PostgreSQL escaping test. Got: " + e.getMessage());
-            assertFalse(e.getMessage().toLowerCase().contains("you have an error in your sql"),
-                    "Should not get SQL error. Got: " + e.getMessage());
+            assertNoSqlError(e);
             assertFalse(e.getMessage().toLowerCase().contains("error") && e.getMessage().toLowerCase().contains("position"),
                     "Should not get PostgreSQL position error. Got: " + e.getMessage());
-
             log.info("PostgreSQL escaping prevented SQL injection with validation error");
         }
     }
@@ -428,7 +350,7 @@ public class SqlInjectionReportingServiceIntegrationTest extends BaseLoanIntegra
         int operationsPerThread = 3;
         ExecutorService executor = Executors.newFixedThreadPool(threadCount);
 
-        List<Future<Boolean>> futures = new java.util.ArrayList<>();
+        List<Future<Boolean>> futures = new ArrayList<>();
 
         for (int i = 0; i < threadCount; i++) {
             final int threadId = i;
@@ -443,16 +365,14 @@ public class SqlInjectionReportingServiceIntegrationTest extends BaseLoanIntegra
                             Map<String, String> queryParams = new HashMap<>();
                             queryParams.put("R_officeId", "1");
 
-                            Utils.performServerGet(requestSpec, responseSpec,
-                                    "/fineract-provider/api/v1/runreports/" + URLEncoder.encode(input, StandardCharsets.UTF_8)
-                                            + "?genericResultSet=false&" + toQueryString(queryParams),
-                                    null);
+                            runReport(input, queryParams);
                         }
                         return true;
-                    } catch (AssertionError e) {
+                    } catch (CallFailedRuntimeException e) {
                         // 404 is expected for non-existent reports
-                        return e.getMessage().contains("404");
-                    } catch (Exception e) {
+                        if (e.getStatus() == SC_NOT_FOUND) {
+                            return true;
+                        }
                         log.error("Error in thread {}: {}", threadId, e.getMessage());
                         return false;
                     }
@@ -488,15 +408,12 @@ public class SqlInjectionReportingServiceIntegrationTest extends BaseLoanIntegra
         maliciousParams.put("R_userId", "<script>alert('xss')</script>");
 
         try {
-            Utils.performServerGet(requestSpec, responseSpec, "/fineract-provider/api/v1/runreports/" + TEST_REPORT_NAME
-                    + "?genericResultSet=false&" + toQueryString(maliciousParams), null);
+            runReport(TEST_REPORT_NAME, maliciousParams);
             // If we get here without exception, the response should be safe
             log.info("Complex parameter injection prevented - query executed safely");
-        } catch (AssertionError e) {
+        } catch (CallFailedRuntimeException e) {
             // Should get parameter validation error, not SQL injection
-            assertFalse(e.getMessage().toLowerCase().contains("syntax error"), "Should not get SQL syntax error. Got: " + e.getMessage());
-            assertFalse(e.getMessage().toLowerCase().contains("you have an error in your sql"),
-                    "Should not get SQL error. Got: " + e.getMessage());
+            assertNoSqlError(e);
             assertFalse(e.getMessage().toLowerCase().contains("table") && e.getMessage().toLowerCase().contains("exist"),
                     "Should not get table exists error. Got: " + e.getMessage());
         }
@@ -515,26 +432,16 @@ public class SqlInjectionReportingServiceIntegrationTest extends BaseLoanIntegra
         queryParams.put(paramName, paramValue);
 
         try {
-            String response = Utils.performServerGet(requestSpec, responseSpec,
-                    "/fineract-provider/api/v1/runreports/" + TEST_REPORT_NAME + "?genericResultSet=false&" + toQueryString(queryParams),
-                    null);
-
+            // Valid parameters should return data successfully; a SQL error would have failed the call instead
             // Valid parameters should return data successfully
-            assertNotNull(response);
-
             // Should not contain SQL error indicators
-            assertFalse(response.toLowerCase().contains("syntax error"));
-            assertFalse(response.toLowerCase().contains("sql exception"));
+            assertNotNull(runReport(TEST_REPORT_NAME, queryParams));
 
             log.debug("Legitimate parameter '{}' = '{}' processed successfully", paramName, paramValue);
-        } catch (AssertionError e) {
+        } catch (CallFailedRuntimeException e) {
             // For legitimate parameters, we should not get errors unless it's a data issue
             // But definitely not SQL syntax errors
-            assertFalse(e.getMessage().toLowerCase().contains("syntax error"),
-                    "Should not get SQL syntax error for legitimate parameter. Got: " + e.getMessage());
-            assertFalse(e.getMessage().toLowerCase().contains("you have an error in your sql"),
-                    "Should not get SQL error for legitimate parameter. Got: " + e.getMessage());
-
+            assertNoSqlError(e);
             log.info("Parameter validation for '{}' = '{}': {}", paramName, paramValue, e.getMessage());
         }
     }
@@ -552,10 +459,9 @@ public class SqlInjectionReportingServiceIntegrationTest extends BaseLoanIntegra
         queryParams.put("R_officeId", "1");
 
         try {
-            Utils.performServerGet(requestSpec, responseSpec, "/fineract-provider/api/v1/runreports/"
-                    + URLEncoder.encode(testInput, StandardCharsets.UTF_8) + "?genericResultSet=false&" + toQueryString(queryParams), null);
-        } catch (AssertionError e) {
-            assertTrue(e.getMessage().contains("404") || e.getMessage().contains("400"),
+            runReport(testInput, queryParams);
+        } catch (CallFailedRuntimeException e) {
+            assertTrue(e.getStatus() == SC_NOT_FOUND || e.getStatus() == SC_BAD_REQUEST,
                     "Expected safe failure (404/400), but got: " + e.getMessage());
             assertFalse(e.getMessage().toLowerCase().contains("syntax error"));
             assertFalse(e.getMessage().toLowerCase().contains("sql"));
@@ -573,33 +479,48 @@ public class SqlInjectionReportingServiceIntegrationTest extends BaseLoanIntegra
         assertNotNull(booleanReportId, "BOOLEAN test report should be created before execution");
         assertNotNull(booleanReportName, "BOOLEAN test report name should be initialized");
 
+        // A successful run returns the rows; a non-2xx status throws and fails the test
         // Use direct request to avoid hidden auth mismatch and assert exact behavior
-        Response runResponse = given().spec(requestSpec).accept(ContentType.JSON).when().get("/fineract-provider/api/v1/runreports/"
-                + URLEncoder.encode(booleanReportName, StandardCharsets.UTF_8) + "?genericResultSet=false");
+        List<Map<String, Object>> rows = runReport(booleanReportName, Map.of());
 
-        String response = runResponse.asString();
-        assertTrue(runResponse.getStatusCode() == 200, "Expected status 200 but was " + runResponse.getStatusCode() + " body: " + response);
-
-        assertNotNull(response);
-        assertFalse(response.isBlank());
-        assertFalse(response.contains("Data type 'BOOLEAN' is not supported"));
-        assertTrue(response.toLowerCase().contains("active"),
-                "Response should contain boolean column alias 'active', but was: " + response);
-        assertTrue(response.toLowerCase().contains("true") || response.toLowerCase().contains("1"),
-                "Response should contain boolean value (true/1), but was: " + response);
+        assertNotNull(rows);
+        assertFalse(rows.isEmpty(), "The BOOLEAN report should return a row");
+        Map<String, Object> row = rows.get(0);
+        assertTrue(row.containsKey(BOOLEAN_REPORT_COLUMN), "Response should contain boolean column alias 'active', but was: " + rows);
+        Object active = row.get(BOOLEAN_REPORT_COLUMN);
+        assertTrue(Boolean.TRUE.equals(active) || "true".equalsIgnoreCase(String.valueOf(active)) || "1".equals(String.valueOf(active)),
+                "Response should contain boolean value (true/1), but was: " + rows);
     }
 
-    private String toQueryString(Map<String, String> params) {
-        StringBuilder sb = new StringBuilder();
-        for (Map.Entry<String, String> entry : params.entrySet()) {
-            if (sb.length() > 0) {
-                sb.append("&");
-            }
-            sb.append(entry.getKey()).append("=");
-            if (entry.getValue() != null) {
-                sb.append(URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8));
-            }
-        }
-        return sb.toString();
+    private void assertNoSqlError(RuntimeException exception) {
+        assertFalse(exception.getMessage().toLowerCase().contains("syntax error"),
+                "Should not get SQL syntax error, got: " + exception.getMessage());
+        assertFalse(exception.getMessage().toLowerCase().contains("you have an error in your sql"),
+                "Should not get SQL error, got: " + exception.getMessage());
+    }
+
+    /**
+     * Runs a report with {@code genericResultSet=false}, the shape the pre-migration test asserted on: the server
+     * answers a plain array of rows rather than the {@code columnHeaders}/{@code data} Generic Resultset. Both shapes
+     * come out of the same {@code retrieveGenericResultset} call the SQL-injection prevention lives in.
+     */
+    private List<Map<String, Object>> runReport(String reportName, Map<String, String> parameters) {
+        Map<String, String> queryParameters = new HashMap<>(parameters);
+        queryParameters.put(GENERIC_RESULT_SET_PARAM, "false");
+        return ok(() -> runReports().runReportGetRows(reportName, queryParameters));
+    }
+
+    private static Map<String, String> withReportType(Map<String, String> parameters, String reportType) {
+        Map<String, String> queryParameters = new HashMap<>(parameters);
+        queryParameters.put(REPORT_TYPE_PARAM, reportType);
+        return queryParameters;
+    }
+
+    private static ReportsApi reports() {
+        return FineractFeignClientHelper.getFineractFeignClient().reports();
+    }
+
+    private static RunReportsApi runReports() {
+        return FineractFeignClientHelper.getFineractFeignClient().runReports();
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/SqlInjectionReportingServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/SqlInjectionReportingServiceIntegrationTest.java
@@ -18,25 +18,22 @@
  */
 package org.apache.fineract.integrationtests;
 
-import static io.restassured.RestAssured.given;
+import static org.apache.fineract.client.feign.util.FeignCalls.ok;
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
+import static org.apache.http.HttpStatus.SC_NOT_FOUND;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.response.Response;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -44,8 +41,12 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.fineract.infrastructure.security.service.SqlInjectionPreventerService;
-import org.apache.fineract.integrationtests.common.Utils;
+import org.apache.fineract.client.feign.services.ReportsApi;
+import org.apache.fineract.client.feign.services.RunReportsApi;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
+import org.apache.fineract.client.models.GetReportsResponse;
+import org.apache.fineract.client.models.PostRepostRequest;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -58,38 +59,26 @@ import org.junit.jupiter.params.provider.ValueSource;
  *
  * Tests the migration from ESAPI to native database escaping and validates that CVE-2025-5878 is fixed. Covers
  * ReadReportingServiceImpl security measures through actual API endpoints.
- *
- * @see ReadReportingServiceImpl
- * @see SqlInjectionPreventerService
  */
 @Slf4j
-public class SqlInjectionReportingServiceIntegrationTest extends BaseLoanIntegrationTest {
+public class SqlInjectionReportingServiceIntegrationTest {
 
-    private RequestSpecification requestSpec;
-    private ResponseSpecification responseSpec;
-    private ResponseSpecification createOrReadResponseSpec;
     private Long testReportId = null;
     private Long booleanReportId = null;
     private static final String TEST_REPORT_NAME = "SQL_Injection_Test_Report";
     private static final String TEST_REPORT_SQL = "SELECT 1 as test_column, 'Test Data' as test_name";
     private static final String BOOLEAN_REPORT_SQL = "SELECT (1 = 1) AS active";
+    private static final String TEST_REPORT_COLUMN = "test_column";
+    private static final String BOOLEAN_REPORT_COLUMN = "active";
+    private static final String REPORT_TYPE_TABLE = "Table";
+    private static final String REPORT_CATEGORY_CLIENT = "Client";
+    private static final String GENERIC_RESULT_SET_PARAM = "genericResultSet";
+    private static final String REPORT_TYPE_PARAM = "reportType";
     private String booleanReportName;
 
     @BeforeEach
     public void setup() {
         Locale.setDefault(Locale.ENGLISH);
-        Utils.initializeRESTAssured();
-        this.requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        this.requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        this.requestSpec.header("Fineract-Platform-TenantId", "default");
-
-        // Keep strict 200 for runreports GET assertions used in tests
-        this.responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-
-        // Creation endpoints may return 201 in some environments
-        this.createOrReadResponseSpec = new ResponseSpecBuilder()
-                .expectStatusCode(org.hamcrest.Matchers.anyOf(org.hamcrest.Matchers.is(200), org.hamcrest.Matchers.is(201))).build();
-
         // Create test report for the tests
         createTestReportIfNotExists();
     }
@@ -99,7 +88,7 @@ public class SqlInjectionReportingServiceIntegrationTest extends BaseLoanIntegra
         // Clean up test report after tests
         if (testReportId != null) {
             try {
-                deleteTestReport();
+                deleteReport(testReportId);
             } catch (Exception e) {
                 log.warn("Failed to clean up test report: {}", e.getMessage());
             } finally {
@@ -108,7 +97,7 @@ public class SqlInjectionReportingServiceIntegrationTest extends BaseLoanIntegra
         }
         if (booleanReportId != null) {
             try {
-                deleteBooleanReport();
+                deleteReport(booleanReportId);
             } catch (Exception e) {
                 log.warn("Failed to clean up boolean test report: {}", e.getMessage());
             } finally {
@@ -120,64 +109,25 @@ public class SqlInjectionReportingServiceIntegrationTest extends BaseLoanIntegra
 
     private void createTestReportIfNotExists() {
         try {
-            // First try to get the report to see if it exists - use direct RestAssured call to handle 404
-            Response response = given().spec(requestSpec).when().get("/fineract-provider/api/v1/reports");
-
-            if (response.getStatusCode() == 200) {
-                String existingReports = response.asString();
-                if (existingReports.contains("\"reportName\":\"" + TEST_REPORT_NAME + "\"")) {
-                    log.info("Test report '{}' already exists", TEST_REPORT_NAME);
-                    // Extract the ID for cleanup
-                    try {
-                        String pattern = "\"id\":(\\d+)[^}]*\"reportName\":\"" + TEST_REPORT_NAME + "\"";
-                        java.util.regex.Pattern p = java.util.regex.Pattern.compile(pattern);
-                        java.util.regex.Matcher m = p.matcher(existingReports);
-                        if (m.find()) {
-                            testReportId = Long.parseLong(m.group(1));
-                            log.info("Found existing test report with ID: {}", testReportId);
-                        }
-                    } catch (Exception ex) {
-                        log.debug("Could not extract existing report ID");
-                    }
-                    return;
-                }
-            } else if (response.getStatusCode() == 404) {
-                log.debug("Reports endpoint returned 404 (no reports exist yet), will create report");
-            } else {
-                log.debug("Reports endpoint returned unexpected status: {}, will try to create report", response.getStatusCode());
+            Long existingId = findReportIdByName(TEST_REPORT_NAME);
+            if (existingId != null) {
+                testReportId = existingId;
+                log.info("Found existing test report '{}' with ID: {}", TEST_REPORT_NAME, testReportId);
+                return;
             }
-        } catch (Exception e) {
-            log.debug("Report list fetch failed, will try to create report: {}", e.getMessage());
+        } catch (CallFailedRuntimeException e) {
+            log.debug("Report list fetch failed with status {}, will try to create report: {}", e.getStatus(), e.getResponseBody());
         }
-        // Create the test report
-        String reportJson = "{" + "\"reportName\": \"" + TEST_REPORT_NAME + "\"," + "\"reportType\": \"Table\","
-                + "\"reportCategory\": \"Client\"," + "\"reportSql\": \"" + TEST_REPORT_SQL + "\","
-                + "\"description\": \"Test report for SQL injection prevention tests\"," + "\"useReport\": true" + "}";
 
         try {
-            // Use direct RestAssured call to handle different response codes
-            Response postResponse = given().spec(requestSpec).contentType(ContentType.JSON).body(reportJson).when()
-                    .post("/fineract-provider/api/v1/reports");
-
-            if (postResponse.getStatusCode() == 200 || postResponse.getStatusCode() == 201) {
-                String response = postResponse.asString();
-                // Extract report ID from response for cleanup
-                if (response.contains("resourceId")) {
-                    String idStr = response.replaceAll(".*\"resourceId\":(\\d+).*", "$1");
-                    testReportId = Long.parseLong(idStr);
-                    log.info("Created test report with ID: {}", testReportId);
-                } else {
-                    throw new RuntimeException("Test report creation failed - no resourceId in response: " + response);
-                }
-            } else {
-                String errorResponse = postResponse.asString();
-                log.error("Report creation failed - Status: {}, Body: {}, Headers: {}", postResponse.getStatusCode(), errorResponse,
-                        postResponse.getHeaders());
-                log.error("Sent JSON: {}", reportJson);
-                throw new RuntimeException(
-                        "Test report creation failed with status " + postResponse.getStatusCode() + ": " + errorResponse);
+            testReportId = ok(() -> reports()
+                    .createReport(reportRequest(TEST_REPORT_NAME, TEST_REPORT_SQL, "Test report for SQL injection prevention tests")))
+                    .getResourceId();
+            if (testReportId == null) {
+                throw new RuntimeException("Test report creation failed - no resourceId in the response");
             }
-        } catch (Exception e) {
+            log.info("Created test report with ID: {}", testReportId);
+        } catch (RuntimeException e) {
             // This is a critical failure - tests cannot proceed without the test report
             throw new RuntimeException(
                     "CRITICAL: Could not create test report '" + TEST_REPORT_NAME + "'. Tests cannot proceed. Error: " + e.getMessage(), e);
@@ -185,60 +135,52 @@ public class SqlInjectionReportingServiceIntegrationTest extends BaseLoanIntegra
     }
 
     private void createBooleanReport() {
-        booleanReportName = "BOOLEAN_Runreports_Test_Report_" + java.util.UUID.randomUUID();
+        booleanReportName = "BOOLEAN_Runreports_Test_Report_" + UUID.randomUUID();
 
-        String reportJson = "{" + "\"reportName\": \"" + booleanReportName + "\"," + "\"reportType\": \"Table\","
-                + "\"reportCategory\": \"Client\"," + "\"reportSql\": \"" + BOOLEAN_REPORT_SQL + "\","
-                + "\"description\": \"Test report for BOOLEAN runreports support\"," + "\"useReport\": true" + "}";
-
-        Response postResponse = given().spec(requestSpec).contentType(ContentType.JSON).body(reportJson).when()
-                .post("/fineract-provider/api/v1/reports");
-
-        if (postResponse.getStatusCode() == 200 || postResponse.getStatusCode() == 201) {
-            String response = postResponse.asString();
-            if (response.contains("resourceId")) {
-                String idStr = response.replaceAll(".*\"resourceId\":(\\d+).*", "$1");
-                booleanReportId = Long.parseLong(idStr);
-                log.info("Created BOOLEAN test report with ID: {}, name: {}", booleanReportId, booleanReportName);
-            } else {
-                throw new RuntimeException("BOOLEAN test report creation failed - no resourceId in response: " + response);
-            }
-        } else {
-            throw new RuntimeException(
-                    "BOOLEAN test report creation failed with status " + postResponse.getStatusCode() + ": " + postResponse.asString());
-        }
-    }
-
-    private void deleteTestReport() {
-        if (testReportId == null) {
-            return;
-        }
-
-        Response deleteResponse = given().spec(requestSpec).contentType(ContentType.JSON).when()
-                .delete("/fineract-provider/api/v1/reports/" + testReportId);
-
-        if (deleteResponse.getStatusCode() == 200 || deleteResponse.getStatusCode() == 204 || deleteResponse.getStatusCode() == 404) {
-            log.info("Deleted (or already absent) test report with ID: {}", testReportId);
-        } else {
-            throw new RuntimeException("Failed deleting test report with ID " + testReportId + ", status: " + deleteResponse.getStatusCode()
-                    + ", body: " + deleteResponse.asString());
-        }
-    }
-
-    private void deleteBooleanReport() {
+        booleanReportId = ok(() -> reports()
+                .createReport(reportRequest(booleanReportName, BOOLEAN_REPORT_SQL, "Test report for BOOLEAN runreports support")))
+                .getResourceId();
         if (booleanReportId == null) {
+            throw new RuntimeException("BOOLEAN test report creation failed - no resourceId in the response");
+        }
+        log.info("Created BOOLEAN test report with ID: {}, name: {}", booleanReportId, booleanReportName);
+    }
+
+    private void deleteReport(Long reportId) {
+        if (reportId == null) {
             return;
         }
-
-        Response deleteResponse = given().spec(requestSpec).contentType(ContentType.JSON).when()
-                .delete("/fineract-provider/api/v1/reports/" + booleanReportId);
-
-        if (deleteResponse.getStatusCode() == 200 || deleteResponse.getStatusCode() == 204 || deleteResponse.getStatusCode() == 404) {
-            log.info("Deleted (or already absent) BOOLEAN test report with ID: {}", booleanReportId);
-        } else {
-            throw new RuntimeException("Failed deleting BOOLEAN test report with ID " + booleanReportId + ", status: "
-                    + deleteResponse.getStatusCode() + ", body: " + deleteResponse.asString());
+        try {
+            ok(() -> reports().deleteReport(reportId));
+            log.info("Deleted test report with ID: {}", reportId);
+        } catch (CallFailedRuntimeException e) {
+            // Treat an already-absent report as successfully cleaned up. Compare the status code itself: the message
+            // embeds the request path, so a report whose id contains "404" would match a naive substring check.
+            if (e.getStatus() == SC_NOT_FOUND) {
+                log.info("Test report with ID {} already absent", reportId);
+                return;
+            }
+            throw new RuntimeException("Failed deleting test report with ID " + reportId + ", status: " + e.getStatus(), e);
         }
+    }
+
+    /** Finds a report id by exact name, or {@code null} when no report of that name exists. */
+    private static Long findReportIdByName(String reportName) {
+        return ok(() -> reports().retrieveAllReports()).stream()//
+                .filter(report -> reportName.equals(report.getReportName()))//
+                .map(GetReportsResponse::getId)//
+                .findFirst()//
+                .orElse(null);
+    }
+
+    private static PostRepostRequest reportRequest(String reportName, String reportSql, String description) {
+        return new PostRepostRequest()//
+                .reportName(reportName)//
+                .reportType(REPORT_TYPE_TABLE)//
+                .reportCategory(REPORT_CATEGORY_CLIENT)//
+                .reportSql(reportSql)//
+                .description(description)//
+                .useReport(true);
     }
 
     /**
@@ -253,18 +195,15 @@ public class SqlInjectionReportingServiceIntegrationTest extends BaseLoanIntegra
         queryParams.put("R_officeId", "1");
 
         // Test with the test report we created in setup - this MUST succeed
-        String response = Utils.performServerGet(requestSpec, responseSpec,
-                "/fineract-provider/api/v1/runreports/" + TEST_REPORT_NAME + "?genericResultSet=false&" + toQueryString(queryParams), null);
+        List<Map<String, Object>> rows = runReport(TEST_REPORT_NAME, queryParams);
 
-        assertNotNull(response);
-        assertNotEquals("", response.trim());
+        assertNotNull(rows);
+        assertFalse(rows.isEmpty(), "The report should return at least one row");
 
-        // Debug: Log actual response to understand structure
-        log.info("Response from report execution: {}", response);
+        log.info("Response from report execution: {}", rows);
 
-        // Verify response is valid JSON structure
-        assertTrue(response.contains("columnHeaders") || response.contains("data") || response.contains("test_column"),
-                "Response should contain expected JSON structure, but got: " + response);
+        assertTrue(rows.stream().allMatch(row -> row.containsKey(TEST_REPORT_COLUMN)),
+                "Every row should carry the report's own column, but got: " + rows);
     }
 
     /**
@@ -284,21 +223,14 @@ public class SqlInjectionReportingServiceIntegrationTest extends BaseLoanIntegra
         // This should either succeed with empty/safe results or fail with validation error
         // but NOT with SQL syntax errors
         try {
-            Utils.performServerGet(requestSpec, responseSpec, "/fineract-provider/api/v1/runreports/" + TEST_REPORT_NAME
-                    + "?genericResultSet=false&" + toQueryString(maliciousParams), null);
-
+            runReport(TEST_REPORT_NAME, maliciousParams);
             // If we get here, the SQL injection was prevented and handled safely
             log.info("SQL injection prevented - query executed safely with malicious parameters");
-        } catch (AssertionError exception) {
-            // The response should indicate parameter validation error or safe handling
-            // NOT SQL syntax errors which would indicate successful injection
-            assertFalse(exception.getMessage().toLowerCase().contains("syntax error"),
-                    "Should not get SQL syntax error, got: " + exception.getMessage());
-            assertFalse(exception.getMessage().toLowerCase().contains("you have an error in your sql"),
-                    "Should not get SQL error, got: " + exception.getMessage());
+        } catch (CallFailedRuntimeException exception) {
+            assertNoSqlError(exception);
             // Should be a validation error, not a 404
-            assertFalse(exception.getMessage().contains("404"), "Should not get 404 - report should exist. Got: " + exception.getMessage());
-
+            assertNotEquals(SC_NOT_FOUND, exception.getStatus(),
+                    "Should not get 404 - report should exist. Got: " + exception.getMessage());
             log.info("Got expected validation error: {}", exception.getMessage());
         }
     }
@@ -317,12 +249,11 @@ public class SqlInjectionReportingServiceIntegrationTest extends BaseLoanIntegra
 
         // Test that valid report types work through the API
         try {
-            Utils.performServerGet(requestSpec, responseSpec,
-                    "/runreports/TestReport?reportType=" + validType + "&genericResultSet=false&" + toQueryString(queryParams), null);
+            runReport("TestReport", withReportType(queryParams, validType));
             // Should get a proper response or 404 (report not found), not validation error
-        } catch (AssertionError e) {
+        } catch (CallFailedRuntimeException e) {
             // For valid types, we expect 404 (report not found), not validation errors
-            assertTrue(e.getMessage().contains("404"));
+            assertEquals(SC_NOT_FOUND, e.getStatus(), "Expected 404 for a valid report type, got: " + e.getMessage());
         }
     }
 
@@ -338,13 +269,12 @@ public class SqlInjectionReportingServiceIntegrationTest extends BaseLoanIntegra
         queryParams.put("R_officeId", "1");
 
         // These should be rejected and result in 404 (report not found) or validation error
-        AssertionError exception = assertThrows(AssertionError.class, () -> {
-            Utils.performServerGet(requestSpec, responseSpec,
-                    "/runreports/TestReport?reportType=" + invalidType + "&genericResultSet=false&" + toQueryString(queryParams), null);
-        });
+        CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
+                () -> runReport("TestReport", withReportType(queryParams, invalidType)));
 
         // Should get 404 or validation error, not SQL execution error
-        assertTrue(exception.getMessage().contains("404") || exception.getMessage().contains("validation"));
+        assertTrue(exception.getStatus() == SC_NOT_FOUND || exception.getResponseBody().toLowerCase(Locale.ROOT).contains("validation"),
+                "Expected 404 or a validation error, got: " + exception.getMessage());
         assertFalse(exception.getMessage().toLowerCase().contains("sql syntax"));
     }
 
@@ -363,20 +293,12 @@ public class SqlInjectionReportingServiceIntegrationTest extends BaseLoanIntegra
 
         // Use the real test report to ensure SQL injection prevention works with actual queries
         try {
-            String response = Utils.performServerGet(requestSpec, responseSpec,
-                    "/fineract-provider/api/v1/runreports/" + TEST_REPORT_NAME + "?genericResultSet=false&" + toQueryString(queryParams),
-                    null);
-
+            assertNotNull(runReport(TEST_REPORT_NAME, queryParams));
             // If successful, the special characters were safely escaped
-            assertNotNull(response);
             log.info("MySQL/MariaDB special characters safely escaped");
-        } catch (AssertionError e) {
+        } catch (CallFailedRuntimeException e) {
             // Should not get SQL syntax errors - only validation errors
-            assertFalse(e.getMessage().toLowerCase().contains("syntax error"),
-                    "Should not get SQL syntax error for MySQL escaping test. Got: " + e.getMessage());
-            assertFalse(e.getMessage().toLowerCase().contains("you have an error in your sql"),
-                    "Should not get SQL error. Got: " + e.getMessage());
-
+            assertNoSqlError(e);
             log.info("MySQL/MariaDB escaping prevented SQL injection with validation error");
         }
     }
@@ -397,22 +319,14 @@ public class SqlInjectionReportingServiceIntegrationTest extends BaseLoanIntegra
 
         // Use the real test report to ensure SQL injection prevention works
         try {
-            String response = Utils.performServerGet(requestSpec, responseSpec,
-                    "/fineract-provider/api/v1/runreports/" + TEST_REPORT_NAME + "?genericResultSet=false&" + toQueryString(queryParams),
-                    null);
-
+            assertNotNull(runReport(TEST_REPORT_NAME, queryParams));
             // If successful, the PostgreSQL special syntax was safely escaped
-            assertNotNull(response);
             log.info("PostgreSQL special characters and syntax safely escaped");
-        } catch (AssertionError e) {
+        } catch (CallFailedRuntimeException e) {
             // Should not get SQL syntax errors - only validation errors
-            assertFalse(e.getMessage().toLowerCase().contains("syntax error"),
-                    "Should not get SQL syntax error for PostgreSQL escaping test. Got: " + e.getMessage());
-            assertFalse(e.getMessage().toLowerCase().contains("you have an error in your sql"),
-                    "Should not get SQL error. Got: " + e.getMessage());
+            assertNoSqlError(e);
             assertFalse(e.getMessage().toLowerCase().contains("error") && e.getMessage().toLowerCase().contains("position"),
                     "Should not get PostgreSQL position error. Got: " + e.getMessage());
-
             log.info("PostgreSQL escaping prevented SQL injection with validation error");
         }
     }
@@ -428,7 +342,7 @@ public class SqlInjectionReportingServiceIntegrationTest extends BaseLoanIntegra
         int operationsPerThread = 3;
         ExecutorService executor = Executors.newFixedThreadPool(threadCount);
 
-        List<Future<Boolean>> futures = new java.util.ArrayList<>();
+        List<Future<Boolean>> futures = new ArrayList<>();
 
         for (int i = 0; i < threadCount; i++) {
             final int threadId = i;
@@ -443,16 +357,14 @@ public class SqlInjectionReportingServiceIntegrationTest extends BaseLoanIntegra
                             Map<String, String> queryParams = new HashMap<>();
                             queryParams.put("R_officeId", "1");
 
-                            Utils.performServerGet(requestSpec, responseSpec,
-                                    "/fineract-provider/api/v1/runreports/" + URLEncoder.encode(input, StandardCharsets.UTF_8)
-                                            + "?genericResultSet=false&" + toQueryString(queryParams),
-                                    null);
+                            runReport(input, queryParams);
                         }
                         return true;
-                    } catch (AssertionError e) {
+                    } catch (CallFailedRuntimeException e) {
                         // 404 is expected for non-existent reports
-                        return e.getMessage().contains("404");
-                    } catch (Exception e) {
+                        if (e.getStatus() == SC_NOT_FOUND) {
+                            return true;
+                        }
                         log.error("Error in thread {}: {}", threadId, e.getMessage());
                         return false;
                     }
@@ -488,15 +400,12 @@ public class SqlInjectionReportingServiceIntegrationTest extends BaseLoanIntegra
         maliciousParams.put("R_userId", "<script>alert('xss')</script>");
 
         try {
-            Utils.performServerGet(requestSpec, responseSpec, "/fineract-provider/api/v1/runreports/" + TEST_REPORT_NAME
-                    + "?genericResultSet=false&" + toQueryString(maliciousParams), null);
+            runReport(TEST_REPORT_NAME, maliciousParams);
             // If we get here without exception, the response should be safe
             log.info("Complex parameter injection prevented - query executed safely");
-        } catch (AssertionError e) {
+        } catch (CallFailedRuntimeException e) {
             // Should get parameter validation error, not SQL injection
-            assertFalse(e.getMessage().toLowerCase().contains("syntax error"), "Should not get SQL syntax error. Got: " + e.getMessage());
-            assertFalse(e.getMessage().toLowerCase().contains("you have an error in your sql"),
-                    "Should not get SQL error. Got: " + e.getMessage());
+            assertNoSqlError(e);
             assertFalse(e.getMessage().toLowerCase().contains("table") && e.getMessage().toLowerCase().contains("exist"),
                     "Should not get table exists error. Got: " + e.getMessage());
         }
@@ -515,26 +424,14 @@ public class SqlInjectionReportingServiceIntegrationTest extends BaseLoanIntegra
         queryParams.put(paramName, paramValue);
 
         try {
-            String response = Utils.performServerGet(requestSpec, responseSpec,
-                    "/fineract-provider/api/v1/runreports/" + TEST_REPORT_NAME + "?genericResultSet=false&" + toQueryString(queryParams),
-                    null);
-
-            // Valid parameters should return data successfully
-            assertNotNull(response);
-
-            // Should not contain SQL error indicators
-            assertFalse(response.toLowerCase().contains("syntax error"));
-            assertFalse(response.toLowerCase().contains("sql exception"));
+            // Valid parameters should return data successfully; a SQL error would have failed the call instead
+            assertNotNull(runReport(TEST_REPORT_NAME, queryParams));
 
             log.debug("Legitimate parameter '{}' = '{}' processed successfully", paramName, paramValue);
-        } catch (AssertionError e) {
+        } catch (CallFailedRuntimeException e) {
             // For legitimate parameters, we should not get errors unless it's a data issue
             // But definitely not SQL syntax errors
-            assertFalse(e.getMessage().toLowerCase().contains("syntax error"),
-                    "Should not get SQL syntax error for legitimate parameter. Got: " + e.getMessage());
-            assertFalse(e.getMessage().toLowerCase().contains("you have an error in your sql"),
-                    "Should not get SQL error for legitimate parameter. Got: " + e.getMessage());
-
+            assertNoSqlError(e);
             log.info("Parameter validation for '{}' = '{}': {}", paramName, paramValue, e.getMessage());
         }
     }
@@ -552,10 +449,9 @@ public class SqlInjectionReportingServiceIntegrationTest extends BaseLoanIntegra
         queryParams.put("R_officeId", "1");
 
         try {
-            Utils.performServerGet(requestSpec, responseSpec, "/fineract-provider/api/v1/runreports/"
-                    + URLEncoder.encode(testInput, StandardCharsets.UTF_8) + "?genericResultSet=false&" + toQueryString(queryParams), null);
-        } catch (AssertionError e) {
-            assertTrue(e.getMessage().contains("404") || e.getMessage().contains("400"),
+            runReport(testInput, queryParams);
+        } catch (CallFailedRuntimeException e) {
+            assertTrue(e.getStatus() == SC_NOT_FOUND || e.getStatus() == SC_BAD_REQUEST,
                     "Expected safe failure (404/400), but got: " + e.getMessage());
             assertFalse(e.getMessage().toLowerCase().contains("syntax error"));
             assertFalse(e.getMessage().toLowerCase().contains("sql"));
@@ -564,42 +460,53 @@ public class SqlInjectionReportingServiceIntegrationTest extends BaseLoanIntegra
         }
     }
 
-    /**
-     * Helper method to convert parameters map to query string
-     */
     @Test
     void shouldExecuteReportSuccessfullyWhenReportContainsBooleanColumn() {
         createBooleanReport();
         assertNotNull(booleanReportId, "BOOLEAN test report should be created before execution");
         assertNotNull(booleanReportName, "BOOLEAN test report name should be initialized");
 
-        // Use direct request to avoid hidden auth mismatch and assert exact behavior
-        Response runResponse = given().spec(requestSpec).accept(ContentType.JSON).when().get("/fineract-provider/api/v1/runreports/"
-                + URLEncoder.encode(booleanReportName, StandardCharsets.UTF_8) + "?genericResultSet=false");
+        // A successful run returns the rows; a non-2xx status throws and fails the test
+        List<Map<String, Object>> rows = runReport(booleanReportName, Map.of());
 
-        String response = runResponse.asString();
-        assertTrue(runResponse.getStatusCode() == 200, "Expected status 200 but was " + runResponse.getStatusCode() + " body: " + response);
-
-        assertNotNull(response);
-        assertFalse(response.isBlank());
-        assertFalse(response.contains("Data type 'BOOLEAN' is not supported"));
-        assertTrue(response.toLowerCase().contains("active"),
-                "Response should contain boolean column alias 'active', but was: " + response);
-        assertTrue(response.toLowerCase().contains("true") || response.toLowerCase().contains("1"),
-                "Response should contain boolean value (true/1), but was: " + response);
+        assertNotNull(rows);
+        assertFalse(rows.isEmpty(), "The BOOLEAN report should return a row");
+        Map<String, Object> row = rows.get(0);
+        assertTrue(row.containsKey(BOOLEAN_REPORT_COLUMN), "Response should contain boolean column alias 'active', but was: " + rows);
+        Object active = row.get(BOOLEAN_REPORT_COLUMN);
+        assertTrue(Boolean.TRUE.equals(active) || "true".equalsIgnoreCase(String.valueOf(active)) || "1".equals(String.valueOf(active)),
+                "Response should contain boolean value (true/1), but was: " + rows);
     }
 
-    private String toQueryString(Map<String, String> params) {
-        StringBuilder sb = new StringBuilder();
-        for (Map.Entry<String, String> entry : params.entrySet()) {
-            if (sb.length() > 0) {
-                sb.append("&");
-            }
-            sb.append(entry.getKey()).append("=");
-            if (entry.getValue() != null) {
-                sb.append(URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8));
-            }
-        }
-        return sb.toString();
+    private void assertNoSqlError(RuntimeException exception) {
+        assertFalse(exception.getMessage().toLowerCase().contains("syntax error"),
+                "Should not get SQL syntax error, got: " + exception.getMessage());
+        assertFalse(exception.getMessage().toLowerCase().contains("you have an error in your sql"),
+                "Should not get SQL error, got: " + exception.getMessage());
+    }
+
+    /**
+     * Runs a report with {@code genericResultSet=false}, the shape the pre-migration test asserted on: the server
+     * answers a plain array of rows rather than the {@code columnHeaders}/{@code data} Generic Resultset. Both shapes
+     * come out of the same {@code retrieveGenericResultset} call the SQL-injection prevention lives in.
+     */
+    private List<Map<String, Object>> runReport(String reportName, Map<String, String> parameters) {
+        Map<String, String> queryParameters = new HashMap<>(parameters);
+        queryParameters.put(GENERIC_RESULT_SET_PARAM, "false");
+        return ok(() -> runReports().runReportGetRows(reportName, queryParameters));
+    }
+
+    private static Map<String, String> withReportType(Map<String, String> parameters, String reportType) {
+        Map<String, String> queryParameters = new HashMap<>(parameters);
+        queryParameters.put(REPORT_TYPE_PARAM, reportType);
+        return queryParameters;
+    }
+
+    private static ReportsApi reports() {
+        return FineractFeignClientHelper.getFineractFeignClient().reports();
+    }
+
+    private static RunReportsApi runReports() {
+        return FineractFeignClientHelper.getFineractFeignClient().runReports();
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/UserLoanPermissionTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/UserLoanPermissionTest.java
@@ -18,22 +18,35 @@
  */
 package org.apache.fineract.integrationtests;
 
+import static org.apache.fineract.client.feign.util.FeignCalls.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import java.math.BigDecimal;
+import java.util.function.Function;
+import org.apache.fineract.client.feign.FineractFeignClient;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
 import org.apache.fineract.client.models.PostLoanProductsRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdRequest;
-import org.apache.fineract.client.models.PostLoansLoanIdResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsRequest;
+import org.apache.fineract.client.models.PostLoansLoanIdTransactionsResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsTransactionIdRequest;
-import org.apache.fineract.client.models.PostLoansResponse;
+import org.apache.fineract.client.models.PostRolesRequest;
+import org.apache.fineract.client.models.PostUsersRequest;
 import org.apache.fineract.client.models.PutLoansApprovedAmountRequest;
-import org.apache.fineract.client.util.Calls;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.junit.jupiter.api.Assertions;
+import org.apache.fineract.client.models.PutRolesRoleIdPermissionsRequest;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.SupportedInterestRefundTypesItem;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
+import org.apache.fineract.integrationtests.common.Utils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import retrofit2.Response;
 
-public class UserLoanPermissionTest extends BaseLoanIntegrationTest {
+public class UserLoanPermissionTest extends FeignLoanTestBase {
+
+    private static final String TEST_USER_PASSWORD = "AKleRbDhK421$";
+    private static final Long HEAD_OFFICE_ID = 1L;
 
     Long clientId;
     Long loanProductId;
@@ -42,31 +55,28 @@ public class UserLoanPermissionTest extends BaseLoanIntegrationTest {
     @BeforeEach
     public void setup() {
         if (clientId == null) {
-            clientId = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            clientId = createClient();
         }
         if (loanProductId == null) {
-            loanProductId = loanProductHelper.createLoanProduct(create4IProgressiveWithCapitalizedIncome()
+            loanProductId = createLoanProduct(create4IProgressiveWithCapitalizedIncome()
                     .addSupportedInterestRefundTypesItem(SupportedInterestRefundTypesItem.MERCHANT_ISSUED_REFUND)
                     .overAppliedCalculationType(null).overAppliedNumber(null).allowApprovedDisbursedAmountsOverApplied(false)
                     .enableBuyDownFee(true).buyDownFeeCalculationType(PostLoanProductsRequest.BuyDownFeeCalculationTypeEnum.FLAT)
                     .buyDownFeeStrategy(PostLoanProductsRequest.BuyDownFeeStrategyEnum.EQUAL_AMORTIZATION)
                     .buyDownFeeIncomeType(PostLoanProductsRequest.BuyDownFeeIncomeTypeEnum.FEE)
-                    .receivableInterestAccountId(interestReceivableAccount.getAccountID().longValue())
-                    .receivableFeeAccountId(feeReceivableAccount.getAccountID().longValue())
-                    .receivablePenaltyAccountId(penaltyReceivableAccount.getAccountID().longValue())
-                    .buyDownExpenseAccountId(buyDownExpenseAccount.getAccountID().longValue())
-                    .incomeFromBuyDownAccountId(feeIncomeAccount.getAccountID().longValue())
-                    .deferredIncomeLiabilityAccountId(deferredIncomeLiabilityAccount.getAccountID().longValue())).getResourceId();
+                    .receivableInterestAccountId(getAccounts().getInterestReceivableAccount().getAccountID().longValue())
+                    .receivableFeeAccountId(getAccounts().getFeeReceivableAccount().getAccountID().longValue())
+                    .receivablePenaltyAccountId(getAccounts().getPenaltyReceivableAccount().getAccountID().longValue())
+                    .buyDownExpenseAccountId(getAccounts().getBuyDownExpenseAccount().getAccountID().longValue())
+                    .incomeFromBuyDownAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())
+                    .deferredIncomeLiabilityAccountId(getAccounts().getDeferredIncomeLiabilityAccount().getAccountID().longValue()));
         }
         runAt("1 January 2025", () -> {
+            loanId = applyForLoan(applyLP2ProgressiveLoanRequest(clientId, loanProductId, "1 January 2025", 10000.0, 12.0, 4, null));
 
-            PostLoansResponse postLoansResponse = loanTransactionHelper
-                    .applyLoan(applyLP2ProgressiveLoanRequest(clientId, loanProductId, "1 January 2025", 10000.0, 12.0, 4, null));
+            approveLoan(loanId, approveLoanRequest(2000.0, "1 January 2025"));
 
-            loanTransactionHelper.approveLoan(postLoansResponse.getResourceId(), approveLoanRequest(2000.0, "1 January 2025"));
-
-            loanId = postLoansResponse.getResourceId();
-            disburseLoan(loanId, BigDecimal.valueOf(1000.0), "1 January 2025");
+            disburseLoan(loanId, LoanRequestBuilders.disburseLoan(1000.0, "1 January 2025"));
         });
     }
 
@@ -104,14 +114,13 @@ public class UserLoanPermissionTest extends BaseLoanIntegrationTest {
     @Test
     public void testManualInterestRefundPermission() {
         runAt("1 February 2025", () -> {
-            final Long merchantIssuedRefundId = loanTransactionHelper
-                    .makeMerchantIssuedRefund(loanId,
-                            new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).locale("en")
-                                    .transactionDate("01 February 2025").transactionAmount(100.0D).interestRefundCalculation(false))
+            final Long merchantIssuedRefundId = makeMerchantIssuedRefund(loanId,
+                    new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN).locale("en").transactionDate("01 February 2025")
+                            .transactionAmount(100.0D).interestRefundCalculation(false))
                     .getResourceId();
 
             performPermissionTestForRequest("MANUAL_INTEREST_REFUND_TRANSACTION_LOAN",
-                    fineractClient -> fineractClient.loanTransactions.adjustLoanTransaction(loanId, merchantIssuedRefundId,
+                    fineractClient -> fineractClient.loanTransactions().adjustLoanTransaction(loanId, merchantIssuedRefundId,
                             new PostLoansLoanIdTransactionsTransactionIdRequest().dateFormat(DATETIME_PATTERN).locale("en")
                                     .transactionAmount(1.20D),
                             "interest-refund"));
@@ -122,20 +131,24 @@ public class UserLoanPermissionTest extends BaseLoanIntegrationTest {
     public void testUpdateApprovedAmountPermission() {
         runAt("1 January 2025", () -> {
             // disbursement should be rejected upon validation error
-            Response<PostLoansLoanIdResponse> response = Calls.executeU(
-                    fineractClient().loans.handleCommandsLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2025")
-                            .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(2000.0)).locale("en"), "disburse"));
-
-            Assertions.assertEquals(403, response.code());
+            CallFailedRuntimeException exception = fail(
+                    () -> fineractClient().loans()
+                            .handleCommandsLoan(
+                                    loanId, new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2025")
+                                            .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(2000.0)).locale("en"),
+                                    "disburse"));
+            assertEquals(403, exception.getStatus());
 
             // update approved amount
             performPermissionTestForRequest("UPDATE_APPROVED_AMOUNT_LOAN",
-                    fineractClient -> fineractClient.loans.updateApprovedAmountLoan(loanId,
+                    fineractClient -> fineractClient.loans().updateApprovedAmountLoan(loanId,
                             new PutLoansApprovedAmountRequest().amount(BigDecimal.valueOf(4000.0d)).locale("en")));
 
             // disbursement should be performed without error
-            Calls.ok(fineractClient().loans.handleCommandsLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2025")
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(2000.0)).locale("en"), "disburse"));
+            ok(() -> fineractClient().loans().handleCommandsLoan(loanId,
+                    new PostLoansLoanIdRequest().actualDisbursementDate("1 January 2025").dateFormat(DATETIME_PATTERN)
+                            .transactionAmount(BigDecimal.valueOf(2000.0)).locale("en"),
+                    "disburse"));
         });
     }
 
@@ -143,12 +156,75 @@ public class UserLoanPermissionTest extends BaseLoanIntegrationTest {
     public void testContractTerminationAndUndoContractTerminationPermission() {
 
         runAt("2 January 2025", () -> {
-            performPermissionTestForRequest("CONTRACT_TERMINATION_LOAN", fineractClient -> fineractClient.loans.handleCommandsLoan(loanId,
+            performPermissionTestForRequest("CONTRACT_TERMINATION_LOAN", fineractClient -> fineractClient.loans().handleCommandsLoan(loanId,
                     new PostLoansLoanIdRequest().note(""), "contractTermination"));
 
             performPermissionTestForRequest("CONTRACT_TERMINATION_UNDO_LOAN",
-                    fineractClient -> fineractClient.loans.handleCommandsLoan(loanId,
+                    fineractClient -> fineractClient.loans().handleCommandsLoan(loanId,
                             new PostLoansLoanIdRequest().note("Contract Termination Undo Test Note"), "undoContractTermination"));
         });
+    }
+
+    /**
+     * Executes a loan transaction request via a freshly created user that lacks the given permission (asserting a 403),
+     * then grants the permission and re-executes it (asserting success). Returns the successful response body.
+     */
+    private PostLoansLoanIdTransactionsResponse makeLoanTransactionWithPermissionVerification(final Long loanId,
+            final PostLoansLoanIdTransactionsRequest postLoansLoanIdTransactionsRequest, final String command, final String permission) {
+        return performPermissionTestForRequest(permission, fineractClient -> fineractClient.loanTransactions()
+                .handleCommandsLoanTransaction(loanId, postLoansLoanIdTransactionsRequest, command));
+    }
+
+    /**
+     * Executes a loan transaction adjustment via a freshly created user that lacks the given permission (asserting a
+     * 403), then grants the permission and re-executes it (asserting success).
+     */
+    private void adjustLoanTransactionWithPermissionVerification(final Long loanId, final Long transactionIdToAdjust,
+            final PostLoansLoanIdTransactionsTransactionIdRequest postLoansLoanIdTransactionsRequest, final String command,
+            final String permission) {
+        performPermissionTestForRequest(permission, fineractClient -> fineractClient.loanTransactions().adjustLoanTransaction(loanId,
+                transactionIdToAdjust, postLoansLoanIdTransactionsRequest, command));
+    }
+
+    /**
+     * Creates a role with the given permission disabled and a user holding that role. Runs {@code callback} as that
+     * user, asserting it fails with a 403; then enables the permission and runs it again, asserting success and
+     * returning the response body.
+     */
+    private <T> T performPermissionTestForRequest(final String permission, final Function<FineractFeignClient, T> callback) {
+        final FineractFeignClient adminClient = fineractClient();
+
+        final String roleName = Utils.uniqueRandomStringGenerator("TEST_ROLE_", 10);
+        final Long roleId = ok(
+                () -> adminClient.roles().createRole(new PostRolesRequest().name(roleName).description("Test role Description")))
+                .getResourceId();
+        ok(() -> adminClient.roles().updateRolePermissions(roleId,
+                new PutRolesRoleIdPermissionsRequest().putPermissionsItem(permission, false)));
+
+        final String firstname = Utils.randomFirstNameGenerator();
+        final String lastname = Utils.randomLastNameGenerator();
+        final String userName = Utils.uniqueRandomStringGenerator("testUserName", 4);
+        final String email = firstname + "." + lastname + "@whatever.mifos.org";
+        ok(() -> adminClient.users()
+                .createUser(new PostUsersRequest().addRolesItem(roleId).email(email).firstname(firstname).lastname(lastname)
+                        .repeatPassword(TEST_USER_PASSWORD).sendPasswordToEmail(false).officeId(HEAD_OFFICE_ID).username(userName)
+                        .password(TEST_USER_PASSWORD)));
+
+        final FineractFeignClient userClient = FineractFeignClientHelper.createNewFineractFeignClient(userName, TEST_USER_PASSWORD);
+
+        // try to make transaction - should fail
+        final CallFailedRuntimeException exception = fail(() -> callback.apply(userClient));
+        assertEquals(403, exception.getStatus());
+
+        // edit role to have permission for transaction
+        ok(() -> adminClient.roles().updateRolePermissions(roleId,
+                new PutRolesRoleIdPermissionsRequest().putPermissionsItem(permission, true)));
+
+        // try to make transaction - should pass
+        final T grantedResponse = callback.apply(userClient);
+        // A non-2xx status already throws, but a 2xx with no body would mean the command never ran. The pre-migration
+        // test asserted the status was exactly 200; asserting a body is present is the typed-client equivalent.
+        assertNotNull(grantedResponse, "Expected a response body once '" + permission + "' was granted, but the command returned none");
+        return grantedResponse;
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/accounting/GLAccountIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/accounting/GLAccountIntegrationTest.java
@@ -24,8 +24,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.Month;
 import java.util.Calendar;
 import org.apache.fineract.accounting.glaccount.domain.GLAccountType;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
 import org.apache.fineract.client.models.GetGLAccountsResponse;
 import org.apache.fineract.client.models.JournalEntryCommand;
 import org.apache.fineract.client.models.PostGLAccountsRequest;
@@ -33,75 +35,71 @@ import org.apache.fineract.client.models.PostGLAccountsResponse;
 import org.apache.fineract.client.models.PostLoanProductsRequest;
 import org.apache.fineract.client.models.PutGLAccountsRequest;
 import org.apache.fineract.client.models.SingleDebitOrCreditEntryCommand;
-import org.apache.fineract.client.util.CallFailedRuntimeException;
-import org.apache.fineract.integrationtests.BaseLoanIntegrationTest;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
 import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.accounting.AccountHelper;
-import org.apache.fineract.integrationtests.common.accounting.JournalEntryHelper;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class GLAccountIntegrationTest extends BaseLoanIntegrationTest {
+public class GLAccountIntegrationTest extends FeignLoanTestBase {
 
     @Test
     public void createUpdateDeleteGLAccountTest() {
         // CREATE
         String uniqueString = Utils.uniqueRandomStringGenerator("UNIQUE_FEE_INCOME" + Calendar.getInstance().getTimeInMillis(), 5);
         final PostGLAccountsResponse newAccount = createGLAccount(uniqueString);
-        GetGLAccountsResponse accountDetails = AccountHelper.getGLAccount(newAccount.getResourceId());
-        Assertions.assertEquals(uniqueString, accountDetails.getGlCode());
-        Assertions.assertEquals(uniqueString, accountDetails.getName());
-        Assertions.assertEquals(true, accountDetails.getManualEntriesAllowed());
-        Assertions.assertEquals((long) GLAccountType.INCOME.getValue(), accountDetails.getType().getId());
-        Assertions.assertEquals(1L, accountDetails.getUsage().getId());
-        Assertions.assertEquals(uniqueString, accountDetails.getDescription());
+        GetGLAccountsResponse accountDetails = accountHelper.getGLAccount(newAccount.getResourceId());
+        assertEquals(uniqueString, accountDetails.getGlCode());
+        assertEquals(uniqueString, accountDetails.getName());
+        assertEquals(true, accountDetails.getManualEntriesAllowed());
+        assertEquals((long) GLAccountType.INCOME.getValue(), accountDetails.getType().getId());
+        assertEquals(1L, accountDetails.getUsage().getId());
+        assertEquals(uniqueString, accountDetails.getDescription());
         // UPDATE
-        AccountHelper.updateGLAccount(newAccount.getResourceId(), new PutGLAccountsRequest().description("newDescription").name("newName")
+        accountHelper.updateGLAccount(newAccount.getResourceId(), new PutGLAccountsRequest().description("newDescription").name("newName")
                 .glCode("newGLCode").type(GLAccountType.ASSET.getValue()).manualEntriesAllowed(false).usage(2));
-        accountDetails = AccountHelper.getGLAccount(newAccount.getResourceId());
-        Assertions.assertEquals("newDescription", accountDetails.getDescription());
-        Assertions.assertEquals("newName", accountDetails.getName());
-        Assertions.assertEquals("newGLCode", accountDetails.getGlCode());
-        Assertions.assertEquals((long) GLAccountType.ASSET.getValue(), accountDetails.getType().getId());
-        Assertions.assertEquals(2L, accountDetails.getUsage().getId());
+        accountDetails = accountHelper.getGLAccount(newAccount.getResourceId());
+        assertEquals("newDescription", accountDetails.getDescription());
+        assertEquals("newName", accountDetails.getName());
+        assertEquals("newGLCode", accountDetails.getGlCode());
+        assertEquals((long) GLAccountType.ASSET.getValue(), accountDetails.getType().getId());
+        assertEquals(2L, accountDetails.getUsage().getId());
         // DELETE
-        AccountHelper.deleteGLAccount(newAccount.getResourceId());
+        accountHelper.deleteGLAccount(newAccount.getResourceId());
     }
 
     @Test
     public void testDeleteGLAccountWhileThereAreChildren() {
         String uniqueNameForParent = Utils.uniqueRandomStringGenerator("UNIQUE_FEE_INCOME" + Calendar.getInstance().getTimeInMillis(), 5);
-        final PostGLAccountsResponse newParentAccount = AccountHelper
+        final PostGLAccountsResponse newParentAccount = accountHelper
                 .createGLAccount(new PostGLAccountsRequest().type(GLAccountType.INCOME.getValue()).glCode(uniqueNameForParent)
                         .manualEntriesAllowed(true).usage(2).description(uniqueNameForParent).name(uniqueNameForParent));
         String uniqueNameForChild = Utils.uniqueRandomStringGenerator("UNIQUE_FEE_INCOME" + Calendar.getInstance().getTimeInMillis(), 5);
-        final PostGLAccountsResponse newChildAccount = AccountHelper.createGLAccount(
+        final PostGLAccountsResponse newChildAccount = accountHelper.createGLAccount(
                 new PostGLAccountsRequest().type(GLAccountType.INCOME.getValue()).glCode(uniqueNameForChild).manualEntriesAllowed(true)
                         .usage(1).parentId(newParentAccount.getResourceId()).description(uniqueNameForChild).name(uniqueNameForChild));
         // DELETE
         CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                () -> AccountHelper.deleteGLAccount(newParentAccount.getResourceId()));
-        assertEquals(403, exception.getResponse().code());
+                () -> accountHelper.deleteGLAccount(newParentAccount.getResourceId()));
+        assertEquals(403, exception.getStatus());
         assertTrue(exception.getMessage().contains("error.msg.glaccount.glcode.invalid.delete.has.children"));
-        AccountHelper.deleteGLAccount(newChildAccount.getResourceId());
-        AccountHelper.deleteGLAccount(newParentAccount.getResourceId());
+        accountHelper.deleteGLAccount(newChildAccount.getResourceId());
+        accountHelper.deleteGLAccount(newParentAccount.getResourceId());
     }
 
     @Test
     public void testDeleteGLAccountWhileMappedToProduct() {
         String uniqueString = Utils.uniqueRandomStringGenerator("UNIQUE_FEE_INCOME" + Calendar.getInstance().getTimeInMillis(), 5);
         final PostGLAccountsResponse newAccount = createGLAccount(uniqueString);
-        loanProductHelper.createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
+        createLoanProduct(create4IProgressive().enableIncomeCapitalization(true)
                 .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)
                 .capitalizedIncomeStrategy(PostLoanProductsRequest.CapitalizedIncomeStrategyEnum.EQUAL_AMORTIZATION)
-                .deferredIncomeLiabilityAccountId(deferredIncomeLiabilityAccount.getAccountID().longValue())
+                .deferredIncomeLiabilityAccountId(deferredIncomeLiabilityAccount().getAccountID().longValue())
                 .incomeFromCapitalizationAccountId(newAccount.getResourceId())
                 .capitalizedIncomeType(PostLoanProductsRequest.CapitalizedIncomeTypeEnum.FEE));
 
         // DELETE
         CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                () -> AccountHelper.deleteGLAccount(newAccount.getResourceId()));
-        assertEquals(403, exception.getResponse().code());
+                () -> accountHelper.deleteGLAccount(newAccount.getResourceId()));
+        assertEquals(403, exception.getStatus());
         assertTrue(exception.getMessage().contains("error.msg.glaccount.glcode.invalid.delete.product.mapping"));
     }
 
@@ -112,21 +110,20 @@ public class GLAccountIntegrationTest extends BaseLoanIntegrationTest {
             final PostGLAccountsResponse newAccount = createGLAccount(uniqueString);
             uniqueString = Utils.uniqueRandomStringGenerator("UNIQUE_FEE_INCOME" + Calendar.getInstance().getTimeInMillis(), 5);
             final PostGLAccountsResponse newAccount2 = createGLAccount(uniqueString);
-            JournalEntryHelper.createJournalEntry("", new JournalEntryCommand().amount(BigDecimal.TEN).officeId(1L).currencyCode("USD")
-                    .locale("en").dateFormat("uuuu-MM-dd").transactionDate(LocalDate.of(2024, 1, 1))
+            journalHelper.createJournalEntry(new JournalEntryCommand().amount(BigDecimal.TEN).officeId(1L).currencyCode("USD").locale("en")
+                    .dateFormat("uuuu-MM-dd").transactionDate(LocalDate.of(2024, Month.JANUARY, 1))
                     .addCreditsItem(new SingleDebitOrCreditEntryCommand().glAccountId(newAccount.getResourceId()).amount(BigDecimal.TEN))
                     .addDebitsItem(new SingleDebitOrCreditEntryCommand().glAccountId(newAccount2.getResourceId()).amount(BigDecimal.TEN)));
             // DELETE
             CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                    () -> AccountHelper.deleteGLAccount(newAccount.getResourceId()));
-            assertEquals(403, exception.getResponse().code());
+                    () -> accountHelper.deleteGLAccount(newAccount.getResourceId()));
+            assertEquals(403, exception.getStatus());
             assertTrue(exception.getMessage().contains("error.msg.glaccount.glcode.invalid.delete.transactions.logged"));
         });
     }
 
     private PostGLAccountsResponse createGLAccount(String uniqueString) {
-        return AccountHelper.createGLAccount(new PostGLAccountsRequest().type(GLAccountType.INCOME.getValue()).glCode(uniqueString)
+        return accountHelper.createGLAccount(new PostGLAccountsRequest().type(GLAccountType.INCOME.getValue()).glCode(uniqueString)
                 .manualEntriesAllowed(true).usage(1).description(uniqueString).name(uniqueString));
     }
-
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/FeignLoanTestBase.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/FeignLoanTestBase.java
@@ -864,6 +864,11 @@ public abstract class FeignLoanTestBase extends FeignIntegrationTest implements 
         LoanAccountLockHelper.placeSoftLockOnLoanAccount(loanId, "LOAN_COB_CHUNK_PROCESSING");
     }
 
+    /** A lock that carries an error message is a hard lock: it stays until a catch-up COB clears it. */
+    protected void placeHardLockOnLoan(Long loanId, String error) {
+        LoanAccountLockHelper.placeSoftLockOnLoanAccount(loanId, "LOAN_COB_CHUNK_PROCESSING", error);
+    }
+
     protected void verifyLastClosedBusinessDate(Long loanId, String lastClosedBusinessDate) {
         GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
         assertNotNull(loanDetails.getLastClosedBusinessDate());
@@ -1546,6 +1551,22 @@ public abstract class FeignLoanTestBase extends FeignIntegrationTest implements 
         LoanTestValidators.verifyRepaymentSchedule(loanDetails, installments);
     }
 
+    protected PostLoanProductsRequest createOnePeriod30DaysPeriodicAccrualProductWithAdvancedPaymentAllocationAndInterestRecalculation(
+            double interestRatePerPeriod, Integer rescheduleStrategyMethod) {
+        return createOnePeriod30DaysPeriodicAccrualProduct(interestRatePerPeriod)//
+                .transactionProcessingStrategyCode(LoanTestData.TransactionProcessingStrategyCode.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)//
+                .loanScheduleType("PROGRESSIVE")//
+                .loanScheduleProcessingType("HORIZONTAL")//
+                .addPaymentAllocationItem(createDefaultPaymentAllocation("NEXT_INSTALLMENT"))//
+                .enableDownPayment(false)//
+                .isInterestRecalculationEnabled(true)//
+                .interestRecalculationCompoundingMethod(LoanTestData.InterestRecalculationCompoundingMethod.NONE)//
+                .preClosureInterestCalculationStrategy(1)//
+                .recalculationRestFrequencyType(LoanTestData.RecalculationRestFrequencyType.SAME_AS_REPAYMENT_PERIOD)//
+                .allowPartialPeriodInterestCalculation(true)//
+                .rescheduleStrategyMethod(rescheduleStrategyMethod);
+    }
+
     protected PostLoanProductsRequest createOnePeriod30DaysLongNoInterestPeriodicAccrualProductWithAdvancedPaymentAllocation() {
         return createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct()
                 .transactionProcessingStrategyCode("advanced-payment-allocation-strategy").loanScheduleType("PROGRESSIVE")
@@ -1819,16 +1840,28 @@ public abstract class FeignLoanTestBase extends FeignIntegrationTest implements 
         return installment(principalAmount, interestAmount, totalOutstanding, false, dueDate);
     }
 
-    protected AdvancedPaymentData createDefaultPaymentAllocation() {
+    protected static AdvancedPaymentData createDefaultPaymentAllocation() {
         return LoanRequestBuilders.defaultPaymentAllocation();
     }
 
-    protected AdvancedPaymentData createDefaultPaymentAllocation(String futureInstallmentAllocationRule) {
+    protected static AdvancedPaymentData createDefaultPaymentAllocation(String futureInstallmentAllocationRule) {
         return LoanRequestBuilders.paymentAllocation("DEFAULT", futureInstallmentAllocationRule);
     }
 
-    protected AdvancedPaymentData createPaymentAllocation(String transactionType, String futureInstallmentAllocationRule) {
+    protected static AdvancedPaymentData createPaymentAllocation(String transactionType, String futureInstallmentAllocationRule) {
         return LoanRequestBuilders.paymentAllocation(transactionType, futureInstallmentAllocationRule);
+    }
+
+    protected Account loansReceivableAccount() {
+        return getAccounts().getLoansReceivableAccount();
+    }
+
+    protected Account fundSource() {
+        return getAccounts().getFundSource();
+    }
+
+    protected Account overpaymentAccount() {
+        return getAccounts().getOverpaymentAccount();
     }
 
     protected List<AdvancedPaymentData> getAdvancedPaymentAllocationRules(Long loanId) {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/FeignLoanTestBase.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/FeignLoanTestBase.java
@@ -30,6 +30,7 @@ import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -43,6 +44,11 @@ import org.apache.fineract.client.feign.FineractFeignClient;
 import org.apache.fineract.client.feign.ObjectMapperFactory;
 import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
 import org.apache.fineract.client.models.AdvancedPaymentData;
+import org.apache.fineract.client.models.AllowAttributeOverrides;
+import org.apache.fineract.client.models.BatchRequest;
+import org.apache.fineract.client.models.BatchResponse;
+import org.apache.fineract.client.models.BuyDownFeeAmortizationDetails;
+import org.apache.fineract.client.models.CapitalizedIncomeDetails;
 import org.apache.fineract.client.models.ChargeRequest;
 import org.apache.fineract.client.models.DeleteLoansLoanIdChargesChargeIdResponse;
 import org.apache.fineract.client.models.DeleteLoansLoanIdResponse;
@@ -50,6 +56,7 @@ import org.apache.fineract.client.models.DisbursementDetail;
 import org.apache.fineract.client.models.GetDelinquencyTagHistoryResponse;
 import org.apache.fineract.client.models.GetJournalEntriesTransactionIdResponse;
 import org.apache.fineract.client.models.GetLoanProductsProductIdResponse;
+import org.apache.fineract.client.models.GetLoanProductsTemplateResponse;
 import org.apache.fineract.client.models.GetLoansApprovalTemplateResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdChargesChargeIdResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdChargesTemplateResponse;
@@ -58,7 +65,10 @@ import org.apache.fineract.client.models.GetLoansLoanIdStatus;
 import org.apache.fineract.client.models.GetLoansLoanIdTransactionsResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdTransactionsTemplateResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdTransactionsTransactionIdResponse;
+import org.apache.fineract.client.models.GetLoansResponse;
 import org.apache.fineract.client.models.LoanApprovedAmountHistoryData;
+import org.apache.fineract.client.models.LoanCapitalizedIncomeData;
+import org.apache.fineract.client.models.LoanPointInTimeData;
 import org.apache.fineract.client.models.LoanScheduleData;
 import org.apache.fineract.client.models.PostChargesResponse;
 import org.apache.fineract.client.models.PostCreateRescheduleLoansRequest;
@@ -87,10 +97,12 @@ import org.apache.fineract.client.models.PutLoansLoanIdChargesChargeIdRequest;
 import org.apache.fineract.client.models.PutLoansLoanIdChargesChargeIdResponse;
 import org.apache.fineract.client.models.PutLoansLoanIdRequest;
 import org.apache.fineract.client.models.PutLoansLoanIdResponse;
+import org.apache.fineract.client.models.RetrieveLoansPointInTimeRequest;
 import org.apache.fineract.client.models.TransactionType;
 import org.apache.fineract.infrastructure.event.external.data.ExternalEventResponse;
 import org.apache.fineract.integrationtests.client.FeignIntegrationTest;
 import org.apache.fineract.integrationtests.client.feign.helpers.FeignAccountHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignBatchHelper;
 import org.apache.fineract.integrationtests.client.feign.helpers.FeignBusinessDateHelper;
 import org.apache.fineract.integrationtests.client.feign.helpers.FeignChargesHelper;
 import org.apache.fineract.integrationtests.client.feign.helpers.FeignClientHelper;
@@ -104,6 +116,7 @@ import org.apache.fineract.integrationtests.client.feign.helpers.FeignSavingsPro
 import org.apache.fineract.integrationtests.client.feign.helpers.FeignSavingsTransactionHelper;
 import org.apache.fineract.integrationtests.client.feign.helpers.FeignSchedulerHelper;
 import org.apache.fineract.integrationtests.client.feign.helpers.FeignTransactionHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignUserHelper;
 import org.apache.fineract.integrationtests.client.feign.modules.ChargeRequestBuilders;
 import org.apache.fineract.integrationtests.client.feign.modules.LoanProductTemplates;
 import org.apache.fineract.integrationtests.client.feign.modules.LoanRequestBuilders;
@@ -115,8 +128,10 @@ import org.apache.fineract.integrationtests.common.PaymentTypeHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.common.accounting.Account;
 import org.apache.fineract.integrationtests.common.accounting.PeriodicAccrualAccountingHelper;
+import org.apache.fineract.integrationtests.common.error.ErrorResponse;
 import org.apache.fineract.integrationtests.common.externalevents.BusinessEvent;
 import org.apache.fineract.integrationtests.common.externalevents.ExternalEventsExtension;
+import org.apache.fineract.integrationtests.common.loans.LoanAccountLockHelper;
 import org.apache.fineract.integrationtests.common.loans.LoanTestLifecycleExtension;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanStatus;
 import org.apache.fineract.portfolio.loanaccount.domain.transactionprocessor.impl.AdvancedPaymentScheduleTransactionProcessor;
@@ -142,6 +157,9 @@ public abstract class FeignLoanTestBase extends FeignIntegrationTest implements 
     protected static FeignSchedulerHelper schedulerHelper;
     protected static FeignExternalEventHelper externalEventHelper;
     protected static LoanTestAccounts accounts;
+
+    private FineractFeignClient activeBatchClient = FineractFeignClientHelper.getFineractFeignClient();
+    private FineractFeignClient nonByPassClient;
 
     @BeforeAll
     public static void setupHelpers() {
@@ -210,8 +228,112 @@ public abstract class FeignLoanTestBase extends FeignIntegrationTest implements 
         return loanHelper.updateLoanProduct(productId, request);
     }
 
+    protected GetLoanProductsTemplateResponse getLoanProductTemplate(boolean isProductMixTemplate) {
+        return loanHelper.getLoanProductTemplate(isProductMixTemplate);
+    }
+
+    protected PutLoanProductsProductIdRequest update4IProgressive(String name, String shortName, Long delinquencyBucketId) {
+        return new PutLoanProductsProductIdRequest().name(name).shortName(shortName).description("4 installment product - progressive")//
+                .includeInBorrowerCycle(false)//
+                .useBorrowerCycle(false)//
+                .currencyCode("EUR")//
+                .digitsAfterDecimal(2)//
+                .principal(1000.0)//
+                .minPrincipal(100.0)//
+                .maxPrincipal(10000.0)//
+                .numberOfRepayments(4)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS_L.intValue())//
+                .interestRatePerPeriod(10D)//
+                .minInterestRatePerPeriod(0D)//
+                .maxInterestRatePerPeriod(120D)//
+                .interestRateFrequencyType(LoanTestData.InterestRateFrequencyType.YEARS)//
+                .isLinkedToFloatingInterestRates(false)//
+                .allowVariableInstallments(false)//
+                .amortizationType(LoanTestData.AmortizationType.EQUAL_INSTALLMENTS)//
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE)//
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.DAILY)//
+                .allowPartialPeriodInterestCalculation(false)//
+                .transactionProcessingStrategyCode(AdvancedPaymentScheduleTransactionProcessor.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)//
+                .paymentAllocation(List.of(createDefaultPaymentAllocation("NEXT_INSTALLMENT")))//
+                .creditAllocation(List.of())//
+                .overdueDaysForNPA(179)//
+                .daysInMonthType(30L)//
+                .daysInYearType(360L)//
+                .isInterestRecalculationEnabled(true)//
+                .interestRecalculationCompoundingMethod(0)//
+                .rescheduleStrategyMethod(LoanTestData.RescheduleStrategyMethod.ADJUST_LAST_UNPAID_PERIOD)//
+                .recalculationRestFrequencyType(LoanTestData.RecalculationRestFrequencyType.DAILY)//
+                .recalculationRestFrequencyInterval(1)//
+                .isArrearsBasedOnOriginalSchedule(false)//
+                .isCompoundingToBePostedAsTransaction(false)//
+                .preClosureInterestCalculationStrategy(1)//
+                .allowCompoundingOnEod(false)//
+                .canDefineInstallmentAmount(true)//
+                .repaymentStartDateType(1)//
+                .charges(List.of())//
+                .principalVariationsForBorrowerCycle(List.of())//
+                .interestRateVariationsForBorrowerCycle(List.of())//
+                .numberOfRepaymentVariationsForBorrowerCycle(List.of())//
+                .accountingRule(3)//
+                .canUseForTopup(false)//
+                .fundSourceAccountId(getAccounts().getFundSource().getAccountID().longValue())//
+                .loanPortfolioAccountId(getAccounts().getLoansReceivableAccount().getAccountID().longValue())//
+                .transfersInSuspenseAccountId(getAccounts().getSuspenseAccount().getAccountID().longValue())//
+                .interestOnLoanAccountId(getAccounts().getInterestIncomeAccount().getAccountID().longValue())//
+                .incomeFromFeeAccountId(getAccounts().getFeeIncomeAccount().getAccountID().longValue())//
+                .incomeFromPenaltyAccountId(getAccounts().getPenaltyIncomeAccount().getAccountID().longValue())//
+                .incomeFromRecoveryAccountId(getAccounts().getRecoveriesAccount().getAccountID().longValue())//
+                .writeOffAccountId(getAccounts().getWrittenOffAccount().getAccountID().longValue())//
+                .overpaymentLiabilityAccountId(getAccounts().getOverpaymentAccount().getAccountID().longValue())//
+                .receivableInterestAccountId(getAccounts().getInterestReceivableAccount().getAccountID().longValue())//
+                .receivableFeeAccountId(getAccounts().getFeeReceivableAccount().getAccountID().longValue())//
+                .receivablePenaltyAccountId(getAccounts().getPenaltyReceivableAccount().getAccountID().longValue())//
+                .goodwillCreditAccountId(getAccounts().getGoodwillExpenseAccount().getAccountID().longValue())//
+                .incomeFromGoodwillCreditInterestAccountId(getAccounts().getInterestIncomeChargeOffAccount().getAccountID().longValue())//
+                .incomeFromGoodwillCreditFeesAccountId(getAccounts().getFeeChargeOffAccount().getAccountID().longValue())//
+                .incomeFromGoodwillCreditPenaltyAccountId(getAccounts().getFeeChargeOffAccount().getAccountID().longValue())//
+                .incomeFromChargeOffInterestAccountId(getAccounts().getInterestIncomeChargeOffAccount().getAccountID().longValue())//
+                .incomeFromChargeOffFeesAccountId(getAccounts().getFeeChargeOffAccount().getAccountID().longValue())//
+                .incomeFromChargeOffPenaltyAccountId(getAccounts().getPenaltyChargeOffAccount().getAccountID().longValue())//
+                .chargeOffExpenseAccountId(getAccounts().getChargeOffExpenseAccount().getAccountID().longValue())//
+                .chargeOffFraudExpenseAccountId(getAccounts().getChargeOffFraudExpenseAccount().getAccountID().longValue())//
+                .dateFormat(LoanTestData.DATETIME_PATTERN)//
+                .locale("en")//
+                .enableAccrualActivityPosting(false)//
+                .multiDisburseLoan(true)//
+                .maxTrancheCount(10)//
+                .outstandingLoanBalance(10000.0)//
+                .disallowExpectedDisbursements(true)//
+                .allowApprovedDisbursedAmountsOverApplied(true)//
+                .overAppliedCalculationType("percentage")//
+                .overAppliedNumber(50)//
+                .principalThresholdForLastInstallment(50)//
+                .holdGuaranteeFunds(false)//
+                .accountMovesOutOfNPAOnlyOnArrearsCompletion(false)//
+                .allowAttributeOverrides(new AllowAttributeOverrides()//
+                        .amortizationType(true)//
+                        .interestType(true)//
+                        .transactionProcessingStrategyCode(true)//
+                        .interestCalculationPeriodType(true)//
+                        .inArrearsTolerance(true)//
+                        .repaymentEvery(true)//
+                        .graceOnPrincipalAndInterestPayment(true)//
+                        .graceOnArrearsAgeing(true)//
+                ).isEqualAmortization(false)//
+                .delinquencyBucketId(delinquencyBucketId)//
+                .enableDownPayment(false)//
+                .enableInstallmentLevelDelinquency(false)//
+                .loanScheduleType("PROGRESSIVE")//
+                .loanScheduleProcessingType("HORIZONTAL");
+    }
+
     protected Long applyForLoan(PostLoansRequest request) {
         return loanHelper.applyForLoan(request).getLoanId();
+    }
+
+    protected PostLoansResponse calculateLoanSchedule(PostLoansRequest request) {
+        return loanHelper.calculateLoanSchedule(request);
     }
 
     protected Long applyForLoanFromJson(String loanApplicationJson) {
@@ -220,6 +342,10 @@ public abstract class FeignLoanTestBase extends FeignIntegrationTest implements 
 
     protected PostLoansLoanIdResponse approveLoan(Long loanId, PostLoansLoanIdRequest request) {
         return loanHelper.approveLoan(loanId, request);
+    }
+
+    protected GetLoansResponse retrieveAllLoans(String accountNumber, String associations, Long clientId) {
+        return loanHelper.retrieveAllLoans(accountNumber, associations, clientId);
     }
 
     protected PostLoansLoanIdRequest approveLoanRequest(Double amount, String approvalDate) {
@@ -728,12 +854,138 @@ public abstract class FeignLoanTestBase extends FeignIntegrationTest implements 
         transactionHelper.executeInlineCOB(loanIds);
     }
 
+    protected void placeHardLockOnLoan(Long loanId) {
+        LoanAccountLockHelper.placeSoftLockOnLoanAccount(loanId, "LOAN_COB_CHUNK_PROCESSING");
+    }
+
+    protected void verifyLastClosedBusinessDate(Long loanId, String lastClosedBusinessDate) {
+        GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
+        assertNotNull(loanDetails.getLastClosedBusinessDate());
+        assertEquals(lastClosedBusinessDate, loanDetails.getLastClosedBusinessDate().format(dateTimeFormatter));
+    }
+
+    /**
+     * Runs the given action with batch requests issued as a user that lacks the loan-checker bypass permission, so
+     * loan-lock enforcement is not bypassed. Mirrors {@code BaseLoanIntegrationTest.runAsNonByPass}.
+     */
+    protected void runAsNonByPass(Runnable runnable) {
+        FineractFeignClient previous = activeBatchClient;
+        activeBatchClient = getNonByPassClient();
+        try {
+            runnable.run();
+        } finally {
+            activeBatchClient = previous;
+        }
+    }
+
+    private FineractFeignClient getNonByPassClient() {
+        if (nonByPassClient == null) {
+            nonByPassClient = FeignUserHelper.getSimpleUserWithoutBypassPermissionClient();
+        }
+        return nonByPassClient;
+    }
+
+    protected BatchRequestBuilder batchRequest() {
+        return new BatchRequestBuilder(new FeignBatchHelper(activeBatchClient));
+    }
+
+    public static final class BatchRequestBuilder {
+
+        private final FeignBatchHelper batchHelper;
+        private final List<BatchRequest> requests = new ArrayList<>();
+
+        private BatchRequestBuilder(FeignBatchHelper batchHelper) {
+            this.batchHelper = batchHelper;
+        }
+
+        public BatchRequestBuilder rescheduleLoan(Long requestId, Long loanId, String submittedOnDate, String rescheduleFromDate,
+                String adjustedDueDate) {
+            requests.add(new BatchRequest().requestId(requestId).relativeUrl("rescheduleloans").method("POST").body("""
+                        {
+                            "loanId": %d,
+                            "rescheduleFromDate": "%s",
+                            "rescheduleReasonId": 1,
+                            "submittedOnDate": "%s",
+                            "rescheduleReasonComment": "",
+                            "adjustedDueDate": "%s",
+                            "graceOnPrincipal": "",
+                            "graceOnInterest": "",
+                            "extraTerms": "",
+                            "newInterestRate": "",
+                            "dateFormat": "%s",
+                            "locale": "en"
+                        }
+                    """.formatted(loanId, rescheduleFromDate, submittedOnDate, adjustedDueDate, DATETIME_PATTERN)));
+            return this;
+        }
+
+        public BatchRequestBuilder approveRescheduleLoan(Long requestId, Long rescheduleBatchRequestId, String approvedOnDate) {
+            requests.add(new BatchRequest().requestId(requestId).relativeUrl("rescheduleloans/$.resourceId?command=approve").method("POST")
+                    .reference(rescheduleBatchRequestId).body("""
+                                {
+                                    "approvedOnDate": "%s",
+                                    "dateFormat": "%s",
+                                    "locale": "en"
+                                }
+                            """.formatted(approvedOnDate, DATETIME_PATTERN)));
+            return this;
+        }
+
+        public List<BatchResponse> executeEnclosingTransaction() {
+            return batchHelper.executeEnclosingTransaction(requests);
+        }
+
+        public ErrorResponse executeEnclosingTransactionError() {
+            return batchHelper.executeWithoutEnclosingTransactionExpectingError(requests);
+        }
+    }
+
     protected void addCapitalizedIncome(Long loanId, String transactionDate, double amount) {
         transactionHelper.addCapitalizedIncome(loanId, transactionDate, amount);
     }
 
     protected PostLoansLoanIdTransactionsResponse addCapitalizedIncomeTransaction(Long loanId, String transactionDate, double amount) {
         return transactionHelper.addCapitalizedIncome(loanId, transactionDate, amount);
+    }
+
+    protected PostLoansLoanIdTransactionsResponse addCapitalizedIncomeTransaction(Long loanId, String transactionDate, double amount,
+            Long classificationId) {
+        return transactionHelper.addCapitalizedIncome(loanId, transactionDate, amount, classificationId);
+    }
+
+    protected PostLoansLoanIdTransactionsResponse capitalizedIncomeAdjustment(Long loanId, Long capitalizedIncomeTransactionId,
+            String transactionDate, double amount) {
+        return transactionHelper.capitalizedIncomeAdjustment(loanId, capitalizedIncomeTransactionId, transactionDate, amount);
+    }
+
+    protected List<CapitalizedIncomeDetails> fetchCapitalizedIncomeDetails(Long loanId) {
+        return transactionHelper.fetchCapitalizedIncomeDetails(loanId);
+    }
+
+    protected LoanCapitalizedIncomeData fetchLoanCapitalizedIncomeData(Long loanId) {
+        return transactionHelper.fetchLoanCapitalizedIncomeData(loanId);
+    }
+
+    protected PostLoansLoanIdTransactionsResponse makeLoanBuyDownFee(Long loanId, PostLoansLoanIdTransactionsRequest request) {
+        return transactionHelper.makeLoanBuyDownFee(loanId, request);
+    }
+
+    protected PostLoansLoanIdTransactionsResponse makeLoanBuyDownFee(Long loanId, String date, double amount) {
+        return transactionHelper.makeLoanBuyDownFee(loanId, date, amount);
+    }
+
+    protected PostLoansLoanIdTransactionsResponse buyDownFeeAdjustment(Long loanId, Long buyDownFeeTransactionId, String transactionDate,
+            double amount) {
+        return transactionHelper.buyDownFeeAdjustment(loanId, buyDownFeeTransactionId, transactionDate, amount);
+    }
+
+    protected PostLoansLoanIdTransactionsResponse buyDownFeeAdjustment(Long loanId, Long buyDownFeeTransactionId,
+            PostLoansLoanIdTransactionsTransactionIdRequest request) {
+        return transactionHelper.buyDownFeeAdjustment(loanId, buyDownFeeTransactionId, request);
+    }
+
+    protected List<BuyDownFeeAmortizationDetails> fetchBuyDownFeeAmortizationDetails(Long loanId) {
+        return transactionHelper.fetchBuyDownFeeAmortizationDetails(loanId);
     }
 
     protected PutLoansApprovedAmountResponse modifyLoanApprovedAmount(Long loanId, BigDecimal approvedAmount) {
@@ -801,6 +1053,10 @@ public abstract class FeignLoanTestBase extends FeignIntegrationTest implements 
 
     protected PostLoansLoanIdResponse disburseLoan(String date, Integer loanId, String transactionAmount) {
         return loanHelper.disburseLoan(date, loanId.longValue(), transactionAmount);
+    }
+
+    protected PostLoansLoanIdChargesResponse addChargesForLoan(Long loanId, PostLoansLoanIdChargesRequest request) {
+        return loanHelper.addChargesForLoan(loanId, request);
     }
 
     protected Long addChargesForLoan(Integer loanId, String chargeJson) {
@@ -974,6 +1230,10 @@ public abstract class FeignLoanTestBase extends FeignIntegrationTest implements 
 
     protected PutLoansLoanIdResponse modifyLoanApplication(String loanExternalId, String command, PutLoansLoanIdRequest request) {
         return loanHelper.modifyLoanApplication(loanExternalId, command, request);
+    }
+
+    protected PutLoansLoanIdResponse modifyLoanApplication(Long loanId, String command, PutLoansLoanIdRequest request) {
+        return loanHelper.modifyLoanApplication(loanId, command, request);
     }
 
     protected List<GetDelinquencyTagHistoryResponse> getLoanDelinquencyTags(String loanExternalId) {
@@ -1170,6 +1430,44 @@ public abstract class FeignLoanTestBase extends FeignIntegrationTest implements 
         return new LoanTestData.OutstandingAmounts(principal, interestOutstanding, fee, penalty, total);
     }
 
+    protected LoanPointInTimeData getPointInTimeData(Long loanId, String date) {
+        return ok(() -> fineractClient().loansPointInTime().retrieveLoanPointInTime(loanId, date, LoanTestData.DATETIME_PATTERN,
+                LoanTestData.LOCALE));
+    }
+
+    protected List<LoanPointInTimeData> getPointInTimeData(List<Long> loanIds, String date) {
+        RetrieveLoansPointInTimeRequest request = new RetrieveLoansPointInTimeRequest().loanIds(loanIds).date(date)
+                .dateFormat(LoanTestData.DATETIME_PATTERN).locale(LoanTestData.LOCALE);
+        return ok(() -> fineractClient().loansPointInTime().retrieveLoansPointInTime(request));
+    }
+
+    protected void verifyOutstanding(LoanPointInTimeData loan, LoanTestData.OutstandingAmounts outstanding) {
+        assertThat(BigDecimal.valueOf(outstanding.principalOutstanding))
+                .isEqualByComparingTo(loan.getPrincipal().getPrincipalOutstanding());
+        assertThat(BigDecimal.valueOf(outstanding.interestOutstanding)).isEqualByComparingTo(loan.getInterest().getInterestOutstanding());
+        assertThat(BigDecimal.valueOf(outstanding.feeOutstanding)).isEqualByComparingTo(loan.getFee().getFeeChargesOutstanding());
+        assertThat(BigDecimal.valueOf(outstanding.penaltyOutstanding))
+                .isEqualByComparingTo(loan.getPenalty().getPenaltyChargesOutstanding());
+        assertThat(BigDecimal.valueOf(outstanding.totalOutstanding)).isEqualByComparingTo(loan.getTotal().getTotalOutstanding());
+    }
+
+    protected void verifyArrears(LoanPointInTimeData pointInTimeData, boolean isOverDue, String overdueSince) {
+        assertThat(Objects.requireNonNull(pointInTimeData.getArrears()).getOverdue()).isEqualTo(isOverDue);
+        if (isOverDue) {
+            assertThat(Objects.requireNonNull(pointInTimeData.getArrears().getOverDueSince()).toString()).isEqualTo(overdueSince);
+        } else {
+            assertThat(pointInTimeData.getArrears().getOverDueSince()).isNull();
+        }
+    }
+
+    protected Long createInstallmentFeeCharge(double amount) {
+        return chargesHelper.createCharge(ChargeRequestBuilders.loanInstallmentFee(amount)).getResourceId();
+    }
+
+    protected Long createInstallmentPenaltyCharge(double amount) {
+        return chargesHelper.createCharge(ChargeRequestBuilders.loanInstallmentFee(amount).penalty(true)).getResourceId();
+    }
+
     protected LoanTestData.Transaction reversedTransaction(double principalAmount, String type, String date) {
         return new LoanTestData.Transaction(principalAmount, type, date, true);
     }
@@ -1337,6 +1635,10 @@ public abstract class FeignLoanTestBase extends FeignIntegrationTest implements 
         return loanHelper.addSpecifiedDueDateCharge(loanId, chargeId, amount, dueDate).getResourceId();
     }
 
+    protected void deactivateOverdueLoanCharges(Long loanId, String fromDueDate) {
+        loanHelper.deactivateOverdueLoanCharges(loanId, fromDueDate);
+    }
+
     protected Long createDisbursementPercentageCharge(double percentageAmount) {
         return chargesHelper.createCharge(ChargeRequestBuilders.loanDisbursementPercentageFee(percentageAmount)).getResourceId();
     }
@@ -1493,6 +1795,23 @@ public abstract class FeignLoanTestBase extends FeignIntegrationTest implements 
     protected void validateFullyUnpaidRepaymentPeriod(GetLoansLoanIdResponse loanDetails, Integer index, String dueDate,
             double principalDue, double feeDue, double penaltyDue, double interestDue) {
         LoanTestValidators.validateFullyUnpaidRepaymentPeriod(loanDetails, index, dueDate, principalDue, feeDue, penaltyDue, interestDue);
+    }
+
+    protected void validateFullyPaidRepaymentPeriod(GetLoansLoanIdResponse loanDetails, Integer index, String dueDate, double principalDue,
+            double feeDue, double penaltyDue, double interestDue) {
+        LoanTestValidators.validateFullyPaidRepaymentPeriod(loanDetails, index, dueDate, principalDue, feeDue, penaltyDue, interestDue);
+    }
+
+    protected void validateFullyPaidRepaymentPeriod(GetLoansLoanIdResponse loanDetails, Integer index, String dueDate, double principalDue,
+            double feeDue, double penaltyDue, double interestDue, double paidLate) {
+        LoanTestValidators.validateFullyPaidRepaymentPeriod(loanDetails, index, dueDate, principalDue, feeDue, penaltyDue, interestDue,
+                paidLate);
+    }
+
+    protected void validateFullyPaidRepaymentPeriod(GetLoansLoanIdResponse loanDetails, Integer index, String dueDate, double principalDue,
+            double feeDue, double penaltyDue, double interestDue, double paidLate, double paidInAdvance) {
+        LoanTestValidators.validateFullyPaidRepaymentPeriod(loanDetails, index, dueDate, principalDue, feeDue, penaltyDue, interestDue,
+                paidLate, paidInAdvance);
     }
 
     protected void validateRepaymentPeriod(GetLoansLoanIdResponse loanDetails, Integer index, LocalDate dueDate, double principalDue,

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/FeignLoanTestBase.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/FeignLoanTestBase.java
@@ -944,6 +944,23 @@ public abstract class FeignLoanTestBase extends FeignIntegrationTest implements 
             return this;
         }
 
+        /**
+         * Repayment batch request using the pre-versioned {@code loans/{id}/transactions} relative URL (without the
+         * {@code v1/} prefix), to exercise the batch API's backward compatibility with legacy relative URLs.
+         */
+        public BatchRequestBuilder repayLoanLegacyRelativeUrl(Long requestId, Long loanId, String amount, String transactionDate) {
+            requests.add(new BatchRequest().requestId(requestId).relativeUrl("loans/" + loanId + "/transactions?command=repayment")
+                    .method("POST").body("""
+                                {
+                                    "locale": "en",
+                                    "dateFormat": "%s",
+                                    "transactionDate": "%s",
+                                    "transactionAmount": %s
+                                }
+                            """.formatted(DATETIME_PATTERN, transactionDate, amount)));
+            return this;
+        }
+
         public List<BatchResponse> executeEnclosingTransaction() {
             return batchHelper.executeEnclosingTransaction(requests);
         }
@@ -1255,6 +1272,10 @@ public abstract class FeignLoanTestBase extends FeignIntegrationTest implements 
 
     protected List<GetDelinquencyTagHistoryResponse> getLoanDelinquencyTags(String loanExternalId) {
         return loanHelper.getLoanDelinquencyTags(loanExternalId);
+    }
+
+    protected List<GetDelinquencyTagHistoryResponse> getLoanDelinquencyTags(Long loanId) {
+        return loanHelper.getLoanDelinquencyTags(loanId);
     }
 
     protected DeleteLoansLoanIdResponse deleteLoanApplication(String loanExternalId) {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/FeignLoanTestBase.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/FeignLoanTestBase.java
@@ -769,6 +769,12 @@ public abstract class FeignLoanTestBase extends FeignIntegrationTest implements 
         LoanTestValidators.validateRepaymentPeriod(loanDetails, index, dueDate, principalDue, feeDue, penaltyDue, interestDue);
     }
 
+    protected void validateRepaymentPeriod(GetLoansLoanIdResponse loanDetails, Integer index, double principalDue, double principalPaid,
+            double principalOutstanding, double paidInAdvance, double paidLate) {
+        LoanTestValidators.validateRepaymentPeriod(loanDetails, index, principalDue, principalPaid, principalOutstanding, paidInAdvance,
+                paidLate);
+    }
+
     protected void verifyLoanStatus(GetLoansLoanIdResponse loanDetails, Function<GetLoansLoanIdStatus, Boolean> extractor) {
         LoanTestValidators.verifyLoanStatus(loanDetails, extractor);
     }
@@ -1783,6 +1789,13 @@ public abstract class FeignLoanTestBase extends FeignIntegrationTest implements 
 
     protected Long addChargebackForLoan(Long loanId, Long transactionId, Double amount) {
         return applyChargebackTransaction(loanId, transactionId, amount, getPaymentTypeId(0));
+    }
+
+    protected Long addInterestPaymentWaiverForLoan(Long loanId, Double amount, String date) {
+        PostLoansLoanIdTransactionsResponse response = makeInterestPaymentWaiver(loanId,
+                new PostLoansLoanIdTransactionsRequest().dateFormat(LoanTestData.DATETIME_PATTERN).transactionDate(date).locale("en")
+                        .transactionAmount(amount).externalId(UUID.randomUUID().toString()));
+        return response.getResourceId();
     }
 
     protected void validateLoanPrincipalOustandingBalance(GetLoansLoanIdResponse loanDetails, Double amountExpected) {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/FeignLoanTestBase.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/FeignLoanTestBase.java
@@ -931,8 +931,25 @@ public abstract class FeignLoanTestBase extends FeignIntegrationTest implements 
             return this;
         }
 
+        public BatchRequestBuilder repayLoan(Long requestId, Long loanId, String amount, String transactionDate) {
+            requests.add(new BatchRequest().requestId(requestId).relativeUrl("v1/loans/" + loanId + "/transactions?command=repayment")
+                    .method("POST").body("""
+                                {
+                                    "locale": "en",
+                                    "dateFormat": "%s",
+                                    "transactionDate": "%s",
+                                    "transactionAmount": %s
+                                }
+                            """.formatted(DATETIME_PATTERN, transactionDate, amount)));
+            return this;
+        }
+
         public List<BatchResponse> executeEnclosingTransaction() {
             return batchHelper.executeEnclosingTransaction(requests);
+        }
+
+        public List<BatchResponse> executeWithoutEnclosingTransaction() {
+            return batchHelper.executeWithoutEnclosingTransaction(requests);
         }
 
         public ErrorResponse executeEnclosingTransactionError() {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/ClientChargeCommandsApi.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/ClientChargeCommandsApi.java
@@ -1,0 +1,104 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests.client.feign.helpers;
+
+import feign.Headers;
+import feign.Param;
+import feign.RequestLine;
+import java.math.BigDecimal;
+import org.apache.fineract.client.models.PostClientsClientIdChargesResponse;
+
+/**
+ * Applies a client charge whose {@code amount} carries decimal places.
+ *
+ * <p>
+ * The server parses {@code amount} as a {@code BigDecimal} - rounding it to the currency's decimal places is exactly
+ * what {@code ClientChargeRoundingTest} exercises - but {@code ClientChargesApiResourceSwagger} declares it as an
+ * {@code Integer}, so the generated {@code PostClientsClientIdChargesRequest} cannot carry 19.876 or 0.55.
+ *
+ * <p>
+ * The Swagger DTO is simply wrong here and correcting it is the right fix, but it is a breaking OpenAPI change
+ * (swagger-brake R010, {@code integer} to {@code number}) and belongs in its own change rather than in a test
+ * migration. Until then this keeps the call typed end to end, binding the response to the generated model.
+ */
+@Headers({ "Accept: application/json", "Content-Type: application/json" })
+public interface ClientChargeCommandsApi {
+
+    @RequestLine("POST /v1/clients/{clientId}/charges")
+    PostClientsClientIdChargesResponse createClientChargeWithDecimalAmount(@Param("clientId") Long clientId,
+            DecimalAmountClientChargeRequest request);
+
+    /**
+     * Request body for {@link #createClientChargeWithDecimalAmount}. Mirrors the generated
+     * {@code PostClientsClientIdChargesRequest} field for field, except that {@code amount} is a {@link BigDecimal}.
+     */
+    class DecimalAmountClientChargeRequest {
+
+        private BigDecimal amount;
+        private Long chargeId;
+        private String dueDate;
+        private String locale;
+        private String dateFormat;
+
+        public BigDecimal getAmount() {
+            return amount;
+        }
+
+        public DecimalAmountClientChargeRequest amount(BigDecimal amount) {
+            this.amount = amount;
+            return this;
+        }
+
+        public Long getChargeId() {
+            return chargeId;
+        }
+
+        public DecimalAmountClientChargeRequest chargeId(Long chargeId) {
+            this.chargeId = chargeId;
+            return this;
+        }
+
+        public String getDueDate() {
+            return dueDate;
+        }
+
+        public DecimalAmountClientChargeRequest dueDate(String dueDate) {
+            this.dueDate = dueDate;
+            return this;
+        }
+
+        public String getLocale() {
+            return locale;
+        }
+
+        public DecimalAmountClientChargeRequest locale(String locale) {
+            this.locale = locale;
+            return this;
+        }
+
+        public String getDateFormat() {
+            return dateFormat;
+        }
+
+        public DecimalAmountClientChargeRequest dateFormat(String dateFormat) {
+            this.dateFormat = dateFormat;
+            return this;
+        }
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignAccountHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignAccountHelper.java
@@ -22,9 +22,12 @@ import static org.apache.fineract.client.feign.util.FeignCalls.ok;
 
 import java.util.Collections;
 import org.apache.fineract.client.feign.FineractFeignClient;
+import org.apache.fineract.client.models.DeleteGLAccountsResponse;
 import org.apache.fineract.client.models.GetGLAccountsResponse;
 import org.apache.fineract.client.models.PostGLAccountsRequest;
 import org.apache.fineract.client.models.PostGLAccountsResponse;
+import org.apache.fineract.client.models.PutGLAccountsRequest;
+import org.apache.fineract.client.models.PutGLAccountsResponse;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.common.accounting.Account;
 
@@ -79,6 +82,22 @@ public class FeignAccountHelper {
         GetGLAccountsResponse response = ok(
                 () -> fineractClient.generalLedgerAccount().retreiveAccount(account.getAccountID().longValue(), Collections.emptyMap()));
         return response.getGlCode();
+    }
+
+    public PostGLAccountsResponse createGLAccount(PostGLAccountsRequest request) {
+        return ok(() -> fineractClient.generalLedgerAccount().createGLAccount(request));
+    }
+
+    public GetGLAccountsResponse getGLAccount(Long glAccountId) {
+        return ok(() -> fineractClient.generalLedgerAccount().retreiveAccount(glAccountId, Collections.emptyMap()));
+    }
+
+    public PutGLAccountsResponse updateGLAccount(Long glAccountId, PutGLAccountsRequest request) {
+        return ok(() -> fineractClient.generalLedgerAccount().updateGLAccount(glAccountId, request));
+    }
+
+    public DeleteGLAccountsResponse deleteGLAccount(Long glAccountId) {
+        return ok(() -> fineractClient.generalLedgerAccount().deleteGLAccount(glAccountId, Collections.emptyMap()));
     }
 
     private Integer getAccountTypeId(String type) {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignAccountHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignAccountHelper.java
@@ -39,6 +39,22 @@ public class FeignAccountHelper {
         this.fineractClient = fineractClient;
     }
 
+    public Account createAssetAccount() {
+        return createAssetAccount("ASSET");
+    }
+
+    public Account createLiabilityAccount() {
+        return createLiabilityAccount("LIABILITY");
+    }
+
+    public Account createIncomeAccount() {
+        return createIncomeAccount("INCOME");
+    }
+
+    public Account createExpenseAccount() {
+        return createExpenseAccount("EXPENSE");
+    }
+
     public Account createAssetAccount(String name) {
         return createAccount(name, "1", "ASSET");
     }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignAccountTransferHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignAccountTransferHelper.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests.client.feign.helpers;
+
+import static org.apache.fineract.client.feign.util.FeignCalls.ok;
+
+import org.apache.fineract.client.feign.FineractFeignClient;
+import org.apache.fineract.client.models.AccountTransferRequest;
+import org.apache.fineract.client.models.PostAccountTransfersRefundByTransferResponse;
+import org.apache.fineract.integrationtests.client.feign.modules.AccountTransferRequestBuilders;
+import org.apache.fineract.portfolio.account.PortfolioAccountType;
+
+public class FeignAccountTransferHelper {
+
+    private final FineractFeignClient fineractClient;
+
+    public FeignAccountTransferHelper(FineractFeignClient fineractClient) {
+        this.fineractClient = fineractClient;
+    }
+
+    /**
+     * Refunds an overpaid loan by transferring the overpayment into a savings account of the same client.
+     */
+    public PostAccountTransfersRefundByTransferResponse refundLoanByTransfer(String transferDate, Long clientId, Long loanId,
+            Long savingsId, String transferAmount) {
+        AccountTransferRequest request = AccountTransferRequestBuilders.transfer(transferDate, clientId, loanId, PortfolioAccountType.LOAN,
+                clientId, savingsId, PortfolioAccountType.SAVINGS, transferAmount);
+        return refundLoanByTransfer(request);
+    }
+
+    public PostAccountTransfersRefundByTransferResponse refundLoanByTransfer(AccountTransferRequest request) {
+        return ok(() -> fineractClient.accountTransfers().refundByTransfer(request));
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignBatchHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignBatchHelper.java
@@ -44,6 +44,14 @@ public class FeignBatchHelper {
     }
 
     /**
+     * Posts the batch requests with {@code enclosingTransaction=false}; each request is committed independently.
+     * Returns the individual {@link BatchResponse}s (inspect their {@code statusCode}).
+     */
+    public List<BatchResponse> executeWithoutEnclosingTransaction(List<BatchRequest> requests) {
+        return ok(() -> fineractClient.batch().handleBatchRequests(requests, false));
+    }
+
+    /**
      * Posts the batch requests with {@code enclosingTransaction=false} expecting the call itself to fail (e.g. the loan
      * is locked). Returns the parsed {@link ErrorResponse} carrying the HTTP status code.
      */

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignBatchHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignBatchHelper.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests.client.feign.helpers;
+
+import static org.apache.fineract.client.feign.util.FeignCalls.ok;
+
+import java.util.List;
+import org.apache.fineract.client.feign.FineractFeignClient;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
+import org.apache.fineract.client.models.BatchRequest;
+import org.apache.fineract.client.models.BatchResponse;
+import org.apache.fineract.integrationtests.common.error.ErrorResponse;
+
+public class FeignBatchHelper {
+
+    private final FineractFeignClient fineractClient;
+
+    public FeignBatchHelper(FineractFeignClient fineractClient) {
+        this.fineractClient = fineractClient;
+    }
+
+    /**
+     * Posts the batch requests with {@code enclosingTransaction=true}; the whole batch is rolled back if any request
+     * fails. Returns the individual {@link BatchResponse}s on success.
+     */
+    public List<BatchResponse> executeEnclosingTransaction(List<BatchRequest> requests) {
+        return ok(() -> fineractClient.batch().handleBatchRequests(requests, true));
+    }
+
+    /**
+     * Posts the batch requests with {@code enclosingTransaction=false} expecting the call itself to fail (e.g. the loan
+     * is locked). Returns the parsed {@link ErrorResponse} carrying the HTTP status code.
+     */
+    public ErrorResponse executeWithoutEnclosingTransactionExpectingError(List<BatchRequest> requests) {
+        try {
+            ok(() -> fineractClient.batch().handleBatchRequests(requests, false));
+            throw new AssertionError("Expected batch request to fail but it succeeded");
+        } catch (CallFailedRuntimeException e) {
+            ErrorResponse errorResponse = new ErrorResponse();
+            errorResponse.setHttpStatusCode(e.getStatus());
+            return errorResponse;
+        }
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignBusinessStepHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignBusinessStepHelper.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests.client.feign.helpers;
+
+import static org.apache.fineract.client.feign.util.FeignCalls.ok;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.fineract.client.feign.FineractFeignClient;
+import org.apache.fineract.client.models.BusinessStep;
+import org.apache.fineract.client.models.BusinessStepRequest;
+import org.apache.fineract.client.models.JobBusinessStepConfigData;
+
+public class FeignBusinessStepHelper {
+
+    private final FineractFeignClient fineractClient;
+
+    public FeignBusinessStepHelper(FineractFeignClient fineractClient) {
+        this.fineractClient = fineractClient;
+    }
+
+    public JobBusinessStepConfigData getConfiguredBusinessStepsByJobName(String jobName) {
+        return ok(() -> fineractClient.businessStepConfiguration().retrieveAllConfiguredBusinessStep(jobName));
+    }
+
+    public void updateSteps(String jobName, String... steps) {
+        long order = 0;
+        List<BusinessStep> stepList = new ArrayList<>();
+        for (String step : steps) {
+            order++;
+            stepList.add(new BusinessStep().stepName(step).order(order));
+        }
+        ok(() -> {
+            fineractClient.businessStepConfiguration().updateJobBusinessStepConfig(jobName,
+                    new BusinessStepRequest().businessSteps(stepList));
+            return null;
+        });
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignChargesHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignChargesHelper.java
@@ -82,8 +82,12 @@ public class FeignChargesHelper {
         return createCharge(ChargeRequestBuilders.loanSpecifiedDueDatePenalty(amount));
     }
 
-    public PostChargesResponse createLoanSpecifiedDueDatePercentageAmountAndInterestFee(double amount) {
-        return createCharge(ChargeRequestBuilders.loanSpecifiedDueDatePercentageAmountAndInterestFee(amount));
+    public PostChargesResponse createLoanSpecifiedDueDatePercentageOfInterestFee(double percentage) {
+        return createCharge(ChargeRequestBuilders.loanSpecifiedDueDatePercentageOfInterestFee(percentage));
+    }
+
+    public PostChargesResponse createLoanOverdueFeePercentageOfAmountAndInterest(double percentage) {
+        return createCharge(ChargeRequestBuilders.loanOverdueFeePercentageOfAmountAndInterest(percentage));
     }
 
     public PostChargesResponse createClientSpecifiedDueDateCharge(double amount) {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignChargesHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignChargesHelper.java
@@ -35,6 +35,7 @@ import org.apache.fineract.client.models.PostClientsClientIdChargesRequest;
 import org.apache.fineract.client.models.PostClientsClientIdChargesResponse;
 import org.apache.fineract.client.models.PutChargesChargeIdResponse;
 import org.apache.fineract.integrationtests.client.feign.modules.ChargeRequestBuilders;
+import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
 
 public class FeignChargesHelper {
 
@@ -88,6 +89,29 @@ public class FeignChargesHelper {
 
     public PostChargesResponse createLoanOverdueFeePercentageOfAmountAndInterest(double percentage) {
         return createCharge(ChargeRequestBuilders.loanOverdueFeePercentageOfAmountAndInterest(percentage));
+    }
+
+    public PostChargesResponse createLoanDisbursementCharge(ChargeCalculationType chargeCalculationType, double amount) {
+        return createCharge(ChargeRequestBuilders.loanDisbursementCharge(chargeCalculationType, amount));
+    }
+
+    public PostChargesResponse createLoanSpecifiedDueDateCharge(ChargeCalculationType chargeCalculationType, double amount,
+            boolean penalty) {
+        return createCharge(ChargeRequestBuilders.loanSpecifiedDueDateCharge(chargeCalculationType, amount, penalty));
+    }
+
+    public PostChargesResponse createLoanInstallmentCharge(ChargeCalculationType chargeCalculationType, double amount, boolean penalty) {
+        return createCharge(ChargeRequestBuilders.loanInstallmentCharge(chargeCalculationType, amount, penalty));
+    }
+
+    public PostChargesResponse createLoanSpecifiedDueDateAccountTransferCharge(ChargeCalculationType chargeCalculationType, double amount,
+            boolean penalty) {
+        return createCharge(ChargeRequestBuilders.loanSpecifiedDueDateAccountTransferCharge(chargeCalculationType, amount, penalty));
+    }
+
+    public PostChargesResponse createLoanInstallmentAccountTransferCharge(ChargeCalculationType chargeCalculationType, double amount,
+            boolean penalty) {
+        return createCharge(ChargeRequestBuilders.loanInstallmentAccountTransferCharge(chargeCalculationType, amount, penalty));
     }
 
     public PostChargesResponse createClientSpecifiedDueDateCharge(double amount) {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignChargesHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignChargesHelper.java
@@ -122,6 +122,15 @@ public class FeignChargesHelper {
         return ok(() -> fineractClient.clientCharges().createClientCharge(clientId, request));
     }
 
+    /**
+     * Applies a client charge whose amount has decimal places, which the generated request model cannot carry - see
+     * {@link ClientChargeCommandsApi}.
+     */
+    public PostClientsClientIdChargesResponse addClientChargeWithDecimalAmount(Long clientId,
+            ClientChargeCommandsApi.DecimalAmountClientChargeRequest request) {
+        return ok(() -> fineractClient.create(ClientChargeCommandsApi.class).createClientChargeWithDecimalAmount(clientId, request));
+    }
+
     public PostClientsClientIdChargesChargeIdResponse payClientCharge(Long clientId, Long chargeId,
             PostClientsClientIdChargesChargeIdRequest request) {
         return ok(() -> fineractClient.clientCharges().payOrWaiveClientCharge(clientId, chargeId, request, PAY_COMMAND));

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignClientHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignClientHelper.java
@@ -107,6 +107,10 @@ public class FeignClientHelper {
         return ok(() -> fineractClient.clients().retrieveAllClientAccounts(clientId));
     }
 
+    public GetClientsClientIdAccountsResponse getClientAccounts(String externalId) {
+        return ok(() -> fineractClient.clients().retrieveAllClientAccountsByExternalId(externalId));
+    }
+
     public PageClientSearchData searchClients(String text) {
         ClientTextSearch clientTextSearch = new ClientTextSearch();
         clientTextSearch.setText(text);

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignClientHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignClientHelper.java
@@ -22,12 +22,14 @@ import static org.apache.fineract.client.feign.util.FeignCalls.fail;
 import static org.apache.fineract.client.feign.util.FeignCalls.ok;
 
 import java.util.Collections;
+import java.util.Map;
 import org.apache.fineract.client.feign.FineractFeignClient;
 import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
 import org.apache.fineract.client.models.ClientTextSearch;
 import org.apache.fineract.client.models.DeleteClientsClientIdResponse;
 import org.apache.fineract.client.models.GetClientsClientIdAccountsResponse;
 import org.apache.fineract.client.models.GetClientsClientIdResponse;
+import org.apache.fineract.client.models.GetClientsResponse;
 import org.apache.fineract.client.models.PageClientSearchData;
 import org.apache.fineract.client.models.PagedRequestClientTextSearch;
 import org.apache.fineract.client.models.PostClientsClientIdChanges;
@@ -109,6 +111,12 @@ public class FeignClientHelper {
 
     public GetClientsClientIdAccountsResponse getClientAccounts(String externalId) {
         return ok(() -> fineractClient.clients().retrieveAllClientAccountsByExternalId(externalId));
+    }
+
+    /** Number of clients carrying the given external id; {@code 0} when no client was created with it. */
+    public Integer countClientsByExternalId(String externalId) {
+        GetClientsResponse clients = ok(() -> fineractClient.clients().retrieveAllClients(Map.of("externalId", externalId)));
+        return clients.getTotalFilteredRecords();
     }
 
     public PageClientSearchData searchClients(String text) {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignClientHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignClientHelper.java
@@ -105,6 +105,10 @@ public class FeignClientHelper {
         return ok(() -> fineractClient.clients().retrieveAllClientAccounts(clientId));
     }
 
+    public GetClientsClientIdAccountsResponse getClientAccounts(String externalId) {
+        return ok(() -> fineractClient.clients().retrieveAllClientAccountsByExternalId(externalId));
+    }
+
     public PageClientSearchData searchClients(String text) {
         ClientTextSearch clientTextSearch = new ClientTextSearch();
         clientTextSearch.setText(text);

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignClientHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignClientHelper.java
@@ -22,12 +22,14 @@ import static org.apache.fineract.client.feign.util.FeignCalls.fail;
 import static org.apache.fineract.client.feign.util.FeignCalls.ok;
 
 import java.util.Collections;
+import java.util.Map;
 import org.apache.fineract.client.feign.FineractFeignClient;
 import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
 import org.apache.fineract.client.models.ClientTextSearch;
 import org.apache.fineract.client.models.DeleteClientsClientIdResponse;
 import org.apache.fineract.client.models.GetClientsClientIdAccountsResponse;
 import org.apache.fineract.client.models.GetClientsClientIdResponse;
+import org.apache.fineract.client.models.GetClientsResponse;
 import org.apache.fineract.client.models.PageClientSearchData;
 import org.apache.fineract.client.models.PagedRequestClientTextSearch;
 import org.apache.fineract.client.models.PostClientsClientIdRequest;
@@ -107,6 +109,12 @@ public class FeignClientHelper {
 
     public GetClientsClientIdAccountsResponse getClientAccounts(String externalId) {
         return ok(() -> fineractClient.clients().retrieveAllClientAccountsByExternalId(externalId));
+    }
+
+    /** Number of clients carrying the given external id; {@code 0} when no client was created with it. */
+    public Integer countClientsByExternalId(String externalId) {
+        GetClientsResponse clients = ok(() -> fineractClient.clients().retrieveAllClients(Map.of("externalId", externalId)));
+        return clients.getTotalFilteredRecords();
     }
 
     public PageClientSearchData searchClients(String text) {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignCobHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignCobHelper.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests.client.feign.helpers;
+
+import static org.apache.fineract.client.feign.util.FeignCalls.ok;
+
+import java.util.List;
+import org.apache.fineract.client.feign.FineractFeignClient;
+import org.apache.fineract.client.models.COBPartition;
+
+public class FeignCobHelper {
+
+    private final FineractFeignClient fineractClient;
+
+    public FeignCobHelper(FineractFeignClient fineractClient) {
+        this.fineractClient = fineractClient;
+    }
+
+    public List<COBPartition> getCobPartitions(Integer partitionSize) {
+        return ok(() -> fineractClient.internalCob().getCobPartitions(partitionSize));
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignCodeHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignCodeHelper.java
@@ -20,10 +20,13 @@ package org.apache.fineract.integrationtests.client.feign.helpers;
 
 import static org.apache.fineract.client.feign.util.FeignCalls.ok;
 
+import java.util.List;
 import org.apache.fineract.client.feign.FineractFeignClient;
+import org.apache.fineract.client.models.GetCodeValuesDataResponse;
 import org.apache.fineract.client.models.GetCodesResponse;
 import org.apache.fineract.client.models.PostCodeValueDataResponse;
 import org.apache.fineract.client.models.PostCodeValuesDataRequest;
+import org.apache.fineract.integrationtests.common.Utils;
 
 public class FeignCodeHelper {
 
@@ -56,5 +59,24 @@ public class FeignCodeHelper {
 
     public PostCodeValueDataResponse createCodeValue(Long codeId, PostCodeValuesDataRequest request) {
         return ok(() -> fineractClient.codeValues().createCodeValue(codeId, request));
+    }
+
+    public List<GetCodeValuesDataResponse> retrieveAllCodeValues(Long codeId) {
+        return ok(() -> fineractClient.codeValues().retrieveAllCodeValues(codeId));
+    }
+
+    /**
+     * Returns the id of the first code value of the named code, creating one when the code has none yet. System codes
+     * such as {@code LoanRescheduleReason} ship without values, so a test that needs a reason id has to seed one.
+     */
+    public Long retrieveOrCreateCodeValueId(String codeName) {
+        GetCodesResponse code = retrieveCodeByName(codeName);
+        List<GetCodeValuesDataResponse> codeValues = retrieveAllCodeValues(code.getId());
+        if (!codeValues.isEmpty()) {
+            return codeValues.get(0).getId();
+        }
+        String value = Utils.randomStringGenerator("", 3);
+        return createCodeValue(code.getId(), new PostCodeValuesDataRequest().name(value).position(0).description(value).isActive(true))
+                .getSubResourceId();
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignCodeHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignCodeHelper.java
@@ -20,10 +20,13 @@ package org.apache.fineract.integrationtests.client.feign.helpers;
 
 import static org.apache.fineract.client.feign.util.FeignCalls.ok;
 
+import java.util.List;
 import org.apache.fineract.client.feign.FineractFeignClient;
+import org.apache.fineract.client.models.GetCodeValuesDataResponse;
 import org.apache.fineract.client.models.GetCodesResponse;
 import org.apache.fineract.client.models.PostCodeValueDataResponse;
 import org.apache.fineract.client.models.PostCodeValuesDataRequest;
+import org.apache.fineract.integrationtests.common.Utils;
 
 public class FeignCodeHelper {
 
@@ -48,5 +51,24 @@ public class FeignCodeHelper {
 
     public PostCodeValueDataResponse createCodeValue(Long codeId, PostCodeValuesDataRequest request) {
         return ok(() -> fineractClient.codeValues().createCodeValue(codeId, request));
+    }
+
+    public List<GetCodeValuesDataResponse> retrieveAllCodeValues(Long codeId) {
+        return ok(() -> fineractClient.codeValues().retrieveAllCodeValues(codeId));
+    }
+
+    /**
+     * Returns the id of the first code value of the named code, creating one when the code has none yet. System codes
+     * such as {@code LoanRescheduleReason} ship without values, so a test that needs a reason id has to seed one.
+     */
+    public Long retrieveOrCreateCodeValueId(String codeName) {
+        GetCodesResponse code = retrieveCodeByName(codeName);
+        List<GetCodeValuesDataResponse> codeValues = retrieveAllCodeValues(code.getId());
+        if (!codeValues.isEmpty()) {
+            return codeValues.get(0).getId();
+        }
+        String value = Utils.randomStringGenerator("", 3);
+        return createCodeValue(code.getId(), new PostCodeValuesDataRequest().name(value).position(0).description(value).isActive(true))
+                .getSubResourceId();
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignCollateralHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignCollateralHelper.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests.client.feign.helpers;
+
+import static org.apache.fineract.client.feign.util.FeignCalls.ok;
+
+import java.math.BigDecimal;
+import org.apache.fineract.client.feign.FineractFeignClient;
+import org.apache.fineract.client.models.ClientCollateralCreateRequest;
+import org.apache.fineract.client.models.ClientCollateralCreateResponse;
+import org.apache.fineract.client.models.CollateralProductCreateRequest;
+import org.apache.fineract.client.models.CollateralProductCreateResponse;
+import org.apache.fineract.integrationtests.common.Utils;
+
+public class FeignCollateralHelper {
+
+    private static final String LOCALE = "en";
+    private static final BigDecimal DEFAULT_PCT_TO_BASE = BigDecimal.valueOf(40);
+    private static final BigDecimal DEFAULT_BASE_PRICE = BigDecimal.valueOf(100000000);
+    private static final BigDecimal DEFAULT_QUANTITY = BigDecimal.valueOf(100);
+
+    private final FineractFeignClient fineractClient;
+
+    public FeignCollateralHelper(FineractFeignClient fineractClient) {
+        this.fineractClient = fineractClient;
+    }
+
+    /**
+     * Creates a collateral product with the same defaults as the legacy
+     * {@code CollateralManagementHelper.createCollateralProduct}.
+     */
+    public CollateralProductCreateResponse createCollateralProduct() {
+        return ok(() -> fineractClient.collateralManagement()
+                .createCollateral1(new CollateralProductCreateRequest().name(Utils.randomStringGenerator("COLLATERAL_PRODUCT", 5))
+                        .currency("USD").unitType("acre").quality("agriculture").pctToBase(DEFAULT_PCT_TO_BASE)
+                        .basePrice(DEFAULT_BASE_PRICE).locale(LOCALE)));
+    }
+
+    public ClientCollateralCreateResponse createClientCollateral(Long clientId, Long collateralId) {
+        return ok(() -> fineractClient.clientCollateralManagement().addClientCollateral(clientId,
+                new ClientCollateralCreateRequest().collateralId(collateralId).quantity(DEFAULT_QUANTITY).locale(LOCALE)));
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignDatatableHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignDatatableHelper.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests.client.feign.helpers;
+
+import static org.apache.fineract.client.feign.util.FeignCalls.ok;
+
+import org.apache.fineract.client.feign.FineractFeignClient;
+import org.apache.fineract.client.models.DeleteDataTablesDatatableAppTableIdResponse;
+import org.apache.fineract.client.models.DeleteDataTablesResponse;
+import org.apache.fineract.client.models.PostDataTablesAppTableIdResponse;
+import org.apache.fineract.client.models.PostDataTablesRequest;
+import org.apache.fineract.client.models.PostDataTablesResponse;
+
+public class FeignDatatableHelper {
+
+    private final FineractFeignClient fineractClient;
+
+    public FeignDatatableHelper(FineractFeignClient fineractClient) {
+        this.fineractClient = fineractClient;
+    }
+
+    public PostDataTablesResponse createDatatable(PostDataTablesRequest request) {
+        return ok(() -> fineractClient.dataTables().createDatatable(request));
+    }
+
+    /**
+     * Creates one entry in the given datatable for the given application-table row. The entry columns are datatable
+     * specific, so the payload is passed as raw JSON.
+     */
+    public PostDataTablesAppTableIdResponse createDatatableEntry(String datatableName, Long apptableId, String entryJson) {
+        return ok(() -> fineractClient.dataTables().createDatatableEntry(datatableName, apptableId, entryJson));
+    }
+
+    /** Deletes every entry the given datatable holds for the given application-table row. */
+    public DeleteDataTablesDatatableAppTableIdResponse deleteDatatableEntries(String datatableName, Long apptableId) {
+        return ok(() -> fineractClient.dataTables().deleteDatatableEntries(datatableName, apptableId));
+    }
+
+    /** Drops the datatable itself. The server rejects this while the datatable still holds entries. */
+    public DeleteDataTablesResponse deleteDatatable(String datatableName) {
+        return ok(() -> fineractClient.dataTables().deleteDatatable(datatableName));
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignDelinquencyHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignDelinquencyHelper.java
@@ -20,7 +20,9 @@ package org.apache.fineract.integrationtests.client.feign.helpers;
 
 import static org.apache.fineract.client.feign.util.FeignCalls.ok;
 
+import java.util.ArrayList;
 import java.util.List;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.fineract.client.feign.FineractFeignClient;
 import org.apache.fineract.client.models.DeleteDelinquencyBucketResponse;
 import org.apache.fineract.client.models.DeleteDelinquencyRangeResponse;
@@ -32,6 +34,8 @@ import org.apache.fineract.client.models.PostDelinquencyBucketResponse;
 import org.apache.fineract.client.models.PostDelinquencyRangeResponse;
 import org.apache.fineract.client.models.PutDelinquencyBucketResponse;
 import org.apache.fineract.client.models.PutDelinquencyRangeResponse;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
+import org.apache.fineract.integrationtests.common.Utils;
 
 public class FeignDelinquencyHelper {
 
@@ -63,6 +67,25 @@ public class FeignDelinquencyHelper {
 
     public PostDelinquencyBucketResponse createBucket(DelinquencyBucketRequest request) {
         return ok(() -> fineractClient.delinquencyRangeAndBucketsManagement().createBucket(request));
+    }
+
+    public Long createBucket(List<Pair<Integer, Integer>> rangesDef) {
+        List<Long> rangeIds = new ArrayList<>();
+        rangesDef.forEach(
+                range -> rangeIds.add(createRange(new DelinquencyRangeRequest().classification(Utils.randomStringGenerator("DLQ_R_", 10))
+                        .minimumAgeDays(range.getLeft()).maximumAgeDays(range.getRight()).locale(LoanTestData.LOCALE)).getResourceId()));
+        return createBucket(new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds))
+                .getResourceId();
+    }
+
+    public Long createDefaultBucket() {
+        Long range1Id = createRange(new DelinquencyRangeRequest().classification(Utils.randomStringGenerator("DLQ_R_", 10))
+                .minimumAgeDays(1).maximumAgeDays(3).locale(LoanTestData.LOCALE)).getResourceId();
+        Long range2Id = createRange(new DelinquencyRangeRequest().classification(Utils.randomStringGenerator("DLQ_R_", 10))
+                .minimumAgeDays(4).maximumAgeDays(60).locale(LoanTestData.LOCALE)).getResourceId();
+        return createBucket(
+                new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(List.of(range1Id, range2Id)))
+                .getResourceId();
     }
 
     public DelinquencyBucketResponse getBucket(Long bucketId) {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignExternalAssetOwnerHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignExternalAssetOwnerHelper.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests.client.feign.helpers;
+
+import static org.apache.fineract.client.feign.util.FeignCalls.ok;
+
+import java.util.List;
+import org.apache.fineract.accounting.common.AccountingConstants;
+import org.apache.fineract.client.feign.FineractFeignClient;
+import org.apache.fineract.client.models.ExternalAssetOwnerRequest;
+import org.apache.fineract.client.models.ExternalTransferOwnerData;
+import org.apache.fineract.client.models.GetFinancialActivityAccountsResponse;
+import org.apache.fineract.client.models.PostExternalAssetOwnerRequest;
+import org.apache.fineract.client.models.PostExternalAssetOwnerResponse;
+import org.apache.fineract.client.models.PostFinancialActivityAccountsRequest;
+import org.apache.fineract.client.models.PostInitiateTransferResponse;
+import org.apache.fineract.integrationtests.common.accounting.Account;
+
+public class FeignExternalAssetOwnerHelper {
+
+    private final FineractFeignClient fineractClient;
+
+    public FeignExternalAssetOwnerHelper(FineractFeignClient fineractClient) {
+        this.fineractClient = fineractClient;
+    }
+
+    public PostExternalAssetOwnerResponse createExternalAssetOwner(PostExternalAssetOwnerRequest request) {
+        return ok(() -> fineractClient.externalAssetOwners().createExternalAssetOwner(request));
+    }
+
+    public List<ExternalTransferOwnerData> retrieveExternalAssetOwners() {
+        return ok(() -> fineractClient.externalAssetOwners().retrieveExternalAssetOwners());
+    }
+
+    public PostInitiateTransferResponse initiateTransferByLoanId(Long loanId, String command, ExternalAssetOwnerRequest request) {
+        return ok(() -> fineractClient.externalAssetOwners().transferRequestWithLoanId(loanId, request, command));
+    }
+
+    public void setProperFinancialActivity(Account transferAccount) {
+        List<GetFinancialActivityAccountsResponse> financialMappings = ok(
+                () -> fineractClient.mappingFinancialActivitiesToAccounts().retrieveAll());
+        financialMappings.forEach(mapping -> ok(() -> fineractClient.mappingFinancialActivitiesToAccounts()
+                .deleteGLAccountMappingFinancialActivityAccount(mapping.getId())));
+        ok(() -> fineractClient.mappingFinancialActivitiesToAccounts()
+                .createGLAccountMappingFinancialActivityAccount(new PostFinancialActivityAccountsRequest()
+                        .financialActivityId((long) AccountingConstants.FinancialActivity.ASSET_TRANSFER.getValue())
+                        .glAccountId((long) transferAccount.getAccountID())));
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignExternalAssetOwnerHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignExternalAssetOwnerHelper.java
@@ -19,13 +19,24 @@
 package org.apache.fineract.integrationtests.client.feign.helpers;
 
 import static org.apache.fineract.client.feign.util.FeignCalls.ok;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import org.apache.fineract.accounting.common.AccountingConstants;
 import org.apache.fineract.client.feign.FineractFeignClient;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
 import org.apache.fineract.client.models.ExternalAssetOwnerRequest;
+import org.apache.fineract.client.models.ExternalAssetOwnerSearchRequest;
+import org.apache.fineract.client.models.ExternalOwnerJournalEntryData;
+import org.apache.fineract.client.models.ExternalOwnerTransferJournalEntryData;
+import org.apache.fineract.client.models.ExternalTransferData;
 import org.apache.fineract.client.models.ExternalTransferOwnerData;
 import org.apache.fineract.client.models.GetFinancialActivityAccountsResponse;
+import org.apache.fineract.client.models.PageExternalTransferData;
+import org.apache.fineract.client.models.PagedRequestExternalAssetOwnerSearchRequest;
 import org.apache.fineract.client.models.PostExternalAssetOwnerRequest;
 import org.apache.fineract.client.models.PostExternalAssetOwnerResponse;
 import org.apache.fineract.client.models.PostFinancialActivityAccountsRequest;
@@ -33,6 +44,15 @@ import org.apache.fineract.client.models.PostInitiateTransferResponse;
 import org.apache.fineract.integrationtests.common.accounting.Account;
 
 public class FeignExternalAssetOwnerHelper {
+
+    private static final int DEFAULT_OFFSET = 0;
+    private static final int DEFAULT_LIMIT = 100;
+    // increase it if tests create more than 200 items
+    private static final int DEFAULT_SEARCH_PAGE_SIZE = 200;
+    private static final int FORBIDDEN = 403;
+    private static final String EFFECTIVE_ATTRIBUTE = "effective";
+    private static final String SETTLEMENT_ATTRIBUTE = "settlement";
+    private static final String CANCEL_COMMAND = "cancel";
 
     private final FineractFeignClient fineractClient;
 
@@ -50,6 +70,59 @@ public class FeignExternalAssetOwnerHelper {
 
     public PostInitiateTransferResponse initiateTransferByLoanId(Long loanId, String command, ExternalAssetOwnerRequest request) {
         return ok(() -> fineractClient.externalAssetOwners().transferRequestWithLoanId(loanId, request, command));
+    }
+
+    public void cancelTransferByTransferExternalId(String transferExternalId) {
+        ok(() -> fineractClient.externalAssetOwners().transferRequestWithIdByExternalId(transferExternalId, CANCEL_COMMAND));
+    }
+
+    public void cancelTransferByTransferExternalIdError(String transferExternalId) {
+        CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
+                () -> ok(() -> fineractClient.externalAssetOwners().transferRequestWithIdByExternalId(transferExternalId, CANCEL_COMMAND)));
+        assertEquals(FORBIDDEN, exception.getStatus());
+    }
+
+    public PageExternalTransferData retrieveTransfersByLoanId(Long loanId) {
+        return ok(() -> fineractClient.externalAssetOwners().getTransfers(null, loanId, null, DEFAULT_OFFSET, DEFAULT_LIMIT));
+    }
+
+    public ExternalTransferData retrieveActiveTransferByTransferExternalId(String transferExternalId) {
+        return ok(() -> fineractClient.externalAssetOwners().getActiveTransfer(transferExternalId, null, null));
+    }
+
+    public ExternalTransferData retrieveActiveTransferByLoanId(Long loanId) {
+        return ok(() -> fineractClient.externalAssetOwners().getActiveTransfer(null, loanId, null));
+    }
+
+    public ExternalOwnerTransferJournalEntryData retrieveJournalEntriesOfTransfer(Long transferId) {
+        return ok(() -> fineractClient.externalAssetOwners().getJournalEntriesOfTransfer(transferId, DEFAULT_OFFSET, DEFAULT_LIMIT));
+    }
+
+    public ExternalOwnerJournalEntryData retrieveJournalEntriesOfOwner(String ownerExternalId) {
+        return ok(() -> fineractClient.externalAssetOwners().getJournalEntriesOfOwner(ownerExternalId, DEFAULT_OFFSET, DEFAULT_LIMIT));
+    }
+
+    public PageExternalTransferData searchExternalAssetOwnerTransfer(PagedRequestExternalAssetOwnerSearchRequest request) {
+        return ok(() -> fineractClient.externalAssetOwners().searchInvestorData(request));
+    }
+
+    public PagedRequestExternalAssetOwnerSearchRequest buildExternalAssetOwnerSearchRequest(String text, String attribute,
+            LocalDate fromDate, LocalDate toDate, Integer page, Integer size) {
+        PagedRequestExternalAssetOwnerSearchRequest pagedRequest = new PagedRequestExternalAssetOwnerSearchRequest();
+        ExternalAssetOwnerSearchRequest searchRequest = new ExternalAssetOwnerSearchRequest();
+        searchRequest.text(text);
+        if (EFFECTIVE_ATTRIBUTE.equals(attribute)) {
+            searchRequest.setEffectiveFromDate(fromDate);
+            searchRequest.setEffectiveToDate(toDate);
+        } else if (SETTLEMENT_ATTRIBUTE.equals(attribute)) {
+            searchRequest.setSubmittedFromDate(fromDate);
+            searchRequest.setSubmittedToDate(toDate);
+        }
+        pagedRequest.setRequest(searchRequest);
+        pagedRequest.setSorts(new ArrayList<>());
+        pagedRequest.setPage(page != null ? page : DEFAULT_OFFSET);
+        pagedRequest.setSize(size != null ? size : DEFAULT_SEARCH_PAGE_SIZE);
+        return pagedRequest;
     }
 
     public void setProperFinancialActivity(Account transferAccount) {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignExternalEventHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignExternalEventHelper.java
@@ -43,6 +43,14 @@ public class FeignExternalEventHelper {
         configurationHelper.updateConfigurations(Map.of(eventName, false));
     }
 
+    public void configureBusinessEvent(String eventName, boolean enabled) {
+        if (enabled) {
+            enableBusinessEvent(eventName);
+        } else {
+            disableBusinessEvent(eventName);
+        }
+    }
+
     public List<ExternalEventResponse> getExternalEventsByType(String type) {
         return ok(() -> internalEventsApi.getAllExternalEvents(Map.of("type", type)));
     }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignExternalEventHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignExternalEventHelper.java
@@ -46,6 +46,14 @@ public class FeignExternalEventHelper {
                 new ExternalEventConfigurationUpdateRequest().externalEventConfigurations(Map.of(eventName, false))));
     }
 
+    public void configureBusinessEvent(String eventName, boolean enabled) {
+        if (enabled) {
+            enableBusinessEvent(eventName);
+        } else {
+            disableBusinessEvent(eventName);
+        }
+    }
+
     public List<ExternalEventResponse> getExternalEventsByType(String type) {
         return ok(() -> internalEventsApi.getAllExternalEvents(Map.of("type", type)));
     }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignFundHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignFundHelper.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests.client.feign.helpers;
+
+import static org.apache.fineract.client.feign.util.FeignCalls.ok;
+
+import java.util.UUID;
+import org.apache.fineract.client.feign.FineractFeignClient;
+import org.apache.fineract.client.models.FundRequest;
+import org.apache.fineract.client.models.PostFundsResponse;
+import org.apache.fineract.integrationtests.common.Utils;
+
+public class FeignFundHelper {
+
+    private final FineractFeignClient fineractClient;
+
+    public FeignFundHelper(FineractFeignClient fineractClient) {
+        this.fineractClient = fineractClient;
+    }
+
+    public PostFundsResponse createFund(FundRequest request) {
+        return ok(() -> fineractClient.funds().createFund(request));
+    }
+
+    public PostFundsResponse createFund() {
+        return createFund(new FundRequest().name(Utils.uniqueRandomStringGenerator("", 10)).externalId(UUID.randomUUID().toString()));
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignGlobalConfigurationHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignGlobalConfigurationHelper.java
@@ -61,6 +61,11 @@ public class FeignGlobalConfigurationHelper {
                 .orElseThrow(() -> new RuntimeException("Configuration not found: " + configName));
     }
 
+    public GlobalConfigurationPropertyData getGlobalConfigurationByName(String configName) {
+        List<GlobalConfigurationPropertyData> configs = getConfigurationList();
+        return configs.stream().filter(c -> configName.equals(c.getName())).findFirst().orElse(null);
+    }
+
     private List<GlobalConfigurationPropertyData> getConfigurationList() {
         GetGlobalConfigurationsResponse response = ok(() -> fineractClient.globalConfiguration().retrieveConfiguration(false));
         return response.getGlobalConfiguration();

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignGlobalConfigurationHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignGlobalConfigurationHelper.java
@@ -29,9 +29,19 @@ import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
 public class FeignGlobalConfigurationHelper {
 
     private final FineractFeignClient fineractClient;
+    private final InternalConfigurationsApi internalConfigurationsApi;
 
     public FeignGlobalConfigurationHelper(FineractFeignClient fineractClient) {
         this.fineractClient = fineractClient;
+        this.internalConfigurationsApi = fineractClient.create(InternalConfigurationsApi.class);
+    }
+
+    /** Sets a numeric global configuration value and applies it immediately, without a tenant refresh. */
+    public void updateGlobalConfigurationInternal(String configName, Long value) {
+        ok(() -> {
+            internalConfigurationsApi.updateInternalGlobalConfiguration(configName, value);
+            return null;
+        });
     }
 
     public void enableOriginatorCreationDuringLoanApplication() {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignJournalEntryHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignJournalEntryHelper.java
@@ -31,7 +31,9 @@ import java.util.Map;
 import java.util.Objects;
 import org.apache.fineract.client.feign.FineractFeignClient;
 import org.apache.fineract.client.models.GetJournalEntriesTransactionIdResponse;
+import org.apache.fineract.client.models.JournalEntryCommand;
 import org.apache.fineract.client.models.JournalEntryTransactionItem;
+import org.apache.fineract.client.models.PostJournalEntriesResponse;
 import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
 import org.apache.fineract.integrationtests.common.accounting.Account;
 
@@ -41,6 +43,10 @@ public class FeignJournalEntryHelper {
 
     public FeignJournalEntryHelper(FineractFeignClient fineractClient) {
         this.fineractClient = fineractClient;
+    }
+
+    public PostJournalEntriesResponse createJournalEntry(JournalEntryCommand command) {
+        return ok(() -> fineractClient.journalEntries().createGLJournalEntry("", command));
     }
 
     public GetJournalEntriesTransactionIdResponse getJournalEntriesForLoan(Long loanId) {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignLoanCOBCatchUpHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignLoanCOBCatchUpHelper.java
@@ -21,6 +21,7 @@ package org.apache.fineract.integrationtests.client.feign.helpers;
 import static org.apache.fineract.client.feign.util.FeignCalls.executeVoid;
 import static org.apache.fineract.client.feign.util.FeignCalls.ok;
 
+import java.time.LocalDate;
 import org.apache.fineract.client.feign.FineractFeignClient;
 import org.apache.fineract.client.models.IsCatchUpRunningDTO;
 import org.apache.fineract.client.models.OldestCOBProcessedLoanDTO;
@@ -43,6 +44,11 @@ public class FeignLoanCOBCatchUpHelper {
 
     public boolean isLoanCOBCatchUpRunning() {
         return Boolean.TRUE.equals(executeGetLoanCatchUpStatus().getCatchUpRunning());
+    }
+
+    public boolean isLoanCOBCatchUpFinishedFor(LocalDate cobBusinessDate) {
+        return !Boolean.TRUE.equals(executeGetLoanCatchUpStatus().getCatchUpRunning())
+                && cobBusinessDate.equals(executeRetrieveOldestCOBProcessedLoan().getCobProcessedDate());
     }
 
     public OldestCOBProcessedLoanDTO executeRetrieveOldestCOBProcessedLoan() {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignLoanCOBCatchUpHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignLoanCOBCatchUpHelper.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests.client.feign.helpers;
+
+import static org.apache.fineract.client.feign.util.FeignCalls.executeVoid;
+import static org.apache.fineract.client.feign.util.FeignCalls.ok;
+
+import org.apache.fineract.client.feign.FineractFeignClient;
+import org.apache.fineract.client.models.IsCatchUpRunningDTO;
+import org.apache.fineract.client.models.OldestCOBProcessedLoanDTO;
+
+public class FeignLoanCOBCatchUpHelper {
+
+    private final FineractFeignClient fineractClient;
+
+    public FeignLoanCOBCatchUpHelper(FineractFeignClient fineractClient) {
+        this.fineractClient = fineractClient;
+    }
+
+    public void executeLoanCOBCatchUp() {
+        executeVoid(() -> fineractClient.loanCobCatchUp().executeLoanCOBCatchUp());
+    }
+
+    public IsCatchUpRunningDTO executeGetLoanCatchUpStatus() {
+        return ok(() -> fineractClient.loanCobCatchUp().isCatchUpRunning());
+    }
+
+    public OldestCOBProcessedLoanDTO executeRetrieveOldestCOBProcessedLoan() {
+        return ok(() -> fineractClient.loanCobCatchUp().getOldestCOBProcessedLoan());
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignLoanCOBCatchUpHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignLoanCOBCatchUpHelper.java
@@ -41,6 +41,10 @@ public class FeignLoanCOBCatchUpHelper {
         return ok(() -> fineractClient.loanCobCatchUp().isCatchUpRunning());
     }
 
+    public boolean isLoanCOBCatchUpRunning() {
+        return Boolean.TRUE.equals(executeGetLoanCatchUpStatus().getCatchUpRunning());
+    }
+
     public OldestCOBProcessedLoanDTO executeRetrieveOldestCOBProcessedLoan() {
         return ok(() -> fineractClient.loanCobCatchUp().getOldestCOBProcessedLoan());
     }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignLoanHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignLoanHelper.java
@@ -18,6 +18,7 @@
  */
 package org.apache.fineract.integrationtests.client.feign.helpers;
 
+import static org.apache.fineract.client.feign.util.FeignCalls.executeVoid;
 import static org.apache.fineract.client.feign.util.FeignCalls.fail;
 import static org.apache.fineract.client.feign.util.FeignCalls.ok;
 
@@ -41,19 +42,26 @@ import org.apache.fineract.client.models.CommandProcessingResult;
 import org.apache.fineract.client.models.DeleteLoansLoanIdChargesChargeIdResponse;
 import org.apache.fineract.client.models.DeleteLoansLoanIdResponse;
 import org.apache.fineract.client.models.DisbursementDetail;
+import org.apache.fineract.client.models.GetDelinquencyActionsResponse;
 import org.apache.fineract.client.models.GetDelinquencyTagHistoryResponse;
 import org.apache.fineract.client.models.GetLoanProductsProductIdResponse;
+import org.apache.fineract.client.models.GetLoanProductsTemplateResponse;
 import org.apache.fineract.client.models.GetLoanRescheduleRequestResponse;
 import org.apache.fineract.client.models.GetLoansApprovalTemplateResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdChargesChargeIdResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdChargesTemplateResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
+import org.apache.fineract.client.models.GetLoansResponse;
+import org.apache.fineract.client.models.InterestPauseRequestDto;
+import org.apache.fineract.client.models.InterestPauseResponseDto;
 import org.apache.fineract.client.models.LoanApprovedAmountHistoryData;
 import org.apache.fineract.client.models.PostAddAndDeleteDisbursementDetailRequest;
 import org.apache.fineract.client.models.PostCreateRescheduleLoansRequest;
 import org.apache.fineract.client.models.PostCreateRescheduleLoansResponse;
 import org.apache.fineract.client.models.PostLoanProductsRequest;
 import org.apache.fineract.client.models.PostLoanProductsResponse;
+import org.apache.fineract.client.models.PostLoansDelinquencyActionRequest;
+import org.apache.fineract.client.models.PostLoansDelinquencyActionResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdChargesChargeIdRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdChargesChargeIdResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdChargesRequest;
@@ -94,6 +102,39 @@ public class FeignLoanHelper {
 
     public FeignLoanHelper(FineractFeignClient fineractClient) {
         this.fineractClient = fineractClient;
+    }
+
+    public CommandProcessingResult createInterestPause(Long loanId, InterestPauseRequestDto request) {
+        return ok(() -> fineractClient.loanInterestPause().createLoanInterestPause(loanId, request));
+    }
+
+    public CommandProcessingResult createInterestPauseByExternalId(String loanExternalId, InterestPauseRequestDto request) {
+        return ok(() -> fineractClient.loanInterestPause().createLoanInterestPauseByExternalId(loanExternalId, request));
+    }
+
+    public List<InterestPauseResponseDto> retrieveInterestPauses(Long loanId) {
+        return ok(() -> fineractClient.loanInterestPause().retrieveAllLoanInterestPauses(loanId));
+    }
+
+    public List<InterestPauseResponseDto> retrieveInterestPausesByExternalId(String loanExternalId) {
+        return ok(() -> fineractClient.loanInterestPause().retrieveAllLoanInterestPausesByExternalId(loanExternalId));
+    }
+
+    public CommandProcessingResult updateInterestPause(Long loanId, Long variationId, InterestPauseRequestDto request) {
+        return ok(() -> fineractClient.loanInterestPause().updateLoanInterestPause(loanId, variationId, request));
+    }
+
+    public CommandProcessingResult updateInterestPauseByExternalId(String loanExternalId, Long variationId,
+            InterestPauseRequestDto request) {
+        return ok(() -> fineractClient.loanInterestPause().updateLoanInterestPauseByExternalId(loanExternalId, variationId, request));
+    }
+
+    public void deleteInterestPause(Long loanId, Long variationId) {
+        executeVoid(() -> fineractClient.loanInterestPause().deleteLoanInterestPause(loanId, variationId));
+    }
+
+    public void deleteInterestPauseByExternalId(String loanExternalId, Long variationId) {
+        executeVoid(() -> fineractClient.loanInterestPause().deleteLoanInterestPauseByExternalId(loanExternalId, variationId));
     }
 
     public PostLoanProductsResponse createSimpleLoanProduct() {
@@ -187,12 +228,45 @@ public class FeignLoanHelper {
         return ok(() -> fineractClient.loanProducts().updateLoanProduct(productId, request));
     }
 
+    public GetLoanProductsTemplateResponse getLoanProductTemplate(Boolean isProductMixTemplate) {
+        return ok(() -> fineractClient.loanProducts().retrieveTemplateLoanProduct(isProductMixTemplate));
+    }
+
     public PostLoansResponse applyForLoan(PostLoansRequest request) {
         return ok(() -> fineractClient.loans().calculateOrSubmitLoanApplication(request, (String) null));
     }
 
+    public PostLoansResponse calculateLoanSchedule(PostLoansRequest request) {
+        return ok(() -> fineractClient.loans().calculateOrSubmitLoanApplication(request, "calculateLoanSchedule"));
+    }
+
+    public GetLoansResponse retrieveAllLoans(String accountNumber, String associations, Long clientId) {
+        return ok(() -> fineractClient.loans().retrieveAllLoans(null, 0, 10, null, null, accountNumber, associations, clientId, null));
+    }
+
     public PostLoansLoanIdResponse approveLoan(Long loanId, PostLoansLoanIdRequest request) {
         return ok(() -> fineractClient.loans().handleCommandsLoan(loanId, request, Map.of("command", "approve")));
+    }
+
+    public PostLoansDelinquencyActionResponse createLoanDelinquencyAction(Long loanId, String action, String startDate, String endDate) {
+        PostLoansDelinquencyActionRequest request = new PostLoansDelinquencyActionRequest().action(action).startDate(startDate)
+                .endDate(endDate).locale("en").dateFormat("dd MMMM yyyy");
+        return ok(() -> fineractClient.loans().createDelinquencyActionLoan(loanId, request));
+    }
+
+    public PostLoansDelinquencyActionResponse createLoanDelinquencyAction(String loanExternalId, String action, String startDate,
+            String endDate) {
+        PostLoansDelinquencyActionRequest request = new PostLoansDelinquencyActionRequest().action(action).startDate(startDate)
+                .endDate(endDate).locale("en").dateFormat("dd MMMM yyyy");
+        return ok(() -> fineractClient.loans().createDelinquencyActionLoanByExternalId(loanExternalId, request));
+    }
+
+    public List<GetDelinquencyActionsResponse> getLoanDelinquencyActions(Long loanId) {
+        return ok(() -> fineractClient.loans().retrieveDelinquencyActionsLoan(loanId));
+    }
+
+    public List<GetDelinquencyActionsResponse> getLoanDelinquencyActions(String loanExternalId) {
+        return ok(() -> fineractClient.loans().retrieveDelinquencyActionsLoanByExternalId(loanExternalId));
     }
 
     // TODO: Rewrite to use fineract-client instead!
@@ -238,6 +312,10 @@ public class FeignLoanHelper {
     public PutLoansLoanIdResponse markAsFraud(Long loanId, boolean fraud) {
         return ok(() -> fineractClient.loans().updateLoanApplication(loanId, new PutLoansLoanIdRequest().fraud(fraud),
                 Map.of("command", "markAsFraud")));
+    }
+
+    public PutLoansLoanIdResponse modifyLoanApplication(Long loanId, String command, PutLoansLoanIdRequest request) {
+        return ok(() -> fineractClient.loans().updateLoanApplication(loanId, request, Map.of("command", command)));
     }
 
     public PostLoansLoanIdTransactionsResponse closeLoan(Long loanId, PostLoansLoanIdTransactionsRequest request) {
@@ -368,6 +446,12 @@ public class FeignLoanHelper {
 
     public PostLoansLoanIdChargesResponse addLoanCharge(Long loanId, PostLoansLoanIdChargesRequest request) {
         return ok(() -> fineractClient.loanCharges().createOrPayLoanCharge(loanId, request, (String) null));
+    }
+
+    public PostLoansLoanIdChargesResponse deactivateOverdueLoanCharges(Long loanId, String fromDueDate) {
+        PostLoansLoanIdChargesRequest request = new PostLoansLoanIdChargesRequest().dueDate(fromDueDate).dateFormat("dd MMMM yyyy")
+                .locale("en");
+        return ok(() -> fineractClient.loanCharges().createOrPayLoanCharge(loanId, request, "deactivateOverdue"));
     }
 
     public List<GetLoansLoanIdChargesChargeIdResponse> getLoanCharges(Long loanId) {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignLoanHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignLoanHelper.java
@@ -315,7 +315,7 @@ public class FeignLoanHelper {
     }
 
     public PutLoansLoanIdResponse modifyLoanApplication(Long loanId, String command, PutLoansLoanIdRequest request) {
-        return ok(() -> fineractClient.loans().updateLoanApplication(loanId, request, Map.of("command", command)));
+        return ok(() -> fineractClient.loans().updateLoanApplication(loanId, request, command));
     }
 
     public PostLoansLoanIdTransactionsResponse closeLoan(Long loanId, PostLoansLoanIdTransactionsRequest request) {
@@ -345,6 +345,11 @@ public class FeignLoanHelper {
     public GetLoansLoanIdResponse getLoanDetails(Long loanId) {
         return ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("associations", "all", "exclude", "guarantors,futureSchedule")));
+    }
+
+    /** Retrieves the loan with an explicit {@code associations} list, e.g. to include {@code futureSchedule}. */
+    public GetLoansLoanIdResponse getLoanDetails(Long loanId, String associations) {
+        return ok(() -> fineractClient.loans().retrieveOneLoan(loanId, Map.of("associations", associations)));
     }
 
     public GetLoansLoanIdResponse getLoanDetailsByExternalId(String loanExternalId) {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignLoanHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignLoanHelper.java
@@ -722,6 +722,10 @@ public class FeignLoanHelper {
         return ok(() -> fineractClient.loans().retrieveDelinquencyTagHistoryLoanByExternalId(loanExternalId));
     }
 
+    public List<GetDelinquencyTagHistoryResponse> getLoanDelinquencyTags(Long loanId) {
+        return ok(() -> fineractClient.loans().retrieveDelinquencyTagHistoryLoan(loanId));
+    }
+
     public PostLoansLoanIdChargesResponse addLoanCharge(String loanExternalId, PostLoansLoanIdChargesRequest request) {
         return ok(() -> fineractClient.loanCharges().executeLoanChargeByLoanExternalId(loanExternalId, request, (String) null));
     }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignReportHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignReportHelper.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests.client.feign.helpers;
+
+import static org.apache.fineract.client.feign.util.FeignCalls.ok;
+
+import java.util.Map;
+import org.apache.fineract.client.feign.FineractFeignClient;
+import org.apache.fineract.client.models.RunReportsResponse;
+
+public class FeignReportHelper {
+
+    private final FineractFeignClient fineractClient;
+
+    public FeignReportHelper(FineractFeignClient fineractClient) {
+        this.fineractClient = fineractClient;
+    }
+
+    /**
+     * Runs a table report and returns its generic result set: the column headers plus one row per record.
+     *
+     * @param reportParameters
+     *            the report's {@code R_}-prefixed parameters, as expected by the report definition
+     */
+    public RunReportsResponse runReport(String reportName, Map<String, String> reportParameters) {
+        return ok(() -> fineractClient.runReports().runReportGetData(reportName, reportParameters));
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignSavingsHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignSavingsHelper.java
@@ -28,6 +28,7 @@ import org.apache.fineract.client.models.PostSavingsAccountsAccountIdResponse;
 import org.apache.fineract.client.models.PostSavingsAccountsRequest;
 import org.apache.fineract.client.models.PostSavingsAccountsResponse;
 import org.apache.fineract.client.models.SavingsAccountData;
+import org.apache.fineract.client.models.SavingsAccountSummaryData;
 import org.apache.fineract.integrationtests.client.feign.modules.SavingsRequestBuilders;
 
 public class FeignSavingsHelper {
@@ -77,6 +78,10 @@ public class FeignSavingsHelper {
 
     public SavingsAccountData getSavingsDetails(Long savingsId, String associations) {
         return ok(() -> fineractClient.savingsAccount().retrieveSavingsAccount(savingsId, Map.of("associations", associations)));
+    }
+
+    public SavingsAccountSummaryData getSavingsSummary(Long savingsId) {
+        return getSavingsDetails(savingsId, "summary").getSummary();
     }
 
     public DeleteSavingsAccountsAccountIdResponse deleteSavingsApplication(Long savingsId) {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignSchedulerHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignSchedulerHelper.java
@@ -28,6 +28,7 @@ import org.apache.fineract.client.feign.util.FeignCalls;
 import org.apache.fineract.client.models.ExecuteJobRequest;
 import org.apache.fineract.client.models.GetJobsJobIDJobRunHistoryResponse;
 import org.apache.fineract.client.models.GetJobsResponse;
+import org.apache.fineract.client.models.GetSchedulerResponse;
 import org.apache.fineract.client.models.JobDetailHistoryDataSwagger;
 import org.awaitility.Awaitility;
 
@@ -45,6 +46,19 @@ public class FeignSchedulerHelper {
 
     public void startScheduler() {
         FeignCalls.executeVoid(() -> fineractClient.scheduler().handleCommandsScheduler("start"));
+    }
+
+    public boolean getSchedulerStatus() {
+        GetSchedulerResponse response = ok(() -> fineractClient.scheduler().retrieveSchedulerStatus());
+        return Boolean.TRUE.equals(response.getActive());
+    }
+
+    public void updateSchedulerStatus(boolean enabled) {
+        if (enabled) {
+            startScheduler();
+        } else {
+            stopScheduler();
+        }
     }
 
     public void executeAndAwaitJob(String jobDisplayName) {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignTransactionHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignTransactionHelper.java
@@ -27,10 +27,13 @@ import java.util.List;
 import java.util.Map;
 import org.apache.fineract.client.feign.FineractFeignClient;
 import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
+import org.apache.fineract.client.models.BuyDownFeeAmortizationDetails;
+import org.apache.fineract.client.models.CapitalizedIncomeDetails;
 import org.apache.fineract.client.models.GetLoansLoanIdTransactionsResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdTransactionsTemplateResponse;
 import org.apache.fineract.client.models.GetLoansLoanIdTransactionsTransactionIdResponse;
 import org.apache.fineract.client.models.InlineJobRequest;
+import org.apache.fineract.client.models.LoanCapitalizedIncomeData;
 import org.apache.fineract.client.models.LoanScheduleData;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsResponse;
@@ -61,6 +64,55 @@ public class FeignTransactionHelper {
                         .handleCommandsLoanTransaction(loanId, new PostLoansLoanIdTransactionsRequest().transactionAmount(amount)
                                 .transactionDate(transactionDate).dateFormat("dd MMMM yyyy").locale("en"),
                                 Map.of("command", "capitalizedIncome")));
+    }
+
+    public PostLoansLoanIdTransactionsResponse addCapitalizedIncome(Long loanId, String transactionDate, double amount,
+            Long classificationId) {
+        return ok(() -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId,
+                new PostLoansLoanIdTransactionsRequest().transactionAmount(amount).transactionDate(transactionDate)
+                        .dateFormat("dd MMMM yyyy").locale("en").classificationId(classificationId),
+                Map.of("command", "capitalizedIncome")));
+    }
+
+    public PostLoansLoanIdTransactionsResponse capitalizedIncomeAdjustment(Long loanId, Long capitalizedIncomeTransactionId,
+            String transactionDate, double amount) {
+        PostLoansLoanIdTransactionsTransactionIdRequest request = new PostLoansLoanIdTransactionsTransactionIdRequest()
+                .transactionAmount(amount).transactionDate(transactionDate).dateFormat("dd MMMM yyyy").locale("en");
+        return ok(() -> fineractClient.loanTransactions().adjustLoanTransaction(loanId, capitalizedIncomeTransactionId, request,
+                "capitalizedIncomeAdjustment"));
+    }
+
+    public List<CapitalizedIncomeDetails> fetchCapitalizedIncomeDetails(Long loanId) {
+        return ok(() -> fineractClient.loanCapitalizedIncome().fetchCapitalizedIncomeDetails(loanId));
+    }
+
+    public LoanCapitalizedIncomeData fetchLoanCapitalizedIncomeData(Long loanId) {
+        return ok(() -> fineractClient.loanCapitalizedIncome().fetchLoanCapitalizedIncomeData(loanId));
+    }
+
+    public PostLoansLoanIdTransactionsResponse makeLoanBuyDownFee(Long loanId, PostLoansLoanIdTransactionsRequest request) {
+        return ok(() -> fineractClient.loanTransactions().handleCommandsLoanTransaction(loanId, request, Map.of("command", "buyDownFee")));
+    }
+
+    public PostLoansLoanIdTransactionsResponse makeLoanBuyDownFee(Long loanId, String date, double amount) {
+        return makeLoanBuyDownFee(loanId, new PostLoansLoanIdTransactionsRequest().dateFormat("dd MMMM yyyy").transactionDate(date)
+                .locale("en").transactionAmount(amount));
+    }
+
+    public PostLoansLoanIdTransactionsResponse buyDownFeeAdjustment(Long loanId, Long buyDownFeeTransactionId, String transactionDate,
+            double amount) {
+        return buyDownFeeAdjustment(loanId, buyDownFeeTransactionId, new PostLoansLoanIdTransactionsTransactionIdRequest()
+                .transactionAmount(amount).transactionDate(transactionDate).dateFormat("dd MMMM yyyy").locale("en"));
+    }
+
+    public PostLoansLoanIdTransactionsResponse buyDownFeeAdjustment(Long loanId, Long buyDownFeeTransactionId,
+            PostLoansLoanIdTransactionsTransactionIdRequest request) {
+        return ok(() -> fineractClient.loanTransactions().adjustLoanTransaction(loanId, buyDownFeeTransactionId, request,
+                "buyDownFeeAdjustment"));
+    }
+
+    public List<BuyDownFeeAmortizationDetails> fetchBuyDownFeeAmortizationDetails(Long loanId) {
+        return ok(() -> fineractClient.loanBuyDownFees().retrieveLoanBuyDownFeeAmortizationDetails(loanId));
     }
 
     public GetLoansLoanIdTransactionsTemplateResponse getPrepaymentAmount(Long loanId, String transactionDate, String dateFormat) {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignUserHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignUserHelper.java
@@ -1,0 +1,83 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests.client.feign.helpers;
+
+import static org.apache.fineract.client.feign.util.FeignCalls.ok;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.fineract.client.feign.FineractFeignClient;
+import org.apache.fineract.client.models.GetOfficesResponse;
+import org.apache.fineract.client.models.PostRolesRequest;
+import org.apache.fineract.client.models.PostRolesResponse;
+import org.apache.fineract.client.models.PostUsersRequest;
+import org.apache.fineract.client.models.PostUsersResponse;
+import org.apache.fineract.client.models.PutRolesRoleIdPermissionsRequest;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
+import org.apache.fineract.integrationtests.common.OfficeHelper;
+import org.apache.fineract.integrationtests.common.Utils;
+
+public final class FeignUserHelper {
+
+    private static final String SIMPLE_USER_PASSWORD = "QwE!5rTy#9uP0";
+    private static final String REPAYMENT_LOAN_PERMISSION = "REPAYMENT_LOAN";
+    private static final String READ_LOAN_PERMISSION = "READ_LOAN";
+
+    private static FineractFeignClient simpleUserWithoutBypassPermissionClient;
+
+    private FeignUserHelper() {}
+
+    /**
+     * Lazily creates a simple user whose role lacks the loan-checker bypass permission (but can read and repay loans
+     * and manage loan reschedules) and returns a Feign client authenticated as that user. Mirrors
+     * {@code UserHelper.getSimpleUserWithoutBypassPermission}. The user and client are created once per JVM and reused.
+     */
+    public static FineractFeignClient getSimpleUserWithoutBypassPermissionClient() {
+        if (simpleUserWithoutBypassPermissionClient == null) {
+            String username = Utils.uniqueRandomStringGenerator("NonByPassUser", 4);
+            createSimpleUser(username);
+            simpleUserWithoutBypassPermissionClient = FineractFeignClientHelper.createNewFineractFeignClient(username,
+                    SIMPLE_USER_PASSWORD);
+        }
+        return simpleUserWithoutBypassPermissionClient;
+    }
+
+    private static void createSimpleUser(String username) {
+        FineractFeignClient adminClient = FineractFeignClientHelper.getFineractFeignClient();
+        GetOfficesResponse headOffice = OfficeHelper.getHeadOffice();
+
+        PostRolesResponse roleResponse = ok(
+                () -> adminClient.roles().createRole(new PostRolesRequest().name(Utils.uniqueRandomStringGenerator("Role_Name_", 5))
+                        .description(Utils.randomStringGenerator("Role_Description_", 10))));
+        Long roleId = roleResponse.getResourceId();
+
+        Map<String, Boolean> permissions = Map.of(REPAYMENT_LOAN_PERMISSION, true, READ_LOAN_PERMISSION, true, "READ_RESCHEDULELOAN", true,
+                "CREATE_RESCHEDULELOAN", true, "REJECT_RESCHEDULELOAN", true, "APPROVE_RESCHEDULELOAN", true);
+        ok(() -> adminClient.roles().updateRolePermissions(roleId, new PutRolesRoleIdPermissionsRequest().permissions(permissions)));
+
+        PostUsersResponse userResponse = ok(() -> adminClient.users()
+                .createUser(new PostUsersRequest().username(username).firstname(Utils.randomFirstNameGenerator())
+                        .lastname(Utils.randomLastNameGenerator()).email("whatever@mifos.org").password(SIMPLE_USER_PASSWORD)
+                        .repeatPassword(SIMPLE_USER_PASSWORD).sendPasswordToEmail(false).roles(List.of(roleId))
+                        .officeId(headOffice.getId())));
+        if (userResponse.getResourceId() == null) {
+            throw new IllegalStateException("Failed to create non-bypass user " + username);
+        }
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignUserHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignUserHelper.java
@@ -1,0 +1,83 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests.client.feign.helpers;
+
+import static org.apache.fineract.client.feign.util.FeignCalls.ok;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.fineract.client.feign.FineractFeignClient;
+import org.apache.fineract.client.models.GetOfficesResponse;
+import org.apache.fineract.client.models.PostRolesRequest;
+import org.apache.fineract.client.models.PostRolesResponse;
+import org.apache.fineract.client.models.PostUsersRequest;
+import org.apache.fineract.client.models.PostUsersResponse;
+import org.apache.fineract.client.models.PutRolesRoleIdPermissionsRequest;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
+import org.apache.fineract.integrationtests.common.OfficeHelper;
+import org.apache.fineract.integrationtests.common.Utils;
+
+public final class FeignUserHelper {
+
+    private static final String SIMPLE_USER_PASSWORD = "QwE!5rTy#9uP0";
+    private static final String REPAYMENT_LOAN_PERMISSION = "REPAYMENT_LOAN";
+    private static final String READ_LOAN_PERMISSION = "READ_LOAN";
+
+    private static FineractFeignClient simpleUserWithoutBypassPermissionClient;
+
+    private FeignUserHelper() {}
+
+    /**
+     * Lazily creates a simple user whose role lacks the loan-checker bypass permission (but can read and repay loans
+     * and manage loan reschedules) and returns a Feign client authenticated as that user. Mirrors
+     * {@code UserHelper.getSimpleUserWithoutBypassPermission}. The user and client are created once per JVM and reused.
+     */
+    public static synchronized FineractFeignClient getSimpleUserWithoutBypassPermissionClient() {
+        if (simpleUserWithoutBypassPermissionClient == null) {
+            String username = Utils.uniqueRandomStringGenerator("NonByPassUser", 4);
+            createSimpleUser(username);
+            simpleUserWithoutBypassPermissionClient = FineractFeignClientHelper.createNewFineractFeignClient(username,
+                    SIMPLE_USER_PASSWORD);
+        }
+        return simpleUserWithoutBypassPermissionClient;
+    }
+
+    private static void createSimpleUser(String username) {
+        FineractFeignClient adminClient = FineractFeignClientHelper.getFineractFeignClient();
+        GetOfficesResponse headOffice = OfficeHelper.getHeadOffice();
+
+        PostRolesResponse roleResponse = ok(
+                () -> adminClient.roles().createRole(new PostRolesRequest().name(Utils.uniqueRandomStringGenerator("Role_Name_", 5))
+                        .description(Utils.randomStringGenerator("Role_Description_", 10))));
+        Long roleId = roleResponse.getResourceId();
+
+        Map<String, Boolean> permissions = Map.of(REPAYMENT_LOAN_PERMISSION, true, READ_LOAN_PERMISSION, true, "READ_RESCHEDULELOAN", true,
+                "CREATE_RESCHEDULELOAN", true, "REJECT_RESCHEDULELOAN", true, "APPROVE_RESCHEDULELOAN", true);
+        ok(() -> adminClient.roles().updateRolePermissions(roleId, new PutRolesRoleIdPermissionsRequest().permissions(permissions)));
+
+        PostUsersResponse userResponse = ok(() -> adminClient.users()
+                .createUser(new PostUsersRequest().username(username).firstname(Utils.randomFirstNameGenerator())
+                        .lastname(Utils.randomLastNameGenerator()).email("whatever@mifos.org").password(SIMPLE_USER_PASSWORD)
+                        .repeatPassword(SIMPLE_USER_PASSWORD).sendPasswordToEmail(false).roles(List.of(roleId))
+                        .officeId(headOffice.getId())));
+        if (userResponse.getResourceId() == null) {
+            throw new IllegalStateException("Failed to create non-bypass user " + username);
+        }
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/InternalConfigurationsApi.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/InternalConfigurationsApi.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests.client.feign.helpers;
+
+import feign.Headers;
+import feign.Param;
+import feign.RequestLine;
+
+/**
+ * Feign interface for the internal-only global configuration API. Unlike the public configuration endpoint, this one
+ * applies the new value immediately rather than on the next tenant refresh. Check
+ * InternalConfigurationsApiResource.java for the server-side implementation.
+ */
+@Headers({ "Accept: application/json", "Content-Type: application/json" })
+public interface InternalConfigurationsApi {
+
+    @RequestLine("PUT /v1/internal/configurations/name/{configName}/value/{configValue}")
+    void updateInternalGlobalConfiguration(@Param("configName") String configName, @Param("configValue") Long configValue);
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/LoanChargeCommandsApi.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/LoanChargeCommandsApi.java
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests.client.feign.helpers;
+
+import feign.Headers;
+import feign.Param;
+import feign.RequestLine;
+import org.apache.fineract.client.models.PostLoansLoanIdChargesResponse;
+
+/**
+ * Feign interface for the one loan-charge request shape the generated client cannot express. It binds to the generated
+ * response model, so the call stays typed end to end and does not build a JSON body by hand.
+ *
+ * <p>
+ * This is the only loan-charge call that needs it - everything else goes through the generated
+ * {@code fineractClient.loanCharges()} API.
+ */
+@Headers({ "Accept: application/json", "Content-Type: application/json" })
+public interface LoanChargeCommandsApi {
+
+    /**
+     * Adds a loan charge whose {@code amount} is a locale-formatted decimal <em>string</em> (the German
+     * {@code "50,05"}), which is what the server is being asked to parse here.
+     *
+     * <p>
+     * {@code PostLoansLoanIdChargesRequest.amount} is a JSON number, so the generated model cannot carry a decimal
+     * comma. Retyping it as a String at source is not the answer: that model is used by 118 call sites across
+     * integration-tests, fineract-e2e-tests-core and fineract-e2e-tests-runner, all of which pass a number - the spec
+     * would become a lie for every one of them to serve this single case. One schema cannot declare both "number" and
+     * "locale-formatted string", so this operation gets its own request model.
+     */
+    @RequestLine("POST /v1/loans/{loanId}/charges")
+    PostLoansLoanIdChargesResponse createLoanChargeWithLocaleFormattedAmount(@Param("loanId") Long loanId,
+            LocaleFormattedAmountLoanChargeRequest request);
+
+    /**
+     * Request body for {@link #createLoanChargeWithLocaleFormattedAmount}. Mirrors the wire shape the pre-migration
+     * test sent: both {@code amount} and {@code chargeId} are JSON strings, the former formatted for {@code locale}.
+     */
+    class LocaleFormattedAmountLoanChargeRequest {
+
+        private String chargeId;
+        private String amount;
+        private String locale;
+        private String dateFormat;
+
+        public String getChargeId() {
+            return chargeId;
+        }
+
+        public LocaleFormattedAmountLoanChargeRequest chargeId(String chargeId) {
+            this.chargeId = chargeId;
+            return this;
+        }
+
+        public String getAmount() {
+            return amount;
+        }
+
+        public LocaleFormattedAmountLoanChargeRequest amount(String amount) {
+            this.amount = amount;
+            return this;
+        }
+
+        public String getLocale() {
+            return locale;
+        }
+
+        public LocaleFormattedAmountLoanChargeRequest locale(String locale) {
+            this.locale = locale;
+            return this;
+        }
+
+        public String getDateFormat() {
+            return dateFormat;
+        }
+
+        public LocaleFormattedAmountLoanChargeRequest dateFormat(String dateFormat) {
+            this.dateFormat = dateFormat;
+            return this;
+        }
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/LoanChargeCommandsApi.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/LoanChargeCommandsApi.java
@@ -1,0 +1,115 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests.client.feign.helpers;
+
+import feign.Headers;
+import feign.Param;
+import feign.RequestLine;
+import org.apache.fineract.client.models.PostLoansLoanIdChargesChargeIdResponse;
+import org.apache.fineract.client.models.PostLoansLoanIdChargesResponse;
+
+/**
+ * Feign interface for the two loan-charge request shapes the generated client cannot express. Both bind to the
+ * generated response models, so the calls stay typed end to end; neither builds a JSON body by hand.
+ *
+ * <p>
+ * These are the only loan-charge calls that need it - everything else goes through the generated
+ * {@code fineractClient.loanCharges()} API.
+ */
+@Headers({ "Accept: application/json", "Content-Type: application/json" })
+public interface LoanChargeCommandsApi {
+
+    /**
+     * Waives a loan charge in full, sending <em>no</em> request body.
+     *
+     * <p>
+     * The generated {@code executeLoanCharge} always serialises at least <code>{}</code>, which this endpoint answers
+     * with a 500. The pre-migration test sent an empty body here, so this reproduces it exactly. A request model cannot
+     * express "no body at all", which is why this needs its own declaration rather than a Swagger DTO change.
+     *
+     * <p>
+     * Waiving a single installment of an instalment fee <em>does</em> take a body and goes through the generated
+     * client's typed {@code waiveLoanCharge} instead.
+     */
+    @RequestLine("POST /v1/loans/{loanId}/charges/{loanChargeId}?command=waive")
+    PostLoansLoanIdChargesChargeIdResponse waiveLoanChargeInFull(@Param("loanId") Long loanId, @Param("loanChargeId") Long loanChargeId);
+
+    /**
+     * Adds a loan charge whose {@code amount} is a locale-formatted decimal <em>string</em> (the German
+     * {@code "50,05"}), which is what the server is being asked to parse here.
+     *
+     * <p>
+     * {@code PostLoansLoanIdChargesRequest.amount} is a JSON number, so the generated model cannot carry a decimal
+     * comma. Retyping it as a String at source is not the answer: that model is used by 118 call sites across
+     * integration-tests, fineract-e2e-tests-core and fineract-e2e-tests-runner, all of which pass a number - the spec
+     * would become a lie for every one of them to serve this single case. One schema cannot declare both "number" and
+     * "locale-formatted string", so this operation gets its own request model.
+     */
+    @RequestLine("POST /v1/loans/{loanId}/charges")
+    PostLoansLoanIdChargesResponse createLoanChargeWithLocaleFormattedAmount(@Param("loanId") Long loanId,
+            LocaleFormattedAmountLoanChargeRequest request);
+
+    /**
+     * Request body for {@link #createLoanChargeWithLocaleFormattedAmount}. Mirrors the wire shape the pre-migration
+     * test sent: both {@code amount} and {@code chargeId} are JSON strings, the former formatted for {@code locale}.
+     */
+    class LocaleFormattedAmountLoanChargeRequest {
+
+        private String chargeId;
+        private String amount;
+        private String locale;
+        private String dateFormat;
+
+        public String getChargeId() {
+            return chargeId;
+        }
+
+        public LocaleFormattedAmountLoanChargeRequest chargeId(String chargeId) {
+            this.chargeId = chargeId;
+            return this;
+        }
+
+        public String getAmount() {
+            return amount;
+        }
+
+        public LocaleFormattedAmountLoanChargeRequest amount(String amount) {
+            this.amount = amount;
+            return this;
+        }
+
+        public String getLocale() {
+            return locale;
+        }
+
+        public LocaleFormattedAmountLoanChargeRequest locale(String locale) {
+            this.locale = locale;
+            return this;
+        }
+
+        public String getDateFormat() {
+            return dateFormat;
+        }
+
+        public LocaleFormattedAmountLoanChargeRequest dateFormat(String dateFormat) {
+            this.dateFormat = dateFormat;
+            return this;
+        }
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/LoanProductCommandsApi.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/LoanProductCommandsApi.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests.client.feign.helpers;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import feign.Headers;
+import feign.Param;
+import feign.RequestLine;
+import org.apache.fineract.client.models.PutLoanProductsProductIdResponse;
+
+/**
+ * Detaching a loan product's delinquency bucket needs a body that carries an explicit JSON {@code null}:
+ * {@code LoanProductWritePlatformServiceJpaRepositoryImpl} gates the update on
+ * {@code command.parameterExists("delinquencyBucketId")}, so the key has to be <em>present</em> with a null value.
+ *
+ * <p>
+ * The generated {@code PutLoanProductsProductIdRequest} cannot express that: the mapper's global {@code NON_NULL} drops
+ * a null property, so {@code .delinquencyBucketId(null)} serialises to <code>{}</code> and the bucket is never cleared.
+ * Declaring the property {@code nullable} in the spec would model it as a {@code JsonNullable<Long>} and fix it for SDK
+ * consumers, but it cannot fix it here: {@code fineract-client} (Retrofit/Gson) and {@code fineract-client-feign}
+ * (Jackson) both generate into {@code org.apache.fineract.client.models}, and {@code integration-tests} puts the
+ * Retrofit artifact on the test classpath first ({@code integration-tests/dependencies.gradle}), so the Retrofit model
+ * - a plain {@code Long} - wins the name clash and the Jackson annotations never reach the wire. Measured, not assumed.
+ *
+ * <p>
+ * So the spec is left alone and this keeps the call typed end to end, binding the response to the generated model.
+ * Resolving the classpath shadowing is a separate concern: 46 test files import Retrofit-only packages and 430 import
+ * the shared model package.
+ */
+@Headers({ "Accept: application/json", "Content-Type: application/json" })
+public interface LoanProductCommandsApi {
+
+    @RequestLine("PUT /v1/loanproducts/{productId}")
+    PutLoanProductsProductIdResponse clearDelinquencyBucket(@Param("productId") Long productId, ClearDelinquencyBucketRequest request);
+
+    /**
+     * Body for {@link #clearDelinquencyBucket}: serialises to {@code {"delinquencyBucketId":null}}. The property-level
+     * {@code @JsonInclude(ALWAYS)} is what overrides the mapper's global {@code NON_NULL}.
+     */
+    class ClearDelinquencyBucketRequest {
+
+        @JsonInclude(JsonInclude.Include.ALWAYS)
+        private final Long delinquencyBucketId = null;
+
+        public Long getDelinquencyBucketId() {
+            return delinquencyBucketId;
+        }
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/LoanProductCommandsApi.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/LoanProductCommandsApi.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests.client.feign.helpers;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import feign.Headers;
+import feign.Param;
+import feign.RequestLine;
+import org.apache.fineract.client.models.PutLoanProductsProductIdResponse;
+
+/**
+ * Loan-product updates that have to send an explicit JSON {@code null}.
+ *
+ * <p>
+ * {@code LoanProductWritePlatformServiceJpaRepositoryImpl} gates the update on
+ * {@code command.parameterExists("delinquencyBucketId")}, so clearing the bucket requires the key to be
+ * <em>present</em> with a null value. The generated {@code PutLoanProductsProductIdRequest} cannot express that: its
+ * properties are {@code @JsonInclude(USE_DEFAULTS)} and {@code ObjectMapperFactory} sets {@code NON_NULL} globally, so
+ * a null field is dropped from the body and the server never takes the clearing branch.
+ *
+ * <p>
+ * Marking the field {@code nullable} in the Swagger DTO does not help - the generator emits a plain
+ * {@code @Nullable Long}, not a {@code JsonNullable}, so serialisation is unchanged. A property-level
+ * {@code @JsonInclude(ALWAYS)} is what actually overrides the mapper default, hence this request model.
+ */
+@Headers({ "Accept: application/json", "Content-Type: application/json" })
+public interface LoanProductCommandsApi {
+
+    @RequestLine("PUT /v1/loanproducts/{productId}")
+    PutLoanProductsProductIdResponse clearDelinquencyBucket(@Param("productId") Long productId, ClearDelinquencyBucketRequest request);
+
+    /**
+     * Body for {@link #clearDelinquencyBucket}: serialises to {@code {"delinquencyBucketId":null}}.
+     */
+    class ClearDelinquencyBucketRequest {
+
+        @JsonInclude(JsonInclude.Include.ALWAYS)
+        private final Long delinquencyBucketId = null;
+
+        public Long getDelinquencyBucketId() {
+            return delinquencyBucketId;
+        }
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/modules/AccountTransferRequestBuilders.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/modules/AccountTransferRequestBuilders.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests.client.feign.modules;
+
+import org.apache.fineract.client.models.AccountTransferRequest;
+import org.apache.fineract.portfolio.account.PortfolioAccountType;
+
+public final class AccountTransferRequestBuilders {
+
+    public static final Long HEAD_OFFICE_ID = 1L;
+
+    private static final String TRANSFER_DESCRIPTION = "Transfer";
+
+    /**
+     * Account transfers are posted with {@code en_GB}, matching the locale the RestAssured
+     * {@code AccountTransferHelper} used before the migration. The shared {@link FeignTestConstants#LOCALE} is plain
+     * {@code en}; keeping the original locale here avoids changing how the server parses transfer amounts and dates.
+     */
+    private static final String TRANSFER_LOCALE = "en_GB";
+
+    private AccountTransferRequestBuilders() {}
+
+    /** A transfer between two accounts of the head office, e.g. a loan overpayment refunded into savings. */
+    public static AccountTransferRequest transfer(String transferDate, Long fromClientId, Long fromAccountId,
+            PortfolioAccountType fromAccountType, Long toClientId, Long toAccountId, PortfolioAccountType toAccountType,
+            String transferAmount) {
+        return new AccountTransferRequest()//
+                .dateFormat(FeignTestConstants.DATETIME_PATTERN)//
+                .locale(TRANSFER_LOCALE)//
+                .fromClientId(String.valueOf(fromClientId))//
+                .fromAccountId(String.valueOf(fromAccountId))//
+                .fromAccountType(String.valueOf(fromAccountType.getValue()))//
+                .fromOfficeId(String.valueOf(HEAD_OFFICE_ID))//
+                .toClientId(String.valueOf(toClientId))//
+                .toAccountId(String.valueOf(toAccountId))//
+                .toAccountType(String.valueOf(toAccountType.getValue()))//
+                .toOfficeId(String.valueOf(HEAD_OFFICE_ID))//
+                .transferDate(transferDate)//
+                .transferAmount(transferAmount)//
+                .transferDescription(TRANSFER_DESCRIPTION);
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/modules/BatchRequestBuilders.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/modules/BatchRequestBuilders.java
@@ -1,0 +1,486 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests.client.feign.modules;
+
+import com.google.gson.Gson;
+import jakarta.ws.rs.HttpMethod;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.apache.fineract.client.models.BatchRequest;
+import org.apache.fineract.integrationtests.common.Utils;
+import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
+
+/**
+ * Builds the individual {@link BatchRequest}s posted to the Batch API. The Batch API takes each entry as a raw relative
+ * URL plus a raw JSON body, so the bodies here are assembled as JSON strings rather than typed models; the enclosing
+ * request itself is the generated {@link BatchRequest} model.
+ *
+ * <p>
+ * A request may resolve an id from an earlier response in the same batch via a JSON path placeholder (for example
+ * {@code $.loanId}) combined with {@code reference} pointing at that earlier request's id.
+ */
+public final class BatchRequestBuilders {
+
+    private static final String DATE_FORMAT = FeignTestConstants.DATETIME_PATTERN;
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern(DATE_FORMAT);
+    private static final String LOCALE = FeignTestConstants.LOCALE;
+    private static final String LOAN_APPLICATION_LOCALE = "en_GB";
+    private static final Gson GSON = new Gson();
+
+    /** Default principal applied by the loan-application batch requests. */
+    private static final String DEFAULT_LOAN_AMOUNT = "10,000.00";
+    /** Default number of days before today used as the loan submission/approval date. */
+    private static final int DEFAULT_SUBMITTED_DAYS_AGO = 10;
+    /** Default number of days before today used as the disbursement date. */
+    private static final int DEFAULT_DISBURSEMENT_DAYS_AGO = 8;
+
+    private BatchRequestBuilders() {}
+
+    private static String today() {
+        return format(LocalDate.now(Utils.getZoneIdOfTenant()));
+    }
+
+    private static String format(final LocalDate date) {
+        return date.format(DATE_FORMATTER);
+    }
+
+    private static LocalDate daysAgo(final int days) {
+        return LocalDate.now(Utils.getZoneIdOfTenant()).minusDays(days);
+    }
+
+    private static BatchRequest request(final Long requestId, final Long reference, final String relativeUrl, final String method,
+            final String body) {
+        return new BatchRequest().requestId(requestId).reference(reference).relativeUrl(relativeUrl).method(method).body(body);
+    }
+
+    // Clients
+
+    /**
+     * Creates a client in {@code pending} status (active=false). An empty {@code externalId} is replaced by a random
+     * one, so that repeated runs against a long-lived server do not collide.
+     */
+    public static BatchRequest createClient(final Long requestId, final String externalId) {
+        final String resolvedExternalId = externalId.isEmpty() ? UUID.randomUUID().toString() : externalId;
+        final String body = """
+                {"officeId": 1, "legalFormId": 1, "firstname": "Petra", "lastname": "Yton", "externalId": "%s", \
+                "dateFormat": "%s", "locale": "%s", "active": false, "submittedOnDate": "04 March 2009"}""".formatted(resolvedExternalId,
+                DATE_FORMAT, LOCALE);
+        return request(requestId, null, "v1/clients", HttpMethod.POST, body);
+    }
+
+    /** Creates a client already in {@code active} status. */
+    public static BatchRequest createActiveClient(final Long requestId, final String externalId) {
+        final String body = """
+                {"officeId": 1, "legalFormId": 1, "firstname": "Petra", "lastname": "Yton", "externalId": "%s", \
+                "dateFormat": "%s", "locale": "%s", "active": true, "activationDate": "04 March 2010", \
+                "submittedOnDate": "04 March 2010"}""".formatted(externalId, DATE_FORMAT, LOCALE);
+        return request(requestId, null, "v1/clients", HttpMethod.POST, body);
+    }
+
+    public static BatchRequest updateClient(final Long requestId, final Long reference) {
+        return request(requestId, reference, "v1/clients/$.clientId", HttpMethod.PUT,
+                "{\"firstname\": \"TestFirstName\", \"lastname\": \"TestLastName\"}");
+    }
+
+    public static BatchRequest activateClient(final Long requestId, final Long reference) {
+        final String body = "{\"locale\": \"%s\", \"dateFormat\": \"%s\", \"activationDate\": \"01 March 2011\"}".formatted(LOCALE,
+                DATE_FORMAT);
+        return request(requestId, reference, "v1/clients/$.clientId?command=activate", HttpMethod.POST, body);
+    }
+
+    // Loan application
+
+    /** Applies for a loan on behalf of the client created by the referenced request. */
+    public static BatchRequest applyLoan(final Long requestId, final Long reference, final Long productId, final Long clientCollateralId) {
+        return applyLoan(requestId, reference, productId, clientCollateralId, daysAgo(DEFAULT_SUBMITTED_DAYS_AGO), DEFAULT_LOAN_AMOUNT);
+    }
+
+    public static BatchRequest applyLoan(final Long requestId, final Long reference, final Long productId, final Long clientCollateralId,
+            final LocalDate submittedOnDate, final String loanAmount) {
+        final String dateString = format(submittedOnDate);
+        final String collateral = clientCollateralId == null ? ""
+                : "\"collateral\": [{\"clientCollateralId\": \"%d\", \"quantity\": \"1\"}],".formatted(clientCollateralId);
+        final String body = """
+                {"dateFormat": "%s", "locale": "%s", "clientId": "$.clientId", "productId": %d, "principal": "%s", \
+                "loanTermFrequency": 10, "loanTermFrequencyType": 2, "loanType": "individual", "numberOfRepayments": 10, \
+                "repaymentEvery": 1, "repaymentFrequencyType": 2, "interestRatePerPeriod": 10, "amortizationType": 1, \
+                "interestType": 0, "interestCalculationPeriodType": 1, "transactionProcessingStrategyCode": "%s", \
+                "expectedDisbursementDate": "%s", %s"submittedOnDate": "%s"}""".formatted(DATE_FORMAT, LOAN_APPLICATION_LOCALE, productId,
+                loanAmount, LoanProductTestBuilder.DEFAULT_STRATEGY, dateString, collateral, dateString);
+        return request(requestId, reference, "v1/loans", HttpMethod.POST, body);
+    }
+
+    /** Applies for a loan for an already existing client, with a random loan external id. */
+    public static BatchRequest applyLoanWithClientId(final Long requestId, final Long clientId, final Long productId) {
+        return applyLoanWithClientIdAndExternalId(requestId, clientId, productId, UUID.randomUUID().toString());
+    }
+
+    public static BatchRequest applyLoanWithClientIdAndExternalId(final Long requestId, final Long clientId, final Long productId,
+            final String externalId) {
+        final String body = """
+                {"dateFormat": "%s", "locale": "%s", "clientId": %d, "productId": %d, "principal": "%s", \
+                "loanTermFrequency": 10, "loanTermFrequencyType": 2, "loanType": "individual", "numberOfRepayments": 10, \
+                "repaymentEvery": 1, "repaymentFrequencyType": 2, "interestRatePerPeriod": 10, "amortizationType": 1, \
+                "interestType": 0, "interestCalculationPeriodType": 1, "transactionProcessingStrategyCode": "%s", \
+                "expectedDisbursementDate": "10 Jun 2013", "submittedOnDate": "10 Jun 2013", "externalId": "%s"}""".formatted(DATE_FORMAT,
+                LOAN_APPLICATION_LOCALE, clientId, productId, DEFAULT_LOAN_AMOUNT, LoanProductTestBuilder.DEFAULT_STRATEGY, externalId);
+        return request(requestId, null, "v1/loans", HttpMethod.POST, body);
+    }
+
+    public static BatchRequest applySavings(final Long requestId, final Long reference, final Long productId) {
+        final String body = """
+                {"clientId": "$.clientId", "productId": %d, "locale": "%s", "dateFormat": "%s", \
+                "submittedOnDate": "01 March 2011"}""".formatted(productId, LOCALE, DATE_FORMAT);
+        return request(requestId, reference, "v1/savingsaccounts", HttpMethod.POST, body);
+    }
+
+    // Loan state transitions
+
+    public static BatchRequest approveLoan(final Long requestId, final Long reference) {
+        return approveLoan(requestId, reference, daysAgo(DEFAULT_SUBMITTED_DAYS_AGO));
+    }
+
+    public static BatchRequest approveLoan(final Long requestId, final Long reference, final LocalDate approvedOnDate) {
+        return request(requestId, reference, "v1/loans/$.loanId?command=approve", HttpMethod.POST, approveLoanBody(approvedOnDate));
+    }
+
+    /**
+     * Approve request pointing at a non-existent {@code approveX} command, used to assert the batch API answers 501 for
+     * an unknown command without aborting the rest of the batch.
+     */
+    public static BatchRequest approveLoanWithUnknownCommand(final Long requestId, final Long reference) {
+        final String dateString = format(daysAgo(DEFAULT_SUBMITTED_DAYS_AGO));
+        final String body = """
+                {"locale": "%s", "dateFormat": "%s", "approvedOnDate": "%s", "note": "Loan approval note"}""".formatted(LOCALE, DATE_FORMAT,
+                dateString);
+        return request(requestId, reference, "v1/loans/$.loanId?command=approveX", HttpMethod.POST, body);
+    }
+
+    public static BatchRequest disburseLoan(final Long requestId, final Long reference) {
+        return disburseLoan(requestId, reference, daysAgo(DEFAULT_DISBURSEMENT_DAYS_AGO));
+    }
+
+    public static BatchRequest disburseLoan(final Long requestId, final Long reference, final LocalDate disbursementDate) {
+        return request(requestId, reference, "v1/loans/$.loanId?command=disburse", HttpMethod.POST, disburseLoanBody(disbursementDate));
+    }
+
+    /** Approves or disburses the loan addressed by the external id resolved from the referenced response. */
+    public static BatchRequest transitionLoanStateByExternalId(final Long requestId, final Long reference, final LocalDate date,
+            final String command) {
+        final String body = switch (command) {
+            case "approve" -> approveLoanBody(date);
+            case "disburse" -> disburseLoanBody(date);
+            default -> throw new IllegalArgumentException("Unsupported loan state transition command: " + command);
+        };
+        return request(requestId, reference, "v1/loans/external-id/$.resourceExternalId?command=" + command, HttpMethod.POST, body);
+    }
+
+    private static String approveLoanBody(final LocalDate approvedOnDate) {
+        final String dateString = format(approvedOnDate);
+        return """
+                {"locale": "%s", "dateFormat": "%s", "approvedOnDate": "%s", "note": "Loan approval note", \
+                "expectedDisbursementDate": "%s"}""".formatted(LOCALE, DATE_FORMAT, dateString, dateString);
+    }
+
+    private static String disburseLoanBody(final LocalDate disbursementDate) {
+        return "{\"locale\": \"%s\", \"dateFormat\": \"%s\", \"actualDisbursementDate\": \"%s\"}".formatted(LOCALE, DATE_FORMAT,
+                format(disbursementDate));
+    }
+
+    public static BatchRequest markLoanAsFraud(final Long requestId, final Long reference) {
+        return request(requestId, reference, "v1/loans/$.loanId?command=markAsFraud", HttpMethod.PUT, "{\"fraud\": \"true\"}");
+    }
+
+    public static BatchRequest markLoanAsFraudByExternalId(final Long requestId, final Long reference) {
+        return request(requestId, reference, "v1/loans/external-id/$.resourceExternalId?command=markAsFraud", HttpMethod.PUT,
+                "{\"fraud\": \"true\"}");
+    }
+
+    // Loan transactions
+
+    public static BatchRequest repayLoan(final Long requestId, final Long reference, final String amount) {
+        return createTransaction(requestId, reference, "repayment", amount);
+    }
+
+    public static BatchRequest creditBalanceRefund(final Long requestId, final Long reference, final String amount) {
+        return createTransaction(requestId, reference, "creditBalanceRefund", amount);
+    }
+
+    public static BatchRequest goodwillCredit(final Long requestId, final Long reference, final String amount) {
+        return createTransaction(requestId, reference, "goodwillCredit", amount);
+    }
+
+    public static BatchRequest merchantIssuedRefund(final Long requestId, final Long reference, final String amount) {
+        return createTransaction(requestId, reference, "merchantIssuedRefund", amount);
+    }
+
+    public static BatchRequest payoutRefund(final Long requestId, final Long reference, final String amount) {
+        return createTransaction(requestId, reference, "payoutRefund", amount);
+    }
+
+    private static BatchRequest createTransaction(final Long requestId, final Long reference, final String transactionCommand,
+            final String amount) {
+        final String body = """
+                {"locale": "%s", "dateFormat": "%s", "transactionDate": "%s", "transactionAmount": %s, "note": null}""".formatted(LOCALE,
+                DATE_FORMAT, today(), amount);
+        return request(requestId, reference, "v1/loans/$.loanId/transactions?command=" + transactionCommand, HttpMethod.POST, body);
+    }
+
+    public static BatchRequest createTransactionByLoanExternalId(final Long requestId, final Long reference,
+            final String transactionCommand, final String amount, final LocalDate transactionDate) {
+        final String body = transactionBody(amount, transactionDate);
+        return request(requestId, reference, "v1/loans/external-id/$.externalId/transactions?command=" + transactionCommand,
+                HttpMethod.POST, body);
+    }
+
+    public static BatchRequest chargeOff(final Long requestId, final Long reference) {
+        final String body = "{\"locale\": \"%s\", \"dateFormat\": \"%s\", \"transactionDate\": \"%s\", \"note\": null}".formatted(LOCALE,
+                DATE_FORMAT, today());
+        return request(requestId, reference, "v1/loans/$.loanId/transactions?command=charge-off", HttpMethod.POST, body);
+    }
+
+    /** Adjusts (an amount of {@code 0} reverses) the transaction created by the referenced request. */
+    public static BatchRequest adjustTransaction(final Long requestId, final Long reference, final String amount,
+            final LocalDate transactionDate) {
+        return request(requestId, reference, "v1/loans/$.loanId/transactions/$.resourceId", HttpMethod.POST,
+                transactionBody(amount, transactionDate));
+    }
+
+    public static BatchRequest adjustTransactionByExternalId(final Long requestId, final Long reference, final String loanExternalId,
+            final String transactionExternalId, final String amount, final LocalDate transactionDate) {
+        final String relativeUrl = "v1/loans/external-id/%s/transactions/external-id/%s".formatted(loanExternalId, transactionExternalId);
+        return request(requestId, reference, relativeUrl, HttpMethod.POST, transactionBody(amount, transactionDate));
+    }
+
+    public static BatchRequest chargebackTransaction(final Long requestId, final Long reference, final String amount) {
+        final String body = "{\"locale\": \"%s\", \"transactionAmount\": %s, \"paymentTypeId\": 2}".formatted(LOCALE, amount);
+        return request(requestId, reference, "v1/loans/$.loanId/transactions/$.resourceId?command=chargeback", HttpMethod.POST, body);
+    }
+
+    private static String transactionBody(final String amount, final LocalDate transactionDate) {
+        return """
+                {"locale": "%s", "dateFormat": "%s", "transactionDate": "%s", "transactionAmount": %s}""".formatted(LOCALE, DATE_FORMAT,
+                format(transactionDate), amount);
+    }
+
+    /**
+     * Repayment addressed by an explicit loan id. {@code apiVersionPrefixed} selects between the current
+     * {@code v1/loans/...} relative URL and the legacy un-prefixed {@code loans/...} one, both of which the batch API
+     * must accept.
+     */
+    public static BatchRequest repayLoanByLoanId(final Long requestId, final Long loanId, final String amount,
+            final boolean apiVersionPrefixed) {
+        final String relativeUrl = (apiVersionPrefixed ? "v1/loans/" : "loans/") + loanId + "/transactions?command=repayment";
+        final String body = transactionBody(amount, LocalDate.now(Utils.getZoneIdOfTenant()));
+        return request(requestId, null, relativeUrl, HttpMethod.POST, body);
+    }
+
+    // Loan charges
+
+    public static BatchRequest createChargeByLoanId(final Long requestId, final Long reference, final Long chargeId) {
+        return request(requestId, reference, "v1/loans/$.loanId/charges", HttpMethod.POST, createChargeBody(chargeId));
+    }
+
+    public static BatchRequest createChargeByLoanExternalId(final Long requestId, final Long reference, final Long chargeId) {
+        return request(requestId, reference, "v1/loans/external-id/$.externalId/charges", HttpMethod.POST, createChargeBody(chargeId));
+    }
+
+    private static String createChargeBody(final Long chargeId) {
+        return """
+                {"chargeId": "%d", "locale": "%s", "amount": "100.0", "dateFormat": "%s", "dueDate": "%s"}""".formatted(chargeId, LOCALE,
+                DATE_FORMAT, today());
+    }
+
+    public static BatchRequest collectChargesByLoanId(final Long requestId, final Long reference) {
+        return request(requestId, reference, "v1/loans/$.loanId/charges", HttpMethod.GET, "{ }");
+    }
+
+    public static BatchRequest collectChargesByLoanExternalId(final Long requestId, final Long reference) {
+        return request(requestId, reference, "v1/loans/external-id/$.externalId/charges", HttpMethod.GET, "{ }");
+    }
+
+    public static BatchRequest getChargeByLoanIdChargeId(final Long requestId, final Long reference) {
+        return request(requestId, reference, "v1/loans/$.loanId/charges/$.resourceId", HttpMethod.GET, "{}");
+    }
+
+    public static BatchRequest getChargeByLoanExternalIdChargeExternalId(final Long requestId, final Long reference,
+            final String loanExternalId, final String chargeExternalId) {
+        final String relativeUrl = "v1/loans/external-id/%s/charges/external-id/%s".formatted(loanExternalId, chargeExternalId);
+        return request(requestId, reference, relativeUrl, HttpMethod.GET, "{}");
+    }
+
+    public static BatchRequest adjustCharge(final Long requestId, final Long reference) {
+        return request(requestId, reference, "v1/loans/$.loanId/charges/$.resourceId?command=adjustment", HttpMethod.POST,
+                adjustChargeBody());
+    }
+
+    public static BatchRequest adjustChargeByExternalId(final Long requestId, final Long reference, final String loanExternalId,
+            final String chargeExternalId) {
+        final String relativeUrl = "v1/loans/external-id/%s/charges/external-id/%s?command=adjustment".formatted(loanExternalId,
+                chargeExternalId);
+        return request(requestId, reference, relativeUrl, HttpMethod.POST, adjustChargeBody());
+    }
+
+    private static String adjustChargeBody() {
+        return "{\"amount\": 7.00, \"locale\": \"%s\"}".formatted(LOCALE);
+    }
+
+    // Loan reads
+
+    /** Reads the loan whose id is resolved from the referenced response. */
+    public static BatchRequest getLoanByReference(final Long requestId, final Long reference, final String queryParameter) {
+        return request(requestId, reference, withQueryParameter("v1/loans/$.loanId", queryParameter), HttpMethod.GET, "{}");
+    }
+
+    /** Reads the loan whose external id is resolved from the referenced response. */
+    public static BatchRequest getLoanByExternalIdReference(final Long requestId, final Long reference, final String queryParameter) {
+        return request(requestId, reference, withQueryParameter("v1/loans/external-id/$.resourceExternalId", queryParameter),
+                HttpMethod.GET, "{}");
+    }
+
+    /** Reads the loan addressed by an explicit loan id. */
+    public static BatchRequest getLoanByLoanId(final Long requestId, final Long reference, final Long loanId, final String queryParameter) {
+        return request(requestId, reference, withQueryParameter("v1/loans/" + loanId, queryParameter), HttpMethod.GET, "{}");
+    }
+
+    public static BatchRequest getTransactionById(final Long requestId, final Long reference, final boolean subResourceId) {
+        final String relativeUrl = "v1/loans/$.loanId/transactions/" + (subResourceId ? "$.subResourceId" : "$.resourceId");
+        return request(requestId, reference, relativeUrl, HttpMethod.GET, "{}");
+    }
+
+    public static BatchRequest getTransactionByExternalId(final Long requestId, final Long reference, final String loanExternalId,
+            final boolean subResourceExternalId) {
+        final String transactionExternalId = subResourceExternalId ? "$.subResourceExternalId" : "$.resourceExternalId";
+        final String relativeUrl = "v1/loans/external-id/%s/transactions/external-id/%s".formatted(loanExternalId, transactionExternalId);
+        return request(requestId, reference, relativeUrl, HttpMethod.GET, "{}");
+    }
+
+    // Loan rescheduling
+
+    public static BatchRequest createRescheduleLoan(final Long requestId, final Long reference, final LocalDate rescheduleFromDate,
+            final Long rescheduleReasonId, final LocalDate adjustedDueDate) {
+        final String body = """
+                {"locale": "%s", "dateFormat": "%s", "submittedOnDate": "%s", "rescheduleFromDate": "%s", \
+                "rescheduleReasonId": %d, "adjustedDueDate": "%s", "loanId": "$.loanId"}""".formatted(LOCALE, DATE_FORMAT, today(),
+                format(rescheduleFromDate), rescheduleReasonId, format(adjustedDueDate));
+        return request(requestId, reference, "v1/rescheduleloans", HttpMethod.POST, body);
+    }
+
+    public static BatchRequest approveRescheduleLoan(final Long requestId, final Long reference) {
+        final String body = "{\"locale\": \"%s\", \"dateFormat\": \"%s\", \"approvedOnDate\": \"%s\"}".formatted(LOCALE, DATE_FORMAT,
+                today());
+        return request(requestId, reference, "v1/rescheduleloans/$.resourceId?command=approve", HttpMethod.POST, body);
+    }
+
+    // Datatables
+
+    public static BatchRequest createDatatableEntry(final Long requestId, final String datatableName, final Long entityId,
+            final List<String> columnNames) {
+        final String relativeUrl = "v1/datatables/%s/%d".formatted(datatableName, entityId);
+        return request(requestId, null, relativeUrl, HttpMethod.POST, randomColumnValuesJson(columnNames));
+    }
+
+    public static BatchRequest updateDatatableEntryByEntryId(final Long requestId, final Long reference, final String datatableName,
+            final Long entityId, final Long datatableEntryId, final List<String> columnNames) {
+        final String relativeUrl = "v1/datatables/%s/%d/%d".formatted(datatableName, entityId, datatableEntryId);
+        return request(requestId, reference, relativeUrl, HttpMethod.PUT, randomColumnValuesJson(columnNames));
+    }
+
+    public static BatchRequest getDatatableEntries(final Long requestId, final Long reference, final String datatableName,
+            final Long entityId, final String queryParameter) {
+        final String relativeUrl = withQueryParameter("v1/datatables/%s/%d".formatted(datatableName, entityId), queryParameter);
+        return request(requestId, reference, relativeUrl, HttpMethod.GET, "{}");
+    }
+
+    public static BatchRequest getDatatableEntryByAppTableId(final Long requestId, final Long reference, final String datatableName,
+            final Long entityId, final String appTableId, final String queryParameter) {
+        final String relativeUrl = withQueryParameter("v1/datatables/%s/%d/%s".formatted(datatableName, entityId, appTableId),
+                queryParameter);
+        return request(requestId, reference, relativeUrl, HttpMethod.GET, "{}");
+    }
+
+    public static BatchRequest queryDatatableEntries(final Long requestId, final String datatableName, final String columnName,
+            final String columnValue, final String resultColumns) {
+        final String relativeUrl = "v1/datatables/%s/query?columnFilter=%s&valueFilter=%s&resultColumns=%s".formatted(datatableName,
+                columnName, columnValue, resultColumns);
+        return request(requestId, null, relativeUrl, HttpMethod.GET, "{}");
+    }
+
+    public static BatchRequest updateDatatableEntry(final Long requestId, final Long reference, final String datatableName,
+            final String resourceId, final String columnName, final String columnValue) {
+        final String relativeUrl = "v1/datatables/%s/%s".formatted(datatableName, resourceId);
+        return request(requestId, reference, relativeUrl, HttpMethod.PUT, GSON.toJson(Map.of(columnName, columnValue)));
+    }
+
+    public static BatchRequest updateDatatableEntry(final Long requestId, final Long reference, final String datatableName,
+            final String resourceId, final String subResourceId, final String columnName, final String columnValue) {
+        final String relativeUrl = "v1/datatables/%s/%s/%s".formatted(datatableName, resourceId, subResourceId);
+        return request(requestId, reference, relativeUrl, HttpMethod.PUT, GSON.toJson(Map.of(columnName, columnValue)));
+    }
+
+    private static String randomColumnValuesJson(final List<String> columnNames) {
+        return GSON.toJson(columnNames.stream().collect(Collectors.toMap(name -> name, name -> Utils.randomStringGenerator("VAL_", 3))));
+    }
+
+    // Savings accounts
+
+    public static BatchRequest getSavingsAccount(final Long requestId, final Long reference, final Long savingsId,
+            final String queryParameter) {
+        final String relativeUrl = withQueryParameter("v1/savingsaccounts/" + savingsId, queryParameter);
+        return request(requestId, reference, relativeUrl, HttpMethod.GET, "{}");
+    }
+
+    public static BatchRequest depositSavingsAccount(final Long requestId, final Long reference, final float amount) {
+        return savingsTransaction(requestId, reference, "deposit", savingsTransactionBody(amount));
+    }
+
+    public static BatchRequest withdrawSavingsAccount(final Long requestId, final Long reference, final float amount) {
+        return savingsTransaction(requestId, reference, "withdrawal", savingsTransactionBody(amount));
+    }
+
+    public static BatchRequest holdAmountOnSavingsAccount(final Long requestId, final Long reference, final float amount) {
+        final String body = """
+                {"locale": "%s", "dateFormat": "%s", "transactionDate": "%s", "transactionAmount": "%s", \
+                "reasonForBlock": "test"}""".formatted(LOCALE, DATE_FORMAT, today(), amount);
+        return savingsTransaction(requestId, reference, "holdAmount", body);
+    }
+
+    public static BatchRequest releaseAmountOnSavingsAccount(final Long requestId, final Long reference, final Long transactionId) {
+        final String relativeUrl = "v1/savingsaccounts/$.id/transactions/%d?command=releaseAmount".formatted(transactionId);
+        return request(requestId, reference, relativeUrl, HttpMethod.POST, "{\"isBulk\": \"false\"}");
+    }
+
+    private static BatchRequest savingsTransaction(final Long requestId, final Long reference, final String command, final String body) {
+        return request(requestId, reference, "v1/savingsaccounts/$.id/transactions?command=" + command, HttpMethod.POST, body);
+    }
+
+    private static String savingsTransactionBody(final float amount) {
+        return """
+                {"locale": "%s", "dateFormat": "%s", "transactionDate": "%s", "transactionAmount": "%s", \
+                "paymentTypeId": "1"}""".formatted(LOCALE, DATE_FORMAT, today(), amount);
+    }
+
+    private static String withQueryParameter(final String relativeUrl, final String queryParameter) {
+        return queryParameter == null ? relativeUrl : relativeUrl + "?" + queryParameter;
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/modules/ChargeRequestBuilders.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/modules/ChargeRequestBuilders.java
@@ -31,9 +31,11 @@ public final class ChargeRequestBuilders {
     private static final int CHARGE_TIME_TYPE_INSTALLMENT_FEE = 8;
     private static final int CHARGE_TIME_TYPE_OVERDUE_INSTALLMENT_FEE = 9;
 
+    // Mirrors org.apache.fineract.portfolio.charge.domain.ChargeCalculationType
     private static final int CHARGE_CALCULATION_TYPE_FLAT = 1;
     private static final int CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT = 2;
-    private static final int CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT_AND_INTEREST = 4;
+    private static final int CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT_AND_INTEREST = 3;
+    private static final int CHARGE_CALCULATION_TYPE_PERCENTAGE_INTEREST = 4;
 
     private static final int CHARGE_PAYMENT_MODE_REGULAR = 0;
     private static final int CHARGE_PAYMENT_MODE_ACCOUNT_TRANSFER = 1;
@@ -81,10 +83,10 @@ public final class ChargeRequestBuilders {
                 .penalty(true);
     }
 
-    public static ChargeRequest loanSpecifiedDueDatePercentageAmountAndInterestFee(double amount) {
-        return baseLoanCharge(amount, DEFAULT_CURRENCY)//
+    public static ChargeRequest loanSpecifiedDueDatePercentageOfInterestFee(double percentage) {
+        return baseLoanCharge(percentage, DEFAULT_CURRENCY)//
                 .chargeTimeType(CHARGE_TIME_TYPE_SPECIFIED_DUE_DATE)//
-                .chargeCalculationType(CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT_AND_INTEREST);
+                .chargeCalculationType(CHARGE_CALCULATION_TYPE_PERCENTAGE_INTEREST);
     }
 
     public static ChargeRequest loanSpecifiedDueDateAccountTransferFee(double amount, boolean penalty) {
@@ -94,6 +96,10 @@ public final class ChargeRequestBuilders {
     public static ChargeRequest loanInstallmentFee(double amount) {
         return baseLoanCharge(amount, DEFAULT_CURRENCY)//
                 .chargeTimeType(CHARGE_TIME_TYPE_INSTALLMENT_FEE);
+    }
+
+    public static ChargeRequest loanOverdueFeePercentageOfAmountAndInterest(double percentage) {
+        return loanOverdueFee(percentage).chargeCalculationType(CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT_AND_INTEREST);
     }
 
     public static ChargeRequest loanOverdueFee(double amount) {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/modules/ChargeRequestBuilders.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/modules/ChargeRequestBuilders.java
@@ -20,25 +20,12 @@ package org.apache.fineract.integrationtests.client.feign.modules;
 
 import org.apache.fineract.client.models.ChargeRequest;
 import org.apache.fineract.integrationtests.common.Utils;
+import org.apache.fineract.portfolio.charge.domain.ChargeAppliesTo;
+import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
+import org.apache.fineract.portfolio.charge.domain.ChargePaymentMode;
+import org.apache.fineract.portfolio.charge.domain.ChargeTimeType;
 
 public final class ChargeRequestBuilders {
-
-    private static final int CHARGE_APPLIES_TO_LOAN = 1;
-    private static final int CHARGE_APPLIES_TO_CLIENT = 3;
-
-    private static final int CHARGE_TIME_TYPE_DISBURSEMENT = 1;
-    private static final int CHARGE_TIME_TYPE_SPECIFIED_DUE_DATE = 2;
-    private static final int CHARGE_TIME_TYPE_INSTALLMENT_FEE = 8;
-    private static final int CHARGE_TIME_TYPE_OVERDUE_INSTALLMENT_FEE = 9;
-
-    // Mirrors org.apache.fineract.portfolio.charge.domain.ChargeCalculationType
-    private static final int CHARGE_CALCULATION_TYPE_FLAT = 1;
-    private static final int CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT = 2;
-    private static final int CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT_AND_INTEREST = 3;
-    private static final int CHARGE_CALCULATION_TYPE_PERCENTAGE_INTEREST = 4;
-
-    private static final int CHARGE_PAYMENT_MODE_REGULAR = 0;
-    private static final int CHARGE_PAYMENT_MODE_ACCOUNT_TRANSFER = 1;
 
     private static final String DEFAULT_CURRENCY = "USD";
     private static final String DEFAULT_LOCALE = "en";
@@ -51,7 +38,7 @@ public final class ChargeRequestBuilders {
 
     public static ChargeRequest loanDisbursementFee(double amount, String currencyCode) {
         return baseLoanCharge(amount, currencyCode)//
-                .chargeTimeType(CHARGE_TIME_TYPE_DISBURSEMENT);
+                .chargeTimeType(ChargeTimeType.DISBURSEMENT.getValue());
     }
 
     public static ChargeRequest loanDisbursementPercentageFee(double percentage) {
@@ -60,8 +47,8 @@ public final class ChargeRequestBuilders {
 
     public static ChargeRequest loanDisbursementPercentageFee(double percentage, String currencyCode) {
         return baseLoanCharge(percentage, currencyCode)//
-                .chargeTimeType(CHARGE_TIME_TYPE_DISBURSEMENT)//
-                .chargeCalculationType(CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT);
+                .chargeTimeType(ChargeTimeType.DISBURSEMENT.getValue())//
+                .chargeCalculationType(ChargeCalculationType.PERCENT_OF_AMOUNT.getValue());
     }
 
     public static ChargeRequest loanSpecifiedDueDateFee(double amount) {
@@ -70,7 +57,7 @@ public final class ChargeRequestBuilders {
 
     public static ChargeRequest loanSpecifiedDueDateFee(double amount, String currencyCode) {
         return baseLoanCharge(amount, currencyCode)//
-                .chargeTimeType(CHARGE_TIME_TYPE_SPECIFIED_DUE_DATE);
+                .chargeTimeType(ChargeTimeType.SPECIFIED_DUE_DATE.getValue());
     }
 
     public static ChargeRequest loanSpecifiedDueDatePenalty(double amount) {
@@ -79,42 +66,79 @@ public final class ChargeRequestBuilders {
 
     public static ChargeRequest loanSpecifiedDueDatePenalty(double amount, String currencyCode) {
         return baseLoanCharge(amount, currencyCode)//
-                .chargeTimeType(CHARGE_TIME_TYPE_SPECIFIED_DUE_DATE)//
+                .chargeTimeType(ChargeTimeType.SPECIFIED_DUE_DATE.getValue())//
                 .penalty(true);
     }
 
     public static ChargeRequest loanSpecifiedDueDatePercentageOfInterestFee(double percentage) {
         return baseLoanCharge(percentage, DEFAULT_CURRENCY)//
-                .chargeTimeType(CHARGE_TIME_TYPE_SPECIFIED_DUE_DATE)//
-                .chargeCalculationType(CHARGE_CALCULATION_TYPE_PERCENTAGE_INTEREST);
+                .chargeTimeType(ChargeTimeType.SPECIFIED_DUE_DATE.getValue())//
+                .chargeCalculationType(ChargeCalculationType.PERCENT_OF_INTEREST.getValue());
     }
 
     public static ChargeRequest loanSpecifiedDueDateAccountTransferFee(double amount, boolean penalty) {
-        return loanSpecifiedDueDateFee(amount).chargePaymentMode(CHARGE_PAYMENT_MODE_ACCOUNT_TRANSFER).penalty(penalty);
+        return loanSpecifiedDueDateAccountTransferCharge(ChargeCalculationType.FLAT, amount, penalty);
     }
 
     public static ChargeRequest loanInstallmentFee(double amount) {
         return baseLoanCharge(amount, DEFAULT_CURRENCY)//
-                .chargeTimeType(CHARGE_TIME_TYPE_INSTALLMENT_FEE);
+                .chargeTimeType(ChargeTimeType.INSTALMENT_FEE.getValue());
     }
 
     public static ChargeRequest loanOverdueFeePercentageOfAmountAndInterest(double percentage) {
-        return loanOverdueFee(percentage).chargeCalculationType(CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT_AND_INTEREST);
+        return loanOverdueFee(percentage).chargeCalculationType(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST.getValue());
     }
 
     public static ChargeRequest loanOverdueFee(double amount) {
         return baseLoanCharge(amount, DEFAULT_CURRENCY)//
-                .chargeTimeType(CHARGE_TIME_TYPE_OVERDUE_INSTALLMENT_FEE)//
+                .chargeTimeType(ChargeTimeType.OVERDUE_INSTALLMENT.getValue())//
                 .penalty(true);
+    }
+
+    /** A disbursement-time loan charge with an explicit calculation type. */
+    public static ChargeRequest loanDisbursementCharge(ChargeCalculationType chargeCalculationType, double amount) {
+        return baseLoanCharge(amount, DEFAULT_CURRENCY)//
+                .chargeTimeType(ChargeTimeType.DISBURSEMENT.getValue())//
+                .chargeCalculationType(chargeCalculationType.getValue());
+    }
+
+    /** A specified-due-date loan charge with an explicit calculation type. */
+    public static ChargeRequest loanSpecifiedDueDateCharge(ChargeCalculationType chargeCalculationType, double amount, boolean penalty) {
+        return baseLoanCharge(amount, DEFAULT_CURRENCY)//
+                .chargeTimeType(ChargeTimeType.SPECIFIED_DUE_DATE.getValue())//
+                .chargeCalculationType(chargeCalculationType.getValue())//
+                .penalty(penalty);
+    }
+
+    /** An installment-fee loan charge with an explicit calculation type. */
+    public static ChargeRequest loanInstallmentCharge(ChargeCalculationType chargeCalculationType, double amount, boolean penalty) {
+        return baseLoanCharge(amount, DEFAULT_CURRENCY)//
+                .chargeTimeType(ChargeTimeType.INSTALMENT_FEE.getValue())//
+                .chargeCalculationType(chargeCalculationType.getValue())//
+                .penalty(penalty);
+    }
+
+    /** Same as {@link #loanSpecifiedDueDateCharge}, but paid by transfer from a linked savings account. */
+    public static ChargeRequest loanSpecifiedDueDateAccountTransferCharge(ChargeCalculationType chargeCalculationType, double amount,
+            boolean penalty) {
+        return loanSpecifiedDueDateCharge(chargeCalculationType, amount, penalty)//
+                .chargePaymentMode(ChargePaymentMode.ACCOUNT_TRANSFER.getValue());
+    }
+
+    /** Same as {@link #loanInstallmentCharge}, but paid by transfer from a linked savings account. */
+    public static ChargeRequest loanInstallmentAccountTransferCharge(ChargeCalculationType chargeCalculationType, double amount,
+            boolean penalty) {
+        return loanInstallmentCharge(chargeCalculationType, amount, penalty)//
+                .chargePaymentMode(ChargePaymentMode.ACCOUNT_TRANSFER.getValue());
     }
 
     public static ChargeRequest clientSpecifiedDueDateFee(double amount) {
         return new ChargeRequest()//
                 .name(Utils.uniqueRandomStringGenerator("Charge_Client_", 6))//
-                .chargeAppliesTo(CHARGE_APPLIES_TO_CLIENT)//
-                .chargeTimeType(CHARGE_TIME_TYPE_SPECIFIED_DUE_DATE)//
-                .chargeCalculationType(CHARGE_CALCULATION_TYPE_FLAT)//
-                .chargePaymentMode(CHARGE_PAYMENT_MODE_REGULAR)//
+                .chargeAppliesTo(ChargeAppliesTo.CLIENT.getValue())//
+                .chargeTimeType(ChargeTimeType.SPECIFIED_DUE_DATE.getValue())//
+                .chargeCalculationType(ChargeCalculationType.FLAT.getValue())//
+                .chargePaymentMode(ChargePaymentMode.REGULAR.getValue())//
                 .currencyCode(DEFAULT_CURRENCY)//
                 .amount(amount)//
                 .active(true)//
@@ -124,9 +148,9 @@ public final class ChargeRequestBuilders {
     private static ChargeRequest baseLoanCharge(double amount, String currencyCode) {
         return new ChargeRequest()//
                 .name(Utils.uniqueRandomStringGenerator("Charge_Loan_", 6))//
-                .chargeAppliesTo(CHARGE_APPLIES_TO_LOAN)//
-                .chargeCalculationType(CHARGE_CALCULATION_TYPE_FLAT)//
-                .chargePaymentMode(CHARGE_PAYMENT_MODE_REGULAR)//
+                .chargeAppliesTo(ChargeAppliesTo.LOAN.getValue())//
+                .chargeCalculationType(ChargeCalculationType.FLAT.getValue())//
+                .chargePaymentMode(ChargePaymentMode.REGULAR.getValue())//
                 .currencyCode(currencyCode)//
                 .amount(amount)//
                 .active(true)//

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/modules/ClientRequestBuilders.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/modules/ClientRequestBuilders.java
@@ -40,6 +40,18 @@ public final class ClientRequestBuilders {
                 .locale(LoanTestData.LOCALE);
     }
 
+    public static PostClientsRequest createActivePersonClient(String activationDate) {
+        return new PostClientsRequest()//
+                .officeId(1L)//
+                .legalFormId(1L)//
+                .firstname(Utils.randomFirstNameGenerator())//
+                .lastname(Utils.randomLastNameGenerator())//
+                .active(true)//
+                .activationDate(activationDate)//
+                .dateFormat(LoanTestData.DATETIME_PATTERN)//
+                .locale(LoanTestData.LOCALE);
+    }
+
     public static PostClientsClientIdRequest activateClient(String activationDate) {
         return new PostClientsClientIdRequest()//
                 .locale(LoanTestData.LOCALE)//

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/modules/LoanProductTemplates.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/modules/LoanProductTemplates.java
@@ -506,6 +506,25 @@ public interface LoanProductTemplates {
                 .loanScheduleProcessingType("HORIZONTAL");
     }
 
+    default PostLoanProductsRequest create4ICumulative() {
+        return create4IProgressive()//
+                .transactionProcessingStrategyCode(
+                        LoanProductTestBuilder.DUE_PENALTY_FEE_INTEREST_PRINCIPAL_IN_ADVANCE_PRINCIPAL_PENALTY_FEE_INTEREST_STRATEGY)//
+                .paymentAllocation(null)//
+                .rescheduleStrategyMethod(RescheduleStrategyMethod.RESCHEDULE_NEXT_REPAYMENTS)//
+                .allowAttributeOverrides(new AllowAttributeOverrides()//
+                        .amortizationType(true)//
+                        .interestType(true)//
+                        .transactionProcessingStrategyCode(true)//
+                        .interestCalculationPeriodType(true)//
+                        .inArrearsTolerance(true)//
+                        .repaymentEvery(true)//
+                        .graceOnPrincipalAndInterestPayment(true)//
+                        .graceOnArrearsAgeing(true))//
+                .loanScheduleType(LoanScheduleType.CUMULATIVE.toString())//
+                .loanScheduleProcessingType(null);
+    }
+
     default PostLoanProductsRequest create4IProgressiveWithCapitalizedIncome() {
         return create4IProgressive().enableIncomeCapitalization(true)//
                 .capitalizedIncomeCalculationType(PostLoanProductsRequest.CapitalizedIncomeCalculationTypeEnum.FLAT)//

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/modules/LoanRequestBuilders.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/modules/LoanRequestBuilders.java
@@ -44,6 +44,7 @@ import org.apache.fineract.client.models.PostLoansLoanIdRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsRequest;
 import org.apache.fineract.client.models.PostLoansRequest;
 import org.apache.fineract.client.models.PostUpdateRescheduleLoansRequest;
+import org.apache.fineract.portfolio.loanproduct.domain.PaymentAllocationType;
 
 public final class LoanRequestBuilders {
 
@@ -430,6 +431,11 @@ public final class LoanRequestBuilders {
         AtomicInteger order = new AtomicInteger(1);
         return Stream.of(paymentAllocationRules)
                 .map(rule -> new PaymentAllocationOrder().paymentAllocationRule(rule).order(order.getAndIncrement())).toList();
+    }
+
+    /** Type-safe variant of {@link #paymentAllocationOrder(String...)}, ordered as given. */
+    public static List<PaymentAllocationOrder> paymentAllocationOrder(PaymentAllocationType... paymentAllocationTypes) {
+        return paymentAllocationOrder(Stream.of(paymentAllocationTypes).map(PaymentAllocationType::name).toArray(String[]::new));
     }
 
     public static CreditAllocationData creditAllocation(String transactionType, String... creditAllocationRules) {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/modules/LoanTestData.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/modules/LoanTestData.java
@@ -129,6 +129,9 @@ public final class LoanTestData {
     public static final class InterestRecalculationCompoundingMethod {
 
         public static final Integer NONE = 0;
+        public static final Integer INTEREST = 1;
+        public static final Integer FEE = 2;
+        public static final Integer INTEREST_AND_FEE = 3;
 
         private InterestRecalculationCompoundingMethod() {}
     }
@@ -141,6 +144,10 @@ public final class LoanTestData {
         public static final Integer DAYS = 0;
         public static final Long DAYS_L = 0L;
         public static final String DAYS_STRING = "DAYS";
+        public static final Integer WEEKS = 1;
+        public static final Long WEEKS_L = 1L;
+        public static final String WEEKS_STRING = "WEEKS";
+        public static final Integer YEARS = 3;
 
         private RepaymentFrequencyType() {}
     }
@@ -149,8 +156,29 @@ public final class LoanTestData {
 
         public static final Integer SAME_AS_REPAYMENT_PERIOD = 1;
         public static final Integer DAILY = 2;
+        public static final Integer WEEKLY = 3;
+        public static final Integer MONTHLY = 4;
 
         private RecalculationRestFrequencyType() {}
+    }
+
+    /** Shares the numeric domain of {@link RecalculationRestFrequencyType}, but names the compounding side. */
+    public static final class RecalculationCompoundingFrequencyType {
+
+        public static final Integer SAME_AS_REPAYMENT_PERIOD = 1;
+        public static final Integer DAILY = 2;
+        public static final Integer WEEKLY = 3;
+        public static final Integer MONTHLY = 4;
+
+        private RecalculationCompoundingFrequencyType() {}
+    }
+
+    public static final class PreClosureInterestCalculationStrategy {
+
+        public static final Integer TILL_PRE_CLOSE_DATE = 1;
+        public static final Integer TILL_REST_FREQUENCY_DATE = 2;
+
+        private PreClosureInterestCalculationStrategy() {}
     }
 
     public static final class InterestCalculationPeriodType {
@@ -180,6 +208,7 @@ public final class LoanTestData {
     public static final class RescheduleStrategyMethod {
 
         public static final Integer RESCHEDULE_NEXT_REPAYMENTS = 1;
+        public static final Integer REDUCE_NUMBER_OF_INSTALLMENTS = 2;
         public static final Integer REDUCE_EMI_AMOUNT = 3;
         public static final Integer ADJUST_LAST_UNPAID_PERIOD = 4;
 

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/modules/LoanTestValidators.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/modules/LoanTestValidators.java
@@ -87,6 +87,7 @@ public final class LoanTestValidators {
                 return;
             }
 
+            // The API omits manuallyReversed for non-reversed transactions, so null and false are the same state.
             boolean found = transactionsByDate.stream()
                     .anyMatch(item -> Objects.equals(Utils.getDoubleValue(item.getAmount()), tr.amount)
                             && Objects.equals(item.getType().getValue(), tr.type)
@@ -97,7 +98,7 @@ public final class LoanTestValidators {
                             && Objects.equals(Utils.getDoubleValue(item.getPenaltyChargesPortion()), tr.penaltyPortion)
                             && Objects.equals(Utils.getDoubleValue(item.getOverpaymentPortion()), tr.overpaymentPortion)
                             && Objects.equals(Utils.getDoubleValue(item.getUnrecognizedIncomePortion()), tr.unrecognizedPortion)
-                            && (tr.reversed == null || Objects.equals(item.getManuallyReversed(), tr.reversed)));
+                            && Boolean.TRUE.equals(item.getManuallyReversed()) == Boolean.TRUE.equals(tr.reversed));
 
             if (!found) {
                 StringBuilder errorMessage = new StringBuilder();

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/cob/CobPartitioningTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/cob/CobPartitioningTest.java
@@ -18,19 +18,12 @@
  */
 package org.apache.fineract.integrationtests.cob;
 
-import static org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType.BUSINESS_DATE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.path.json.JsonPath;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -38,104 +31,74 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.fineract.accounting.common.AccountingConstants;
 import org.apache.fineract.client.models.COBPartition;
-import org.apache.fineract.client.models.GetFinancialActivityAccountsResponse;
-import org.apache.fineract.client.models.PostFinancialActivityAccountsRequest;
+import org.apache.fineract.client.models.ChargeRequest;
+import org.apache.fineract.client.models.LoanProductChargeData;
+import org.apache.fineract.client.models.PostLoanProductsRequest;
+import org.apache.fineract.client.models.PostLoansRequest;
 import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
+import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
-import org.apache.fineract.integrationtests.BaseLoanIntegrationTest;
-import org.apache.fineract.integrationtests.common.BusinessDateHelper;
-import org.apache.fineract.integrationtests.common.BusinessStepHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.CollateralManagementHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignBusinessStepHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignCobHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignExternalAssetOwnerHelper;
+import org.apache.fineract.integrationtests.client.feign.modules.ChargeRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.common.accounting.Account;
-import org.apache.fineract.integrationtests.common.accounting.AccountHelper;
-import org.apache.fineract.integrationtests.common.accounting.FinancialActivityAccountHelper;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
-import org.apache.fineract.integrationtests.common.loans.CobHelper;
-import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanStatusChecker;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.junit.jupiter.api.Assertions;
+import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanStatus;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.springframework.lang.NonNull;
 
-@SuppressWarnings("rawtypes")
 @Slf4j
-public class CobPartitioningTest extends BaseLoanIntegrationTest {
+public class CobPartitioningTest extends FeignLoanTestBase {
 
     public static final int N = 10;
-    private static ResponseSpecification RESPONSE_SPEC;
-    private static RequestSpecification REQUEST_SPEC;
-    private static Account ASSET_ACCOUNT;
-    private static Account FEE_PENALTY_ACCOUNT;
-    private static Account TRANSFER_ACCOUNT;
-    private static Account EXPENSE_ACCOUNT;
-    private static Account INCOME_ACCOUNT;
-    private static Account OVERPAYMENT_ACCOUNT;
-    private static FinancialActivityAccountHelper FINANCIAL_ACTIVITY_ACCOUNT_HELPER;
-    private static LoanTransactionHelper LOAN_TRANSACTION_HELPER;
-    private static LocalDate TODAYS_DATE;
+    private static final String CUMULATIVE_STRATEGY = "mifos-standard-strategy";
+    private static LocalDate todaysDate;
+
+    private final FeignExternalAssetOwnerHelper externalAssetOwnerHelper = new FeignExternalAssetOwnerHelper(
+            FineractFeignClientHelper.getFineractFeignClient());
 
     @BeforeAll
-    public static void setupInvestorBusinessStep() {
-        Utils.initializeRESTAssured();
-        REQUEST_SPEC = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        REQUEST_SPEC.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        RESPONSE_SPEC = new ResponseSpecBuilder().expectStatusCode(200).build();
-        AccountHelper accountHelper = new AccountHelper(REQUEST_SPEC, RESPONSE_SPEC);
-        FINANCIAL_ACTIVITY_ACCOUNT_HELPER = new FinancialActivityAccountHelper(REQUEST_SPEC);
-        LOAN_TRANSACTION_HELPER = new LoanTransactionHelper(REQUEST_SPEC, RESPONSE_SPEC);
-
-        TODAYS_DATE = Utils.getLocalDateOfTenant();
-        new BusinessStepHelper().updateSteps("LOAN_CLOSE_OF_BUSINESS", "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION",
-                "CHECK_LOAN_REPAYMENT_DUE", "CHECK_LOAN_REPAYMENT_OVERDUE", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
+    public static void setupBusinessStep() {
+        todaysDate = Utils.getLocalDateOfTenant();
+        new FeignBusinessStepHelper(FineractFeignClientHelper.getFineractFeignClient()).updateSteps("LOAN_CLOSE_OF_BUSINESS",
+                "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION", "CHECK_LOAN_REPAYMENT_DUE",
+                "CHECK_LOAN_REPAYMENT_OVERDUE", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
                 "EXTERNAL_ASSET_OWNER_TRANSFER");
-
-        ASSET_ACCOUNT = accountHelper.createAssetAccount();
-        FEE_PENALTY_ACCOUNT = accountHelper.createAssetAccount();
-        TRANSFER_ACCOUNT = accountHelper.createAssetAccount();
-        EXPENSE_ACCOUNT = accountHelper.createExpenseAccount();
-        INCOME_ACCOUNT = accountHelper.createIncomeAccount();
-        OVERPAYMENT_ACCOUNT = accountHelper.createLiabilityAccount();
-
-        setProperFinancialActivity(TRANSFER_ACCOUNT);
-    }
-
-    private static void setProperFinancialActivity(Account transferAccount) {
-        List<GetFinancialActivityAccountsResponse> financialMappings = FINANCIAL_ACTIVITY_ACCOUNT_HELPER.getAllFinancialActivityAccounts();
-        financialMappings.forEach(mapping -> FINANCIAL_ACTIVITY_ACCOUNT_HELPER.deleteFinancialActivityAccount(mapping.getId()));
-        FINANCIAL_ACTIVITY_ACCOUNT_HELPER.createFinancialActivityAccount(new PostFinancialActivityAccountsRequest()
-                .financialActivityId((long) AccountingConstants.FinancialActivity.ASSET_TRANSFER.getValue())
-                .glAccountId((long) transferAccount.getAccountID()));
     }
 
     @Test
     public void testLoanCOBPartitioningQuery() throws InterruptedException {
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
         try {
-            ExecutorService executorService = Executors.newFixedThreadPool(10);
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2020-03-02");
+            // The EXTERNAL_ASSET_OWNER_TRANSFER COB step registered above needs an ASSET_TRANSFER -> GL mapping to run.
+            // Created here rather than in @BeforeAll because accountHelper is not initialised at static-init time.
+            Account transferAccount = accountHelper.createAssetAccount(Utils.uniqueRandomStringGenerator("TRANSFER_", 5));
+            externalAssetOwnerHelper.setProperFinancialActivity(transferAccount);
+            setInitialBusinessDate("02 March 2020");
 
-            List<Integer> loanIds = new CopyOnWriteArrayList<>();
+            List<Long> loanIds = new CopyOnWriteArrayList<>();
 
             // Let's create 1, 2, ..., N-1, N loans
             final CountDownLatch createLatch = new CountDownLatch(N - 1);
-            Integer loanProductID = createLoanProduct();
+            Long loanProductId = createLoanProduct();
             List<Future<?>> futures = new ArrayList<>();
             // Warm up (EclipseLink sometimes fails if JPQL cache is not warm up but concurrent queries are executed)
-            Integer clientID = createClient();
-            Integer loanID = createLoanForClient(clientID, loanProductID);
-            loanIds.add(loanID);
+            Long clientId = createClient();
+            Long loanId = createLoanForClient(clientId, loanProductId);
+            loanIds.add(loanId);
             for (int i = 1; i < N; i++) {
                 futures.add(executorService.submit(() -> {
-                    Integer internalClientID = createClient();
-                    Integer internalLoanID = createLoanForClient(internalClientID, loanProductID);
-                    loanIds.add(internalLoanID);
+                    Long internalClientId = createClient();
+                    Long internalLoanId = createLoanForClient(internalClientId, loanProductId);
+                    loanIds.add(internalLoanId);
                     createLatch.countDown();
                 }));
             }
@@ -146,41 +109,33 @@ public class CobPartitioningTest extends BaseLoanIntegrationTest {
             Collections.sort(loanIds);
             final CountDownLatch closeLatch = new CountDownLatch(N - 5);
             // Warm up (EclipseLink sometimes fails if JPQL cache is not warm up but concurrent queries are executed)
-            LOAN_TRANSACTION_HELPER.forecloseLoan("02 March 2020", loanIds.get(2));
+            forecloseLoan(loanIds.get(2), LoanRequestBuilders.forecloseLoan("02 March 2020"));
             for (int i = 3; i < N - 2; i++) {
                 final int idx = i;
                 futures.add(executorService.submit(() -> {
-                    LOAN_TRANSACTION_HELPER.forecloseLoan("02 March 2020", loanIds.get(idx));
+                    forecloseLoan(loanIds.get(idx), LoanRequestBuilders.forecloseLoan("02 March 2020"));
                     closeLatch.countDown();
                 }));
             }
-            futures.forEach(future -> {
-                try {
-                    future.get(); // turn any possible async failures into errors
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
-            });
-            closeLatch.await();
+            waitForFutures(futures, closeLatch);
 
             // Let's retrieve the partitions
-            List<COBPartition> cobPartitions = CobHelper.getCobPartitions(3);
+            List<COBPartition> cobPartitions = new FeignCobHelper(FineractFeignClientHelper.getFineractFeignClient()).getCobPartitions(3);
             log.info("\nLoans created: {},\nRetrieved partitions: {}", loanIds, cobPartitions);
-            Assertions.assertEquals(2, cobPartitions.size());
+            assertEquals(2, cobPartitions.size());
 
-            Assertions.assertEquals(loanIds.get(0), cobPartitions.get(0).getMinId().intValue());
-            Assertions.assertEquals(loanIds.get(8), cobPartitions.get(0).getMaxId().intValue());
+            assertEquals(loanIds.get(0), cobPartitions.get(0).getMinId());
+            assertEquals(loanIds.get(8), cobPartitions.get(0).getMaxId());
 
-            Assertions.assertEquals(loanIds.get(9), cobPartitions.get(1).getMinId().intValue());
-            Assertions.assertEquals(loanIds.get(9), cobPartitions.get(1).getMaxId().intValue());
-
-            executorService.shutdown();
+            assertEquals(loanIds.get(9), cobPartitions.get(1).getMinId());
+            assertEquals(loanIds.get(9), cobPartitions.get(1).getMaxId());
         } finally {
+            executorService.shutdown();
             cleanUpAndRestoreBusinessDate();
         }
     }
 
-    private static void waitForFutures(List<Future<?>> futures, CountDownLatch createLatch) throws InterruptedException {
+    private static void waitForFutures(List<Future<?>> futures, CountDownLatch latch) throws InterruptedException {
         futures.forEach(future -> {
             try {
                 future.get(); // turn any possible async failures into errors
@@ -188,103 +143,46 @@ public class CobPartitioningTest extends BaseLoanIntegrationTest {
                 throw new RuntimeException(e);
             }
         });
-        createLatch.await();
+        latch.await();
     }
 
     private void setInitialBusinessDate(String date) {
         globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                 new PutGlobalConfigurationsRequest().enabled(true));
-        BusinessDateHelper.updateBusinessDate(BUSINESS_DATE, LocalDate.parse(date));
+        updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), date);
         globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
                 new PutGlobalConfigurationsRequest().value(0L));
     }
 
     private void cleanUpAndRestoreBusinessDate() {
-        REQUEST_SPEC = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        REQUEST_SPEC.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        REQUEST_SPEC.header("Fineract-Platform-TenantId", "default");
-        RESPONSE_SPEC = new ResponseSpecBuilder().expectStatusCode(200).build();
-        BusinessDateHelper.updateBusinessDate(BUSINESS_DATE, TODAYS_DATE);
+        updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), todaysDate.format(dateTimeFormatter));
         globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                 new PutGlobalConfigurationsRequest().enabled(false));
         globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, false);
     }
 
-    @NonNull
-    private Integer createClient() {
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        Assertions.assertNotNull(clientID);
-        return clientID;
+    private Long createLoanProduct() {
+        ChargeRequest overdueFeeCharge = ChargeRequestBuilders.loanOverdueFee(1.0)
+                .chargeCalculationType(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST.getValue());
+        Long overdueFeeChargeId = chargesHelper.createCharge(overdueFeeCharge).getResourceId();
+
+        PostLoanProductsRequest product = create4Period1MonthLongWithoutInterestProduct(CUMULATIVE_STRATEGY).principal(15000.0)
+                .charges(List.of(new LoanProductChargeData().id(overdueFeeChargeId)));
+        return createLoanProduct(product);
     }
 
-    private Integer createLoanProduct() {
-        Integer overdueFeeChargeId = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
-        Assertions.assertNotNull(overdueFeeChargeId);
-
-        Integer loanProductID = createLoanProduct(overdueFeeChargeId.toString());
-        Assertions.assertNotNull(loanProductID);
-        return loanProductID;
+    private Long createLoanForClient(Long clientId, Long loanProductId) {
+        PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "01 March 2020", 15000.0, 4)//
+                .repaymentEvery(1)//
+                .loanTermFrequency(4)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS);
+        Long loanId = applyForLoan(applicationRequest);
+        verifyLoanStatus(loanId, LoanStatus.SUBMITTED_AND_PENDING_APPROVAL);
+        approveLoan(loanId, approveLoanRequest(15000.0, "01 March 2020"));
+        verifyLoanStatus(loanId, LoanStatus.APPROVED);
+        disburseLoan(loanId, BigDecimal.valueOf(15000.0), "02 March 2020");
+        verifyLoanStatus(loanId, LoanStatus.ACTIVE);
+        return loanId;
     }
-
-    @NonNull
-    private Integer createLoanForClient(Integer clientID, Integer loanProductID) {
-
-        HashMap loanStatusHashMap;
-
-        Integer loanID = applyForLoanApplication(clientID.toString(), loanProductID.toString(), "1 March 2020");
-
-        Assertions.assertNotNull(loanID);
-
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
-
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("01 March 2020", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("02 March 2020", loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-        return loanID;
-    }
-
-    private Integer createLoanProduct(final String chargeId) {
-
-        final String loanProductJSON = new LoanProductTestBuilder().withPrincipal("15,000.00").withNumberOfRepayments("4")
-                .withRepaymentAfterEvery("1").withRepaymentTypeAsMonth().withinterestRatePerPeriod("1")
-                .withAccountingRulePeriodicAccrual(new Account[] { ASSET_ACCOUNT, EXPENSE_ACCOUNT, INCOME_ACCOUNT, OVERPAYMENT_ACCOUNT })
-                .withInterestRateFrequencyTypeAsMonths().withAmortizationTypeAsEqualInstallments().withInterestTypeAsDecliningBalance()
-                .withFeeAndPenaltyAssetAccount(FEE_PENALTY_ACCOUNT).build(chargeId);
-        return LOAN_TRANSACTION_HELPER.getLoanProductId(loanProductJSON);
-    }
-
-    private Integer applyForLoanApplication(final String clientID, final String loanProductID, final String date) {
-        List<HashMap> collaterals = new ArrayList<>();
-        Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
-        Assertions.assertNotNull(collateralId);
-        Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC, clientID, collateralId);
-        Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
-
-        String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal("15,000.00").withLoanTermFrequency("4")
-                .withLoanTermFrequencyAsMonths().withNumberOfRepayments("4").withRepaymentEveryAfter("1")
-                .withRepaymentFrequencyTypeAsMonths().withInterestRatePerPeriod("2").withAmortizationTypeAsEqualInstallments()
-                .withInterestTypeAsDecliningBalance().withInterestCalculationPeriodTypeSameAsRepaymentPeriod()
-                .withExpectedDisbursementDate(date).withSubmittedOnDate(date).withCollaterals(collaterals)
-                .build(clientID, loanProductID, null);
-        return LOAN_TRANSACTION_HELPER.getLoanId(loanApplicationJSON);
-    }
-
-    private void addCollaterals(List<HashMap> collaterals, Integer collateralId, BigDecimal quantity) {
-        collaterals.add(collaterals(collateralId, quantity));
-    }
-
-    private HashMap<String, String> collaterals(Integer collateralId, BigDecimal quantity) {
-        HashMap<String, String> collateral = new HashMap<>(2);
-        collateral.put("clientCollateralId", collateralId.toString());
-        collateral.put("quantity", quantity.toString());
-        return collateral;
-    }
-
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/cob/CobPartitioningTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/cob/CobPartitioningTest.java
@@ -18,19 +18,12 @@
  */
 package org.apache.fineract.integrationtests.cob;
 
-import static org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType.BUSINESS_DATE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.path.json.JsonPath;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -38,104 +31,73 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.fineract.accounting.common.AccountingConstants;
 import org.apache.fineract.client.models.COBPartition;
-import org.apache.fineract.client.models.GetFinancialActivityAccountsResponse;
-import org.apache.fineract.client.models.PostFinancialActivityAccountsRequest;
+import org.apache.fineract.client.models.ChargeRequest;
+import org.apache.fineract.client.models.LoanProductChargeData;
+import org.apache.fineract.client.models.PostLoanProductsRequest;
+import org.apache.fineract.client.models.PostLoansRequest;
 import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
+import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
-import org.apache.fineract.integrationtests.BaseLoanIntegrationTest;
-import org.apache.fineract.integrationtests.common.BusinessDateHelper;
-import org.apache.fineract.integrationtests.common.BusinessStepHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.CollateralManagementHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignBusinessStepHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignCobHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignExternalAssetOwnerHelper;
+import org.apache.fineract.integrationtests.client.feign.modules.ChargeRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.common.accounting.Account;
-import org.apache.fineract.integrationtests.common.accounting.AccountHelper;
-import org.apache.fineract.integrationtests.common.accounting.FinancialActivityAccountHelper;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
-import org.apache.fineract.integrationtests.common.loans.CobHelper;
-import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanStatusChecker;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.junit.jupiter.api.Assertions;
+import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.springframework.lang.NonNull;
 
-@SuppressWarnings("rawtypes")
 @Slf4j
-public class CobPartitioningTest extends BaseLoanIntegrationTest {
+public class CobPartitioningTest extends FeignLoanTestBase {
 
     public static final int N = 10;
-    private static ResponseSpecification RESPONSE_SPEC;
-    private static RequestSpecification REQUEST_SPEC;
-    private static Account ASSET_ACCOUNT;
-    private static Account FEE_PENALTY_ACCOUNT;
-    private static Account TRANSFER_ACCOUNT;
-    private static Account EXPENSE_ACCOUNT;
-    private static Account INCOME_ACCOUNT;
-    private static Account OVERPAYMENT_ACCOUNT;
-    private static FinancialActivityAccountHelper FINANCIAL_ACTIVITY_ACCOUNT_HELPER;
-    private static LoanTransactionHelper LOAN_TRANSACTION_HELPER;
-    private static LocalDate TODAYS_DATE;
+    private static final String CUMULATIVE_STRATEGY = "mifos-standard-strategy";
+    private static LocalDate todaysDate;
+
+    private final FeignExternalAssetOwnerHelper externalAssetOwnerHelper = new FeignExternalAssetOwnerHelper(
+            FineractFeignClientHelper.getFineractFeignClient());
 
     @BeforeAll
-    public static void setupInvestorBusinessStep() {
-        Utils.initializeRESTAssured();
-        REQUEST_SPEC = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        REQUEST_SPEC.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        RESPONSE_SPEC = new ResponseSpecBuilder().expectStatusCode(200).build();
-        AccountHelper accountHelper = new AccountHelper(REQUEST_SPEC, RESPONSE_SPEC);
-        FINANCIAL_ACTIVITY_ACCOUNT_HELPER = new FinancialActivityAccountHelper(REQUEST_SPEC);
-        LOAN_TRANSACTION_HELPER = new LoanTransactionHelper(REQUEST_SPEC, RESPONSE_SPEC);
-
-        TODAYS_DATE = Utils.getLocalDateOfTenant();
-        new BusinessStepHelper().updateSteps("LOAN_CLOSE_OF_BUSINESS", "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION",
-                "CHECK_LOAN_REPAYMENT_DUE", "CHECK_LOAN_REPAYMENT_OVERDUE", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
+    public static void setupBusinessStep() {
+        todaysDate = Utils.getLocalDateOfTenant();
+        new FeignBusinessStepHelper(FineractFeignClientHelper.getFineractFeignClient()).updateSteps("LOAN_CLOSE_OF_BUSINESS",
+                "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION", "CHECK_LOAN_REPAYMENT_DUE",
+                "CHECK_LOAN_REPAYMENT_OVERDUE", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
                 "EXTERNAL_ASSET_OWNER_TRANSFER");
-
-        ASSET_ACCOUNT = accountHelper.createAssetAccount();
-        FEE_PENALTY_ACCOUNT = accountHelper.createAssetAccount();
-        TRANSFER_ACCOUNT = accountHelper.createAssetAccount();
-        EXPENSE_ACCOUNT = accountHelper.createExpenseAccount();
-        INCOME_ACCOUNT = accountHelper.createIncomeAccount();
-        OVERPAYMENT_ACCOUNT = accountHelper.createLiabilityAccount();
-
-        setProperFinancialActivity(TRANSFER_ACCOUNT);
-    }
-
-    private static void setProperFinancialActivity(Account transferAccount) {
-        List<GetFinancialActivityAccountsResponse> financialMappings = FINANCIAL_ACTIVITY_ACCOUNT_HELPER.getAllFinancialActivityAccounts();
-        financialMappings.forEach(mapping -> FINANCIAL_ACTIVITY_ACCOUNT_HELPER.deleteFinancialActivityAccount(mapping.getId()));
-        FINANCIAL_ACTIVITY_ACCOUNT_HELPER.createFinancialActivityAccount(new PostFinancialActivityAccountsRequest()
-                .financialActivityId((long) AccountingConstants.FinancialActivity.ASSET_TRANSFER.getValue())
-                .glAccountId((long) transferAccount.getAccountID()));
     }
 
     @Test
     public void testLoanCOBPartitioningQuery() throws InterruptedException {
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
         try {
-            ExecutorService executorService = Executors.newFixedThreadPool(10);
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2020-03-02");
+            // The EXTERNAL_ASSET_OWNER_TRANSFER COB step registered above needs an ASSET_TRANSFER -> GL mapping to run.
+            // Created here rather than in @BeforeAll because accountHelper is not initialised at static-init time.
+            Account transferAccount = accountHelper.createAssetAccount(Utils.uniqueRandomStringGenerator("TRANSFER_", 5));
+            externalAssetOwnerHelper.setProperFinancialActivity(transferAccount);
+            setInitialBusinessDate("02 March 2020");
 
-            List<Integer> loanIds = new CopyOnWriteArrayList<>();
+            List<Long> loanIds = new CopyOnWriteArrayList<>();
 
             // Let's create 1, 2, ..., N-1, N loans
             final CountDownLatch createLatch = new CountDownLatch(N - 1);
-            Integer loanProductID = createLoanProduct();
+            Long loanProductId = createLoanProduct();
             List<Future<?>> futures = new ArrayList<>();
             // Warm up (EclipseLink sometimes fails if JPQL cache is not warm up but concurrent queries are executed)
-            Integer clientID = createClient();
-            Integer loanID = createLoanForClient(clientID, loanProductID);
-            loanIds.add(loanID);
+            Long clientId = createClient();
+            Long loanId = createLoanForClient(clientId, loanProductId);
+            loanIds.add(loanId);
             for (int i = 1; i < N; i++) {
                 futures.add(executorService.submit(() -> {
-                    Integer internalClientID = createClient();
-                    Integer internalLoanID = createLoanForClient(internalClientID, loanProductID);
-                    loanIds.add(internalLoanID);
+                    Long internalClientId = createClient();
+                    Long internalLoanId = createLoanForClient(internalClientId, loanProductId);
+                    loanIds.add(internalLoanId);
                     createLatch.countDown();
                 }));
             }
@@ -146,41 +108,33 @@ public class CobPartitioningTest extends BaseLoanIntegrationTest {
             Collections.sort(loanIds);
             final CountDownLatch closeLatch = new CountDownLatch(N - 5);
             // Warm up (EclipseLink sometimes fails if JPQL cache is not warm up but concurrent queries are executed)
-            LOAN_TRANSACTION_HELPER.forecloseLoan("02 March 2020", loanIds.get(2));
+            forecloseLoan(loanIds.get(2), LoanRequestBuilders.forecloseLoan("02 March 2020"));
             for (int i = 3; i < N - 2; i++) {
                 final int idx = i;
                 futures.add(executorService.submit(() -> {
-                    LOAN_TRANSACTION_HELPER.forecloseLoan("02 March 2020", loanIds.get(idx));
+                    forecloseLoan(loanIds.get(idx), LoanRequestBuilders.forecloseLoan("02 March 2020"));
                     closeLatch.countDown();
                 }));
             }
-            futures.forEach(future -> {
-                try {
-                    future.get(); // turn any possible async failures into errors
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
-            });
-            closeLatch.await();
+            waitForFutures(futures, closeLatch);
 
             // Let's retrieve the partitions
-            List<COBPartition> cobPartitions = CobHelper.getCobPartitions(3);
+            List<COBPartition> cobPartitions = new FeignCobHelper(FineractFeignClientHelper.getFineractFeignClient()).getCobPartitions(3);
             log.info("\nLoans created: {},\nRetrieved partitions: {}", loanIds, cobPartitions);
-            Assertions.assertEquals(2, cobPartitions.size());
+            assertEquals(2, cobPartitions.size());
 
-            Assertions.assertEquals(loanIds.get(0), cobPartitions.get(0).getMinId().intValue());
-            Assertions.assertEquals(loanIds.get(8), cobPartitions.get(0).getMaxId().intValue());
+            assertEquals(loanIds.get(0), cobPartitions.get(0).getMinId());
+            assertEquals(loanIds.get(8), cobPartitions.get(0).getMaxId());
 
-            Assertions.assertEquals(loanIds.get(9), cobPartitions.get(1).getMinId().intValue());
-            Assertions.assertEquals(loanIds.get(9), cobPartitions.get(1).getMaxId().intValue());
-
-            executorService.shutdown();
+            assertEquals(loanIds.get(9), cobPartitions.get(1).getMinId());
+            assertEquals(loanIds.get(9), cobPartitions.get(1).getMaxId());
         } finally {
+            executorService.shutdown();
             cleanUpAndRestoreBusinessDate();
         }
     }
 
-    private static void waitForFutures(List<Future<?>> futures, CountDownLatch createLatch) throws InterruptedException {
+    private static void waitForFutures(List<Future<?>> futures, CountDownLatch latch) throws InterruptedException {
         futures.forEach(future -> {
             try {
                 future.get(); // turn any possible async failures into errors
@@ -188,103 +142,43 @@ public class CobPartitioningTest extends BaseLoanIntegrationTest {
                 throw new RuntimeException(e);
             }
         });
-        createLatch.await();
+        latch.await();
     }
 
     private void setInitialBusinessDate(String date) {
         globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                 new PutGlobalConfigurationsRequest().enabled(true));
-        BusinessDateHelper.updateBusinessDate(BUSINESS_DATE, LocalDate.parse(date));
+        updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), date);
         globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
                 new PutGlobalConfigurationsRequest().value(0L));
     }
 
     private void cleanUpAndRestoreBusinessDate() {
-        REQUEST_SPEC = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        REQUEST_SPEC.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        REQUEST_SPEC.header("Fineract-Platform-TenantId", "default");
-        RESPONSE_SPEC = new ResponseSpecBuilder().expectStatusCode(200).build();
-        BusinessDateHelper.updateBusinessDate(BUSINESS_DATE, TODAYS_DATE);
+        updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), todaysDate.format(dateTimeFormatter));
         globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                 new PutGlobalConfigurationsRequest().enabled(false));
         globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, false);
     }
 
-    @NonNull
-    private Integer createClient() {
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        Assertions.assertNotNull(clientID);
-        return clientID;
+    private Long createLoanProduct() {
+        ChargeRequest overdueFeeCharge = ChargeRequestBuilders.loanOverdueFee(1.0)
+                .chargeCalculationType(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST.getValue());
+        Long overdueFeeChargeId = chargesHelper.createCharge(overdueFeeCharge).getResourceId();
+
+        PostLoanProductsRequest product = create4Period1MonthLongWithoutInterestProduct(CUMULATIVE_STRATEGY).principal(15000.0)
+                .charges(List.of(new LoanProductChargeData().id(overdueFeeChargeId)));
+        return createLoanProduct(product);
     }
 
-    private Integer createLoanProduct() {
-        Integer overdueFeeChargeId = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
-        Assertions.assertNotNull(overdueFeeChargeId);
-
-        Integer loanProductID = createLoanProduct(overdueFeeChargeId.toString());
-        Assertions.assertNotNull(loanProductID);
-        return loanProductID;
+    private Long createLoanForClient(Long clientId, Long loanProductId) {
+        PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "01 March 2020", 15000.0, 4)//
+                .repaymentEvery(1)//
+                .loanTermFrequency(4)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS);
+        Long loanId = applyForLoan(applicationRequest);
+        approveLoan(loanId, approveLoanRequest(15000.0, "01 March 2020"));
+        disburseLoan(loanId, BigDecimal.valueOf(15000.0), "02 March 2020");
+        return loanId;
     }
-
-    @NonNull
-    private Integer createLoanForClient(Integer clientID, Integer loanProductID) {
-
-        HashMap loanStatusHashMap;
-
-        Integer loanID = applyForLoanApplication(clientID.toString(), loanProductID.toString(), "1 March 2020");
-
-        Assertions.assertNotNull(loanID);
-
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
-
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("01 March 2020", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("02 March 2020", loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-        return loanID;
-    }
-
-    private Integer createLoanProduct(final String chargeId) {
-
-        final String loanProductJSON = new LoanProductTestBuilder().withPrincipal("15,000.00").withNumberOfRepayments("4")
-                .withRepaymentAfterEvery("1").withRepaymentTypeAsMonth().withinterestRatePerPeriod("1")
-                .withAccountingRulePeriodicAccrual(new Account[] { ASSET_ACCOUNT, EXPENSE_ACCOUNT, INCOME_ACCOUNT, OVERPAYMENT_ACCOUNT })
-                .withInterestRateFrequencyTypeAsMonths().withAmortizationTypeAsEqualInstallments().withInterestTypeAsDecliningBalance()
-                .withFeeAndPenaltyAssetAccount(FEE_PENALTY_ACCOUNT).build(chargeId);
-        return LOAN_TRANSACTION_HELPER.getLoanProductId(loanProductJSON);
-    }
-
-    private Integer applyForLoanApplication(final String clientID, final String loanProductID, final String date) {
-        List<HashMap> collaterals = new ArrayList<>();
-        Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
-        Assertions.assertNotNull(collateralId);
-        Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC, clientID, collateralId);
-        Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
-
-        String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal("15,000.00").withLoanTermFrequency("4")
-                .withLoanTermFrequencyAsMonths().withNumberOfRepayments("4").withRepaymentEveryAfter("1")
-                .withRepaymentFrequencyTypeAsMonths().withInterestRatePerPeriod("2").withAmortizationTypeAsEqualInstallments()
-                .withInterestTypeAsDecliningBalance().withInterestCalculationPeriodTypeSameAsRepaymentPeriod()
-                .withExpectedDisbursementDate(date).withSubmittedOnDate(date).withCollaterals(collaterals)
-                .build(clientID, loanProductID, null);
-        return LOAN_TRANSACTION_HELPER.getLoanId(loanApplicationJSON);
-    }
-
-    private void addCollaterals(List<HashMap> collaterals, Integer collateralId, BigDecimal quantity) {
-        collaterals.add(collaterals(collateralId, quantity));
-    }
-
-    private HashMap<String, String> collaterals(Integer collateralId, BigDecimal quantity) {
-        HashMap<String, String> collateral = new HashMap<>(2);
-        collateral.put("clientCollateralId", collateralId.toString());
-        collateral.put("quantity", quantity.toString());
-        return collateral;
-    }
-
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/inlinecob/InlineLoanCOBTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/inlinecob/InlineLoanCOBTest.java
@@ -20,130 +20,67 @@ package org.apache.fineract.integrationtests.inlinecob;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.path.json.JsonPath;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.LongStream;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.fineract.batch.domain.BatchRequest;
-import org.apache.fineract.batch.domain.BatchResponse;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
+import org.apache.fineract.client.models.BatchResponse;
+import org.apache.fineract.client.models.ChargeRequest;
 import org.apache.fineract.client.models.DelinquencyBucketRequest;
 import org.apache.fineract.client.models.DelinquencyBucketResponse;
 import org.apache.fineract.client.models.DelinquencyRangeRequest;
-import org.apache.fineract.client.models.DelinquencyRangeResponse;
 import org.apache.fineract.client.models.GetDelinquencyTagHistoryResponse;
-import org.apache.fineract.client.models.GetLoansLoanIdResponse;
+import org.apache.fineract.client.models.LoanProductChargeData;
 import org.apache.fineract.client.models.PostDelinquencyBucketResponse;
 import org.apache.fineract.client.models.PostDelinquencyRangeResponse;
+import org.apache.fineract.client.models.PostLoanProductsRequest;
+import org.apache.fineract.client.models.PostLoansRequest;
 import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
 import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
-import org.apache.fineract.integrationtests.BaseLoanIntegrationTest;
-import org.apache.fineract.integrationtests.common.BatchHelper;
-import org.apache.fineract.integrationtests.common.BusinessDateHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.CollateralManagementHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignDelinquencyHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignTransactionHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignUserHelper;
+import org.apache.fineract.integrationtests.client.feign.modules.ChargeRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
-import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanStatusChecker;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.apache.fineract.integrationtests.common.products.DelinquencyBucketsHelper;
-import org.apache.fineract.integrationtests.common.products.DelinquencyRangesHelper;
-import org.apache.fineract.integrationtests.useradministration.users.UserHelper;
+import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanStatus;
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-@Slf4j
-public class InlineLoanCOBTest extends BaseLoanIntegrationTest {
+public class InlineLoanCOBTest extends FeignLoanTestBase {
 
-    private ResponseSpecification responseSpec;
-    private RequestSpecification requestSpec;
-    private InlineLoanCOBHelper inlineLoanCOBHelper;
-    private LoanTransactionHelper loanTransactionHelper;
-
-    @BeforeEach
-    public void setup() {
-        Utils.initializeRESTAssured();
-        requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        requestSpec.header("Fineract-Platform-TenantId", "default");
-        responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        inlineLoanCOBHelper = new InlineLoanCOBHelper(requestSpec, responseSpec);
-    }
+    private static final String CUMULATIVE_STRATEGY = "mifos-standard-strategy";
+    private static final Long REPAYMENT_BATCH_REQUEST_ID = 4730L;
+    private static final int INLINE_COB_MAX_LOAN_IDS = 1000;
 
     @Test
     public void testInlineCOB() {
         try {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
+            enableBusinessDateAtMarch2();
+            Long loanId = createOverdueLoan();
 
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 2));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
-                    new PutGlobalConfigurationsRequest().value(0L));
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
+            updateBusinessDate(BusinessDateType.COB_DATE.name(), "02 March 2020");
+            executeInlineCOB(loanId);
+            verifyLastClosedBusinessDate(loanId, "02 March 2020");
 
-            final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec);
-            Assertions.assertNotNull(clientID);
+            updateBusinessDate(BusinessDateType.COB_DATE.name(), "03 March 2020");
+            executeInlineCOB(loanId);
+            verifyLastClosedBusinessDate(loanId, "03 March 2020");
 
-            Integer overdueFeeChargeId = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
-            Assertions.assertNotNull(overdueFeeChargeId);
-
-            final Integer loanProductID = createLoanProduct(overdueFeeChargeId.toString());
-            Assertions.assertNotNull(loanProductID);
-            HashMap loanStatusHashMap;
-
-            final Integer loanID = applyForLoanApplication(clientID.toString(), loanProductID.toString(), null, "1 March 2020");
-
-            Assertions.assertNotNull(loanID);
-
-            loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
-
-            loanStatusHashMap = loanTransactionHelper.approveLoan("01 March 2020", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-
-            String loanDetails = loanTransactionHelper.getLoanDetails(requestSpec, responseSpec, loanID);
-            loanStatusHashMap = loanTransactionHelper.disburseLoanWithNetDisbursalAmount("02 March 2020", loanID,
-                    JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.COB_DATE, LocalDate.of(2020, 3, 2));
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanID.longValue()));
-            GetLoansLoanIdResponse loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 2), loan.getLastClosedBusinessDate());
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.COB_DATE, LocalDate.of(2020, 3, 3));
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanID.longValue()));
-
-            loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 3), loan.getLastClosedBusinessDate());
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.COB_DATE, LocalDate.of(2020, 3, 10));
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanID.longValue()));
-
-            loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 10), loan.getLastClosedBusinessDate());
+            updateBusinessDate(BusinessDateType.COB_DATE.name(), "10 March 2020");
+            executeInlineCOB(loanId);
+            verifyLastClosedBusinessDate(loanId, "10 March 2020");
         } finally {
-            requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-            requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-            requestSpec.header("Fineract-Platform-TenantId", "default");
-            responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
+            disableBusinessDate();
         }
     }
 
@@ -152,402 +89,193 @@ public class InlineLoanCOBTest extends BaseLoanIntegrationTest {
         try {
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
+            FeignDelinquencyHelper delinquencyHelper = new FeignDelinquencyHelper(FineractFeignClientHelper.getFineractFeignClient());
 
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-
-            final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec);
-            Assertions.assertNotNull(clientID);
-
-            Integer overdueFeeChargeId = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
-            Assertions.assertNotNull(overdueFeeChargeId);
-
-            ArrayList<Long> rangeIds = new ArrayList<>();
+            List<Long> rangeIds = new ArrayList<>();
             // First Range
-            PostDelinquencyRangeResponse delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                    .minimumAgeDays(1).maximumAgeDays(3).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
-            rangeIds.add(delinquencyRangeResponse.getResourceId());
-
-            DelinquencyRangeResponse range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
-
+            PostDelinquencyRangeResponse firstRange = delinquencyHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(1)
+                    .maximumAgeDays(3).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+            rangeIds.add(firstRange.getResourceId());
             // Second Range
-            delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(4)
+            PostDelinquencyRangeResponse secondRange = delinquencyHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(4)
                     .maximumAgeDays(60).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
-            rangeIds.add(delinquencyRangeResponse.getResourceId());
+            rangeIds.add(secondRange.getResourceId());
 
-            range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
-            final String classificationExpected = range.getClassification();
-            log.info("Expected Delinquency Range classification after Disbursement {}", classificationExpected);
-
-            PostDelinquencyBucketResponse delinquencyBucketResponse = DelinquencyBucketsHelper
+            PostDelinquencyBucketResponse delinquencyBucketResponse = delinquencyHelper
                     .createBucket(new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds));
             assertNotNull(delinquencyBucketResponse);
-            final DelinquencyBucketResponse delinquencyBucket = DelinquencyBucketsHelper
-                    .getBucket(delinquencyBucketResponse.getResourceId());
+            DelinquencyBucketResponse delinquencyBucket = delinquencyHelper.getBucket(delinquencyBucketResponse.getResourceId());
 
-            final Integer loanProductID = createLoanProduct(loanTransactionHelper, delinquencyBucket.getId());
+            Long loanId = createDelinquentLoan(delinquencyBucket.getId());
 
-            Assertions.assertNotNull(loanProductID);
-            HashMap loanStatusHashMap;
+            updateBusinessDate(BusinessDateType.COB_DATE.name(), "02 March 2020");
+            executeInlineCOB(loanId);
+            assertTrue(getLoanDelinquencyTags(loanId).isEmpty());
+            verifyLastClosedBusinessDate(loanId, "02 March 2020");
 
-            final Integer loanID = applyForLoanApplication(clientID.toString(), loanProductID.toString(), null, "1 March 2020");
+            updateBusinessDate(BusinessDateType.COB_DATE.name(), "04 April 2020");
+            executeInlineCOB(loanId);
+            List<GetDelinquencyTagHistoryResponse> loanDelinquencyTags = getLoanDelinquencyTags(loanId);
+            verifyLastClosedBusinessDate(loanId, "04 April 2020");
+            assertEquals(1, loanDelinquencyTags.size());
+            assertEquals("2020-04-03", loanDelinquencyTags.get(0).getAddedOnDate().toString());
 
-            Assertions.assertNotNull(loanID);
-
-            loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
-
-            loanStatusHashMap = loanTransactionHelper.approveLoan("01 March 2020", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-
-            String loanDetails = loanTransactionHelper.getLoanDetails(requestSpec, responseSpec, loanID);
-            loanStatusHashMap = loanTransactionHelper.disburseLoanWithNetDisbursalAmount("02 March 2020", loanID,
-                    JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.COB_DATE, LocalDate.of(2020, 3, 2));
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanID.longValue()));
-            GetLoansLoanIdResponse loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            ArrayList<GetDelinquencyTagHistoryResponse> loanDelinquencyTags = loanTransactionHelper.getLoanDelinquencyTags(requestSpec,
-                    responseSpec, loanID);
-            Assertions.assertTrue(loanDelinquencyTags.isEmpty());
-            Assertions.assertEquals(LocalDate.of(2020, 3, 2), loan.getLastClosedBusinessDate());
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.COB_DATE, LocalDate.of(2020, 4, 4));
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanID.longValue()));
-
-            loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            loanDelinquencyTags = loanTransactionHelper.getLoanDelinquencyTags(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 4, 4), loan.getLastClosedBusinessDate());
-            Assertions.assertEquals(1, loanDelinquencyTags.size());
-            Assertions.assertEquals(LocalDate.of(2020, 4, 3), loanDelinquencyTags.get(0).getAddedOnDate());
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.COB_DATE, LocalDate.of(2020, 4, 10));
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanID.longValue()));
-
-            loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            loanDelinquencyTags = loanTransactionHelper.getLoanDelinquencyTags(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 4, 10), loan.getLastClosedBusinessDate());
-            Assertions.assertEquals(2, loanDelinquencyTags.size());
-            Assertions.assertEquals(LocalDate.of(2020, 4, 3), loanDelinquencyTags.get(1).getAddedOnDate());
-            Assertions.assertEquals(LocalDate.of(2020, 4, 6), loanDelinquencyTags.get(0).getAddedOnDate());
+            updateBusinessDate(BusinessDateType.COB_DATE.name(), "10 April 2020");
+            executeInlineCOB(loanId);
+            loanDelinquencyTags = getLoanDelinquencyTags(loanId);
+            verifyLastClosedBusinessDate(loanId, "10 April 2020");
+            assertEquals(2, loanDelinquencyTags.size());
+            assertEquals("2020-04-03", loanDelinquencyTags.get(1).getAddedOnDate().toString());
+            assertEquals("2020-04-06", loanDelinquencyTags.get(0).getAddedOnDate().toString());
         } finally {
-            requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-            requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-            requestSpec.header("Fineract-Platform-TenantId", "default");
-            responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
+            disableBusinessDate();
         }
     }
 
     @Test
     public void testInlineCOBOnRepaymentWithSoftLockedLoan() {
         try {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
+            enableBusinessDateAtMarch2();
+            Long loanId = createOverdueLoan();
 
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 2));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
-                    new PutGlobalConfigurationsRequest().value(0L));
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
+            updateBusinessDate(BusinessDateType.COB_DATE.name(), "02 March 2020");
+            executeInlineCOB(loanId);
+            verifyLastClosedBusinessDate(loanId, "02 March 2020");
 
-            final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec);
-            Assertions.assertNotNull(clientID);
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), "10 March 2020");
 
-            Integer overdueFeeChargeId = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
-            Assertions.assertNotNull(overdueFeeChargeId);
+            makeRepaymentAsNonByPassUser(loanId, "10 March 2020", 10.0);
 
-            final Integer loanProductID = createLoanProduct(overdueFeeChargeId.toString());
-            Assertions.assertNotNull(loanProductID);
-            HashMap loanStatusHashMap;
-            final Integer loanID = applyForLoanApplication(clientID.toString(), loanProductID.toString(), null, "1 March 2020");
-
-            Assertions.assertNotNull(loanID);
-
-            loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
-
-            loanStatusHashMap = loanTransactionHelper.approveLoan("01 March 2020", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-
-            String loanDetails = loanTransactionHelper.getLoanDetails(requestSpec, responseSpec, loanID);
-            loanStatusHashMap = loanTransactionHelper.disburseLoanWithNetDisbursalAmount("02 March 2020", loanID,
-                    JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.COB_DATE, LocalDate.of(2020, 3, 2));
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanID.longValue()));
-            GetLoansLoanIdResponse loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 2), loan.getLastClosedBusinessDate());
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 10));
-
-            requestSpec = UserHelper.getSimpleUserWithoutBypassPermission(requestSpec, responseSpec);
-
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-
-            loanTransactionHelper.makeRepayment("10 March 2020", 10.0f, loanID);
-
-            loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 9), loan.getLastClosedBusinessDate());
+            verifyLastClosedBusinessDate(loanId, "09 March 2020");
         } finally {
-            requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-            requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-            requestSpec.header("Fineract-Platform-TenantId", "default");
-            responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
+            disableBusinessDate();
         }
     }
 
     @Test
     public void testInlineCOBCatchUpOnRepaymentWithNotLockedLoan() {
         try {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 2));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
-                    new PutGlobalConfigurationsRequest().value(0L));
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
+            enableBusinessDateAtMarch2();
+            Long loanId = createOverdueLoan();
 
-            final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec);
-            Assertions.assertNotNull(clientID);
+            updateBusinessDate(BusinessDateType.COB_DATE.name(), "02 March 2020");
+            executeInlineCOB(loanId);
+            verifyLastClosedBusinessDate(loanId, "02 March 2020");
 
-            Integer overdueFeeChargeId = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
-            Assertions.assertNotNull(overdueFeeChargeId);
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), "10 March 2020");
 
-            final Integer loanProductID = createLoanProduct(overdueFeeChargeId.toString());
-            Assertions.assertNotNull(loanProductID);
-            HashMap loanStatusHashMap;
-            final Integer loanID = applyForLoanApplication(clientID.toString(), loanProductID.toString(), null, "1 March 2020");
+            makeRepaymentAsNonByPassUser(loanId, "10 March 2020", 10.0);
 
-            Assertions.assertNotNull(loanID);
-
-            loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
-
-            loanStatusHashMap = loanTransactionHelper.approveLoan("01 March 2020", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-
-            String loanDetails = loanTransactionHelper.getLoanDetails(requestSpec, responseSpec, loanID);
-            loanStatusHashMap = loanTransactionHelper.disburseLoanWithNetDisbursalAmount("02 March 2020", loanID,
-                    JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.COB_DATE, LocalDate.of(2020, 3, 2));
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanID.longValue()));
-            GetLoansLoanIdResponse loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 2), loan.getLastClosedBusinessDate());
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 10));
-
-            requestSpec = UserHelper.getSimpleUserWithoutBypassPermission(requestSpec, responseSpec);
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-
-            loanTransactionHelper.makeRepayment("10 March 2020", 10.0f, loanID);
-
-            loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 9), loan.getLastClosedBusinessDate());
+            verifyLastClosedBusinessDate(loanId, "09 March 2020");
         } finally {
-            requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-            requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-            requestSpec.header("Fineract-Platform-TenantId", "default");
-            responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
+            disableBusinessDate();
         }
     }
 
     @Test
     public void testInlineCOBOnBatchAPIWithOldRelativeUrls() {
         try {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 2));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
-                    new PutGlobalConfigurationsRequest().value(0L));
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
+            enableBusinessDateAtMarch2();
+            Long loanId = createOverdueLoan();
 
-            final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec);
-            Assertions.assertNotNull(clientID);
+            updateBusinessDate(BusinessDateType.COB_DATE.name(), "02 March 2020");
+            executeInlineCOB(loanId);
+            verifyLastClosedBusinessDate(loanId, "02 March 2020");
 
-            Integer overdueFeeChargeId = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
-            Assertions.assertNotNull(overdueFeeChargeId);
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), "10 March 2020");
 
-            final Integer loanProductID = createLoanProduct(overdueFeeChargeId.toString());
-            Assertions.assertNotNull(loanProductID);
-            HashMap loanStatusHashMap;
-            final Integer loanID = applyForLoanApplication(clientID.toString(), loanProductID.toString(), null, "1 March 2020");
+            AtomicReference<List<BatchResponse>> responseRef = new AtomicReference<>();
+            runAsNonByPass(() -> responseRef
+                    .set(batchRequest().repayLoanLegacyRelativeUrl(REPAYMENT_BATCH_REQUEST_ID, loanId, "10", "10 March 2020")
+                            .executeWithoutEnclosingTransaction()));
+            assertEquals(HttpStatus.SC_OK, responseRef.get().get(0).getStatusCode().intValue(), "Verify Status Code 200 for Repayment");
 
-            Assertions.assertNotNull(loanID);
-
-            loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
-
-            loanStatusHashMap = loanTransactionHelper.approveLoan("01 March 2020", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-
-            String loanDetails = loanTransactionHelper.getLoanDetails(requestSpec, responseSpec, loanID);
-            loanStatusHashMap = loanTransactionHelper.disburseLoanWithNetDisbursalAmount("02 March 2020", loanID,
-                    JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.COB_DATE, LocalDate.of(2020, 3, 2));
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanID.longValue()));
-            GetLoansLoanIdResponse loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 2), loan.getLastClosedBusinessDate());
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 10));
-
-            requestSpec = UserHelper.getSimpleUserWithoutBypassPermission(requestSpec, responseSpec);
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-
-            final BatchRequest br1 = BatchHelper.oldRepayLoanRequestWithGivenLoanId(4730L, loanID, "10", LocalDate.of(2020, 3, 10));
-
-            final List<BatchRequest> batchRequests = new ArrayList<>();
-
-            batchRequests.add(br1);
-
-            final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-
-            final List<BatchResponse> response = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec,
-                    this.responseSpec, jsonifiedRequest);
-            Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(0).getStatusCode(), "Verify Status Code 200 for Repayment");
-
-            loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 9), loan.getLastClosedBusinessDate());
+            verifyLastClosedBusinessDate(loanId, "09 March 2020");
         } finally {
-            requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-            requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-            requestSpec.header("Fineract-Platform-TenantId", "default");
-            responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
+            disableBusinessDate();
         }
     }
 
     @Test
     public void testInlineCOBOnBatchAPI() {
         try {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 2));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
-                    new PutGlobalConfigurationsRequest().value(0L));
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
+            enableBusinessDateAtMarch2();
+            Long loanId = createOverdueLoan();
 
-            final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec);
-            Assertions.assertNotNull(clientID);
+            updateBusinessDate(BusinessDateType.COB_DATE.name(), "02 March 2020");
+            executeInlineCOB(loanId);
+            verifyLastClosedBusinessDate(loanId, "02 March 2020");
 
-            Integer overdueFeeChargeId = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
-            Assertions.assertNotNull(overdueFeeChargeId);
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), "10 March 2020");
 
-            final Integer loanProductID = createLoanProduct(overdueFeeChargeId.toString());
-            Assertions.assertNotNull(loanProductID);
-            HashMap loanStatusHashMap;
-            final Integer loanID = applyForLoanApplication(clientID.toString(), loanProductID.toString(), null, "1 March 2020");
+            AtomicReference<List<BatchResponse>> responseRef = new AtomicReference<>();
+            runAsNonByPass(() -> responseRef.set(batchRequest().repayLoan(REPAYMENT_BATCH_REQUEST_ID, loanId, "10", "10 March 2020")
+                    .executeWithoutEnclosingTransaction()));
+            assertEquals(HttpStatus.SC_OK, responseRef.get().get(0).getStatusCode().intValue(), "Verify Status Code 200 for Repayment");
 
-            Assertions.assertNotNull(loanID);
-
-            loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
-
-            loanStatusHashMap = loanTransactionHelper.approveLoan("01 March 2020", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-
-            String loanDetails = loanTransactionHelper.getLoanDetails(requestSpec, responseSpec, loanID);
-            loanStatusHashMap = loanTransactionHelper.disburseLoanWithNetDisbursalAmount("02 March 2020", loanID,
-                    JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.COB_DATE, LocalDate.of(2020, 3, 2));
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanID.longValue()));
-            GetLoansLoanIdResponse loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 2), loan.getLastClosedBusinessDate());
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 10));
-
-            requestSpec = UserHelper.getSimpleUserWithoutBypassPermission(requestSpec, responseSpec);
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-
-            final BatchRequest br1 = BatchHelper.repayLoanRequestWithGivenLoanId(4730L, loanID, "10", LocalDate.of(2020, 3, 10));
-
-            final List<BatchRequest> batchRequests = new ArrayList<>();
-
-            batchRequests.add(br1);
-
-            final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-
-            final List<BatchResponse> response = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec,
-                    this.responseSpec, jsonifiedRequest);
-            Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(0).getStatusCode(), "Verify Status Code 200 for Repayment");
-
-            loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 9), loan.getLastClosedBusinessDate());
+            verifyLastClosedBusinessDate(loanId, "09 March 2020");
         } finally {
-            requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-            requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-            requestSpec.header("Fineract-Platform-TenantId", "default");
-            responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
+            disableBusinessDate();
         }
     }
 
     @Test
     public void testInlineCOBRequestBodyItemLimitValidation() {
-        responseSpec = new ResponseSpecBuilder().expectStatusCode(400).build();
-        inlineLoanCOBHelper = new InlineLoanCOBHelper(requestSpec, responseSpec);
-        List<Long> loanIds = LongStream.rangeClosed(1, 1001).boxed().toList();
-        String responseUserMessage = inlineLoanCOBHelper.executeInlineCOB(loanIds, "defaultUserMessage");
-        assertEquals("Size of the loan IDs list cannot be over 1000", responseUserMessage);
+        List<Long> loanIds = LongStream.rangeClosed(1, INLINE_COB_MAX_LOAN_IDS + 1).boxed().toList();
+        CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class, () -> executeInlineCOB(loanIds));
+        assertEquals(HttpStatus.SC_BAD_REQUEST, exception.getStatus());
+        assertTrue(exception.getMessage().contains("Size of the loan IDs list cannot be over " + INLINE_COB_MAX_LOAN_IDS),
+                "Expected the item-limit validation message but got: " + exception.getMessage());
     }
 
-    private Integer createLoanProduct(final String chargeId) {
-        final String loanProductJSON = new LoanProductTestBuilder().withPrincipal("15,000.00").withNumberOfRepayments("4")
-                .withRepaymentAfterEvery("1").withRepaymentTypeAsMonth().withinterestRatePerPeriod("1")
-                .withInterestRateFrequencyTypeAsMonths().withAmortizationTypeAsEqualInstallments().withInterestTypeAsDecliningBalance()
-                .build(chargeId);
-        return this.loanTransactionHelper.getLoanProductId(loanProductJSON);
+    private void enableBusinessDateAtMarch2() {
+        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+                new PutGlobalConfigurationsRequest().enabled(true));
+        updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), "02 March 2020");
+        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
+                new PutGlobalConfigurationsRequest().value(0L));
     }
 
-    private Integer createLoanProduct(final LoanTransactionHelper loanTransactionHelper, final Long delinquencyBucketId) {
-        final HashMap<String, Object> loanProductMap = new LoanProductTestBuilder().build(null, delinquencyBucketId);
-        return loanTransactionHelper.getLoanProductId(Utils.convertToJson(loanProductMap));
+    private void disableBusinessDate() {
+        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+                new PutGlobalConfigurationsRequest().enabled(false));
     }
 
-    private Integer applyForLoanApplication(final String clientID, final String loanProductID, final String savingsID, final String date) {
-
-        List<HashMap> collaterals = new ArrayList<>();
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(this.requestSpec, this.responseSpec);
-        Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(this.requestSpec, this.responseSpec, clientID,
-                collateralId);
-        Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
-
-        final String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal("15,000.00").withLoanTermFrequency("4")
-                .withLoanTermFrequencyAsMonths().withNumberOfRepayments("4").withRepaymentEveryAfter("1")
-                .withRepaymentFrequencyTypeAsMonths().withInterestRatePerPeriod("2").withAmortizationTypeAsEqualInstallments()
-                .withInterestTypeAsDecliningBalance().withInterestCalculationPeriodTypeSameAsRepaymentPeriod()
-                .withExpectedDisbursementDate(date).withSubmittedOnDate(date).withCollaterals(collaterals)
-                .build(clientID, loanProductID, savingsID);
-        return this.loanTransactionHelper.getLoanId(loanApplicationJSON);
+    private void makeRepaymentAsNonByPassUser(Long loanId, String date, double amount) {
+        FeignTransactionHelper nonByPassTransactionHelper = new FeignTransactionHelper(
+                FeignUserHelper.getSimpleUserWithoutBypassPermissionClient());
+        nonByPassTransactionHelper.makeLoanRepayment(loanId, "repayment", date, amount);
     }
 
-    private void addCollaterals(List<HashMap> collaterals, Integer collateralId, BigDecimal quantity) {
-        collaterals.add(collaterals(collateralId, quantity));
+    private Long createOverdueLoan() {
+        Long clientId = createClient();
+        ChargeRequest overdueFeeCharge = ChargeRequestBuilders.loanOverdueFee(1.0)
+                .chargeCalculationType(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST.getValue());
+        Long overdueFeeChargeId = chargesHelper.createCharge(overdueFeeCharge).getResourceId();
+        PostLoanProductsRequest product = create4Period1MonthLongWithoutInterestProduct(CUMULATIVE_STRATEGY).principal(15000.0)
+                .charges(List.of(new LoanProductChargeData().id(overdueFeeChargeId)));
+        return applyApproveDisburse(clientId, createLoanProduct(product));
     }
 
-    private HashMap<String, String> collaterals(Integer collateralId, BigDecimal quantity) {
-        HashMap<String, String> collateral = new HashMap<>(2);
-        collateral.put("clientCollateralId", collateralId.toString());
-        collateral.put("quantity", quantity.toString());
-        return collateral;
+    private Long createDelinquentLoan(Long delinquencyBucketId) {
+        Long clientId = createClient();
+        PostLoanProductsRequest product = create4Period1MonthLongWithoutInterestProduct(CUMULATIVE_STRATEGY).principal(15000.0)
+                .delinquencyBucketId(delinquencyBucketId);
+        return applyApproveDisburse(clientId, createLoanProduct(product));
+    }
+
+    private Long applyApproveDisburse(Long clientId, Long loanProductId) {
+        PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "01 March 2020", 15000.0, 4)//
+                .repaymentEvery(1)//
+                .loanTermFrequency(4)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS);
+        Long loanId = applyForLoan(applicationRequest);
+        verifyLoanStatus(loanId, LoanStatus.SUBMITTED_AND_PENDING_APPROVAL);
+        approveLoan(loanId, approveLoanRequest(15000.0, "01 March 2020"));
+        verifyLoanStatus(loanId, LoanStatus.APPROVED);
+        disburseLoan(loanId, BigDecimal.valueOf(15000.0), "02 March 2020");
+        verifyLoanStatus(loanId, LoanStatus.ACTIVE);
+        return loanId;
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/inlinecob/InlineLoanCOBTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/inlinecob/InlineLoanCOBTest.java
@@ -20,130 +20,66 @@ package org.apache.fineract.integrationtests.inlinecob;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.path.json.JsonPath;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.LongStream;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.fineract.batch.domain.BatchRequest;
-import org.apache.fineract.batch.domain.BatchResponse;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
+import org.apache.fineract.client.models.BatchResponse;
+import org.apache.fineract.client.models.ChargeRequest;
 import org.apache.fineract.client.models.DelinquencyBucketRequest;
 import org.apache.fineract.client.models.DelinquencyBucketResponse;
 import org.apache.fineract.client.models.DelinquencyRangeRequest;
-import org.apache.fineract.client.models.DelinquencyRangeResponse;
 import org.apache.fineract.client.models.GetDelinquencyTagHistoryResponse;
-import org.apache.fineract.client.models.GetLoansLoanIdResponse;
+import org.apache.fineract.client.models.LoanProductChargeData;
 import org.apache.fineract.client.models.PostDelinquencyBucketResponse;
 import org.apache.fineract.client.models.PostDelinquencyRangeResponse;
+import org.apache.fineract.client.models.PostLoanProductsRequest;
+import org.apache.fineract.client.models.PostLoansRequest;
 import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
 import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
-import org.apache.fineract.integrationtests.BaseLoanIntegrationTest;
-import org.apache.fineract.integrationtests.common.BatchHelper;
-import org.apache.fineract.integrationtests.common.BusinessDateHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.CollateralManagementHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignDelinquencyHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignTransactionHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignUserHelper;
+import org.apache.fineract.integrationtests.client.feign.modules.ChargeRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
-import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanStatusChecker;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.apache.fineract.integrationtests.common.products.DelinquencyBucketsHelper;
-import org.apache.fineract.integrationtests.common.products.DelinquencyRangesHelper;
-import org.apache.fineract.integrationtests.useradministration.users.UserHelper;
+import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-@Slf4j
-public class InlineLoanCOBTest extends BaseLoanIntegrationTest {
+public class InlineLoanCOBTest extends FeignLoanTestBase {
 
-    private ResponseSpecification responseSpec;
-    private RequestSpecification requestSpec;
-    private InlineLoanCOBHelper inlineLoanCOBHelper;
-    private LoanTransactionHelper loanTransactionHelper;
-
-    @BeforeEach
-    public void setup() {
-        Utils.initializeRESTAssured();
-        requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        requestSpec.header("Fineract-Platform-TenantId", "default");
-        responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-        inlineLoanCOBHelper = new InlineLoanCOBHelper(requestSpec, responseSpec);
-    }
+    private static final String CUMULATIVE_STRATEGY = "mifos-standard-strategy";
+    private static final Long REPAYMENT_BATCH_REQUEST_ID = 4730L;
+    private static final int INLINE_COB_MAX_LOAN_IDS = 1000;
 
     @Test
     public void testInlineCOB() {
         try {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
+            enableBusinessDateAtMarch2();
+            Long loanId = createOverdueLoan();
 
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 2));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
-                    new PutGlobalConfigurationsRequest().value(0L));
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
+            updateBusinessDate(BusinessDateType.COB_DATE.name(), "02 March 2020");
+            executeInlineCOB(loanId);
+            verifyLastClosedBusinessDate(loanId, "02 March 2020");
 
-            final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec);
-            Assertions.assertNotNull(clientID);
+            updateBusinessDate(BusinessDateType.COB_DATE.name(), "03 March 2020");
+            executeInlineCOB(loanId);
+            verifyLastClosedBusinessDate(loanId, "03 March 2020");
 
-            Integer overdueFeeChargeId = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
-            Assertions.assertNotNull(overdueFeeChargeId);
-
-            final Integer loanProductID = createLoanProduct(overdueFeeChargeId.toString());
-            Assertions.assertNotNull(loanProductID);
-            HashMap loanStatusHashMap;
-
-            final Integer loanID = applyForLoanApplication(clientID.toString(), loanProductID.toString(), null, "1 March 2020");
-
-            Assertions.assertNotNull(loanID);
-
-            loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
-
-            loanStatusHashMap = loanTransactionHelper.approveLoan("01 March 2020", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-
-            String loanDetails = loanTransactionHelper.getLoanDetails(requestSpec, responseSpec, loanID);
-            loanStatusHashMap = loanTransactionHelper.disburseLoanWithNetDisbursalAmount("02 March 2020", loanID,
-                    JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.COB_DATE, LocalDate.of(2020, 3, 2));
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanID.longValue()));
-            GetLoansLoanIdResponse loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 2), loan.getLastClosedBusinessDate());
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.COB_DATE, LocalDate.of(2020, 3, 3));
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanID.longValue()));
-
-            loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 3), loan.getLastClosedBusinessDate());
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.COB_DATE, LocalDate.of(2020, 3, 10));
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanID.longValue()));
-
-            loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 10), loan.getLastClosedBusinessDate());
+            updateBusinessDate(BusinessDateType.COB_DATE.name(), "10 March 2020");
+            executeInlineCOB(loanId);
+            verifyLastClosedBusinessDate(loanId, "10 March 2020");
         } finally {
-            requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-            requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-            requestSpec.header("Fineract-Platform-TenantId", "default");
-            responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
+            disableBusinessDate();
         }
     }
 
@@ -152,402 +88,188 @@ public class InlineLoanCOBTest extends BaseLoanIntegrationTest {
         try {
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
+            FeignDelinquencyHelper delinquencyHelper = new FeignDelinquencyHelper(FineractFeignClientHelper.getFineractFeignClient());
 
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-
-            final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec);
-            Assertions.assertNotNull(clientID);
-
-            Integer overdueFeeChargeId = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
-            Assertions.assertNotNull(overdueFeeChargeId);
-
-            ArrayList<Long> rangeIds = new ArrayList<>();
-            // First Range
-            PostDelinquencyRangeResponse delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest()
-                    .minimumAgeDays(1).maximumAgeDays(3).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
-            rangeIds.add(delinquencyRangeResponse.getResourceId());
-
-            DelinquencyRangeResponse range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
-
-            // Second Range
-            delinquencyRangeResponse = DelinquencyRangesHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(4)
+            List<Long> rangeIds = new ArrayList<>();
+            PostDelinquencyRangeResponse firstRange = delinquencyHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(1)
+                    .maximumAgeDays(3).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
+            rangeIds.add(firstRange.getResourceId());
+            PostDelinquencyRangeResponse secondRange = delinquencyHelper.createRange(new DelinquencyRangeRequest().minimumAgeDays(4)
                     .maximumAgeDays(60).locale("en").classification(Utils.randomStringGenerator("DLQ_R_", 10)));
-            rangeIds.add(delinquencyRangeResponse.getResourceId());
+            rangeIds.add(secondRange.getResourceId());
 
-            range = DelinquencyRangesHelper.getRange(delinquencyRangeResponse.getResourceId());
-            final String classificationExpected = range.getClassification();
-            log.info("Expected Delinquency Range classification after Disbursement {}", classificationExpected);
-
-            PostDelinquencyBucketResponse delinquencyBucketResponse = DelinquencyBucketsHelper
+            PostDelinquencyBucketResponse delinquencyBucketResponse = delinquencyHelper
                     .createBucket(new DelinquencyBucketRequest().name(Utils.randomStringGenerator("DLQ_B_", 10)).ranges(rangeIds));
             assertNotNull(delinquencyBucketResponse);
-            final DelinquencyBucketResponse delinquencyBucket = DelinquencyBucketsHelper
-                    .getBucket(delinquencyBucketResponse.getResourceId());
+            DelinquencyBucketResponse delinquencyBucket = delinquencyHelper.getBucket(delinquencyBucketResponse.getResourceId());
 
-            final Integer loanProductID = createLoanProduct(loanTransactionHelper, delinquencyBucket.getId());
+            Long loanId = createDelinquentLoan(delinquencyBucket.getId());
 
-            Assertions.assertNotNull(loanProductID);
-            HashMap loanStatusHashMap;
+            updateBusinessDate(BusinessDateType.COB_DATE.name(), "02 March 2020");
+            executeInlineCOB(loanId);
+            assertTrue(getLoanDelinquencyTags(loanId).isEmpty());
+            verifyLastClosedBusinessDate(loanId, "02 March 2020");
 
-            final Integer loanID = applyForLoanApplication(clientID.toString(), loanProductID.toString(), null, "1 March 2020");
+            updateBusinessDate(BusinessDateType.COB_DATE.name(), "04 April 2020");
+            executeInlineCOB(loanId);
+            List<GetDelinquencyTagHistoryResponse> loanDelinquencyTags = getLoanDelinquencyTags(loanId);
+            verifyLastClosedBusinessDate(loanId, "04 April 2020");
+            assertEquals(1, loanDelinquencyTags.size());
+            assertEquals("2020-04-03", loanDelinquencyTags.get(0).getAddedOnDate().toString());
 
-            Assertions.assertNotNull(loanID);
-
-            loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
-
-            loanStatusHashMap = loanTransactionHelper.approveLoan("01 March 2020", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-
-            String loanDetails = loanTransactionHelper.getLoanDetails(requestSpec, responseSpec, loanID);
-            loanStatusHashMap = loanTransactionHelper.disburseLoanWithNetDisbursalAmount("02 March 2020", loanID,
-                    JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.COB_DATE, LocalDate.of(2020, 3, 2));
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanID.longValue()));
-            GetLoansLoanIdResponse loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            ArrayList<GetDelinquencyTagHistoryResponse> loanDelinquencyTags = loanTransactionHelper.getLoanDelinquencyTags(requestSpec,
-                    responseSpec, loanID);
-            Assertions.assertTrue(loanDelinquencyTags.isEmpty());
-            Assertions.assertEquals(LocalDate.of(2020, 3, 2), loan.getLastClosedBusinessDate());
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.COB_DATE, LocalDate.of(2020, 4, 4));
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanID.longValue()));
-
-            loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            loanDelinquencyTags = loanTransactionHelper.getLoanDelinquencyTags(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 4, 4), loan.getLastClosedBusinessDate());
-            Assertions.assertEquals(1, loanDelinquencyTags.size());
-            Assertions.assertEquals(LocalDate.of(2020, 4, 3), loanDelinquencyTags.get(0).getAddedOnDate());
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.COB_DATE, LocalDate.of(2020, 4, 10));
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanID.longValue()));
-
-            loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            loanDelinquencyTags = loanTransactionHelper.getLoanDelinquencyTags(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 4, 10), loan.getLastClosedBusinessDate());
-            Assertions.assertEquals(2, loanDelinquencyTags.size());
-            Assertions.assertEquals(LocalDate.of(2020, 4, 3), loanDelinquencyTags.get(1).getAddedOnDate());
-            Assertions.assertEquals(LocalDate.of(2020, 4, 6), loanDelinquencyTags.get(0).getAddedOnDate());
+            updateBusinessDate(BusinessDateType.COB_DATE.name(), "10 April 2020");
+            executeInlineCOB(loanId);
+            loanDelinquencyTags = getLoanDelinquencyTags(loanId);
+            verifyLastClosedBusinessDate(loanId, "10 April 2020");
+            assertEquals(2, loanDelinquencyTags.size());
+            assertEquals("2020-04-03", loanDelinquencyTags.get(1).getAddedOnDate().toString());
+            assertEquals("2020-04-06", loanDelinquencyTags.get(0).getAddedOnDate().toString());
         } finally {
-            requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-            requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-            requestSpec.header("Fineract-Platform-TenantId", "default");
-            responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
+            disableBusinessDate();
         }
     }
 
     @Test
     public void testInlineCOBOnRepaymentWithSoftLockedLoan() {
         try {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
+            enableBusinessDateAtMarch2();
+            Long loanId = createOverdueLoan();
 
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 2));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
-                    new PutGlobalConfigurationsRequest().value(0L));
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
+            updateBusinessDate(BusinessDateType.COB_DATE.name(), "02 March 2020");
+            executeInlineCOB(loanId);
+            verifyLastClosedBusinessDate(loanId, "02 March 2020");
 
-            final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec);
-            Assertions.assertNotNull(clientID);
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), "10 March 2020");
 
-            Integer overdueFeeChargeId = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
-            Assertions.assertNotNull(overdueFeeChargeId);
+            makeRepaymentAsNonByPassUser(loanId, "10 March 2020", 10.0);
 
-            final Integer loanProductID = createLoanProduct(overdueFeeChargeId.toString());
-            Assertions.assertNotNull(loanProductID);
-            HashMap loanStatusHashMap;
-            final Integer loanID = applyForLoanApplication(clientID.toString(), loanProductID.toString(), null, "1 March 2020");
-
-            Assertions.assertNotNull(loanID);
-
-            loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
-
-            loanStatusHashMap = loanTransactionHelper.approveLoan("01 March 2020", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-
-            String loanDetails = loanTransactionHelper.getLoanDetails(requestSpec, responseSpec, loanID);
-            loanStatusHashMap = loanTransactionHelper.disburseLoanWithNetDisbursalAmount("02 March 2020", loanID,
-                    JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.COB_DATE, LocalDate.of(2020, 3, 2));
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanID.longValue()));
-            GetLoansLoanIdResponse loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 2), loan.getLastClosedBusinessDate());
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 10));
-
-            requestSpec = UserHelper.getSimpleUserWithoutBypassPermission(requestSpec, responseSpec);
-
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-
-            loanTransactionHelper.makeRepayment("10 March 2020", 10.0f, loanID);
-
-            loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 9), loan.getLastClosedBusinessDate());
+            verifyLastClosedBusinessDate(loanId, "09 March 2020");
         } finally {
-            requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-            requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-            requestSpec.header("Fineract-Platform-TenantId", "default");
-            responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
+            disableBusinessDate();
         }
     }
 
     @Test
     public void testInlineCOBCatchUpOnRepaymentWithNotLockedLoan() {
         try {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 2));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
-                    new PutGlobalConfigurationsRequest().value(0L));
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
+            enableBusinessDateAtMarch2();
+            Long loanId = createOverdueLoan();
 
-            final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec);
-            Assertions.assertNotNull(clientID);
+            updateBusinessDate(BusinessDateType.COB_DATE.name(), "02 March 2020");
+            executeInlineCOB(loanId);
+            verifyLastClosedBusinessDate(loanId, "02 March 2020");
 
-            Integer overdueFeeChargeId = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
-            Assertions.assertNotNull(overdueFeeChargeId);
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), "10 March 2020");
 
-            final Integer loanProductID = createLoanProduct(overdueFeeChargeId.toString());
-            Assertions.assertNotNull(loanProductID);
-            HashMap loanStatusHashMap;
-            final Integer loanID = applyForLoanApplication(clientID.toString(), loanProductID.toString(), null, "1 March 2020");
+            makeRepaymentAsNonByPassUser(loanId, "10 March 2020", 10.0);
 
-            Assertions.assertNotNull(loanID);
-
-            loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
-
-            loanStatusHashMap = loanTransactionHelper.approveLoan("01 March 2020", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-
-            String loanDetails = loanTransactionHelper.getLoanDetails(requestSpec, responseSpec, loanID);
-            loanStatusHashMap = loanTransactionHelper.disburseLoanWithNetDisbursalAmount("02 March 2020", loanID,
-                    JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.COB_DATE, LocalDate.of(2020, 3, 2));
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanID.longValue()));
-            GetLoansLoanIdResponse loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 2), loan.getLastClosedBusinessDate());
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 10));
-
-            requestSpec = UserHelper.getSimpleUserWithoutBypassPermission(requestSpec, responseSpec);
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-
-            loanTransactionHelper.makeRepayment("10 March 2020", 10.0f, loanID);
-
-            loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 9), loan.getLastClosedBusinessDate());
+            verifyLastClosedBusinessDate(loanId, "09 March 2020");
         } finally {
-            requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-            requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-            requestSpec.header("Fineract-Platform-TenantId", "default");
-            responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
+            disableBusinessDate();
         }
     }
 
     @Test
     public void testInlineCOBOnBatchAPIWithOldRelativeUrls() {
         try {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 2));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
-                    new PutGlobalConfigurationsRequest().value(0L));
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
+            enableBusinessDateAtMarch2();
+            Long loanId = createOverdueLoan();
 
-            final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec);
-            Assertions.assertNotNull(clientID);
+            updateBusinessDate(BusinessDateType.COB_DATE.name(), "02 March 2020");
+            executeInlineCOB(loanId);
+            verifyLastClosedBusinessDate(loanId, "02 March 2020");
 
-            Integer overdueFeeChargeId = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
-            Assertions.assertNotNull(overdueFeeChargeId);
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), "10 March 2020");
 
-            final Integer loanProductID = createLoanProduct(overdueFeeChargeId.toString());
-            Assertions.assertNotNull(loanProductID);
-            HashMap loanStatusHashMap;
-            final Integer loanID = applyForLoanApplication(clientID.toString(), loanProductID.toString(), null, "1 March 2020");
+            AtomicReference<List<BatchResponse>> responseRef = new AtomicReference<>();
+            runAsNonByPass(() -> responseRef
+                    .set(batchRequest().repayLoanLegacyRelativeUrl(REPAYMENT_BATCH_REQUEST_ID, loanId, "10", "10 March 2020")
+                            .executeWithoutEnclosingTransaction()));
+            assertEquals(HttpStatus.SC_OK, responseRef.get().get(0).getStatusCode().intValue(), "Verify Status Code 200 for Repayment");
 
-            Assertions.assertNotNull(loanID);
-
-            loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
-
-            loanStatusHashMap = loanTransactionHelper.approveLoan("01 March 2020", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-
-            String loanDetails = loanTransactionHelper.getLoanDetails(requestSpec, responseSpec, loanID);
-            loanStatusHashMap = loanTransactionHelper.disburseLoanWithNetDisbursalAmount("02 March 2020", loanID,
-                    JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.COB_DATE, LocalDate.of(2020, 3, 2));
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanID.longValue()));
-            GetLoansLoanIdResponse loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 2), loan.getLastClosedBusinessDate());
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 10));
-
-            requestSpec = UserHelper.getSimpleUserWithoutBypassPermission(requestSpec, responseSpec);
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-
-            final BatchRequest br1 = BatchHelper.oldRepayLoanRequestWithGivenLoanId(4730L, loanID, "10", LocalDate.of(2020, 3, 10));
-
-            final List<BatchRequest> batchRequests = new ArrayList<>();
-
-            batchRequests.add(br1);
-
-            final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-
-            final List<BatchResponse> response = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec,
-                    this.responseSpec, jsonifiedRequest);
-            Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(0).getStatusCode(), "Verify Status Code 200 for Repayment");
-
-            loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 9), loan.getLastClosedBusinessDate());
+            verifyLastClosedBusinessDate(loanId, "09 March 2020");
         } finally {
-            requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-            requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-            requestSpec.header("Fineract-Platform-TenantId", "default");
-            responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
+            disableBusinessDate();
         }
     }
 
     @Test
     public void testInlineCOBOnBatchAPI() {
         try {
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(true));
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 2));
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
-                    new PutGlobalConfigurationsRequest().value(0L));
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
+            enableBusinessDateAtMarch2();
+            Long loanId = createOverdueLoan();
 
-            final Integer clientID = ClientHelper.createClient(requestSpec, responseSpec);
-            Assertions.assertNotNull(clientID);
+            updateBusinessDate(BusinessDateType.COB_DATE.name(), "02 March 2020");
+            executeInlineCOB(loanId);
+            verifyLastClosedBusinessDate(loanId, "02 March 2020");
 
-            Integer overdueFeeChargeId = ChargesHelper.createCharges(requestSpec, responseSpec,
-                    ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
-            Assertions.assertNotNull(overdueFeeChargeId);
+            updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), "10 March 2020");
 
-            final Integer loanProductID = createLoanProduct(overdueFeeChargeId.toString());
-            Assertions.assertNotNull(loanProductID);
-            HashMap loanStatusHashMap;
-            final Integer loanID = applyForLoanApplication(clientID.toString(), loanProductID.toString(), null, "1 March 2020");
+            AtomicReference<List<BatchResponse>> responseRef = new AtomicReference<>();
+            runAsNonByPass(() -> responseRef.set(batchRequest().repayLoan(REPAYMENT_BATCH_REQUEST_ID, loanId, "10", "10 March 2020")
+                    .executeWithoutEnclosingTransaction()));
+            assertEquals(HttpStatus.SC_OK, responseRef.get().get(0).getStatusCode().intValue(), "Verify Status Code 200 for Repayment");
 
-            Assertions.assertNotNull(loanID);
-
-            loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(requestSpec, responseSpec, loanID);
-            LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
-
-            loanStatusHashMap = loanTransactionHelper.approveLoan("01 March 2020", loanID);
-            LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-
-            String loanDetails = loanTransactionHelper.getLoanDetails(requestSpec, responseSpec, loanID);
-            loanStatusHashMap = loanTransactionHelper.disburseLoanWithNetDisbursalAmount("02 March 2020", loanID,
-                    JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-            LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.COB_DATE, LocalDate.of(2020, 3, 2));
-            inlineLoanCOBHelper.executeInlineCOB(List.of(loanID.longValue()));
-            GetLoansLoanIdResponse loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 2), loan.getLastClosedBusinessDate());
-
-            BusinessDateHelper.updateBusinessDate(BusinessDateType.BUSINESS_DATE, LocalDate.of(2020, 3, 10));
-
-            requestSpec = UserHelper.getSimpleUserWithoutBypassPermission(requestSpec, responseSpec);
-            loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
-
-            final BatchRequest br1 = BatchHelper.repayLoanRequestWithGivenLoanId(4730L, loanID, "10", LocalDate.of(2020, 3, 10));
-
-            final List<BatchRequest> batchRequests = new ArrayList<>();
-
-            batchRequests.add(br1);
-
-            final String jsonifiedRequest = BatchHelper.toJsonString(batchRequests);
-
-            final List<BatchResponse> response = BatchHelper.postBatchRequestsWithoutEnclosingTransaction(this.requestSpec,
-                    this.responseSpec, jsonifiedRequest);
-            Assertions.assertEquals(HttpStatus.SC_OK, (long) response.get(0).getStatusCode(), "Verify Status Code 200 for Repayment");
-
-            loan = loanTransactionHelper.getLoan(requestSpec, responseSpec, loanID);
-            Assertions.assertEquals(LocalDate.of(2020, 3, 9), loan.getLastClosedBusinessDate());
+            verifyLastClosedBusinessDate(loanId, "09 March 2020");
         } finally {
-            requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-            requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-            requestSpec.header("Fineract-Platform-TenantId", "default");
-            responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
-            globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                    new PutGlobalConfigurationsRequest().enabled(false));
+            disableBusinessDate();
         }
     }
 
     @Test
     public void testInlineCOBRequestBodyItemLimitValidation() {
-        responseSpec = new ResponseSpecBuilder().expectStatusCode(400).build();
-        inlineLoanCOBHelper = new InlineLoanCOBHelper(requestSpec, responseSpec);
-        List<Long> loanIds = LongStream.rangeClosed(1, 1001).boxed().toList();
-        String responseUserMessage = inlineLoanCOBHelper.executeInlineCOB(loanIds, "defaultUserMessage");
-        assertEquals("Size of the loan IDs list cannot be over 1000", responseUserMessage);
+        List<Long> loanIds = LongStream.rangeClosed(1, INLINE_COB_MAX_LOAN_IDS + 1).boxed().toList();
+        CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class, () -> executeInlineCOB(loanIds));
+        assertEquals(HttpStatus.SC_BAD_REQUEST, exception.getStatus());
+        assertTrue(exception.getMessage().contains("Size of the loan IDs list cannot be over " + INLINE_COB_MAX_LOAN_IDS),
+                "Expected the item-limit validation message but got: " + exception.getMessage());
     }
 
-    private Integer createLoanProduct(final String chargeId) {
-        final String loanProductJSON = new LoanProductTestBuilder().withPrincipal("15,000.00").withNumberOfRepayments("4")
-                .withRepaymentAfterEvery("1").withRepaymentTypeAsMonth().withinterestRatePerPeriod("1")
-                .withInterestRateFrequencyTypeAsMonths().withAmortizationTypeAsEqualInstallments().withInterestTypeAsDecliningBalance()
-                .build(chargeId);
-        return this.loanTransactionHelper.getLoanProductId(loanProductJSON);
+    private void enableBusinessDateAtMarch2() {
+        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+                new PutGlobalConfigurationsRequest().enabled(true));
+        updateBusinessDate(BusinessDateType.BUSINESS_DATE.name(), "02 March 2020");
+        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.PENALTY_WAIT_PERIOD,
+                new PutGlobalConfigurationsRequest().value(0L));
     }
 
-    private Integer createLoanProduct(final LoanTransactionHelper loanTransactionHelper, final Long delinquencyBucketId) {
-        final HashMap<String, Object> loanProductMap = new LoanProductTestBuilder().build(null, delinquencyBucketId);
-        return loanTransactionHelper.getLoanProductId(Utils.convertToJson(loanProductMap));
+    private void disableBusinessDate() {
+        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
+                new PutGlobalConfigurationsRequest().enabled(false));
     }
 
-    private Integer applyForLoanApplication(final String clientID, final String loanProductID, final String savingsID, final String date) {
-
-        List<HashMap> collaterals = new ArrayList<>();
-        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(this.requestSpec, this.responseSpec);
-        Assertions.assertNotNull(collateralId);
-        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(this.requestSpec, this.responseSpec, clientID,
-                collateralId);
-        Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
-
-        final String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal("15,000.00").withLoanTermFrequency("4")
-                .withLoanTermFrequencyAsMonths().withNumberOfRepayments("4").withRepaymentEveryAfter("1")
-                .withRepaymentFrequencyTypeAsMonths().withInterestRatePerPeriod("2").withAmortizationTypeAsEqualInstallments()
-                .withInterestTypeAsDecliningBalance().withInterestCalculationPeriodTypeSameAsRepaymentPeriod()
-                .withExpectedDisbursementDate(date).withSubmittedOnDate(date).withCollaterals(collaterals)
-                .build(clientID, loanProductID, savingsID);
-        return this.loanTransactionHelper.getLoanId(loanApplicationJSON);
+    private void makeRepaymentAsNonByPassUser(Long loanId, String date, double amount) {
+        FeignTransactionHelper nonByPassTransactionHelper = new FeignTransactionHelper(
+                FeignUserHelper.getSimpleUserWithoutBypassPermissionClient());
+        nonByPassTransactionHelper.makeLoanRepayment(loanId, "repayment", date, amount);
     }
 
-    private void addCollaterals(List<HashMap> collaterals, Integer collateralId, BigDecimal quantity) {
-        collaterals.add(collaterals(collateralId, quantity));
+    private Long createOverdueLoan() {
+        Long clientId = createClient();
+        ChargeRequest overdueFeeCharge = ChargeRequestBuilders.loanOverdueFee(1.0)
+                .chargeCalculationType(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST.getValue());
+        Long overdueFeeChargeId = chargesHelper.createCharge(overdueFeeCharge).getResourceId();
+        PostLoanProductsRequest product = create4Period1MonthLongWithoutInterestProduct(CUMULATIVE_STRATEGY).principal(15000.0)
+                .charges(List.of(new LoanProductChargeData().id(overdueFeeChargeId)));
+        return applyApproveDisburse(clientId, createLoanProduct(product));
     }
 
-    private HashMap<String, String> collaterals(Integer collateralId, BigDecimal quantity) {
-        HashMap<String, String> collateral = new HashMap<>(2);
-        collateral.put("clientCollateralId", collateralId.toString());
-        collateral.put("quantity", quantity.toString());
-        return collateral;
+    private Long createDelinquentLoan(Long delinquencyBucketId) {
+        Long clientId = createClient();
+        PostLoanProductsRequest product = create4Period1MonthLongWithoutInterestProduct(CUMULATIVE_STRATEGY).principal(15000.0)
+                .delinquencyBucketId(delinquencyBucketId);
+        return applyApproveDisburse(clientId, createLoanProduct(product));
+    }
+
+    private Long applyApproveDisburse(Long clientId, Long loanProductId) {
+        PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "01 March 2020", 15000.0, 4)//
+                .repaymentEvery(1)//
+                .loanTermFrequency(4)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS);
+        Long loanId = applyForLoan(applicationRequest);
+        approveLoan(loanId, approveLoanRequest(15000.0, "01 March 2020"));
+        disburseLoan(loanId, BigDecimal.valueOf(15000.0), "02 March 2020");
+        return loanId;
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/investor/externalassetowner/ExternalAssetOwnerTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/investor/externalassetowner/ExternalAssetOwnerTest.java
@@ -25,30 +25,32 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Optional;
-import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
 import org.apache.fineract.client.models.ExternalTransferOwnerData;
 import org.apache.fineract.client.models.PostExternalAssetOwnerRequest;
 import org.apache.fineract.client.models.PostExternalAssetOwnerResponse;
-import org.apache.fineract.client.util.CallFailedRuntimeException;
-import org.apache.fineract.integrationtests.BaseLoanIntegrationTest;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignExternalAssetOwnerHelper;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
-import org.apache.fineract.integrationtests.investor.InvestorHelper;
 import org.junit.jupiter.api.Test;
 
-@Slf4j
-public class ExternalAssetOwnerTest extends BaseLoanIntegrationTest {
+public class ExternalAssetOwnerTest extends FeignLoanTestBase {
+
+    private final FeignExternalAssetOwnerHelper externalAssetOwnerHelper = new FeignExternalAssetOwnerHelper(
+            FineractFeignClientHelper.getFineractFeignClient());
 
     @Test
     public void testCreateExternalAssetOwnerSuccessfully() {
         final String ownerExternalId = Utils.uniqueRandomStringGenerator("eao", 20);
         final PostExternalAssetOwnerRequest request = new PostExternalAssetOwnerRequest().ownerExternalId(ownerExternalId);
 
-        final PostExternalAssetOwnerResponse response = InvestorHelper.createExternalAssetOwner(request);
+        final PostExternalAssetOwnerResponse response = externalAssetOwnerHelper.createExternalAssetOwner(request);
 
         assertNotNull(response);
         assertNotNull(response.getResourceId());
 
-        List<ExternalTransferOwnerData> externalAssetOwners = InvestorHelper.retrieveExternalAssetOwners();
+        List<ExternalTransferOwnerData> externalAssetOwners = externalAssetOwnerHelper.retrieveExternalAssetOwners();
         assertTrue(externalAssetOwners.size() > 0);
         Optional<ExternalTransferOwnerData> optExternalTransferOwnerData = externalAssetOwners.stream()
                 .filter(eao -> eao.getExternalId().equals(ownerExternalId)).findFirst();
@@ -60,8 +62,8 @@ public class ExternalAssetOwnerTest extends BaseLoanIntegrationTest {
         final PostExternalAssetOwnerRequest request = new PostExternalAssetOwnerRequest().ownerExternalId(null);
 
         final CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                () -> InvestorHelper.createExternalAssetOwner(request));
-        assertEquals(400, exception.getResponse().code());
+                () -> externalAssetOwnerHelper.createExternalAssetOwner(request));
+        assertEquals(400, exception.getStatus());
         assertTrue(exception.getMessage().contains("validation.msg.externalAssetOwner.ownerExternalId.cannot.be.blank"));
     }
 
@@ -70,13 +72,13 @@ public class ExternalAssetOwnerTest extends BaseLoanIntegrationTest {
         final String ownerExternalId = Utils.uniqueRandomStringGenerator("eao", 20);
         final PostExternalAssetOwnerRequest request = new PostExternalAssetOwnerRequest().ownerExternalId(ownerExternalId);
 
-        final PostExternalAssetOwnerResponse firstResponse = InvestorHelper.createExternalAssetOwner(request);
+        final PostExternalAssetOwnerResponse firstResponse = externalAssetOwnerHelper.createExternalAssetOwner(request);
         assertNotNull(firstResponse);
         assertNotNull(firstResponse.getResourceId());
 
         final CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                () -> InvestorHelper.createExternalAssetOwner(request));
-        assertEquals(403, exception.getResponse().code());
+                () -> externalAssetOwnerHelper.createExternalAssetOwner(request));
+        assertEquals(403, exception.getStatus());
         assertTrue(exception.getMessage().contains("error.msg.provided.external.id.already.exists"));
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/investor/externalassetowner/ExternalAssetOwnerToOwnerTransferTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/investor/externalassetowner/ExternalAssetOwnerToOwnerTransferTest.java
@@ -49,8 +49,8 @@ public class ExternalAssetOwnerToOwnerTransferTest extends ExternalAssetOwnerTra
             setInitialBusinessDate(java.time.LocalDate.parse("2020-03-02"));
 
             // Step 1: Create client and loan
-            Integer clientID = createClient();
-            Integer loanID = createLoanForClient(clientID, "02 March 2020");
+            Long clientID = createClient();
+            Long loanID = createLoanForClient(clientID, "02 March 2020");
             addPenaltyForLoan(loanID, "10");
 
             // Step 2: Sell loan to Owner A
@@ -82,7 +82,7 @@ public class ExternalAssetOwnerToOwnerTransferTest extends ExternalAssetOwnerTra
             validateResponse(saleBResponse, loanID);
 
             // Verify the new PENDING transfer was created for Owner B
-            PageExternalTransferData transfers = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            PageExternalTransferData transfers = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID);
             assertNotNull(transfers.getContent());
 
             // Find the new PENDING transfer for Owner B
@@ -95,7 +95,7 @@ public class ExternalAssetOwnerToOwnerTransferTest extends ExternalAssetOwnerTra
             updateBusinessDateAndExecuteCOBJob("2020-03-04");
 
             // Verify final state: Owner A's ACTIVE transfer is expired, Owner B is now ACTIVE
-            transfers = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            transfers = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID);
             assertNotNull(transfers.getContent());
 
             // Owner A's ACTIVE transfer should now have effectiveDateTo = 2020-03-03 (settlement date of Owner B)
@@ -117,7 +117,7 @@ public class ExternalAssetOwnerToOwnerTransferTest extends ExternalAssetOwnerTra
 
             // Verify active mapping now points to Owner B (use direct API, not getAndValidateThereIsActiveMapping
             // which assumes only one ACTIVE transfer)
-            ExternalTransferData activeTransfer = EXTERNAL_ASSET_OWNER_HELPER.retrieveActiveTransferByLoanId(loanID.longValue());
+            ExternalTransferData activeTransfer = EXTERNAL_ASSET_OWNER_HELPER.retrieveActiveTransferByLoanId(loanID);
             assertNotNull(activeTransfer, "There should be an active transfer mapping");
             assertEquals(saleBTransferExternalId, activeTransfer.getTransferExternalId(),
                     "Active mapping should point to Owner B's transfer");
@@ -133,8 +133,8 @@ public class ExternalAssetOwnerToOwnerTransferTest extends ExternalAssetOwnerTra
             setInitialBusinessDate(java.time.LocalDate.parse("2020-03-02"));
 
             // Setup
-            Integer clientID = createClient();
-            Integer loanID = createLoanForClient(clientID, "02 March 2020");
+            Long clientID = createClient();
+            Long loanID = createLoanForClient(clientID, "02 March 2020");
             addPenaltyForLoan(loanID, "10");
 
             // Sell to Owner A and activate via COB
@@ -151,7 +151,7 @@ public class ExternalAssetOwnerToOwnerTransferTest extends ExternalAssetOwnerTra
             updateBusinessDateAndExecuteCOBJob("2020-03-04");
 
             // Verify Owner B is active
-            ExternalTransferData activeTransfer = EXTERNAL_ASSET_OWNER_HELPER.retrieveActiveTransferByLoanId(loanID.longValue());
+            ExternalTransferData activeTransfer = EXTERNAL_ASSET_OWNER_HELPER.retrieveActiveTransferByLoanId(loanID);
             assertEquals(saleBExternalId, activeTransfer.getTransferExternalId());
 
             // Sell from Owner B to Owner C (settlementDate = current business date 2020-03-04)
@@ -161,12 +161,12 @@ public class ExternalAssetOwnerToOwnerTransferTest extends ExternalAssetOwnerTra
             updateBusinessDateAndExecuteCOBJob("2020-03-05");
 
             // Verify Owner C is now active
-            activeTransfer = EXTERNAL_ASSET_OWNER_HELPER.retrieveActiveTransferByLoanId(loanID.longValue());
+            activeTransfer = EXTERNAL_ASSET_OWNER_HELPER.retrieveActiveTransferByLoanId(loanID);
             assertEquals(saleCExternalId, activeTransfer.getTransferExternalId(),
                     "Owner C should be the active owner after chained transfers");
 
             // Verify Owner B's transfer is expired
-            PageExternalTransferData allTransfers = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            PageExternalTransferData allTransfers = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID);
             ExternalTransferData ownerBActive = allTransfers.getContent().stream()
                     .filter(t -> saleBExternalId.equals(t.getTransferExternalId()) && ACTIVE.equals(t.getStatus())).findFirst()
                     .orElse(null);
@@ -185,8 +185,8 @@ public class ExternalAssetOwnerToOwnerTransferTest extends ExternalAssetOwnerTra
             setInitialBusinessDate(java.time.LocalDate.parse("2020-03-02"));
 
             // Setup: create loan and sell to Owner A
-            Integer clientID = createClient();
-            Integer loanID = createLoanForClient(clientID, "02 March 2020");
+            Long clientID = createClient();
+            Long loanID = createLoanForClient(clientID, "02 March 2020");
             addPenaltyForLoan(loanID, "10");
 
             String ownerAExternalId = UUID.randomUUID().toString();
@@ -206,13 +206,13 @@ public class ExternalAssetOwnerToOwnerTransferTest extends ExternalAssetOwnerTra
             EXTERNAL_ASSET_OWNER_HELPER.cancelTransferByTransferExternalId(saleBExternalId);
 
             // Verify Owner A is still the active owner — ACTIVE transfer with effectiveDateTo = 9999-12-31
-            ExternalTransferData activeTransfer = EXTERNAL_ASSET_OWNER_HELPER.retrieveActiveTransferByLoanId(loanID.longValue());
+            ExternalTransferData activeTransfer = EXTERNAL_ASSET_OWNER_HELPER.retrieveActiveTransferByLoanId(loanID);
             assertNotNull(activeTransfer, "Owner A should still be the active owner after cancel");
             assertEquals(saleAExternalId, activeTransfer.getTransferExternalId(),
                     "Active mapping should still point to Owner A after cancel");
 
             // Verify Owner A's ACTIVE transfer is untouched (effectiveDateTo = 9999-12-31)
-            PageExternalTransferData transfers = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            PageExternalTransferData transfers = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID);
             ExternalTransferData ownerAActive = transfers.getContent().stream()
                     .filter(t -> saleAExternalId.equals(t.getTransferExternalId()) && ACTIVE.equals(t.getStatus())
                             && java.time.LocalDate.parse("9999-12-31").equals(t.getEffectiveTo()))
@@ -236,8 +236,8 @@ public class ExternalAssetOwnerToOwnerTransferTest extends ExternalAssetOwnerTra
             setInitialBusinessDate(java.time.LocalDate.parse("2020-03-02"));
 
             // Setup: create loan and sell to Owner A
-            Integer clientID = createClient();
-            Integer loanID = createLoanForClient(clientID, "02 March 2020");
+            Long clientID = createClient();
+            Long loanID = createLoanForClient(clientID, "02 March 2020");
             addPenaltyForLoan(loanID, "10");
 
             String ownerAExternalId = UUID.randomUUID().toString();
@@ -253,15 +253,15 @@ public class ExternalAssetOwnerToOwnerTransferTest extends ExternalAssetOwnerTra
 
             // Write off the loan — this will trigger decline when COB processes the PENDING transfer
             updateBusinessDateAndExecuteCOBJob("2020-03-04");
-            LOAN_TRANSACTION_HELPER.writeOffLoan("04 March 2020", loanID);
+            writeOffLoan("04 March 2020", loanID);
 
             // Verify Owner A is still the active owner (PENDING for Owner B should be declined, not yet settled)
-            ExternalTransferData activeTransfer = EXTERNAL_ASSET_OWNER_HELPER.retrieveActiveTransferByLoanId(loanID.longValue());
+            ExternalTransferData activeTransfer = EXTERNAL_ASSET_OWNER_HELPER.retrieveActiveTransferByLoanId(loanID);
             assertNotNull(activeTransfer, "Owner A should still be the active owner before settlement date");
             assertEquals(saleAExternalId, activeTransfer.getTransferExternalId(), "Active mapping should still point to Owner A");
 
             // Verify Owner B's PENDING transfer is declined
-            PageExternalTransferData transfers = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            PageExternalTransferData transfers = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID);
             ExternalTransferData ownerBDeclined = transfers.getContent().stream()
                     .filter(t -> saleBExternalId.equals(t.getTransferExternalId()) && DECLINED.equals(t.getStatus())).findFirst()
                     .orElse(null);

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/investor/externalassetowner/ExternalAssetOwnerTransferCancelTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/investor/externalassetowner/ExternalAssetOwnerTransferCancelTest.java
@@ -21,345 +21,194 @@ package org.apache.fineract.integrationtests.investor.externalassetowner;
 import static org.apache.fineract.client.models.ExternalTransferData.StatusEnum.BUYBACK;
 import static org.apache.fineract.client.models.ExternalTransferData.StatusEnum.CANCELLED;
 import static org.apache.fineract.client.models.ExternalTransferData.StatusEnum.PENDING;
-import static org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType.BUSINESS_DATE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.path.json.JsonPath;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.apache.fineract.accounting.common.AccountingConstants;
 import org.apache.fineract.client.models.ExternalAssetOwnerRequest;
 import org.apache.fineract.client.models.ExternalOwnerTransferJournalEntryData;
 import org.apache.fineract.client.models.ExternalTransferData;
-import org.apache.fineract.client.models.GetFinancialActivityAccountsResponse;
 import org.apache.fineract.client.models.PageExternalTransferData;
-import org.apache.fineract.client.models.PostFinancialActivityAccountsRequest;
 import org.apache.fineract.client.models.PostInitiateTransferResponse;
-import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
+import org.apache.fineract.client.models.PostLoanProductsRequest;
+import org.apache.fineract.client.models.PostLoansRequest;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
-import org.apache.fineract.integrationtests.BaseLoanIntegrationTest;
-import org.apache.fineract.integrationtests.common.BusinessDateHelper;
-import org.apache.fineract.integrationtests.common.BusinessStepHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.CollateralManagementHelper;
-import org.apache.fineract.integrationtests.common.ExternalAssetOwnerHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignBusinessStepHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignExternalAssetOwnerHelper;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.common.accounting.Account;
-import org.apache.fineract.integrationtests.common.accounting.AccountHelper;
-import org.apache.fineract.integrationtests.common.accounting.FinancialActivityAccountHelper;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
-import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanStatusChecker;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.junit.jupiter.api.Assertions;
+import org.apache.fineract.integrationtests.common.loans.LoanTestLifecycleExtension;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanStatus;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.springframework.lang.NonNull;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@SuppressWarnings("rawtypes")
-public class ExternalAssetOwnerTransferCancelTest extends BaseLoanIntegrationTest {
+@ExtendWith({ LoanTestLifecycleExtension.class })
+public class ExternalAssetOwnerTransferCancelTest extends FeignLoanTestBase {
 
-    public String ownerExternalId;
-    private static ResponseSpecification RESPONSE_SPEC;
-    private static RequestSpecification REQUEST_SPEC;
-    private static Account ASSET_ACCOUNT;
-    private static Account FEE_PENALTY_ACCOUNT;
-    private static Account TRANSFER_ACCOUNT;
-    private static Account EXPENSE_ACCOUNT;
-    private static Account INCOME_ACCOUNT;
-    private static Account OVERPAYMENT_ACCOUNT;
-    private static FinancialActivityAccountHelper FINANCIAL_ACTIVITY_ACCOUNT_HELPER;
-    private static ExternalAssetOwnerHelper EXTERNAL_ASSET_OWNER_HELPER;
-    private static LoanTransactionHelper LOAN_TRANSACTION_HELPER;
-    private static LocalDate TODAYS_DATE;
-    private DateTimeFormatter dateFormatter = new DateTimeFormatterBuilder().appendPattern("dd MMMM yyyy").toFormatter();
+    private static final String DATE_FORMAT_ISO = "yyyy-MM-dd";
+    private static final String SALE_DATE = "2020-03-02";
+    private static final String SALE_DATE_TEXT = "02 March 2020";
+    private static final String SUBMIT_DATE_TEXT = "01 March 2020";
+
+    private final FeignExternalAssetOwnerHelper externalAssetOwnerHelper = new FeignExternalAssetOwnerHelper(
+            FineractFeignClientHelper.getFineractFeignClient());
 
     @BeforeAll
     public static void setupInvestorBusinessStep() {
-        Utils.initializeRESTAssured();
-        REQUEST_SPEC = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        REQUEST_SPEC.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        RESPONSE_SPEC = new ResponseSpecBuilder().expectStatusCode(200).build();
-        AccountHelper accountHelper = new AccountHelper(REQUEST_SPEC, RESPONSE_SPEC);
-        EXTERNAL_ASSET_OWNER_HELPER = new ExternalAssetOwnerHelper();
-        FINANCIAL_ACTIVITY_ACCOUNT_HELPER = new FinancialActivityAccountHelper(REQUEST_SPEC);
-        LOAN_TRANSACTION_HELPER = new LoanTransactionHelper(REQUEST_SPEC, RESPONSE_SPEC);
-
-        TODAYS_DATE = Utils.getLocalDateOfTenant();
-        new BusinessStepHelper().updateSteps("LOAN_CLOSE_OF_BUSINESS", "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION",
-                "CHECK_LOAN_REPAYMENT_DUE", "CHECK_LOAN_REPAYMENT_OVERDUE", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
+        new FeignBusinessStepHelper(FineractFeignClientHelper.getFineractFeignClient()).updateSteps("LOAN_CLOSE_OF_BUSINESS",
+                "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION", "CHECK_LOAN_REPAYMENT_DUE",
+                "CHECK_LOAN_REPAYMENT_OVERDUE", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
                 "EXTERNAL_ASSET_OWNER_TRANSFER");
-
-        ASSET_ACCOUNT = accountHelper.createAssetAccount();
-        FEE_PENALTY_ACCOUNT = accountHelper.createAssetAccount();
-        TRANSFER_ACCOUNT = accountHelper.createAssetAccount();
-        EXPENSE_ACCOUNT = accountHelper.createExpenseAccount();
-        INCOME_ACCOUNT = accountHelper.createIncomeAccount();
-        OVERPAYMENT_ACCOUNT = accountHelper.createLiabilityAccount();
-
-        setProperFinancialActivity(TRANSFER_ACCOUNT);
-    }
-
-    private static void setProperFinancialActivity(Account transferAccount) {
-        List<GetFinancialActivityAccountsResponse> financialMappings = FINANCIAL_ACTIVITY_ACCOUNT_HELPER.getAllFinancialActivityAccounts();
-        financialMappings.forEach(mapping -> FINANCIAL_ACTIVITY_ACCOUNT_HELPER.deleteFinancialActivityAccount(mapping.getId()));
-        FINANCIAL_ACTIVITY_ACCOUNT_HELPER.createFinancialActivityAccount(new PostFinancialActivityAccountsRequest()
-                .financialActivityId((long) AccountingConstants.FinancialActivity.ASSET_TRANSFER.getValue())
-                .glAccountId((long) transferAccount.getAccountID()));
     }
 
     @Test
     public void successCancelSale() {
+        globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
+        Account transferAccount = accountHelper.createAssetAccount(Utils.uniqueRandomStringGenerator("TRANSFER_", 5));
+        externalAssetOwnerHelper.setProperFinancialActivity(transferAccount);
         try {
-            globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2020-03-02");
-            Integer clientID = createClient();
-            Integer loanID = createLoanForClient(clientID);
-            addPenaltyForLoan(loanID, "10");
+            runAt(SALE_DATE_TEXT, () -> {
+                Long loanId = createLoanForClient();
+                addCharge(loanId, true, 10.0, SALE_DATE_TEXT);
 
-            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanID, "2020-03-02");
-            validateResponse(saleTransferResponse, loanID);
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
-                    ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
-                            "9999-12-31", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
-                            new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
-                            new BigDecimal("0.000000")));
+                PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanId, SALE_DATE);
+                validateResponse(saleTransferResponse, loanId);
+                getAndValidateExternalAssetOwnerTransferByLoan(loanId, ExpectedExternalTransferData.expected(PENDING,
+                        saleTransferResponse.getResourceExternalId(), SALE_DATE, SALE_DATE, "9999-12-31"));
 
-            PageExternalTransferData retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
-            retrieveResponse.getContent().forEach(transfer -> getAndValidateThereIsNoJournalEntriesForTransfer(transfer.getTransferId()));
+                PageExternalTransferData retrieveResponse = externalAssetOwnerHelper.retrieveTransfersByLoanId(loanId);
+                retrieveResponse.getContent()
+                        .forEach(transfer -> getAndValidateThereIsNoJournalEntriesForTransfer(transfer.getTransferId()));
 
-            EXTERNAL_ASSET_OWNER_HELPER.cancelTransferByTransferExternalId(saleTransferResponse.getResourceExternalId());
+                externalAssetOwnerHelper.cancelTransferByTransferExternalId(saleTransferResponse.getResourceExternalId());
 
-            // updateBusinessDateAndExecuteCOBJob("2020-03-03");
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
-                    ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
-                            "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
-                            new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
-                            new BigDecimal("0.000000")),
-                    ExpectedExternalTransferData.expected(CANCELLED, saleTransferResponse.getResourceExternalId(), "2020-03-02",
-                            "2020-03-02", "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
-                            new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
-                            new BigDecimal("0.000000")));
+                // updateBusinessDateAndExecuteCOBJob("2020-03-03");
+                getAndValidateExternalAssetOwnerTransferByLoan(loanId,
+                        ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), SALE_DATE, SALE_DATE,
+                                SALE_DATE),
+                        ExpectedExternalTransferData.expected(CANCELLED, saleTransferResponse.getResourceExternalId(), SALE_DATE, SALE_DATE,
+                                SALE_DATE));
+            });
         } finally {
-            cleanUpAndRestoreBusinessDate();
+            globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, false);
         }
-    }
-
-    private void getAndValidateThereIsNoJournalEntriesForTransfer(Long transferId) {
-        ExternalOwnerTransferJournalEntryData result = EXTERNAL_ASSET_OWNER_HELPER.retrieveJournalEntriesOfTransfer(transferId);
-        assertNull(result.getJournalEntryData());
     }
 
     @Test
     public void saleAndBuybackOnTheSameDay() {
+        globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
+        Account transferAccount = accountHelper.createAssetAccount(Utils.uniqueRandomStringGenerator("TRANSFER_", 5));
+        externalAssetOwnerHelper.setProperFinancialActivity(transferAccount);
         try {
-            globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2020-03-02");
-            Integer clientID = createClient();
-            Integer loanID = createLoanForClient(clientID);
+            runAt(SALE_DATE_TEXT, () -> {
+                Long loanId = createLoanForClient();
 
-            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanID, "2020-03-02");
-            validateResponse(saleTransferResponse, loanID);
-            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanID, "2020-03-02");
-            validateResponse(buybackTransferResponse, loanID);
+                PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanId, SALE_DATE);
+                validateResponse(saleTransferResponse, loanId);
+                PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanId, SALE_DATE);
+                validateResponse(buybackTransferResponse, loanId);
 
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
-                    ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
-                            "9999-12-31", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
-                            new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
-                            new BigDecimal("0.000000")),
-                    ExpectedExternalTransferData.expected(BUYBACK, buybackTransferResponse.getResourceExternalId(), "2020-03-02",
-                            "2020-03-02", "9999-12-31", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
-                            new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
-                            new BigDecimal("0.000000")));
-            getAndValidateThereIsNoActiveMapping(saleTransferResponse.getResourceExternalId());
-            getAndValidateThereIsNoActiveMapping(buybackTransferResponse.getResourceExternalId());
+                getAndValidateExternalAssetOwnerTransferByLoan(loanId,
+                        ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), SALE_DATE, SALE_DATE,
+                                "9999-12-31"),
+                        ExpectedExternalTransferData.expected(BUYBACK, buybackTransferResponse.getResourceExternalId(), SALE_DATE,
+                                SALE_DATE, "9999-12-31"));
+                getAndValidateThereIsNoActiveMapping(saleTransferResponse.getResourceExternalId());
+                getAndValidateThereIsNoActiveMapping(buybackTransferResponse.getResourceExternalId());
 
-            EXTERNAL_ASSET_OWNER_HELPER.cancelTransferByTransferExternalIdError(saleTransferResponse.getResourceExternalId());
+                externalAssetOwnerHelper.cancelTransferByTransferExternalIdError(saleTransferResponse.getResourceExternalId());
 
-            EXTERNAL_ASSET_OWNER_HELPER.cancelTransferByTransferExternalId(buybackTransferResponse.getResourceExternalId());
+                externalAssetOwnerHelper.cancelTransferByTransferExternalId(buybackTransferResponse.getResourceExternalId());
 
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
-                    ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
-                            "9999-12-31", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
-                            new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
-                            new BigDecimal("0.000000")),
-                    ExpectedExternalTransferData.expected(BUYBACK, buybackTransferResponse.getResourceExternalId(), "2020-03-02",
-                            "2020-03-02", "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
-                            new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
-                            new BigDecimal("0.000000")),
-                    ExpectedExternalTransferData.expected(CANCELLED, buybackTransferResponse.getResourceExternalId(), "2020-03-02",
-                            "2020-03-02", "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
-                            new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
-                            new BigDecimal("0.000000")));
+                getAndValidateExternalAssetOwnerTransferByLoan(loanId,
+                        ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), SALE_DATE, SALE_DATE,
+                                "9999-12-31"),
+                        ExpectedExternalTransferData.expected(BUYBACK, buybackTransferResponse.getResourceExternalId(), SALE_DATE,
+                                SALE_DATE, SALE_DATE),
+                        ExpectedExternalTransferData.expected(CANCELLED, buybackTransferResponse.getResourceExternalId(), SALE_DATE,
+                                SALE_DATE, SALE_DATE));
 
-            EXTERNAL_ASSET_OWNER_HELPER.cancelTransferByTransferExternalId(saleTransferResponse.getResourceExternalId());
+                externalAssetOwnerHelper.cancelTransferByTransferExternalId(saleTransferResponse.getResourceExternalId());
 
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
-                    ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
-                            "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
-                            new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
-                            new BigDecimal("0.000000")),
-                    ExpectedExternalTransferData.expected(BUYBACK, buybackTransferResponse.getResourceExternalId(), "2020-03-02",
-                            "2020-03-02", "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
-                            new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
-                            new BigDecimal("0.000000")),
-                    ExpectedExternalTransferData.expected(CANCELLED, buybackTransferResponse.getResourceExternalId(), "2020-03-02",
-                            "2020-03-02", "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
-                            new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
-                            new BigDecimal("0.000000")),
-                    ExpectedExternalTransferData.expected(CANCELLED, saleTransferResponse.getResourceExternalId(), "2020-03-02",
-                            "2020-03-02", "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
-                            new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
-                            new BigDecimal("0.000000")));
-            getAndValidateThereIsNoActiveMapping((long) loanID);
+                getAndValidateExternalAssetOwnerTransferByLoan(loanId,
+                        ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), SALE_DATE, SALE_DATE,
+                                SALE_DATE),
+                        ExpectedExternalTransferData.expected(BUYBACK, buybackTransferResponse.getResourceExternalId(), SALE_DATE,
+                                SALE_DATE, SALE_DATE),
+                        ExpectedExternalTransferData.expected(CANCELLED, buybackTransferResponse.getResourceExternalId(), SALE_DATE,
+                                SALE_DATE, SALE_DATE),
+                        ExpectedExternalTransferData.expected(CANCELLED, saleTransferResponse.getResourceExternalId(), SALE_DATE, SALE_DATE,
+                                SALE_DATE));
+                getAndValidateThereIsNoActiveMapping(loanId);
+            });
         } finally {
-            cleanUpAndRestoreBusinessDate();
+            globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, false);
         }
     }
 
-    private PostInitiateTransferResponse createSaleTransfer(Integer loanID, String settlementDate) {
-        String transferExternalId = UUID.randomUUID().toString();
-        ownerExternalId = UUID.randomUUID().toString();
-        return createSaleTransfer(loanID, settlementDate, transferExternalId, ownerExternalId, "1.0");
+    private Long createLoanForClient() {
+        Long clientId = createClient();
+        PostLoanProductsRequest productRequest = createOnePeriod30DaysPeriodicAccrualProduct(2.0)//
+                .numberOfRepayments(4)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS_L)//
+                .principal(15000.0);
+        Long loanProductId = createLoanProduct(productRequest);
+
+        PostLoansRequest loanRequest = applyLoanRequest(clientId, loanProductId, SUBMIT_DATE_TEXT, 15000.0, 4, request -> request//
+                .interestRatePerPeriod(BigDecimal.valueOf(2))//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .loanTermFrequency(4)//
+                .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .dateFormat(LoanTestData.DATETIME_PATTERN).expectedDisbursementDate(SALE_DATE_TEXT).submittedOnDate(SUBMIT_DATE_TEXT));
+        Long loanId = applyForLoan(loanRequest);
+        verifyLoanStatus(loanId, LoanStatus.SUBMITTED_AND_PENDING_APPROVAL);
+        approveLoan(loanId, approveLoanRequest(15000.0, SUBMIT_DATE_TEXT));
+        verifyLoanStatus(loanId, LoanStatus.APPROVED);
+        disburseLoan(loanId, SALE_DATE_TEXT, 15000.0);
+        verifyLoanStatus(loanId, LoanStatus.ACTIVE);
+        return loanId;
     }
 
-    private PostInitiateTransferResponse createSaleTransfer(Integer loanID, String settlementDate, String transferExternalId,
-            String ownerExternalId, String purchasePriceRatio) {
-        PostInitiateTransferResponse saleResponse = EXTERNAL_ASSET_OWNER_HELPER.initiateTransferByLoanId(loanID.longValue(), "sale",
-                new ExternalAssetOwnerRequest().settlementDate(settlementDate).dateFormat("yyyy-MM-dd").locale("en")
-                        .transferExternalId(transferExternalId).ownerExternalId(ownerExternalId).purchasePriceRatio(purchasePriceRatio));
+    private PostInitiateTransferResponse createSaleTransfer(Long loanId, String settlementDate) {
+        String transferExternalId = UUID.randomUUID().toString();
+        String ownerExternalId = UUID.randomUUID().toString();
+        PostInitiateTransferResponse saleResponse = externalAssetOwnerHelper.initiateTransferByLoanId(loanId, "sale",
+                new ExternalAssetOwnerRequest().settlementDate(settlementDate).dateFormat(DATE_FORMAT_ISO).locale("en")
+                        .transferExternalId(transferExternalId).ownerExternalId(ownerExternalId).purchasePriceRatio("1.0"));
         assertEquals(transferExternalId, saleResponse.getResourceExternalId());
         return saleResponse;
     }
 
-    private PostInitiateTransferResponse createBuybackTransfer(Integer loanID, String settlementDate) {
+    private PostInitiateTransferResponse createBuybackTransfer(Long loanId, String settlementDate) {
         String transferExternalId = UUID.randomUUID().toString();
-        PostInitiateTransferResponse saleResponse = EXTERNAL_ASSET_OWNER_HELPER.initiateTransferByLoanId(loanID.longValue(), "buyback",
-                new ExternalAssetOwnerRequest().settlementDate(settlementDate).dateFormat("yyyy-MM-dd").locale("en")
+        PostInitiateTransferResponse buybackResponse = externalAssetOwnerHelper.initiateTransferByLoanId(loanId, "buyback",
+                new ExternalAssetOwnerRequest().settlementDate(settlementDate).dateFormat(DATE_FORMAT_ISO).locale("en")
                         .transferExternalId(transferExternalId));
-        assertEquals(transferExternalId, saleResponse.getResourceExternalId());
-        return saleResponse;
+        assertEquals(transferExternalId, buybackResponse.getResourceExternalId());
+        return buybackResponse;
     }
 
-    private void addPenaltyForLoan(Integer loanID, String amount) {
+    private void getAndValidateThereIsNoJournalEntriesForTransfer(Long transferId) {
+        ExternalOwnerTransferJournalEntryData result = externalAssetOwnerHelper.retrieveJournalEntriesOfTransfer(transferId);
         // Add Charge Penalty
-        Integer penalty = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, amount, true));
-        Integer penalty1LoanChargeId = this.LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID,
-                LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "02 March 2020", amount));
-        assertNotNull(penalty1LoanChargeId);
+        assertNull(result.getJournalEntryData());
     }
 
-    private void setInitialBusinessDate(String date) {
-        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                new PutGlobalConfigurationsRequest().enabled(true));
-        BusinessDateHelper.updateBusinessDate(BUSINESS_DATE, LocalDate.parse(date));
-    }
-
-    private void cleanUpAndRestoreBusinessDate() {
-        REQUEST_SPEC = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        REQUEST_SPEC.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        REQUEST_SPEC.header("Fineract-Platform-TenantId", "default");
-        RESPONSE_SPEC = new ResponseSpecBuilder().expectStatusCode(200).build();
-        BusinessDateHelper.updateBusinessDate(BUSINESS_DATE, TODAYS_DATE);
-        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                new PutGlobalConfigurationsRequest().enabled(false));
-        globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, false);
-    }
-
-    @NonNull
-    private Integer createClient() {
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        Assertions.assertNotNull(clientID);
-        return clientID;
-    }
-
-    @NonNull
-    private Integer createLoanForClient(Integer clientID) {
-        Integer overdueFeeChargeId = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
-        Assertions.assertNotNull(overdueFeeChargeId);
-
-        Integer loanProductID = createLoanProduct(overdueFeeChargeId.toString());
-        Assertions.assertNotNull(loanProductID);
-        HashMap loanStatusHashMap;
-
-        Integer loanID = applyForLoanApplication(clientID.toString(), loanProductID.toString(), "1 March 2020");
-
-        Assertions.assertNotNull(loanID);
-
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
-
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("01 March 2020", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("02 March 2020", loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-        return loanID;
-    }
-
-    private Integer createLoanProduct(final String chargeId) {
-
-        final String loanProductJSON = new LoanProductTestBuilder().withPrincipal("15,000.00").withNumberOfRepayments("4")
-                .withRepaymentAfterEvery("1").withRepaymentTypeAsMonth().withinterestRatePerPeriod("1")
-                .withAccountingRulePeriodicAccrual(new Account[] { ASSET_ACCOUNT, EXPENSE_ACCOUNT, INCOME_ACCOUNT, OVERPAYMENT_ACCOUNT })
-                .withInterestRateFrequencyTypeAsMonths().withAmortizationTypeAsEqualInstallments().withInterestTypeAsDecliningBalance()
-                .withFeeAndPenaltyAssetAccount(FEE_PENALTY_ACCOUNT).build(chargeId);
-        return LOAN_TRANSACTION_HELPER.getLoanProductId(loanProductJSON);
-    }
-
-    private Integer applyForLoanApplication(final String clientID, final String loanProductID, final String date) {
-        List<HashMap> collaterals = new ArrayList<>();
-        Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
-        Assertions.assertNotNull(collateralId);
-        Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC, clientID, collateralId);
-        Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
-
-        String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal("15,000.00").withLoanTermFrequency("4")
-                .withLoanTermFrequencyAsMonths().withNumberOfRepayments("4").withRepaymentEveryAfter("1")
-                .withRepaymentFrequencyTypeAsMonths().withInterestRatePerPeriod("2").withAmortizationTypeAsEqualInstallments()
-                .withInterestTypeAsDecliningBalance().withInterestCalculationPeriodTypeSameAsRepaymentPeriod()
-                .withExpectedDisbursementDate(date).withSubmittedOnDate(date).withCollaterals(collaterals)
-                .build(clientID, loanProductID, null);
-        return LOAN_TRANSACTION_HELPER.getLoanId(loanApplicationJSON);
-    }
-
-    private void addCollaterals(List<HashMap> collaterals, Integer collateralId, BigDecimal quantity) {
-        collaterals.add(collaterals(collateralId, quantity));
-    }
-
-    private HashMap<String, String> collaterals(Integer collateralId, BigDecimal quantity) {
-        HashMap<String, String> collateral = new HashMap<>(2);
-        collateral.put("clientCollateralId", collateralId.toString());
-        collateral.put("quantity", quantity.toString());
-        return collateral;
-    }
-
-    private void getAndValidateExternalAssetOwnerTransferByLoan(Integer loanID, ExpectedExternalTransferData... expectedItems) {
-        PageExternalTransferData retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+    private void getAndValidateExternalAssetOwnerTransferByLoan(Long loanId, ExpectedExternalTransferData... expectedItems) {
+        PageExternalTransferData retrieveResponse = externalAssetOwnerHelper.retrieveTransfersByLoanId(loanId);
         assertEquals(expectedItems.length, retrieveResponse.getNumberOfElements());
 
         for (ExpectedExternalTransferData expected : expectedItems) {
@@ -375,83 +224,42 @@ public class ExternalAssetOwnerTransferCancelTest extends BaseLoanIntegrationTes
             assertEquals(LocalDate.parse(expected.settlementDate), etd.getSettlementDate());
             assertEquals(LocalDate.parse(expected.effectiveFrom), etd.getEffectiveFrom());
             assertEquals(LocalDate.parse(expected.effectiveTo), etd.getEffectiveTo());
-            if (!expected.detailsExpected) {
-                assertNull(etd.getDetails());
-            } else {
-                assertNotNull(etd.getDetails());
-                assertEquals(expected.totalOutstanding, etd.getDetails().getTotalOutstanding());
-                assertEquals(expected.totalPrincipalOutstanding, etd.getDetails().getTotalPrincipalOutstanding());
-                assertEquals(expected.totalInterestOutstanding, etd.getDetails().getTotalInterestOutstanding());
-                assertEquals(expected.totalPenaltyOutstanding, etd.getDetails().getTotalPenaltyChargesOutstanding());
-                assertEquals(expected.totalFeeOutstanding, etd.getDetails().getTotalFeeChargesOutstanding());
-                assertEquals(expected.totalOverpaid, etd.getDetails().getTotalOverpaid());
-            }
+            assertNull(etd.getDetails());
         }
     }
 
     private void getAndValidateThereIsNoActiveMapping(Long loanId) {
-        ExternalTransferData activeTransfer = EXTERNAL_ASSET_OWNER_HELPER.retrieveActiveTransferByLoanId(loanId);
+        ExternalTransferData activeTransfer = externalAssetOwnerHelper.retrieveActiveTransferByLoanId(loanId);
         assertNull(activeTransfer);
     }
 
     private void getAndValidateThereIsNoActiveMapping(String transferExternalId) {
-        ExternalTransferData activeTransfer = EXTERNAL_ASSET_OWNER_HELPER.retrieveActiveTransferByTransferExternalId(transferExternalId);
+        ExternalTransferData activeTransfer = externalAssetOwnerHelper.retrieveActiveTransferByTransferExternalId(transferExternalId);
         assertNull(activeTransfer);
     }
 
-    private void validateResponse(PostInitiateTransferResponse transferResponse, Integer loanID) {
+    private void validateResponse(PostInitiateTransferResponse transferResponse, Long loanId) {
         assertNotNull(transferResponse);
         assertNotNull(transferResponse.getResourceId());
         assertNotNull(transferResponse.getResourceExternalId());
         assertNotNull(transferResponse.getSubResourceId());
-        assertEquals((long) loanID, transferResponse.getSubResourceId());
+        assertEquals(loanId, transferResponse.getSubResourceId());
         assertNotNull(transferResponse.getSubResourceExternalId());
         assertNull(transferResponse.getChanges());
     }
 
     @RequiredArgsConstructor
-    public static class ExpectedExternalTransferData {
+    private static final class ExpectedExternalTransferData {
 
         private final ExternalTransferData.StatusEnum status;
-
         private final String transferExternalId;
-
         private final String settlementDate;
-
         private final String effectiveFrom;
         private final String effectiveTo;
-        private final boolean detailsExpected;
-        private final BigDecimal totalOutstanding;
-        private final BigDecimal totalPrincipalOutstanding;
-        private final BigDecimal totalInterestOutstanding;
-        private final BigDecimal totalPenaltyOutstanding;
-        private final BigDecimal totalFeeOutstanding;
-        private final BigDecimal totalOverpaid;
 
         static ExpectedExternalTransferData expected(ExternalTransferData.StatusEnum status, String transferExternalId,
-                String settlementDate, String effectiveFrom, String effectiveTo, boolean detailsExpected, BigDecimal totalOutstanding,
-                BigDecimal totalPrincipalOutstanding, BigDecimal totalInterestOutstanding, BigDecimal totalPenaltyOutstanding,
-                BigDecimal totalFeeOutstanding, BigDecimal totalOverpaid) {
-            return new ExpectedExternalTransferData(status, transferExternalId, settlementDate, effectiveFrom, effectiveTo, detailsExpected,
-                    totalOutstanding, totalPrincipalOutstanding, totalInterestOutstanding, totalPenaltyOutstanding, totalFeeOutstanding,
-                    totalOverpaid);
+                String settlementDate, String effectiveFrom, String effectiveTo) {
+            return new ExpectedExternalTransferData(status, transferExternalId, settlementDate, effectiveFrom, effectiveTo);
         }
-
-    }
-
-    @RequiredArgsConstructor
-    public static class ExpectedJournalEntryData {
-
-        private final Long glAccountId;
-        private final Long entryTypeId;
-        private final BigDecimal amount;
-        private final LocalDate transactionDate;
-        private final LocalDate submittedOnDate;
-
-        static ExpectedJournalEntryData expected(Long glAccountId, Long entryTypeId, BigDecimal amount, LocalDate transactionDate,
-                LocalDate submittedOnDate) {
-            return new ExpectedJournalEntryData(glAccountId, entryTypeId, amount, transactionDate, submittedOnDate);
-        }
-
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/investor/externalassetowner/ExternalAssetOwnerTransferCancelTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/investor/externalassetowner/ExternalAssetOwnerTransferCancelTest.java
@@ -21,347 +21,188 @@ package org.apache.fineract.integrationtests.investor.externalassetowner;
 import static org.apache.fineract.client.models.ExternalTransferData.StatusEnum.BUYBACK;
 import static org.apache.fineract.client.models.ExternalTransferData.StatusEnum.CANCELLED;
 import static org.apache.fineract.client.models.ExternalTransferData.StatusEnum.PENDING;
-import static org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType.BUSINESS_DATE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.path.json.JsonPath;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.apache.fineract.accounting.common.AccountingConstants;
 import org.apache.fineract.client.models.ExternalAssetOwnerRequest;
 import org.apache.fineract.client.models.ExternalOwnerTransferJournalEntryData;
 import org.apache.fineract.client.models.ExternalTransferData;
-import org.apache.fineract.client.models.GetFinancialActivityAccountsResponse;
 import org.apache.fineract.client.models.PageExternalTransferData;
-import org.apache.fineract.client.models.PostFinancialActivityAccountsRequest;
 import org.apache.fineract.client.models.PostInitiateTransferResponse;
-import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
+import org.apache.fineract.client.models.PostLoanProductsRequest;
+import org.apache.fineract.client.models.PostLoansRequest;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
-import org.apache.fineract.integrationtests.BaseLoanIntegrationTest;
-import org.apache.fineract.integrationtests.common.BusinessDateHelper;
-import org.apache.fineract.integrationtests.common.BusinessStepHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.CollateralManagementHelper;
-import org.apache.fineract.integrationtests.common.ExternalAssetOwnerHelper;
-import org.apache.fineract.integrationtests.common.SchedulerJobHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignBusinessStepHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignExternalAssetOwnerHelper;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.common.accounting.Account;
-import org.apache.fineract.integrationtests.common.accounting.AccountHelper;
-import org.apache.fineract.integrationtests.common.accounting.FinancialActivityAccountHelper;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
-import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanStatusChecker;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.junit.jupiter.api.Assertions;
+import org.apache.fineract.integrationtests.common.loans.LoanTestLifecycleExtension;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.springframework.lang.NonNull;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@SuppressWarnings("rawtypes")
-public class ExternalAssetOwnerTransferCancelTest extends BaseLoanIntegrationTest {
+@ExtendWith({ LoanTestLifecycleExtension.class })
+public class ExternalAssetOwnerTransferCancelTest extends FeignLoanTestBase {
 
-    public String ownerExternalId;
-    private static ResponseSpecification RESPONSE_SPEC;
-    private static RequestSpecification REQUEST_SPEC;
-    private static Account ASSET_ACCOUNT;
-    private static Account FEE_PENALTY_ACCOUNT;
-    private static Account TRANSFER_ACCOUNT;
-    private static Account EXPENSE_ACCOUNT;
-    private static Account INCOME_ACCOUNT;
-    private static Account OVERPAYMENT_ACCOUNT;
-    private static FinancialActivityAccountHelper FINANCIAL_ACTIVITY_ACCOUNT_HELPER;
-    private static ExternalAssetOwnerHelper EXTERNAL_ASSET_OWNER_HELPER;
-    private static LoanTransactionHelper LOAN_TRANSACTION_HELPER;
-    private static SchedulerJobHelper SCHEDULER_JOB_HELPER;
-    private static LocalDate TODAYS_DATE;
-    private DateTimeFormatter dateFormatter = new DateTimeFormatterBuilder().appendPattern("dd MMMM yyyy").toFormatter();
+    private static final String DATE_FORMAT_ISO = "yyyy-MM-dd";
+    private static final String SALE_DATE = "2020-03-02";
+    private static final String SALE_DATE_TEXT = "02 March 2020";
+    private static final String SUBMIT_DATE_TEXT = "01 March 2020";
+
+    private final FeignExternalAssetOwnerHelper externalAssetOwnerHelper = new FeignExternalAssetOwnerHelper(
+            FineractFeignClientHelper.getFineractFeignClient());
 
     @BeforeAll
     public static void setupInvestorBusinessStep() {
-        Utils.initializeRESTAssured();
-        REQUEST_SPEC = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        REQUEST_SPEC.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        RESPONSE_SPEC = new ResponseSpecBuilder().expectStatusCode(200).build();
-        AccountHelper accountHelper = new AccountHelper(REQUEST_SPEC, RESPONSE_SPEC);
-        EXTERNAL_ASSET_OWNER_HELPER = new ExternalAssetOwnerHelper();
-        SCHEDULER_JOB_HELPER = new SchedulerJobHelper(REQUEST_SPEC);
-        FINANCIAL_ACTIVITY_ACCOUNT_HELPER = new FinancialActivityAccountHelper(REQUEST_SPEC);
-        LOAN_TRANSACTION_HELPER = new LoanTransactionHelper(REQUEST_SPEC, RESPONSE_SPEC);
-
-        TODAYS_DATE = Utils.getLocalDateOfTenant();
-        new BusinessStepHelper().updateSteps("LOAN_CLOSE_OF_BUSINESS", "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION",
-                "CHECK_LOAN_REPAYMENT_DUE", "CHECK_LOAN_REPAYMENT_OVERDUE", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
+        new FeignBusinessStepHelper(FineractFeignClientHelper.getFineractFeignClient()).updateSteps("LOAN_CLOSE_OF_BUSINESS",
+                "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION", "CHECK_LOAN_REPAYMENT_DUE",
+                "CHECK_LOAN_REPAYMENT_OVERDUE", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
                 "EXTERNAL_ASSET_OWNER_TRANSFER");
-
-        ASSET_ACCOUNT = accountHelper.createAssetAccount();
-        FEE_PENALTY_ACCOUNT = accountHelper.createAssetAccount();
-        TRANSFER_ACCOUNT = accountHelper.createAssetAccount();
-        EXPENSE_ACCOUNT = accountHelper.createExpenseAccount();
-        INCOME_ACCOUNT = accountHelper.createIncomeAccount();
-        OVERPAYMENT_ACCOUNT = accountHelper.createLiabilityAccount();
-
-        setProperFinancialActivity(TRANSFER_ACCOUNT);
-    }
-
-    private static void setProperFinancialActivity(Account transferAccount) {
-        List<GetFinancialActivityAccountsResponse> financialMappings = FINANCIAL_ACTIVITY_ACCOUNT_HELPER.getAllFinancialActivityAccounts();
-        financialMappings.forEach(mapping -> FINANCIAL_ACTIVITY_ACCOUNT_HELPER.deleteFinancialActivityAccount(mapping.getId()));
-        FINANCIAL_ACTIVITY_ACCOUNT_HELPER.createFinancialActivityAccount(new PostFinancialActivityAccountsRequest()
-                .financialActivityId((long) AccountingConstants.FinancialActivity.ASSET_TRANSFER.getValue())
-                .glAccountId((long) transferAccount.getAccountID()));
     }
 
     @Test
     public void successCancelSale() {
+        globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
+        Account transferAccount = accountHelper.createAssetAccount(Utils.uniqueRandomStringGenerator("TRANSFER_", 5));
+        externalAssetOwnerHelper.setProperFinancialActivity(transferAccount);
         try {
-            globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2020-03-02");
-            Integer clientID = createClient();
-            Integer loanID = createLoanForClient(clientID);
-            addPenaltyForLoan(loanID, "10");
+            runAt(SALE_DATE_TEXT, () -> {
+                Long loanId = createLoanForClient();
+                addCharge(loanId, true, 10.0, SALE_DATE_TEXT);
 
-            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanID, "2020-03-02");
-            validateResponse(saleTransferResponse, loanID);
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
-                    ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
-                            "9999-12-31", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
-                            new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
-                            new BigDecimal("0.000000")));
+                PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanId, SALE_DATE);
+                validateResponse(saleTransferResponse, loanId);
+                getAndValidateExternalAssetOwnerTransferByLoan(loanId, ExpectedExternalTransferData.expected(PENDING,
+                        saleTransferResponse.getResourceExternalId(), SALE_DATE, SALE_DATE, "9999-12-31"));
 
-            PageExternalTransferData retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
-            retrieveResponse.getContent().forEach(transfer -> getAndValidateThereIsNoJournalEntriesForTransfer(transfer.getTransferId()));
+                PageExternalTransferData retrieveResponse = externalAssetOwnerHelper.retrieveTransfersByLoanId(loanId);
+                retrieveResponse.getContent()
+                        .forEach(transfer -> getAndValidateThereIsNoJournalEntriesForTransfer(transfer.getTransferId()));
 
-            EXTERNAL_ASSET_OWNER_HELPER.cancelTransferByTransferExternalId(saleTransferResponse.getResourceExternalId());
+                externalAssetOwnerHelper.cancelTransferByTransferExternalId(saleTransferResponse.getResourceExternalId());
 
-            // updateBusinessDateAndExecuteCOBJob("2020-03-03");
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
-                    ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
-                            "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
-                            new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
-                            new BigDecimal("0.000000")),
-                    ExpectedExternalTransferData.expected(CANCELLED, saleTransferResponse.getResourceExternalId(), "2020-03-02",
-                            "2020-03-02", "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
-                            new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
-                            new BigDecimal("0.000000")));
+                getAndValidateExternalAssetOwnerTransferByLoan(loanId,
+                        ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), SALE_DATE, SALE_DATE,
+                                SALE_DATE),
+                        ExpectedExternalTransferData.expected(CANCELLED, saleTransferResponse.getResourceExternalId(), SALE_DATE, SALE_DATE,
+                                SALE_DATE));
+            });
         } finally {
-            cleanUpAndRestoreBusinessDate();
+            globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, false);
         }
-    }
-
-    private void getAndValidateThereIsNoJournalEntriesForTransfer(Long transferId) {
-        ExternalOwnerTransferJournalEntryData result = EXTERNAL_ASSET_OWNER_HELPER.retrieveJournalEntriesOfTransfer(transferId);
-        assertNull(result.getJournalEntryData());
     }
 
     @Test
     public void saleAndBuybackOnTheSameDay() {
+        globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
+        Account transferAccount = accountHelper.createAssetAccount(Utils.uniqueRandomStringGenerator("TRANSFER_", 5));
+        externalAssetOwnerHelper.setProperFinancialActivity(transferAccount);
         try {
-            globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2020-03-02");
-            Integer clientID = createClient();
-            Integer loanID = createLoanForClient(clientID);
+            runAt(SALE_DATE_TEXT, () -> {
+                Long loanId = createLoanForClient();
 
-            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanID, "2020-03-02");
-            validateResponse(saleTransferResponse, loanID);
-            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanID, "2020-03-02");
-            validateResponse(buybackTransferResponse, loanID);
+                PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanId, SALE_DATE);
+                validateResponse(saleTransferResponse, loanId);
+                PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanId, SALE_DATE);
+                validateResponse(buybackTransferResponse, loanId);
 
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
-                    ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
-                            "9999-12-31", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
-                            new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
-                            new BigDecimal("0.000000")),
-                    ExpectedExternalTransferData.expected(BUYBACK, buybackTransferResponse.getResourceExternalId(), "2020-03-02",
-                            "2020-03-02", "9999-12-31", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
-                            new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
-                            new BigDecimal("0.000000")));
-            getAndValidateThereIsNoActiveMapping(saleTransferResponse.getResourceExternalId());
-            getAndValidateThereIsNoActiveMapping(buybackTransferResponse.getResourceExternalId());
+                getAndValidateExternalAssetOwnerTransferByLoan(loanId,
+                        ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), SALE_DATE, SALE_DATE,
+                                "9999-12-31"),
+                        ExpectedExternalTransferData.expected(BUYBACK, buybackTransferResponse.getResourceExternalId(), SALE_DATE,
+                                SALE_DATE, "9999-12-31"));
+                getAndValidateThereIsNoActiveMapping(saleTransferResponse.getResourceExternalId());
+                getAndValidateThereIsNoActiveMapping(buybackTransferResponse.getResourceExternalId());
 
-            EXTERNAL_ASSET_OWNER_HELPER.cancelTransferByTransferExternalIdError(saleTransferResponse.getResourceExternalId());
+                externalAssetOwnerHelper.cancelTransferByTransferExternalIdError(saleTransferResponse.getResourceExternalId());
 
-            EXTERNAL_ASSET_OWNER_HELPER.cancelTransferByTransferExternalId(buybackTransferResponse.getResourceExternalId());
+                externalAssetOwnerHelper.cancelTransferByTransferExternalId(buybackTransferResponse.getResourceExternalId());
 
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
-                    ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
-                            "9999-12-31", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
-                            new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
-                            new BigDecimal("0.000000")),
-                    ExpectedExternalTransferData.expected(BUYBACK, buybackTransferResponse.getResourceExternalId(), "2020-03-02",
-                            "2020-03-02", "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
-                            new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
-                            new BigDecimal("0.000000")),
-                    ExpectedExternalTransferData.expected(CANCELLED, buybackTransferResponse.getResourceExternalId(), "2020-03-02",
-                            "2020-03-02", "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
-                            new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
-                            new BigDecimal("0.000000")));
+                getAndValidateExternalAssetOwnerTransferByLoan(loanId,
+                        ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), SALE_DATE, SALE_DATE,
+                                "9999-12-31"),
+                        ExpectedExternalTransferData.expected(BUYBACK, buybackTransferResponse.getResourceExternalId(), SALE_DATE,
+                                SALE_DATE, SALE_DATE),
+                        ExpectedExternalTransferData.expected(CANCELLED, buybackTransferResponse.getResourceExternalId(), SALE_DATE,
+                                SALE_DATE, SALE_DATE));
 
-            EXTERNAL_ASSET_OWNER_HELPER.cancelTransferByTransferExternalId(saleTransferResponse.getResourceExternalId());
+                externalAssetOwnerHelper.cancelTransferByTransferExternalId(saleTransferResponse.getResourceExternalId());
 
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
-                    ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
-                            "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
-                            new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
-                            new BigDecimal("0.000000")),
-                    ExpectedExternalTransferData.expected(BUYBACK, buybackTransferResponse.getResourceExternalId(), "2020-03-02",
-                            "2020-03-02", "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
-                            new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
-                            new BigDecimal("0.000000")),
-                    ExpectedExternalTransferData.expected(CANCELLED, buybackTransferResponse.getResourceExternalId(), "2020-03-02",
-                            "2020-03-02", "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
-                            new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
-                            new BigDecimal("0.000000")),
-                    ExpectedExternalTransferData.expected(CANCELLED, saleTransferResponse.getResourceExternalId(), "2020-03-02",
-                            "2020-03-02", "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
-                            new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
-                            new BigDecimal("0.000000")));
-            getAndValidateThereIsNoActiveMapping((long) loanID);
+                getAndValidateExternalAssetOwnerTransferByLoan(loanId,
+                        ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), SALE_DATE, SALE_DATE,
+                                SALE_DATE),
+                        ExpectedExternalTransferData.expected(BUYBACK, buybackTransferResponse.getResourceExternalId(), SALE_DATE,
+                                SALE_DATE, SALE_DATE),
+                        ExpectedExternalTransferData.expected(CANCELLED, buybackTransferResponse.getResourceExternalId(), SALE_DATE,
+                                SALE_DATE, SALE_DATE),
+                        ExpectedExternalTransferData.expected(CANCELLED, saleTransferResponse.getResourceExternalId(), SALE_DATE, SALE_DATE,
+                                SALE_DATE));
+                getAndValidateThereIsNoActiveMapping(loanId);
+            });
         } finally {
-            cleanUpAndRestoreBusinessDate();
+            globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, false);
         }
     }
 
-    private PostInitiateTransferResponse createSaleTransfer(Integer loanID, String settlementDate) {
-        String transferExternalId = UUID.randomUUID().toString();
-        ownerExternalId = UUID.randomUUID().toString();
-        return createSaleTransfer(loanID, settlementDate, transferExternalId, ownerExternalId, "1.0");
+    private Long createLoanForClient() {
+        Long clientId = createClient();
+        PostLoanProductsRequest productRequest = createOnePeriod30DaysPeriodicAccrualProduct(2.0)//
+                .numberOfRepayments(4)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS_L)//
+                .principal(15000.0);
+        Long loanProductId = createLoanProduct(productRequest);
+
+        PostLoansRequest loanRequest = applyLoanRequest(clientId, loanProductId, SUBMIT_DATE_TEXT, 15000.0, 4, request -> request//
+                .interestRatePerPeriod(BigDecimal.valueOf(2))//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .loanTermFrequency(4)//
+                .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                .dateFormat(LoanTestData.DATETIME_PATTERN).expectedDisbursementDate(SALE_DATE_TEXT).submittedOnDate(SUBMIT_DATE_TEXT));
+        Long loanId = applyForLoan(loanRequest);
+        approveLoan(loanId, approveLoanRequest(15000.0, SUBMIT_DATE_TEXT));
+        disburseLoan(loanId, SALE_DATE_TEXT, 15000.0);
+        return loanId;
     }
 
-    private PostInitiateTransferResponse createSaleTransfer(Integer loanID, String settlementDate, String transferExternalId,
-            String ownerExternalId, String purchasePriceRatio) {
-        PostInitiateTransferResponse saleResponse = EXTERNAL_ASSET_OWNER_HELPER.initiateTransferByLoanId(loanID.longValue(), "sale",
-                new ExternalAssetOwnerRequest().settlementDate(settlementDate).dateFormat("yyyy-MM-dd").locale("en")
-                        .transferExternalId(transferExternalId).ownerExternalId(ownerExternalId).purchasePriceRatio(purchasePriceRatio));
+    private PostInitiateTransferResponse createSaleTransfer(Long loanId, String settlementDate) {
+        String transferExternalId = UUID.randomUUID().toString();
+        String ownerExternalId = UUID.randomUUID().toString();
+        PostInitiateTransferResponse saleResponse = externalAssetOwnerHelper.initiateTransferByLoanId(loanId, "sale",
+                new ExternalAssetOwnerRequest().settlementDate(settlementDate).dateFormat(DATE_FORMAT_ISO).locale("en")
+                        .transferExternalId(transferExternalId).ownerExternalId(ownerExternalId).purchasePriceRatio("1.0"));
         assertEquals(transferExternalId, saleResponse.getResourceExternalId());
         return saleResponse;
     }
 
-    private PostInitiateTransferResponse createBuybackTransfer(Integer loanID, String settlementDate) {
+    private PostInitiateTransferResponse createBuybackTransfer(Long loanId, String settlementDate) {
         String transferExternalId = UUID.randomUUID().toString();
-        PostInitiateTransferResponse saleResponse = EXTERNAL_ASSET_OWNER_HELPER.initiateTransferByLoanId(loanID.longValue(), "buyback",
-                new ExternalAssetOwnerRequest().settlementDate(settlementDate).dateFormat("yyyy-MM-dd").locale("en")
+        PostInitiateTransferResponse buybackResponse = externalAssetOwnerHelper.initiateTransferByLoanId(loanId, "buyback",
+                new ExternalAssetOwnerRequest().settlementDate(settlementDate).dateFormat(DATE_FORMAT_ISO).locale("en")
                         .transferExternalId(transferExternalId));
-        assertEquals(transferExternalId, saleResponse.getResourceExternalId());
-        return saleResponse;
+        assertEquals(transferExternalId, buybackResponse.getResourceExternalId());
+        return buybackResponse;
     }
 
-    private void addPenaltyForLoan(Integer loanID, String amount) {
-        // Add Charge Penalty
-        Integer penalty = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, amount, true));
-        Integer penalty1LoanChargeId = this.LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID,
-                LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "02 March 2020", amount));
-        assertNotNull(penalty1LoanChargeId);
+    private void getAndValidateThereIsNoJournalEntriesForTransfer(Long transferId) {
+        ExternalOwnerTransferJournalEntryData result = externalAssetOwnerHelper.retrieveJournalEntriesOfTransfer(transferId);
+        assertNull(result.getJournalEntryData());
     }
 
-    private void setInitialBusinessDate(String date) {
-        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                new PutGlobalConfigurationsRequest().enabled(true));
-        BusinessDateHelper.updateBusinessDate(BUSINESS_DATE, LocalDate.parse(date));
-    }
-
-    private void cleanUpAndRestoreBusinessDate() {
-        REQUEST_SPEC = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        REQUEST_SPEC.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        REQUEST_SPEC.header("Fineract-Platform-TenantId", "default");
-        RESPONSE_SPEC = new ResponseSpecBuilder().expectStatusCode(200).build();
-        BusinessDateHelper.updateBusinessDate(BUSINESS_DATE, TODAYS_DATE);
-        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                new PutGlobalConfigurationsRequest().enabled(false));
-    }
-
-    @NonNull
-    private Integer createClient() {
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        Assertions.assertNotNull(clientID);
-        return clientID;
-    }
-
-    @NonNull
-    private Integer createLoanForClient(Integer clientID) {
-        Integer overdueFeeChargeId = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
-        Assertions.assertNotNull(overdueFeeChargeId);
-
-        Integer loanProductID = createLoanProduct(overdueFeeChargeId.toString());
-        Assertions.assertNotNull(loanProductID);
-        HashMap loanStatusHashMap;
-
-        Integer loanID = applyForLoanApplication(clientID.toString(), loanProductID.toString(), "1 March 2020");
-
-        Assertions.assertNotNull(loanID);
-
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
-
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("01 March 2020", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("02 March 2020", loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-        return loanID;
-    }
-
-    private Integer createLoanProduct(final String chargeId) {
-
-        final String loanProductJSON = new LoanProductTestBuilder().withPrincipal("15,000.00").withNumberOfRepayments("4")
-                .withRepaymentAfterEvery("1").withRepaymentTypeAsMonth().withinterestRatePerPeriod("1")
-                .withAccountingRulePeriodicAccrual(new Account[] { ASSET_ACCOUNT, EXPENSE_ACCOUNT, INCOME_ACCOUNT, OVERPAYMENT_ACCOUNT })
-                .withInterestRateFrequencyTypeAsMonths().withAmortizationTypeAsEqualInstallments().withInterestTypeAsDecliningBalance()
-                .withFeeAndPenaltyAssetAccount(FEE_PENALTY_ACCOUNT).build(chargeId);
-        return LOAN_TRANSACTION_HELPER.getLoanProductId(loanProductJSON);
-    }
-
-    private Integer applyForLoanApplication(final String clientID, final String loanProductID, final String date) {
-        List<HashMap> collaterals = new ArrayList<>();
-        Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
-        Assertions.assertNotNull(collateralId);
-        Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC, clientID, collateralId);
-        Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
-
-        String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal("15,000.00").withLoanTermFrequency("4")
-                .withLoanTermFrequencyAsMonths().withNumberOfRepayments("4").withRepaymentEveryAfter("1")
-                .withRepaymentFrequencyTypeAsMonths().withInterestRatePerPeriod("2").withAmortizationTypeAsEqualInstallments()
-                .withInterestTypeAsDecliningBalance().withInterestCalculationPeriodTypeSameAsRepaymentPeriod()
-                .withExpectedDisbursementDate(date).withSubmittedOnDate(date).withCollaterals(collaterals)
-                .build(clientID, loanProductID, null);
-        return LOAN_TRANSACTION_HELPER.getLoanId(loanApplicationJSON);
-    }
-
-    private void addCollaterals(List<HashMap> collaterals, Integer collateralId, BigDecimal quantity) {
-        collaterals.add(collaterals(collateralId, quantity));
-    }
-
-    private HashMap<String, String> collaterals(Integer collateralId, BigDecimal quantity) {
-        HashMap<String, String> collateral = new HashMap<>(2);
-        collateral.put("clientCollateralId", collateralId.toString());
-        collateral.put("quantity", quantity.toString());
-        return collateral;
-    }
-
-    private void getAndValidateExternalAssetOwnerTransferByLoan(Integer loanID, ExpectedExternalTransferData... expectedItems) {
-        PageExternalTransferData retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+    private void getAndValidateExternalAssetOwnerTransferByLoan(Long loanId, ExpectedExternalTransferData... expectedItems) {
+        PageExternalTransferData retrieveResponse = externalAssetOwnerHelper.retrieveTransfersByLoanId(loanId);
         assertEquals(expectedItems.length, retrieveResponse.getNumberOfElements());
 
         for (ExpectedExternalTransferData expected : expectedItems) {
@@ -377,83 +218,42 @@ public class ExternalAssetOwnerTransferCancelTest extends BaseLoanIntegrationTes
             assertEquals(LocalDate.parse(expected.settlementDate), etd.getSettlementDate());
             assertEquals(LocalDate.parse(expected.effectiveFrom), etd.getEffectiveFrom());
             assertEquals(LocalDate.parse(expected.effectiveTo), etd.getEffectiveTo());
-            if (!expected.detailsExpected) {
-                assertNull(etd.getDetails());
-            } else {
-                assertNotNull(etd.getDetails());
-                assertEquals(expected.totalOutstanding, etd.getDetails().getTotalOutstanding());
-                assertEquals(expected.totalPrincipalOutstanding, etd.getDetails().getTotalPrincipalOutstanding());
-                assertEquals(expected.totalInterestOutstanding, etd.getDetails().getTotalInterestOutstanding());
-                assertEquals(expected.totalPenaltyOutstanding, etd.getDetails().getTotalPenaltyChargesOutstanding());
-                assertEquals(expected.totalFeeOutstanding, etd.getDetails().getTotalFeeChargesOutstanding());
-                assertEquals(expected.totalOverpaid, etd.getDetails().getTotalOverpaid());
-            }
+            assertNull(etd.getDetails());
         }
     }
 
     private void getAndValidateThereIsNoActiveMapping(Long loanId) {
-        ExternalTransferData activeTransfer = EXTERNAL_ASSET_OWNER_HELPER.retrieveActiveTransferByLoanId(loanId);
+        ExternalTransferData activeTransfer = externalAssetOwnerHelper.retrieveActiveTransferByLoanId(loanId);
         assertNull(activeTransfer);
     }
 
     private void getAndValidateThereIsNoActiveMapping(String transferExternalId) {
-        ExternalTransferData activeTransfer = EXTERNAL_ASSET_OWNER_HELPER.retrieveActiveTransferByTransferExternalId(transferExternalId);
+        ExternalTransferData activeTransfer = externalAssetOwnerHelper.retrieveActiveTransferByTransferExternalId(transferExternalId);
         assertNull(activeTransfer);
     }
 
-    private void validateResponse(PostInitiateTransferResponse transferResponse, Integer loanID) {
+    private void validateResponse(PostInitiateTransferResponse transferResponse, Long loanId) {
         assertNotNull(transferResponse);
         assertNotNull(transferResponse.getResourceId());
         assertNotNull(transferResponse.getResourceExternalId());
         assertNotNull(transferResponse.getSubResourceId());
-        assertEquals((long) loanID, transferResponse.getSubResourceId());
+        assertEquals(loanId, transferResponse.getSubResourceId());
         assertNotNull(transferResponse.getSubResourceExternalId());
         assertNull(transferResponse.getChanges());
     }
 
     @RequiredArgsConstructor
-    public static class ExpectedExternalTransferData {
+    private static final class ExpectedExternalTransferData {
 
         private final ExternalTransferData.StatusEnum status;
-
         private final String transferExternalId;
-
         private final String settlementDate;
-
         private final String effectiveFrom;
         private final String effectiveTo;
-        private final boolean detailsExpected;
-        private final BigDecimal totalOutstanding;
-        private final BigDecimal totalPrincipalOutstanding;
-        private final BigDecimal totalInterestOutstanding;
-        private final BigDecimal totalPenaltyOutstanding;
-        private final BigDecimal totalFeeOutstanding;
-        private final BigDecimal totalOverpaid;
 
         static ExpectedExternalTransferData expected(ExternalTransferData.StatusEnum status, String transferExternalId,
-                String settlementDate, String effectiveFrom, String effectiveTo, boolean detailsExpected, BigDecimal totalOutstanding,
-                BigDecimal totalPrincipalOutstanding, BigDecimal totalInterestOutstanding, BigDecimal totalPenaltyOutstanding,
-                BigDecimal totalFeeOutstanding, BigDecimal totalOverpaid) {
-            return new ExpectedExternalTransferData(status, transferExternalId, settlementDate, effectiveFrom, effectiveTo, detailsExpected,
-                    totalOutstanding, totalPrincipalOutstanding, totalInterestOutstanding, totalPenaltyOutstanding, totalFeeOutstanding,
-                    totalOverpaid);
+                String settlementDate, String effectiveFrom, String effectiveTo) {
+            return new ExpectedExternalTransferData(status, transferExternalId, settlementDate, effectiveFrom, effectiveTo);
         }
-
-    }
-
-    @RequiredArgsConstructor
-    public static class ExpectedJournalEntryData {
-
-        private final Long glAccountId;
-        private final Long entryTypeId;
-        private final BigDecimal amount;
-        private final LocalDate transactionDate;
-        private final LocalDate submittedOnDate;
-
-        static ExpectedJournalEntryData expected(Long glAccountId, Long entryTypeId, BigDecimal amount, LocalDate transactionDate,
-                LocalDate submittedOnDate) {
-            return new ExpectedJournalEntryData(glAccountId, entryTypeId, amount, transactionDate, submittedOnDate);
-        }
-
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/investor/externalassetowner/ExternalAssetOwnerTransferTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/investor/externalassetowner/ExternalAssetOwnerTransferTest.java
@@ -18,239 +18,129 @@
  */
 package org.apache.fineract.integrationtests.investor.externalassetowner;
 
-import static org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType.BUSINESS_DATE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.path.json.JsonPath;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.client.models.ExternalAssetOwnerRequest;
-import org.apache.fineract.client.models.ExternalOwnerJournalEntryData;
-import org.apache.fineract.client.models.ExternalOwnerTransferJournalEntryData;
 import org.apache.fineract.client.models.ExternalTransferData;
 import org.apache.fineract.client.models.PageExternalTransferData;
 import org.apache.fineract.client.models.PostInitiateTransferResponse;
+import org.apache.fineract.client.models.PostLoanProductsRequest;
+import org.apache.fineract.client.models.PostLoansRequest;
 import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
-import org.apache.fineract.integrationtests.BaseLoanIntegrationTest;
-import org.apache.fineract.integrationtests.common.BusinessDateHelper;
-import org.apache.fineract.integrationtests.common.BusinessStepHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.CollateralManagementHelper;
-import org.apache.fineract.integrationtests.common.ExternalAssetOwnerHelper;
-import org.apache.fineract.integrationtests.common.SchedulerJobHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignBusinessStepHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignExternalAssetOwnerHelper;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.common.accounting.Account;
-import org.apache.fineract.integrationtests.common.accounting.AccountHelper;
-import org.apache.fineract.integrationtests.common.accounting.FinancialActivityAccountHelper;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
-import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanStatusChecker;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Order;
-import org.springframework.lang.NonNull;
 
-@Slf4j
 @Order(1)
-public class ExternalAssetOwnerTransferTest extends BaseLoanIntegrationTest {
+public class ExternalAssetOwnerTransferTest extends FeignLoanTestBase {
 
-    protected static ResponseSpecification RESPONSE_SPEC;
-    protected static RequestSpecification REQUEST_SPEC;
-    protected static Account ASSET_ACCOUNT;
-    protected static Account FEE_PENALTY_ACCOUNT;
-    protected static Account TRANSFER_ACCOUNT;
-    protected static Account EXPENSE_ACCOUNT;
-    protected static Account INCOME_ACCOUNT;
-    protected static Account OVERPAYMENT_ACCOUNT;
-    protected static FinancialActivityAccountHelper FINANCIAL_ACTIVITY_ACCOUNT_HELPER;
-    protected static ExternalAssetOwnerHelper EXTERNAL_ASSET_OWNER_HELPER;
-    protected static LoanTransactionHelper LOAN_TRANSACTION_HELPER;
-    protected static LocalDate TODAYS_DATE;
+    protected static final String DATE_FORMAT_ISO = "yyyy-MM-dd";
+    protected static final String LOAN_COB_JOB = "Loan COB";
+    protected static final String PENALTY_DUE_DATE = "02 March 2020";
+    protected static final Double LOAN_PRINCIPAL = 15000.0;
+    protected static final Integer LOAN_REPAYMENTS = 4;
+    protected static final BigDecimal LOAN_INTEREST_RATE = BigDecimal.valueOf(2);
+
+    protected static final FeignExternalAssetOwnerHelper EXTERNAL_ASSET_OWNER_HELPER = new FeignExternalAssetOwnerHelper(
+            FineractFeignClientHelper.getFineractFeignClient());
+
     public String ownerExternalId;
-    protected DateTimeFormatter dateFormatter = new DateTimeFormatterBuilder().appendPattern("dd MMMM yyyy").toFormatter();
 
     @BeforeAll
     public static void setupInvestorBusinessStep() {
-        Utils.initializeRESTAssured();
-        REQUEST_SPEC = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        REQUEST_SPEC.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        RESPONSE_SPEC = new ResponseSpecBuilder().expectStatusCode(200).build();
-        AccountHelper accountHelper = new AccountHelper(REQUEST_SPEC, RESPONSE_SPEC);
-        EXTERNAL_ASSET_OWNER_HELPER = new ExternalAssetOwnerHelper();
-        FINANCIAL_ACTIVITY_ACCOUNT_HELPER = new FinancialActivityAccountHelper(REQUEST_SPEC);
-        LOAN_TRANSACTION_HELPER = new LoanTransactionHelper(REQUEST_SPEC, RESPONSE_SPEC);
-
-        TODAYS_DATE = Utils.getLocalDateOfTenant();
-        new BusinessStepHelper().updateSteps("LOAN_CLOSE_OF_BUSINESS", "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION",
-                "CHECK_LOAN_REPAYMENT_DUE", "CHECK_LOAN_REPAYMENT_OVERDUE", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
+        new FeignBusinessStepHelper(FineractFeignClientHelper.getFineractFeignClient()).updateSteps("LOAN_CLOSE_OF_BUSINESS",
+                "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION", "CHECK_LOAN_REPAYMENT_DUE",
+                "CHECK_LOAN_REPAYMENT_OVERDUE", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
                 "EXTERNAL_ASSET_OWNER_TRANSFER");
 
-        ASSET_ACCOUNT = accountHelper.createAssetAccount();
-        FEE_PENALTY_ACCOUNT = accountHelper.createAssetAccount();
-        TRANSFER_ACCOUNT = accountHelper.createAssetAccount();
-        EXPENSE_ACCOUNT = accountHelper.createExpenseAccount();
-        INCOME_ACCOUNT = accountHelper.createIncomeAccount();
-        OVERPAYMENT_ACCOUNT = accountHelper.createLiabilityAccount();
-
-        EXTERNAL_ASSET_OWNER_HELPER.setProperFinancialActivity(FINANCIAL_ACTIVITY_ACCOUNT_HELPER, TRANSFER_ACCOUNT);
+        Account transferAccount = accountHelper.createAssetAccount(Utils.uniqueRandomStringGenerator("TRANSFER_", 5));
+        EXTERNAL_ASSET_OWNER_HELPER.setProperFinancialActivity(transferAccount);
     }
 
     protected void updateBusinessDateAndExecuteCOBJob(String date) {
-        BusinessDateHelper.updateBusinessDate(BUSINESS_DATE, LocalDate.parse(date));
-        SchedulerJobHelper.executeAndAwaitJob("Loan COB");
+        updateBusinessDate(date);
+        schedulerHelper.executeAndAwaitJob(LOAN_COB_JOB);
     }
 
-    protected PostInitiateTransferResponse createSaleTransfer(Integer loanID, String settlementDate) {
+    protected PostInitiateTransferResponse createSaleTransfer(Long loanId, String settlementDate) {
         String transferExternalId = UUID.randomUUID().toString();
         String transferExternalGroupId = UUID.randomUUID().toString();
         ownerExternalId = UUID.randomUUID().toString();
-        return createSaleTransfer(loanID, settlementDate, transferExternalId, transferExternalGroupId, ownerExternalId, "1.0");
+        return createSaleTransfer(loanId, settlementDate, transferExternalId, transferExternalGroupId, ownerExternalId, "1.0");
     }
 
-    protected PostInitiateTransferResponse createSaleTransfer(Integer loanID, String settlementDate, String transferExternalId,
+    protected PostInitiateTransferResponse createSaleTransfer(Long loanId, String settlementDate, String transferExternalId,
             String transferExternalGroupId, String ownerExternalId, String purchasePriceRatio) {
-        PostInitiateTransferResponse saleResponse = EXTERNAL_ASSET_OWNER_HELPER.initiateTransferByLoanId(loanID.longValue(), "sale",
-                new ExternalAssetOwnerRequest().settlementDate(settlementDate).dateFormat("yyyy-MM-dd").locale("en")
+        PostInitiateTransferResponse saleResponse = EXTERNAL_ASSET_OWNER_HELPER.initiateTransferByLoanId(loanId, "sale",
+                new ExternalAssetOwnerRequest().settlementDate(settlementDate).dateFormat(DATE_FORMAT_ISO).locale("en")
                         .transferExternalId(transferExternalId).transferExternalGroupId(transferExternalGroupId)
                         .ownerExternalId(ownerExternalId).purchasePriceRatio(purchasePriceRatio));
         assertEquals(transferExternalId, saleResponse.getResourceExternalId());
         return saleResponse;
     }
 
-    protected PostInitiateTransferResponse createBuybackTransfer(Integer loanID, String settlementDate) {
-        String transferExternalId = UUID.randomUUID().toString();
-        return createBuybackTransfer(loanID, settlementDate, transferExternalId);
-    }
-
-    protected PostInitiateTransferResponse createBuybackTransfer(Integer loanID, String settlementDate, String transferExternalId) {
-        PostInitiateTransferResponse saleResponse = EXTERNAL_ASSET_OWNER_HELPER.initiateTransferByLoanId(loanID.longValue(), "buyback",
-                new ExternalAssetOwnerRequest().settlementDate(settlementDate).dateFormat("yyyy-MM-dd").locale("en")
-                        .transferExternalId(transferExternalId));
-        assertEquals(transferExternalId, saleResponse.getResourceExternalId());
-        return saleResponse;
-    }
-
-    protected void addPenaltyForLoan(Integer loanID, String amount) {
-        // Add Charge Penalty
-        Integer penalty = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, amount, true));
-        Integer penalty1LoanChargeId = LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID,
-                LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "02 March 2020", amount));
-        assertNotNull(penalty1LoanChargeId);
+    protected void addPenaltyForLoan(Long loanId, String amount) {
+        Long penaltyLoanChargeId = addCharge(loanId, true, Double.parseDouble(amount), PENALTY_DUE_DATE);
+        assertNotNull(penaltyLoanChargeId);
     }
 
     protected void setInitialBusinessDate(LocalDate date) {
         globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                 new PutGlobalConfigurationsRequest().enabled(true));
-        BusinessDateHelper.updateBusinessDate(BUSINESS_DATE, date);
+        updateBusinessDate(date.toString());
     }
 
     protected void cleanUpAndRestoreBusinessDate() {
-        REQUEST_SPEC = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        REQUEST_SPEC.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        REQUEST_SPEC.header("Fineract-Platform-TenantId", "default");
-        RESPONSE_SPEC = new ResponseSpecBuilder().expectStatusCode(200).build();
-        BusinessDateHelper.updateBusinessDate(BUSINESS_DATE, TODAYS_DATE);
         globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                 new PutGlobalConfigurationsRequest().enabled(false));
         globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, false);
     }
 
-    @NonNull
-    protected Integer createClient() {
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        Assertions.assertNotNull(clientID);
-        return clientID;
+    protected Long createLoanForClient(Long clientId, String transactionDate) {
+        PostLoanProductsRequest productRequest = createOnePeriod30DaysPeriodicAccrualProduct(2.0)//
+                .numberOfRepayments(LOAN_REPAYMENTS)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS_L)//
+                .installmentAmountInMultiplesOf(null)//
+                .principal(LOAN_PRINCIPAL);
+        Long loanProductId = createLoanProduct(productRequest);
+
+        PostLoansRequest loanRequest = applyLoanRequest(clientId, loanProductId, transactionDate, LOAN_PRINCIPAL, LOAN_REPAYMENTS,
+                request -> request//
+                        .interestRatePerPeriod(LOAN_INTEREST_RATE)//
+                        .repaymentEvery(1)//
+                        .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                        .loanTermFrequency(LOAN_REPAYMENTS)//
+                        .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS));
+        Long loanId = applyForLoan(loanRequest);
+        approveLoan(loanId, approveLoanRequest(LOAN_PRINCIPAL, transactionDate));
+        disburseLoan(loanId, transactionDate, LOAN_PRINCIPAL);
+        return loanId;
     }
 
-    @NonNull
-    protected Integer createLoanForClient(Integer clientID, String transactionDate) {
-        Integer overdueFeeChargeId = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
-        Assertions.assertNotNull(overdueFeeChargeId);
-
-        Integer loanProductID = createLoanProduct(overdueFeeChargeId.toString());
-        Assertions.assertNotNull(loanProductID);
-        HashMap loanStatusHashMap;
-
-        Integer loanID = applyForLoanApplication(clientID.toString(), loanProductID.toString(), transactionDate);
-
-        Assertions.assertNotNull(loanID);
-
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
-
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(transactionDate, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(transactionDate, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-        return loanID;
+    protected void writeOffLoan(String date, Long loanId) {
+        transactionHelper.writeOff(loanId, LoanRequestBuilders.writeOff(date));
     }
 
-    protected Integer createLoanProduct(final String chargeId) {
-
-        final String loanProductJSON = new LoanProductTestBuilder().withPrincipal("15,000.00").withNumberOfRepayments("4")
-                .withRepaymentAfterEvery("1").withRepaymentTypeAsMonth().withinterestRatePerPeriod("1")
-                .withAccountingRulePeriodicAccrual(new Account[] { ASSET_ACCOUNT, EXPENSE_ACCOUNT, INCOME_ACCOUNT, OVERPAYMENT_ACCOUNT })
-                .withInterestRateFrequencyTypeAsMonths().withAmortizationTypeAsEqualInstallments().withInterestTypeAsDecliningBalance()
-                .withFeeAndPenaltyAssetAccount(FEE_PENALTY_ACCOUNT).build(chargeId);
-        return LOAN_TRANSACTION_HELPER.getLoanProductId(loanProductJSON);
-    }
-
-    protected Integer applyForLoanApplication(final String clientID, final String loanProductID, final String date) {
-        List<HashMap> collaterals = new ArrayList<>();
-        Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
-        Assertions.assertNotNull(collateralId);
-        Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC, clientID, collateralId);
-        Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
-
-        String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal("15,000.00").withLoanTermFrequency("4")
-                .withLoanTermFrequencyAsMonths().withNumberOfRepayments("4").withRepaymentEveryAfter("1")
-                .withRepaymentFrequencyTypeAsMonths().withInterestRatePerPeriod("2").withAmortizationTypeAsEqualInstallments()
-                .withInterestTypeAsDecliningBalance().withInterestCalculationPeriodTypeSameAsRepaymentPeriod()
-                .withExpectedDisbursementDate(date).withSubmittedOnDate(date).withCollaterals(collaterals)
-                .build(clientID, loanProductID, null);
-        return LOAN_TRANSACTION_HELPER.getLoanId(loanApplicationJSON);
-    }
-
-    protected void addCollaterals(List<HashMap> collaterals, Integer collateralId, BigDecimal quantity) {
-        collaterals.add(collaterals(collateralId, quantity));
-    }
-
-    protected HashMap<String, String> collaterals(Integer collateralId, BigDecimal quantity) {
-        HashMap<String, String> collateral = new HashMap<>(2);
-        collateral.put("clientCollateralId", collateralId.toString());
-        collateral.put("quantity", quantity.toString());
-        return collateral;
-    }
-
-    protected void getAndValidateExternalAssetOwnerTransferByLoan(Integer loanID, ExpectedExternalTransferData... expectedItems) {
-        PageExternalTransferData retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+    protected void getAndValidateExternalAssetOwnerTransferByLoan(Long loanId, ExpectedExternalTransferData... expectedItems) {
+        PageExternalTransferData retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
         assertEquals(expectedItems.length, retrieveResponse.getNumberOfElements());
         validateExternalAssetOwnerTransfer(retrieveResponse, expectedItems);
     }
@@ -280,90 +170,35 @@ public class ExternalAssetOwnerTransferTest extends BaseLoanIntegrationTest {
                 assertEquals(expected.totalFeeOutstanding, etd.getDetails().getTotalFeeChargesOutstanding());
                 assertEquals(expected.totalOverpaid, etd.getDetails().getTotalOverpaid());
             }
-            if (expected.subStatus != null) {
-                assertEquals(expected.subStatus, etd.getSubStatus());
-            }
         }
     }
 
-    protected void getAndValidateThereIsActiveMapping(Integer loanID) {
-        ExternalTransferData activeTransfer = EXTERNAL_ASSET_OWNER_HELPER.retrieveActiveTransferByLoanId((long) loanID);
+    protected void getAndValidateThereIsActiveMapping(Long loanId) {
+        ExternalTransferData activeTransfer = EXTERNAL_ASSET_OWNER_HELPER.retrieveActiveTransferByLoanId(loanId);
         assertNotNull(activeTransfer);
-        ExternalTransferData retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue()).getContent()
-                .stream().filter(transfer -> ExternalTransferData.StatusEnum.ACTIVE.equals(transfer.getStatus())).findFirst().get();
+        ExternalTransferData retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId).getContent().stream()
+                .filter(transfer -> ExternalTransferData.StatusEnum.ACTIVE.equals(transfer.getStatus())).findFirst().get();
         assertEquals(retrieveResponse.getTransferId(), activeTransfer.getTransferId());
     }
 
-    protected void getAndValidateThereIsNoActiveMapping(Long loanId) {
-        ExternalTransferData activeTransfer = EXTERNAL_ASSET_OWNER_HELPER.retrieveActiveTransferByLoanId(loanId);
-        assertNull(activeTransfer);
-    }
-
-    protected void getAndValidateThereIsNoActiveMapping(String transferExternalId) {
-        ExternalTransferData activeTransfer = EXTERNAL_ASSET_OWNER_HELPER.retrieveActiveTransferByTransferExternalId(transferExternalId);
-        assertNull(activeTransfer);
-    }
-
-    protected void validateResponse(PostInitiateTransferResponse transferResponse, Integer loanID) {
+    protected void validateResponse(PostInitiateTransferResponse transferResponse, Long loanId) {
         assertNotNull(transferResponse);
         assertNotNull(transferResponse.getResourceId());
         assertNotNull(transferResponse.getResourceExternalId());
         assertNotNull(transferResponse.getSubResourceId());
-        assertEquals((long) loanID, transferResponse.getSubResourceId());
+        assertEquals(loanId, transferResponse.getSubResourceId());
         assertNotNull(transferResponse.getSubResourceExternalId());
         assertNull(transferResponse.getChanges());
-    }
-
-    protected void getAndValidateOwnerJournalEntries(String ownerExternalId, ExpectedJournalEntryData... expectedItems) {
-        ExternalOwnerJournalEntryData result = EXTERNAL_ASSET_OWNER_HELPER.retrieveJournalEntriesOfOwner(ownerExternalId);
-        assertNotNull(result);
-        assertEquals(expectedItems.length, result.getJournalEntryData().getTotalElements());
-        int i = 0;
-        assertEquals(ownerExternalId, result.getOwnerData().getExternalId());
-        for (ExpectedJournalEntryData expectedJournalEntryData : expectedItems) {
-            assertTrue(expectedJournalEntryData.amount.compareTo(result.getJournalEntryData().getContent().get(i).getAmount()) == 0);
-            assertEquals(expectedJournalEntryData.entryTypeId, result.getJournalEntryData().getContent().get(i).getEntryType().getId());
-            assertEquals(expectedJournalEntryData.glAccountId, result.getJournalEntryData().getContent().get(i).getGlAccountId());
-            assertEquals(expectedJournalEntryData.transactionDate, result.getJournalEntryData().getContent().get(i).getTransactionDate());
-            assertEquals(expectedJournalEntryData.submittedOnDate, result.getJournalEntryData().getContent().get(i).getSubmittedOnDate());
-            i++;
-        }
-    }
-
-    protected void getAndValidateThereIsJournalEntriesForTransfer(Long transferId, ExpectedJournalEntryData... expectedItems) {
-        ExternalOwnerTransferJournalEntryData result = EXTERNAL_ASSET_OWNER_HELPER.retrieveJournalEntriesOfTransfer(transferId);
-        assertNotNull(result);
-        long totalElements = result.getJournalEntryData().getTotalElements();
-        assertEquals(expectedItems.length, totalElements);
-        int i = 0;
-        assertEquals(transferId, result.getTransferData().getTransferId());
-        for (ExpectedJournalEntryData expectedJournalEntryData : expectedItems) {
-            assertTrue(expectedJournalEntryData.amount.compareTo(result.getJournalEntryData().getContent().get(i).getAmount()) == 0);
-            assertEquals(expectedJournalEntryData.entryTypeId, result.getJournalEntryData().getContent().get(i).getEntryType().getId());
-            assertEquals(expectedJournalEntryData.glAccountId, result.getJournalEntryData().getContent().get(i).getGlAccountId());
-            assertEquals(expectedJournalEntryData.transactionDate, result.getJournalEntryData().getContent().get(i).getTransactionDate());
-            assertEquals(expectedJournalEntryData.submittedOnDate, result.getJournalEntryData().getContent().get(i).getSubmittedOnDate());
-            i++;
-        }
-    }
-
-    protected void getAndValidateThereIsNoJournalEntriesForTransfer(Long transferId) {
-        ExternalOwnerTransferJournalEntryData result = EXTERNAL_ASSET_OWNER_HELPER.retrieveJournalEntriesOfTransfer(transferId);
-        assertNull(result.getJournalEntryData());
     }
 
     @RequiredArgsConstructor
     public static class ExpectedExternalTransferData {
 
         private final ExternalTransferData.StatusEnum status;
-
         private final String transferExternalId;
-
         private final String settlementDate;
-
         private final String effectiveFrom;
         private final String effectiveTo;
-        private final ExternalTransferData.SubStatusEnum subStatus;
         private final boolean detailsExpected;
         private final BigDecimal totalOutstanding;
         private final BigDecimal totalPrincipalOutstanding;
@@ -376,39 +211,9 @@ public class ExternalAssetOwnerTransferTest extends BaseLoanIntegrationTest {
                 String settlementDate, String effectiveFrom, String effectiveTo, boolean detailsExpected, BigDecimal totalOutstanding,
                 BigDecimal totalPrincipalOutstanding, BigDecimal totalInterestOutstanding, BigDecimal totalPenaltyOutstanding,
                 BigDecimal totalFeeOutstanding, BigDecimal totalOverpaid) {
-            return new ExpectedExternalTransferData(status, transferExternalId, settlementDate, effectiveFrom, effectiveTo, null,
-                    detailsExpected, totalOutstanding, totalPrincipalOutstanding, totalInterestOutstanding, totalPenaltyOutstanding,
-                    totalFeeOutstanding, totalOverpaid);
+            return new ExpectedExternalTransferData(status, transferExternalId, settlementDate, effectiveFrom, effectiveTo, detailsExpected,
+                    totalOutstanding, totalPrincipalOutstanding, totalInterestOutstanding, totalPenaltyOutstanding, totalFeeOutstanding,
+                    totalOverpaid);
         }
-
-        static ExpectedExternalTransferData expected(ExternalTransferData.StatusEnum status, String transferExternalId,
-                String settlementDate, String effectiveFrom, String effectiveTo) {
-            return new ExpectedExternalTransferData(status, transferExternalId, settlementDate, effectiveFrom, effectiveTo, null, false,
-                    null, null, null, null, null, null);
-        }
-
-        static ExpectedExternalTransferData expected(ExternalTransferData.StatusEnum status, String transferExternalId,
-                String settlementDate, String effectiveFrom, String effectiveTo, ExternalTransferData.SubStatusEnum subStatus) {
-            return new ExpectedExternalTransferData(status, transferExternalId, settlementDate, effectiveFrom, effectiveTo, subStatus,
-                    false, null, null, null, null, null, null);
-        }
-    }
-
-    @RequiredArgsConstructor
-    public static class ExpectedJournalEntryData {
-
-        private final Long glAccountId;
-
-        private final Long entryTypeId;
-
-        private final BigDecimal amount;
-        private final LocalDate transactionDate;
-        private final LocalDate submittedOnDate;
-
-        static ExpectedJournalEntryData expected(Long glAccountId, Long entryTypeId, BigDecimal amount, LocalDate transactionDate,
-                LocalDate submittedOnDate) {
-            return new ExpectedJournalEntryData(glAccountId, entryTypeId, amount, transactionDate, submittedOnDate);
-        }
-
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/investor/externalassetowner/ExternalAssetOwnerTransferTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/investor/externalassetowner/ExternalAssetOwnerTransferTest.java
@@ -45,6 +45,7 @@ import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
 import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.common.accounting.Account;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanStatus;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Order;
 
@@ -61,6 +62,9 @@ public class ExternalAssetOwnerTransferTest extends FeignLoanTestBase {
     protected static final FeignExternalAssetOwnerHelper EXTERNAL_ASSET_OWNER_HELPER = new FeignExternalAssetOwnerHelper(
             FineractFeignClientHelper.getFineractFeignClient());
 
+    /** The GL account the ASSET_TRANSFER financial activity is mapped to; every sale and buyback books against it. */
+    protected static Account transferAccount;
+
     public String ownerExternalId;
 
     @BeforeAll
@@ -70,7 +74,7 @@ public class ExternalAssetOwnerTransferTest extends FeignLoanTestBase {
                 "CHECK_LOAN_REPAYMENT_OVERDUE", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
                 "EXTERNAL_ASSET_OWNER_TRANSFER");
 
-        Account transferAccount = accountHelper.createAssetAccount(Utils.uniqueRandomStringGenerator("TRANSFER_", 5));
+        transferAccount = accountHelper.createAssetAccount(Utils.uniqueRandomStringGenerator("TRANSFER_", 5));
         EXTERNAL_ASSET_OWNER_HELPER.setProperFinancialActivity(transferAccount);
     }
 
@@ -114,12 +118,20 @@ public class ExternalAssetOwnerTransferTest extends FeignLoanTestBase {
     }
 
     protected Long createLoanForClient(Long clientId, String transactionDate) {
-        PostLoanProductsRequest productRequest = createOnePeriod30DaysPeriodicAccrualProduct(2.0)//
+        return createLoanForClient(clientId, transactionDate, transferrableLoanProduct());
+    }
+
+    /** The loan product shape every transfer test relies on: 15000 principal over 4 monthly installments at 2%. */
+    protected PostLoanProductsRequest transferrableLoanProduct() {
+        return createOnePeriod30DaysPeriodicAccrualProduct(2.0)//
                 .numberOfRepayments(LOAN_REPAYMENTS)//
                 .repaymentEvery(1)//
                 .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS_L)//
                 .installmentAmountInMultiplesOf(null)//
                 .principal(LOAN_PRINCIPAL);
+    }
+
+    protected Long createLoanForClient(Long clientId, String transactionDate, PostLoanProductsRequest productRequest) {
         Long loanProductId = createLoanProduct(productRequest);
 
         PostLoansRequest loanRequest = applyLoanRequest(clientId, loanProductId, transactionDate, LOAN_PRINCIPAL, LOAN_REPAYMENTS,
@@ -130,8 +142,11 @@ public class ExternalAssetOwnerTransferTest extends FeignLoanTestBase {
                         .loanTermFrequency(LOAN_REPAYMENTS)//
                         .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS));
         Long loanId = applyForLoan(loanRequest);
+        verifyLoanStatus(loanId, LoanStatus.SUBMITTED_AND_PENDING_APPROVAL);
         approveLoan(loanId, approveLoanRequest(LOAN_PRINCIPAL, transactionDate));
+        verifyLoanStatus(loanId, LoanStatus.APPROVED);
         disburseLoan(loanId, transactionDate, LOAN_PRINCIPAL);
+        verifyLoanStatus(loanId, LoanStatus.ACTIVE);
         return loanId;
     }
 
@@ -170,6 +185,9 @@ public class ExternalAssetOwnerTransferTest extends FeignLoanTestBase {
                 assertEquals(expected.totalFeeOutstanding, etd.getDetails().getTotalFeeChargesOutstanding());
                 assertEquals(expected.totalOverpaid, etd.getDetails().getTotalOverpaid());
             }
+            if (expected.subStatus != null) {
+                assertEquals(expected.subStatus, etd.getSubStatus());
+            }
         }
     }
 
@@ -199,6 +217,7 @@ public class ExternalAssetOwnerTransferTest extends FeignLoanTestBase {
         private final String settlementDate;
         private final String effectiveFrom;
         private final String effectiveTo;
+        private final ExternalTransferData.SubStatusEnum subStatus;
         private final boolean detailsExpected;
         private final BigDecimal totalOutstanding;
         private final BigDecimal totalPrincipalOutstanding;
@@ -211,9 +230,23 @@ public class ExternalAssetOwnerTransferTest extends FeignLoanTestBase {
                 String settlementDate, String effectiveFrom, String effectiveTo, boolean detailsExpected, BigDecimal totalOutstanding,
                 BigDecimal totalPrincipalOutstanding, BigDecimal totalInterestOutstanding, BigDecimal totalPenaltyOutstanding,
                 BigDecimal totalFeeOutstanding, BigDecimal totalOverpaid) {
-            return new ExpectedExternalTransferData(status, transferExternalId, settlementDate, effectiveFrom, effectiveTo, detailsExpected,
-                    totalOutstanding, totalPrincipalOutstanding, totalInterestOutstanding, totalPenaltyOutstanding, totalFeeOutstanding,
-                    totalOverpaid);
+            return new ExpectedExternalTransferData(status, transferExternalId, settlementDate, effectiveFrom, effectiveTo, null,
+                    detailsExpected, totalOutstanding, totalPrincipalOutstanding, totalInterestOutstanding, totalPenaltyOutstanding,
+                    totalFeeOutstanding, totalOverpaid);
+        }
+
+        /** Expects a transfer that carries no captured loan details; its sub-status is not asserted. */
+        static ExpectedExternalTransferData expected(ExternalTransferData.StatusEnum status, String transferExternalId,
+                String settlementDate, String effectiveFrom, String effectiveTo) {
+            return new ExpectedExternalTransferData(status, transferExternalId, settlementDate, effectiveFrom, effectiveTo, null, false,
+                    null, null, null, null, null, null);
+        }
+
+        /** Expects a transfer that carries no captured loan details, and asserts the reason it reached its status. */
+        static ExpectedExternalTransferData expected(ExternalTransferData.StatusEnum status, String transferExternalId,
+                String settlementDate, String effectiveFrom, String effectiveTo, ExternalTransferData.SubStatusEnum subStatus) {
+            return new ExpectedExternalTransferData(status, transferExternalId, settlementDate, effectiveFrom, effectiveTo, subStatus,
+                    false, null, null, null, null, null, null);
         }
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/investor/externalassetowner/ExternalAssetOwnerTransferTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/investor/externalassetowner/ExternalAssetOwnerTransferTest.java
@@ -18,239 +18,127 @@
  */
 package org.apache.fineract.integrationtests.investor.externalassetowner;
 
-import static org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType.BUSINESS_DATE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.path.json.JsonPath;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.client.models.ExternalAssetOwnerRequest;
-import org.apache.fineract.client.models.ExternalOwnerJournalEntryData;
-import org.apache.fineract.client.models.ExternalOwnerTransferJournalEntryData;
 import org.apache.fineract.client.models.ExternalTransferData;
 import org.apache.fineract.client.models.PageExternalTransferData;
 import org.apache.fineract.client.models.PostInitiateTransferResponse;
+import org.apache.fineract.client.models.PostLoanProductsRequest;
+import org.apache.fineract.client.models.PostLoansRequest;
 import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
-import org.apache.fineract.integrationtests.BaseLoanIntegrationTest;
-import org.apache.fineract.integrationtests.common.BusinessDateHelper;
-import org.apache.fineract.integrationtests.common.BusinessStepHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.CollateralManagementHelper;
-import org.apache.fineract.integrationtests.common.ExternalAssetOwnerHelper;
-import org.apache.fineract.integrationtests.common.SchedulerJobHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignBusinessStepHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignExternalAssetOwnerHelper;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.common.accounting.Account;
-import org.apache.fineract.integrationtests.common.accounting.AccountHelper;
-import org.apache.fineract.integrationtests.common.accounting.FinancialActivityAccountHelper;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
-import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanStatusChecker;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.springframework.lang.NonNull;
 
-@Slf4j
-public class ExternalAssetOwnerTransferTest extends BaseLoanIntegrationTest {
+public class ExternalAssetOwnerTransferTest extends FeignLoanTestBase {
 
-    protected static ResponseSpecification RESPONSE_SPEC;
-    protected static RequestSpecification REQUEST_SPEC;
-    protected static Account ASSET_ACCOUNT;
-    protected static Account FEE_PENALTY_ACCOUNT;
-    protected static Account TRANSFER_ACCOUNT;
-    protected static Account EXPENSE_ACCOUNT;
-    protected static Account INCOME_ACCOUNT;
-    protected static Account OVERPAYMENT_ACCOUNT;
-    protected static FinancialActivityAccountHelper FINANCIAL_ACTIVITY_ACCOUNT_HELPER;
-    protected static ExternalAssetOwnerHelper EXTERNAL_ASSET_OWNER_HELPER;
-    protected static LoanTransactionHelper LOAN_TRANSACTION_HELPER;
-    protected static SchedulerJobHelper SCHEDULER_JOB_HELPER;
-    protected static LocalDate TODAYS_DATE;
+    protected static final String DATE_FORMAT_ISO = "yyyy-MM-dd";
+    protected static final String LOAN_COB_JOB = "Loan COB";
+    protected static final String PENALTY_DUE_DATE = "02 March 2020";
+    protected static final Double LOAN_PRINCIPAL = 15000.0;
+    protected static final Integer LOAN_REPAYMENTS = 4;
+    protected static final BigDecimal LOAN_INTEREST_RATE = BigDecimal.valueOf(2);
+
+    protected static final FeignExternalAssetOwnerHelper EXTERNAL_ASSET_OWNER_HELPER = new FeignExternalAssetOwnerHelper(
+            FineractFeignClientHelper.getFineractFeignClient());
+
     public String ownerExternalId;
-    protected DateTimeFormatter dateFormatter = new DateTimeFormatterBuilder().appendPattern("dd MMMM yyyy").toFormatter();
 
     @BeforeAll
     public static void setupInvestorBusinessStep() {
-        Utils.initializeRESTAssured();
-        REQUEST_SPEC = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        REQUEST_SPEC.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        RESPONSE_SPEC = new ResponseSpecBuilder().expectStatusCode(200).build();
-        AccountHelper accountHelper = new AccountHelper(REQUEST_SPEC, RESPONSE_SPEC);
-        EXTERNAL_ASSET_OWNER_HELPER = new ExternalAssetOwnerHelper();
-        SCHEDULER_JOB_HELPER = new SchedulerJobHelper(REQUEST_SPEC);
-        FINANCIAL_ACTIVITY_ACCOUNT_HELPER = new FinancialActivityAccountHelper(REQUEST_SPEC);
-        LOAN_TRANSACTION_HELPER = new LoanTransactionHelper(REQUEST_SPEC, RESPONSE_SPEC);
-
-        TODAYS_DATE = Utils.getLocalDateOfTenant();
-        new BusinessStepHelper().updateSteps("LOAN_CLOSE_OF_BUSINESS", "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION",
-                "CHECK_LOAN_REPAYMENT_DUE", "CHECK_LOAN_REPAYMENT_OVERDUE", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
+        new FeignBusinessStepHelper(FineractFeignClientHelper.getFineractFeignClient()).updateSteps("LOAN_CLOSE_OF_BUSINESS",
+                "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION", "CHECK_LOAN_REPAYMENT_DUE",
+                "CHECK_LOAN_REPAYMENT_OVERDUE", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
                 "EXTERNAL_ASSET_OWNER_TRANSFER");
 
-        ASSET_ACCOUNT = accountHelper.createAssetAccount();
-        FEE_PENALTY_ACCOUNT = accountHelper.createAssetAccount();
-        TRANSFER_ACCOUNT = accountHelper.createAssetAccount();
-        EXPENSE_ACCOUNT = accountHelper.createExpenseAccount();
-        INCOME_ACCOUNT = accountHelper.createIncomeAccount();
-        OVERPAYMENT_ACCOUNT = accountHelper.createLiabilityAccount();
-
-        EXTERNAL_ASSET_OWNER_HELPER.setProperFinancialActivity(FINANCIAL_ACTIVITY_ACCOUNT_HELPER, TRANSFER_ACCOUNT);
+        Account transferAccount = accountHelper.createAssetAccount(Utils.uniqueRandomStringGenerator("TRANSFER_", 5));
+        EXTERNAL_ASSET_OWNER_HELPER.setProperFinancialActivity(transferAccount);
     }
 
     protected void updateBusinessDateAndExecuteCOBJob(String date) {
-        BusinessDateHelper.updateBusinessDate(BUSINESS_DATE, LocalDate.parse(date));
-        SCHEDULER_JOB_HELPER.executeAndAwaitJob("Loan COB");
+        updateBusinessDate(date);
+        schedulerHelper.executeAndAwaitJob(LOAN_COB_JOB);
     }
 
-    protected PostInitiateTransferResponse createSaleTransfer(Integer loanID, String settlementDate) {
+    protected PostInitiateTransferResponse createSaleTransfer(Long loanId, String settlementDate) {
         String transferExternalId = UUID.randomUUID().toString();
         String transferExternalGroupId = UUID.randomUUID().toString();
         ownerExternalId = UUID.randomUUID().toString();
-        return createSaleTransfer(loanID, settlementDate, transferExternalId, transferExternalGroupId, ownerExternalId, "1.0");
+        return createSaleTransfer(loanId, settlementDate, transferExternalId, transferExternalGroupId, ownerExternalId, "1.0");
     }
 
-    protected PostInitiateTransferResponse createSaleTransfer(Integer loanID, String settlementDate, String transferExternalId,
+    protected PostInitiateTransferResponse createSaleTransfer(Long loanId, String settlementDate, String transferExternalId,
             String transferExternalGroupId, String ownerExternalId, String purchasePriceRatio) {
-        PostInitiateTransferResponse saleResponse = EXTERNAL_ASSET_OWNER_HELPER.initiateTransferByLoanId(loanID.longValue(), "sale",
-                new ExternalAssetOwnerRequest().settlementDate(settlementDate).dateFormat("yyyy-MM-dd").locale("en")
+        PostInitiateTransferResponse saleResponse = EXTERNAL_ASSET_OWNER_HELPER.initiateTransferByLoanId(loanId, "sale",
+                new ExternalAssetOwnerRequest().settlementDate(settlementDate).dateFormat(DATE_FORMAT_ISO).locale("en")
                         .transferExternalId(transferExternalId).transferExternalGroupId(transferExternalGroupId)
                         .ownerExternalId(ownerExternalId).purchasePriceRatio(purchasePriceRatio));
         assertEquals(transferExternalId, saleResponse.getResourceExternalId());
         return saleResponse;
     }
 
-    protected PostInitiateTransferResponse createBuybackTransfer(Integer loanID, String settlementDate) {
-        String transferExternalId = UUID.randomUUID().toString();
-        return createBuybackTransfer(loanID, settlementDate, transferExternalId);
-    }
-
-    protected PostInitiateTransferResponse createBuybackTransfer(Integer loanID, String settlementDate, String transferExternalId) {
-        PostInitiateTransferResponse saleResponse = EXTERNAL_ASSET_OWNER_HELPER.initiateTransferByLoanId(loanID.longValue(), "buyback",
-                new ExternalAssetOwnerRequest().settlementDate(settlementDate).dateFormat("yyyy-MM-dd").locale("en")
-                        .transferExternalId(transferExternalId));
-        assertEquals(transferExternalId, saleResponse.getResourceExternalId());
-        return saleResponse;
-    }
-
-    protected void addPenaltyForLoan(Integer loanID, String amount) {
-        // Add Charge Penalty
-        Integer penalty = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, amount, true));
-        Integer penalty1LoanChargeId = LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID,
-                LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "02 March 2020", amount));
-        assertNotNull(penalty1LoanChargeId);
+    protected void addPenaltyForLoan(Long loanId, String amount) {
+        Long penaltyLoanChargeId = addCharge(loanId, true, Double.parseDouble(amount), PENALTY_DUE_DATE);
+        assertNotNull(penaltyLoanChargeId);
     }
 
     protected void setInitialBusinessDate(LocalDate date) {
         globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                 new PutGlobalConfigurationsRequest().enabled(true));
-        BusinessDateHelper.updateBusinessDate(BUSINESS_DATE, date);
+        updateBusinessDate(date.toString());
     }
 
     protected void cleanUpAndRestoreBusinessDate() {
-        REQUEST_SPEC = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        REQUEST_SPEC.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        REQUEST_SPEC.header("Fineract-Platform-TenantId", "default");
-        RESPONSE_SPEC = new ResponseSpecBuilder().expectStatusCode(200).build();
-        BusinessDateHelper.updateBusinessDate(BUSINESS_DATE, TODAYS_DATE);
         globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                 new PutGlobalConfigurationsRequest().enabled(false));
         globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, false);
     }
 
-    @NonNull
-    protected Integer createClient() {
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        Assertions.assertNotNull(clientID);
-        return clientID;
+    protected Long createLoanForClient(Long clientId, String transactionDate) {
+        PostLoanProductsRequest productRequest = createOnePeriod30DaysPeriodicAccrualProduct(2.0)//
+                .numberOfRepayments(LOAN_REPAYMENTS)//
+                .repaymentEvery(1)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS_L)//
+                .installmentAmountInMultiplesOf(null)//
+                .principal(LOAN_PRINCIPAL);
+        Long loanProductId = createLoanProduct(productRequest);
+
+        PostLoansRequest loanRequest = applyLoanRequest(clientId, loanProductId, transactionDate, LOAN_PRINCIPAL, LOAN_REPAYMENTS,
+                request -> request//
+                        .interestRatePerPeriod(LOAN_INTEREST_RATE)//
+                        .repaymentEvery(1)//
+                        .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)//
+                        .loanTermFrequency(LOAN_REPAYMENTS)//
+                        .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS));
+        Long loanId = applyForLoan(loanRequest);
+        approveLoan(loanId, approveLoanRequest(LOAN_PRINCIPAL, transactionDate));
+        disburseLoan(loanId, transactionDate, LOAN_PRINCIPAL);
+        return loanId;
     }
 
-    @NonNull
-    protected Integer createLoanForClient(Integer clientID, String transactionDate) {
-        Integer overdueFeeChargeId = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
-        Assertions.assertNotNull(overdueFeeChargeId);
-
-        Integer loanProductID = createLoanProduct(overdueFeeChargeId.toString());
-        Assertions.assertNotNull(loanProductID);
-        HashMap loanStatusHashMap;
-
-        Integer loanID = applyForLoanApplication(clientID.toString(), loanProductID.toString(), transactionDate);
-
-        Assertions.assertNotNull(loanID);
-
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
-
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan(transactionDate, loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount(transactionDate, loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-        return loanID;
+    protected void writeOffLoan(String date, Long loanId) {
+        transactionHelper.writeOff(loanId, LoanRequestBuilders.writeOff(date));
     }
 
-    protected Integer createLoanProduct(final String chargeId) {
-
-        final String loanProductJSON = new LoanProductTestBuilder().withPrincipal("15,000.00").withNumberOfRepayments("4")
-                .withRepaymentAfterEvery("1").withRepaymentTypeAsMonth().withinterestRatePerPeriod("1")
-                .withAccountingRulePeriodicAccrual(new Account[] { ASSET_ACCOUNT, EXPENSE_ACCOUNT, INCOME_ACCOUNT, OVERPAYMENT_ACCOUNT })
-                .withInterestRateFrequencyTypeAsMonths().withAmortizationTypeAsEqualInstallments().withInterestTypeAsDecliningBalance()
-                .withFeeAndPenaltyAssetAccount(FEE_PENALTY_ACCOUNT).build(chargeId);
-        return LOAN_TRANSACTION_HELPER.getLoanProductId(loanProductJSON);
-    }
-
-    protected Integer applyForLoanApplication(final String clientID, final String loanProductID, final String date) {
-        List<HashMap> collaterals = new ArrayList<>();
-        Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
-        Assertions.assertNotNull(collateralId);
-        Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC, clientID, collateralId);
-        Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
-
-        String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal("15,000.00").withLoanTermFrequency("4")
-                .withLoanTermFrequencyAsMonths().withNumberOfRepayments("4").withRepaymentEveryAfter("1")
-                .withRepaymentFrequencyTypeAsMonths().withInterestRatePerPeriod("2").withAmortizationTypeAsEqualInstallments()
-                .withInterestTypeAsDecliningBalance().withInterestCalculationPeriodTypeSameAsRepaymentPeriod()
-                .withExpectedDisbursementDate(date).withSubmittedOnDate(date).withCollaterals(collaterals)
-                .build(clientID, loanProductID, null);
-        return LOAN_TRANSACTION_HELPER.getLoanId(loanApplicationJSON);
-    }
-
-    protected void addCollaterals(List<HashMap> collaterals, Integer collateralId, BigDecimal quantity) {
-        collaterals.add(collaterals(collateralId, quantity));
-    }
-
-    protected HashMap<String, String> collaterals(Integer collateralId, BigDecimal quantity) {
-        HashMap<String, String> collateral = new HashMap<>(2);
-        collateral.put("clientCollateralId", collateralId.toString());
-        collateral.put("quantity", quantity.toString());
-        return collateral;
-    }
-
-    protected void getAndValidateExternalAssetOwnerTransferByLoan(Integer loanID, ExpectedExternalTransferData... expectedItems) {
-        PageExternalTransferData retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+    protected void getAndValidateExternalAssetOwnerTransferByLoan(Long loanId, ExpectedExternalTransferData... expectedItems) {
+        PageExternalTransferData retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
         assertEquals(expectedItems.length, retrieveResponse.getNumberOfElements());
         validateExternalAssetOwnerTransfer(retrieveResponse, expectedItems);
     }
@@ -280,90 +168,35 @@ public class ExternalAssetOwnerTransferTest extends BaseLoanIntegrationTest {
                 assertEquals(expected.totalFeeOutstanding, etd.getDetails().getTotalFeeChargesOutstanding());
                 assertEquals(expected.totalOverpaid, etd.getDetails().getTotalOverpaid());
             }
-            if (expected.subStatus != null) {
-                assertEquals(expected.subStatus, etd.getSubStatus());
-            }
         }
     }
 
-    protected void getAndValidateThereIsActiveMapping(Integer loanID) {
-        ExternalTransferData activeTransfer = EXTERNAL_ASSET_OWNER_HELPER.retrieveActiveTransferByLoanId((long) loanID);
+    protected void getAndValidateThereIsActiveMapping(Long loanId) {
+        ExternalTransferData activeTransfer = EXTERNAL_ASSET_OWNER_HELPER.retrieveActiveTransferByLoanId(loanId);
         assertNotNull(activeTransfer);
-        ExternalTransferData retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue()).getContent()
-                .stream().filter(transfer -> ExternalTransferData.StatusEnum.ACTIVE.equals(transfer.getStatus())).findFirst().get();
+        ExternalTransferData retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId).getContent().stream()
+                .filter(transfer -> ExternalTransferData.StatusEnum.ACTIVE.equals(transfer.getStatus())).findFirst().get();
         assertEquals(retrieveResponse.getTransferId(), activeTransfer.getTransferId());
     }
 
-    protected void getAndValidateThereIsNoActiveMapping(Long loanId) {
-        ExternalTransferData activeTransfer = EXTERNAL_ASSET_OWNER_HELPER.retrieveActiveTransferByLoanId(loanId);
-        assertNull(activeTransfer);
-    }
-
-    protected void getAndValidateThereIsNoActiveMapping(String transferExternalId) {
-        ExternalTransferData activeTransfer = EXTERNAL_ASSET_OWNER_HELPER.retrieveActiveTransferByTransferExternalId(transferExternalId);
-        assertNull(activeTransfer);
-    }
-
-    protected void validateResponse(PostInitiateTransferResponse transferResponse, Integer loanID) {
+    protected void validateResponse(PostInitiateTransferResponse transferResponse, Long loanId) {
         assertNotNull(transferResponse);
         assertNotNull(transferResponse.getResourceId());
         assertNotNull(transferResponse.getResourceExternalId());
         assertNotNull(transferResponse.getSubResourceId());
-        assertEquals((long) loanID, transferResponse.getSubResourceId());
+        assertEquals(loanId, transferResponse.getSubResourceId());
         assertNotNull(transferResponse.getSubResourceExternalId());
         assertNull(transferResponse.getChanges());
-    }
-
-    protected void getAndValidateOwnerJournalEntries(String ownerExternalId, ExpectedJournalEntryData... expectedItems) {
-        ExternalOwnerJournalEntryData result = EXTERNAL_ASSET_OWNER_HELPER.retrieveJournalEntriesOfOwner(ownerExternalId);
-        assertNotNull(result);
-        assertEquals(expectedItems.length, result.getJournalEntryData().getTotalElements());
-        int i = 0;
-        assertEquals(ownerExternalId, result.getOwnerData().getExternalId());
-        for (ExpectedJournalEntryData expectedJournalEntryData : expectedItems) {
-            assertTrue(expectedJournalEntryData.amount.compareTo(result.getJournalEntryData().getContent().get(i).getAmount()) == 0);
-            assertEquals(expectedJournalEntryData.entryTypeId, result.getJournalEntryData().getContent().get(i).getEntryType().getId());
-            assertEquals(expectedJournalEntryData.glAccountId, result.getJournalEntryData().getContent().get(i).getGlAccountId());
-            assertEquals(expectedJournalEntryData.transactionDate, result.getJournalEntryData().getContent().get(i).getTransactionDate());
-            assertEquals(expectedJournalEntryData.submittedOnDate, result.getJournalEntryData().getContent().get(i).getSubmittedOnDate());
-            i++;
-        }
-    }
-
-    protected void getAndValidateThereIsJournalEntriesForTransfer(Long transferId, ExpectedJournalEntryData... expectedItems) {
-        ExternalOwnerTransferJournalEntryData result = EXTERNAL_ASSET_OWNER_HELPER.retrieveJournalEntriesOfTransfer(transferId);
-        assertNotNull(result);
-        long totalElements = result.getJournalEntryData().getTotalElements();
-        assertEquals(expectedItems.length, totalElements);
-        int i = 0;
-        assertEquals(transferId, result.getTransferData().getTransferId());
-        for (ExpectedJournalEntryData expectedJournalEntryData : expectedItems) {
-            assertTrue(expectedJournalEntryData.amount.compareTo(result.getJournalEntryData().getContent().get(i).getAmount()) == 0);
-            assertEquals(expectedJournalEntryData.entryTypeId, result.getJournalEntryData().getContent().get(i).getEntryType().getId());
-            assertEquals(expectedJournalEntryData.glAccountId, result.getJournalEntryData().getContent().get(i).getGlAccountId());
-            assertEquals(expectedJournalEntryData.transactionDate, result.getJournalEntryData().getContent().get(i).getTransactionDate());
-            assertEquals(expectedJournalEntryData.submittedOnDate, result.getJournalEntryData().getContent().get(i).getSubmittedOnDate());
-            i++;
-        }
-    }
-
-    protected void getAndValidateThereIsNoJournalEntriesForTransfer(Long transferId) {
-        ExternalOwnerTransferJournalEntryData result = EXTERNAL_ASSET_OWNER_HELPER.retrieveJournalEntriesOfTransfer(transferId);
-        assertNull(result.getJournalEntryData());
     }
 
     @RequiredArgsConstructor
     public static class ExpectedExternalTransferData {
 
         private final ExternalTransferData.StatusEnum status;
-
         private final String transferExternalId;
-
         private final String settlementDate;
-
         private final String effectiveFrom;
         private final String effectiveTo;
-        private final ExternalTransferData.SubStatusEnum subStatus;
         private final boolean detailsExpected;
         private final BigDecimal totalOutstanding;
         private final BigDecimal totalPrincipalOutstanding;
@@ -376,39 +209,9 @@ public class ExternalAssetOwnerTransferTest extends BaseLoanIntegrationTest {
                 String settlementDate, String effectiveFrom, String effectiveTo, boolean detailsExpected, BigDecimal totalOutstanding,
                 BigDecimal totalPrincipalOutstanding, BigDecimal totalInterestOutstanding, BigDecimal totalPenaltyOutstanding,
                 BigDecimal totalFeeOutstanding, BigDecimal totalOverpaid) {
-            return new ExpectedExternalTransferData(status, transferExternalId, settlementDate, effectiveFrom, effectiveTo, null,
-                    detailsExpected, totalOutstanding, totalPrincipalOutstanding, totalInterestOutstanding, totalPenaltyOutstanding,
-                    totalFeeOutstanding, totalOverpaid);
+            return new ExpectedExternalTransferData(status, transferExternalId, settlementDate, effectiveFrom, effectiveTo, detailsExpected,
+                    totalOutstanding, totalPrincipalOutstanding, totalInterestOutstanding, totalPenaltyOutstanding, totalFeeOutstanding,
+                    totalOverpaid);
         }
-
-        static ExpectedExternalTransferData expected(ExternalTransferData.StatusEnum status, String transferExternalId,
-                String settlementDate, String effectiveFrom, String effectiveTo) {
-            return new ExpectedExternalTransferData(status, transferExternalId, settlementDate, effectiveFrom, effectiveTo, null, false,
-                    null, null, null, null, null, null);
-        }
-
-        static ExpectedExternalTransferData expected(ExternalTransferData.StatusEnum status, String transferExternalId,
-                String settlementDate, String effectiveFrom, String effectiveTo, ExternalTransferData.SubStatusEnum subStatus) {
-            return new ExpectedExternalTransferData(status, transferExternalId, settlementDate, effectiveFrom, effectiveTo, subStatus,
-                    false, null, null, null, null, null, null);
-        }
-    }
-
-    @RequiredArgsConstructor
-    public static class ExpectedJournalEntryData {
-
-        private final Long glAccountId;
-
-        private final Long entryTypeId;
-
-        private final BigDecimal amount;
-        private final LocalDate transactionDate;
-        private final LocalDate submittedOnDate;
-
-        static ExpectedJournalEntryData expected(Long glAccountId, Long entryTypeId, BigDecimal amount, LocalDate transactionDate,
-                LocalDate submittedOnDate) {
-            return new ExpectedJournalEntryData(glAccountId, entryTypeId, amount, transactionDate, submittedOnDate);
-        }
-
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/investor/externalassetowner/ExternalAssetOwnerTransferTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/investor/externalassetowner/ExternalAssetOwnerTransferTest.java
@@ -59,6 +59,9 @@ public class ExternalAssetOwnerTransferTest extends FeignLoanTestBase {
     protected static final FeignExternalAssetOwnerHelper EXTERNAL_ASSET_OWNER_HELPER = new FeignExternalAssetOwnerHelper(
             FineractFeignClientHelper.getFineractFeignClient());
 
+    /** The GL account the ASSET_TRANSFER financial activity is mapped to; every sale and buyback books against it. */
+    protected static Account transferAccount;
+
     public String ownerExternalId;
 
     @BeforeAll
@@ -68,7 +71,7 @@ public class ExternalAssetOwnerTransferTest extends FeignLoanTestBase {
                 "CHECK_LOAN_REPAYMENT_OVERDUE", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
                 "EXTERNAL_ASSET_OWNER_TRANSFER");
 
-        Account transferAccount = accountHelper.createAssetAccount(Utils.uniqueRandomStringGenerator("TRANSFER_", 5));
+        transferAccount = accountHelper.createAssetAccount(Utils.uniqueRandomStringGenerator("TRANSFER_", 5));
         EXTERNAL_ASSET_OWNER_HELPER.setProperFinancialActivity(transferAccount);
     }
 
@@ -112,12 +115,20 @@ public class ExternalAssetOwnerTransferTest extends FeignLoanTestBase {
     }
 
     protected Long createLoanForClient(Long clientId, String transactionDate) {
-        PostLoanProductsRequest productRequest = createOnePeriod30DaysPeriodicAccrualProduct(2.0)//
+        return createLoanForClient(clientId, transactionDate, transferrableLoanProduct());
+    }
+
+    /** The loan product shape every transfer test relies on: 15000 principal over 4 monthly installments at 2%. */
+    protected PostLoanProductsRequest transferrableLoanProduct() {
+        return createOnePeriod30DaysPeriodicAccrualProduct(2.0)//
                 .numberOfRepayments(LOAN_REPAYMENTS)//
                 .repaymentEvery(1)//
                 .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS_L)//
                 .installmentAmountInMultiplesOf(null)//
                 .principal(LOAN_PRINCIPAL);
+    }
+
+    protected Long createLoanForClient(Long clientId, String transactionDate, PostLoanProductsRequest productRequest) {
         Long loanProductId = createLoanProduct(productRequest);
 
         PostLoansRequest loanRequest = applyLoanRequest(clientId, loanProductId, transactionDate, LOAN_PRINCIPAL, LOAN_REPAYMENTS,
@@ -168,6 +179,9 @@ public class ExternalAssetOwnerTransferTest extends FeignLoanTestBase {
                 assertEquals(expected.totalFeeOutstanding, etd.getDetails().getTotalFeeChargesOutstanding());
                 assertEquals(expected.totalOverpaid, etd.getDetails().getTotalOverpaid());
             }
+            if (expected.subStatus != null) {
+                assertEquals(expected.subStatus, etd.getSubStatus());
+            }
         }
     }
 
@@ -197,6 +211,7 @@ public class ExternalAssetOwnerTransferTest extends FeignLoanTestBase {
         private final String settlementDate;
         private final String effectiveFrom;
         private final String effectiveTo;
+        private final ExternalTransferData.SubStatusEnum subStatus;
         private final boolean detailsExpected;
         private final BigDecimal totalOutstanding;
         private final BigDecimal totalPrincipalOutstanding;
@@ -209,9 +224,23 @@ public class ExternalAssetOwnerTransferTest extends FeignLoanTestBase {
                 String settlementDate, String effectiveFrom, String effectiveTo, boolean detailsExpected, BigDecimal totalOutstanding,
                 BigDecimal totalPrincipalOutstanding, BigDecimal totalInterestOutstanding, BigDecimal totalPenaltyOutstanding,
                 BigDecimal totalFeeOutstanding, BigDecimal totalOverpaid) {
-            return new ExpectedExternalTransferData(status, transferExternalId, settlementDate, effectiveFrom, effectiveTo, detailsExpected,
-                    totalOutstanding, totalPrincipalOutstanding, totalInterestOutstanding, totalPenaltyOutstanding, totalFeeOutstanding,
-                    totalOverpaid);
+            return new ExpectedExternalTransferData(status, transferExternalId, settlementDate, effectiveFrom, effectiveTo, null,
+                    detailsExpected, totalOutstanding, totalPrincipalOutstanding, totalInterestOutstanding, totalPenaltyOutstanding,
+                    totalFeeOutstanding, totalOverpaid);
+        }
+
+        /** Expects a transfer that carries no captured loan details; its sub-status is not asserted. */
+        static ExpectedExternalTransferData expected(ExternalTransferData.StatusEnum status, String transferExternalId,
+                String settlementDate, String effectiveFrom, String effectiveTo) {
+            return new ExpectedExternalTransferData(status, transferExternalId, settlementDate, effectiveFrom, effectiveTo, null, false,
+                    null, null, null, null, null, null);
+        }
+
+        /** Expects a transfer that carries no captured loan details, and asserts the reason it reached its status. */
+        static ExpectedExternalTransferData expected(ExternalTransferData.StatusEnum status, String transferExternalId,
+                String settlementDate, String effectiveFrom, String effectiveTo, ExternalTransferData.SubStatusEnum subStatus) {
+            return new ExpectedExternalTransferData(status, transferExternalId, settlementDate, effectiveFrom, effectiveTo, subStatus,
+                    false, null, null, null, null, null, null);
         }
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/investor/externalassetowner/ExternalAssetOwnerTransferUndisbursedLoanTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/investor/externalassetowner/ExternalAssetOwnerTransferUndisbursedLoanTest.java
@@ -26,21 +26,16 @@ import java.math.BigDecimal;
 import java.util.UUID;
 import org.apache.fineract.client.models.ExternalAssetOwnerRequest;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
-import org.apache.fineract.client.models.PostClientsResponse;
 import org.apache.fineract.client.models.PostInitiateTransferResponse;
 import org.apache.fineract.client.models.PostLoanProductsRequest;
-import org.apache.fineract.client.models.PostLoanProductsResponse;
-import org.apache.fineract.client.models.PostLoansResponse;
 import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
-import org.apache.fineract.integrationtests.BaseLoanIntegrationTest;
-import org.apache.fineract.integrationtests.common.BusinessStepHelper;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.ExternalAssetOwnerHelper;
-import org.apache.fineract.integrationtests.common.GlobalConfigurationHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignBusinessStepHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignExternalAssetOwnerHelper;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.common.accounting.Account;
-import org.apache.fineract.integrationtests.common.accounting.FinancialActivityAccountHelper;
 import org.apache.fineract.integrationtests.common.loans.LoanTestLifecycleExtension;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -48,25 +43,27 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith({ LoanTestLifecycleExtension.class })
-public class ExternalAssetOwnerTransferUndisbursedLoanTest extends BaseLoanIntegrationTest {
+public class ExternalAssetOwnerTransferUndisbursedLoanTest extends FeignLoanTestBase {
+
+    private final FeignExternalAssetOwnerHelper externalAssetOwnerHelper = new FeignExternalAssetOwnerHelper(
+            FineractFeignClientHelper.getFineractFeignClient());
 
     private Long loan1Id;
     private Long loan2Id;
 
     @BeforeAll
     public static void setup() {
-        new BusinessStepHelper().updateSteps("LOAN_CLOSE_OF_BUSINESS", "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION",
-                "CHECK_LOAN_REPAYMENT_DUE", "CHECK_LOAN_REPAYMENT_OVERDUE", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
+        new FeignBusinessStepHelper(FineractFeignClientHelper.getFineractFeignClient()).updateSteps("LOAN_CLOSE_OF_BUSINESS",
+                "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION", "CHECK_LOAN_REPAYMENT_DUE",
+                "CHECK_LOAN_REPAYMENT_OVERDUE", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
                 "EXTERNAL_ASSET_OWNER_TRANSFER");
-        new GlobalConfigurationHelper().updateGlobalConfiguration(
-                GlobalConfigurationConstants.ALLOWED_LOAN_STATUSES_FOR_EXTERNAL_ASSET_TRANSFER,
+        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ALLOWED_LOAN_STATUSES_FOR_EXTERNAL_ASSET_TRANSFER,
                 new PutGlobalConfigurationsRequest().stringValue("APPROVED,ACTIVE,TRANSFER_IN_PROGRESS,TRANSFER_ON_HOLD"));
     }
 
     @AfterAll
     public static void tearDown() {
-        new GlobalConfigurationHelper().updateGlobalConfiguration(
-                GlobalConfigurationConstants.ALLOWED_LOAN_STATUSES_FOR_EXTERNAL_ASSET_TRANSFER,
+        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ALLOWED_LOAN_STATUSES_FOR_EXTERNAL_ASSET_TRANSFER,
                 new PutGlobalConfigurationsRequest().stringValue("ACTIVE,TRANSFER_IN_PROGRESS,TRANSFER_ON_HOLD"));
     }
 
@@ -74,29 +71,24 @@ public class ExternalAssetOwnerTransferUndisbursedLoanTest extends BaseLoanInteg
     public void testExternalAssetOwnerTransferForUndisbursedLoan() {
         globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
 
-        Account transferAccount = accountHelper.createAssetAccount();
-        FinancialActivityAccountHelper financialActivityAccountHelper = new FinancialActivityAccountHelper(requestSpec);
-        ExternalAssetOwnerHelper externalAssetOwnerHelper = new ExternalAssetOwnerHelper();
-        externalAssetOwnerHelper.setProperFinancialActivity(financialActivityAccountHelper, transferAccount);
+        Account transferAccount = accountHelper.createAssetAccount(Utils.uniqueRandomStringGenerator("TRANSFER_", 5));
+        externalAssetOwnerHelper.setProperFinancialActivity(transferAccount);
 
         try {
             runAt("01 January 2024", () -> {
-                PostClientsResponse client = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest());
-                Long clientId = client.getClientId();
+                Long clientId = createClient();
 
                 PostLoanProductsRequest loanProductRequest = createOnePeriod30DaysPeriodicAccrualProduct(12.0)
                         .name(Utils.uniqueRandomStringGenerator("UNDISBURSED_TEST_", 4))
                         .shortName(Utils.uniqueRandomStringGenerator("UT", 2));
 
-                PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(loanProductRequest);
+                Long loanProductId = createLoanProduct(loanProductRequest);
 
-                PostLoansResponse loanResponse = loanTransactionHelper
-                        .applyLoan(applyLoanRequest(clientId, loanProduct.getResourceId(), "01 January 2024", 10000.0, 4));
-                Long loanId = loanResponse.getLoanId();
+                Long loanId = applyForLoan(applyLoanRequest(clientId, loanProductId, "01 January 2024", 10000.0, 4));
 
-                loanTransactionHelper.approveLoan(loanId, approveLoanRequest(10000.0, "01 January 2024"));
+                approveLoan(loanId, approveLoanRequest(10000.0, "01 January 2024"));
 
-                GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+                GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
                 assertNotNull(loanDetails);
                 assertEquals("loanStatusType.approved", loanDetails.getStatus().getCode());
 
@@ -110,7 +102,7 @@ public class ExternalAssetOwnerTransferUndisbursedLoanTest extends BaseLoanInteg
                 assertNotNull(transferResponse);
                 assertEquals(transferExternalId, transferResponse.getResourceExternalId());
 
-                GetLoansLoanIdResponse loanAfterTransfer = loanTransactionHelper.getLoanDetails(loanId);
+                GetLoansLoanIdResponse loanAfterTransfer = getLoanDetails(loanId);
                 assertNotNull(loanAfterTransfer, "Loan details should not be null");
 
                 if (loanAfterTransfer.getSummary() == null) {
@@ -134,27 +126,22 @@ public class ExternalAssetOwnerTransferUndisbursedLoanTest extends BaseLoanInteg
     public void testExternalAssetOwnerTransferForBackdatedUndisbursedLoan() {
         globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
 
-        Account transferAccount = accountHelper.createAssetAccount();
-        FinancialActivityAccountHelper financialActivityAccountHelper = new FinancialActivityAccountHelper(requestSpec);
-        ExternalAssetOwnerHelper externalAssetOwnerHelper = new ExternalAssetOwnerHelper();
-        externalAssetOwnerHelper.setProperFinancialActivity(financialActivityAccountHelper, transferAccount);
+        Account transferAccount = accountHelper.createAssetAccount(Utils.uniqueRandomStringGenerator("TRANSFER_", 5));
+        externalAssetOwnerHelper.setProperFinancialActivity(transferAccount);
 
         try {
             runAt("01 March 2024", () -> {
-                PostClientsResponse client = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest());
-                Long clientId = client.getClientId();
+                Long clientId = createClient();
 
                 PostLoanProductsRequest loanProductRequest = createOnePeriod30DaysPeriodicAccrualProduct(12.0)
                         .name(Utils.uniqueRandomStringGenerator("BACKDATED_UNDISBURSED_", 4))
                         .shortName(Utils.uniqueRandomStringGenerator("BU", 2));
 
-                PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(loanProductRequest);
+                Long loanProductId = createLoanProduct(loanProductRequest);
 
-                PostLoansResponse loanResponse = loanTransactionHelper
-                        .applyLoan(applyLoanRequest(clientId, loanProduct.getResourceId(), "01 December 2023", 15000.0, 4));
-                Long loanId = loanResponse.getLoanId();
+                Long loanId = applyForLoan(applyLoanRequest(clientId, loanProductId, "01 December 2023", 15000.0, 4));
 
-                loanTransactionHelper.approveLoan(loanId, approveLoanRequest(15000.0, "01 December 2023"));
+                approveLoan(loanId, approveLoanRequest(15000.0, "01 December 2023"));
 
                 String transferExternalId = UUID.randomUUID().toString();
                 String ownerExternalId = UUID.randomUUID().toString();
@@ -166,7 +153,7 @@ public class ExternalAssetOwnerTransferUndisbursedLoanTest extends BaseLoanInteg
                 assertNotNull(transferResponse);
                 assertEquals(transferExternalId, transferResponse.getResourceExternalId());
 
-                GetLoansLoanIdResponse loanAfterTransfer = loanTransactionHelper.getLoanDetails(loanId);
+                GetLoansLoanIdResponse loanAfterTransfer = getLoanDetails(loanId);
                 assertNotNull(loanAfterTransfer, "Loan details should not be null");
 
                 if (loanAfterTransfer.getSummary() == null) {
@@ -190,32 +177,25 @@ public class ExternalAssetOwnerTransferUndisbursedLoanTest extends BaseLoanInteg
     public void testExternalAssetOwnerTransferComparison_DisbursedVsUndisbursed() {
         globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
 
-        Account transferAccount = accountHelper.createAssetAccount();
-        FinancialActivityAccountHelper financialActivityAccountHelper = new FinancialActivityAccountHelper(requestSpec);
-        ExternalAssetOwnerHelper externalAssetOwnerHelper = new ExternalAssetOwnerHelper();
-        externalAssetOwnerHelper.setProperFinancialActivity(financialActivityAccountHelper, transferAccount);
+        Account transferAccount = accountHelper.createAssetAccount(Utils.uniqueRandomStringGenerator("TRANSFER_", 5));
+        externalAssetOwnerHelper.setProperFinancialActivity(transferAccount);
 
         try {
             runAt("01 January 2024", () -> {
-                PostClientsResponse client1 = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest());
-                PostClientsResponse client2 = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+                Long client1Id = createClient();
+                Long client2Id = createClient();
 
                 PostLoanProductsRequest loanProductRequest = createOnePeriod30DaysPeriodicAccrualProduct(12.0)
                         .name(Utils.uniqueRandomStringGenerator("COMPARISON_TEST_", 4))
                         .shortName(Utils.uniqueRandomStringGenerator("CT", 2));
 
-                PostLoanProductsResponse loanProduct = loanProductHelper.createLoanProduct(loanProductRequest);
+                Long loanProductId = createLoanProduct(loanProductRequest);
 
-                PostLoansResponse loan1Response = loanTransactionHelper
-                        .applyLoan(applyLoanRequest(client1.getClientId(), loanProduct.getResourceId(), "01 January 2024", 20000.0, 4));
-                loan1Id = loan1Response.getLoanId();
+                loan1Id = applyForLoan(applyLoanRequest(client1Id, loanProductId, "01 January 2024", 20000.0, 4));
+                loan2Id = applyForLoan(applyLoanRequest(client2Id, loanProductId, "01 January 2024", 20000.0, 4));
 
-                PostLoansResponse loan2Response = loanTransactionHelper
-                        .applyLoan(applyLoanRequest(client2.getClientId(), loanProduct.getResourceId(), "01 January 2024", 20000.0, 4));
-                loan2Id = loan2Response.getLoanId();
-
-                loanTransactionHelper.approveLoan(loan1Id, approveLoanRequest(20000.0, "01 January 2024"));
-                loanTransactionHelper.approveLoan(loan2Id, approveLoanRequest(20000.0, "01 January 2024"));
+                approveLoan(loan1Id, approveLoanRequest(20000.0, "01 January 2024"));
+                approveLoan(loan2Id, approveLoanRequest(20000.0, "01 January 2024"));
 
                 disburseLoan(loan1Id, BigDecimal.valueOf(20000.0), "01 January 2024");
             });
@@ -236,8 +216,11 @@ public class ExternalAssetOwnerTransferUndisbursedLoanTest extends BaseLoanInteg
                         new ExternalAssetOwnerRequest().settlementDate("31 January 2024").dateFormat("dd MMMM yyyy").locale("en")
                                 .transferExternalId(transfer2ExternalId).ownerExternalId(ownerExternalId).purchasePriceRatio("1.0"));
 
-                GetLoansLoanIdResponse disbursedLoan = loanTransactionHelper.getLoanDetails(loan1Id);
-                GetLoansLoanIdResponse undisbursedLoan = loanTransactionHelper.getLoanDetails(loan2Id);
+                assertNotNull(transfer1Response);
+                assertNotNull(transfer2Response);
+
+                GetLoansLoanIdResponse disbursedLoan = getLoanDetails(loan1Id);
+                GetLoansLoanIdResponse undisbursedLoan = getLoanDetails(loan2Id);
 
                 assertNotNull(disbursedLoan, "Disbursed loan details should not be null");
                 assertNotNull(undisbursedLoan, "Undisbursed loan details should not be null");

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/investor/externalassetowner/InitiateExternalAssetOwnerTransferTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/investor/externalassetowner/InitiateExternalAssetOwnerTransferTest.java
@@ -26,7 +26,6 @@ import static org.apache.fineract.client.models.ExternalTransferData.StatusEnum.
 import static org.apache.fineract.client.models.ExternalTransferData.SubStatusEnum.BALANCE_ZERO;
 import static org.apache.fineract.client.models.ExternalTransferData.SubStatusEnum.SAMEDAY_TRANSFERS;
 import static org.apache.fineract.client.models.ExternalTransferData.SubStatusEnum.UNSOLD;
-import static org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType.BUSINESS_DATE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -34,171 +33,156 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.path.json.JsonPath;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
-import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
-import okhttp3.ResponseBody;
-import org.apache.fineract.accounting.common.AccountingConstants;
 import org.apache.fineract.accounting.journalentry.domain.JournalEntryType;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
 import org.apache.fineract.client.models.ExternalAssetOwnerRequest;
 import org.apache.fineract.client.models.ExternalOwnerJournalEntryData;
 import org.apache.fineract.client.models.ExternalOwnerTransferJournalEntryData;
-import org.apache.fineract.client.models.ExternalTransferData;
-import org.apache.fineract.client.models.GetFinancialActivityAccountsResponse;
 import org.apache.fineract.client.models.GetJournalEntriesTransactionIdResponse;
 import org.apache.fineract.client.models.JournalEntryCommand;
+import org.apache.fineract.client.models.JournalEntryData;
 import org.apache.fineract.client.models.JournalEntryTransactionItem;
+import org.apache.fineract.client.models.LoanProductChargeData;
 import org.apache.fineract.client.models.PageExternalTransferData;
-import org.apache.fineract.client.models.PostFinancialActivityAccountsRequest;
 import org.apache.fineract.client.models.PostInitiateTransferResponse;
 import org.apache.fineract.client.models.PostJournalEntriesResponse;
-import org.apache.fineract.client.models.PostLoanProductsResponse;
-import org.apache.fineract.client.models.PostLoansLoanIdRequest;
+import org.apache.fineract.client.models.PostLoanProductsRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsRequest;
-import org.apache.fineract.client.models.PostLoansRequest;
-import org.apache.fineract.client.models.PostLoansResponse;
-import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
+import org.apache.fineract.client.models.ResultsetColumnHeaderData;
+import org.apache.fineract.client.models.RunReportsResponse;
 import org.apache.fineract.client.models.SingleDebitOrCreditEntryCommand;
-import org.apache.fineract.client.util.CallFailedRuntimeException;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
 import org.apache.fineract.infrastructure.event.external.data.ExternalEventResponse;
-import org.apache.fineract.integrationtests.BaseLoanIntegrationTest;
-import org.apache.fineract.integrationtests.common.BusinessDateHelper;
-import org.apache.fineract.integrationtests.common.BusinessStepHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignOfficeHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignReportHelper;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
 import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.CollateralManagementHelper;
-import org.apache.fineract.integrationtests.common.ExternalAssetOwnerHelper;
-import org.apache.fineract.integrationtests.common.OfficeHelper;
-import org.apache.fineract.integrationtests.common.SchedulerJobHelper;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.common.accounting.Account;
-import org.apache.fineract.integrationtests.common.accounting.AccountHelper;
-import org.apache.fineract.integrationtests.common.accounting.FinancialActivityAccountHelper;
-import org.apache.fineract.integrationtests.common.accounting.JournalEntryHelper;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
-import org.apache.fineract.integrationtests.common.externalevents.ExternalEventHelper;
 import org.apache.fineract.integrationtests.common.externalevents.ExternalEventsExtension;
-import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanStatusChecker;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.apache.fineract.integrationtests.common.report.ReportHelper;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanStatus;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.lang.NonNull;
-import retrofit2.Response;
 
-@SuppressWarnings("rawtypes")
 @ExtendWith({ ExternalEventsExtension.class })
 @Order(1)
-public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationTest {
+public class InitiateExternalAssetOwnerTransferTest extends ExternalAssetOwnerTransferTest {
 
-    private static ResponseSpecification RESPONSE_SPEC;
-    private static RequestSpecification REQUEST_SPEC;
-    private static Account ASSET_ACCOUNT;
-    private static Account FEE_PENALTY_ACCOUNT;
-    private static Account TRANSFER_ACCOUNT;
-    private static Account EXPENSE_ACCOUNT;
-    private static Account INCOME_ACCOUNT;
-    private static Account OVERPAYMENT_ACCOUNT;
-    private static FinancialActivityAccountHelper FINANCIAL_ACTIVITY_ACCOUNT_HELPER;
-    private static ExternalAssetOwnerHelper EXTERNAL_ASSET_OWNER_HELPER;
-    private static LoanTransactionHelper LOAN_TRANSACTION_HELPER;
-    private static OfficeHelper OFFICE_HELPER;
-    private static LocalDate TODAYS_DATE;
-    public String ownerExternalId;
-    private static ReportHelper reportHelper;
-    private final DateTimeFormatter dateFormatter = new DateTimeFormatterBuilder().appendPattern("dd MMMM yyyy").toFormatter();
+    private static final String LOAN_OWNERSHIP_TRANSFER_EVENT = "LoanOwnershipTransferBusinessEvent";
+    private static final String TRANSACTION_SUMMARY_REPORT = "Transaction Summary Report with Asset Owner";
+    private static final String SALE_COMMAND = "sale";
+    private static final String BUYBACK_COMMAND = "buyback";
+
+    private static final String LOAN_SUBMITTED_ON_DATE = "02 March 2020";
+    private static final String PENALTY_AMOUNT = "10";
+    private static final double OVERDUE_FEE_PERCENTAGE = 1.0;
+    private static final double PARTIAL_REPAYMENT_AMOUNT = 5.0;
+    private static final double FULL_PLUS_OVERPAYMENT_REPAYMENT_AMOUNT = 15777.42;
+    private static final float OVERPAYING_REPAYMENT_AMOUNT = 16000.0f;
+
+    private static final int BAD_REQUEST = 400;
+    private static final int FORBIDDEN = 403;
+    private static final int NOT_FOUND = 404;
+
+    private static final int PARALLEL_SALE_THREAD_COUNT = 10;
+    private static final int PARALLEL_SALE_TIMEOUT_SECONDS = 30;
+    private static final int EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS = 10;
+
+    /**
+     * Columns of the {@value #TRANSACTION_SUMMARY_REPORT} generic result set, in the order the report projects them.
+     */
+    private static final int REPORT_COLUMN_COUNT = 12;
+    private static final int TRANSACTION_DATE_COLUMN = 0;
+    private static final int PRODUCT_NAME_COLUMN = 1;
+    private static final int TRANSACTION_TYPE_COLUMN = 2;
+    private static final int PAYMENT_TYPE_COLUMN = 3;
+    private static final int CHARGE_TYPE_COLUMN = 4;
+    private static final int REVERSED_COLUMN = 5;
+    private static final int ALLOCATION_TYPE_COLUMN = 6;
+    private static final int CHARGE_OFF_REASON_COLUMN = 7;
+    private static final int AMOUNT_COLUMN = 8;
+    private static final int ASSET_OWNER_ID_COLUMN = 9;
+    private static final int FROM_ASSET_OWNER_ID_COLUMN = 10;
+    private static final int ORIGINATOR_EXTERNAL_IDS_COLUMN = 11;
+
+    private static final String LOAN_PRODUCT_NAME_PATTERN = "^LOAN_PRODUCT_.{6}$";
+    private static final String APPLY_CHARGES_TRANSACTION = "Apply Charges";
+    private static final String ASSET_BUYBACK_TRANSACTION = "Asset Buyback";
+    private static final String REPAYMENT_TRANSACTION = "Repayment";
+    private static final String PRINCIPAL_ALLOCATION = "Principal";
+    private static final String INTEREST_ALLOCATION = "Interest";
+    private static final String FEES_ALLOCATION = "Fees";
+    private static final String PENALTY_ALLOCATION = "Penalty";
+    private static final String UNALLOCATED_CREDIT_ALLOCATION = "Unallocated Credit (UNC)";
+    private static final double AMOUNT_TOLERANCE = 0.01;
+
+    private static final String MANUAL_JOURNAL_ENTRY_DATE_FORMAT = "uuuu-MM-dd";
+    private static final double MANUAL_ENTRY_LOAN_PRINCIPAL = 1000.0;
+    private static final int MANUAL_ENTRY_LOAN_REPAYMENTS = 4;
+    private static final double MANUAL_ENTRY_LOAN_INTEREST_RATE = 12.0;
+    private static final int PRE_CLOSURE_INTEREST_CALCULATION_TILL_PRE_CLOSE_DATE = 1;
+
+    private static Account assetAccount;
+    private static Account feePenaltyAccount;
+    private static Account expenseAccount;
+    private static Account incomeAccount;
+    private static Account overpaymentAccount;
+    private static FeignOfficeHelper officeHelper;
+    private static FeignReportHelper reportHelper;
 
     @BeforeAll
-    public static void setupInvestorBusinessStep() {
-        Utils.initializeRESTAssured();
-        REQUEST_SPEC = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        REQUEST_SPEC.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        RESPONSE_SPEC = new ResponseSpecBuilder().expectStatusCode(200).build();
-        AccountHelper accountHelper = new AccountHelper(REQUEST_SPEC, RESPONSE_SPEC);
-        EXTERNAL_ASSET_OWNER_HELPER = new ExternalAssetOwnerHelper();
-        FINANCIAL_ACTIVITY_ACCOUNT_HELPER = new FinancialActivityAccountHelper(REQUEST_SPEC);
-        LOAN_TRANSACTION_HELPER = new LoanTransactionHelper(REQUEST_SPEC, RESPONSE_SPEC);
-        OFFICE_HELPER = new OfficeHelper();
-
-        TODAYS_DATE = Utils.getLocalDateOfTenant();
-        new BusinessStepHelper().updateSteps("LOAN_CLOSE_OF_BUSINESS", "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION",
-                "CHECK_LOAN_REPAYMENT_DUE", "CHECK_LOAN_REPAYMENT_OVERDUE", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
-                "EXTERNAL_ASSET_OWNER_TRANSFER");
-
-        ASSET_ACCOUNT = accountHelper.createAssetAccount();
-        FEE_PENALTY_ACCOUNT = accountHelper.createAssetAccount();
-        TRANSFER_ACCOUNT = accountHelper.createAssetAccount();
-        EXPENSE_ACCOUNT = accountHelper.createExpenseAccount();
-        INCOME_ACCOUNT = accountHelper.createIncomeAccount();
-        OVERPAYMENT_ACCOUNT = accountHelper.createLiabilityAccount();
-
-        setProperFinancialActivity(TRANSFER_ACCOUNT);
-        reportHelper = new ReportHelper();
-    }
-
-    private static void setProperFinancialActivity(Account transferAccount) {
-        List<GetFinancialActivityAccountsResponse> financialMappings = FINANCIAL_ACTIVITY_ACCOUNT_HELPER.getAllFinancialActivityAccounts();
-        financialMappings.forEach(mapping -> FINANCIAL_ACTIVITY_ACCOUNT_HELPER.deleteFinancialActivityAccount(mapping.getId()));
-        FINANCIAL_ACTIVITY_ACCOUNT_HELPER.createFinancialActivityAccount(new PostFinancialActivityAccountsRequest()
-                .financialActivityId((long) AccountingConstants.FinancialActivity.ASSET_TRANSFER.getValue())
-                .glAccountId((long) transferAccount.getAccountID()));
+    public static void setupAssetOwnerAccounts() {
+        assetAccount = accountHelper.createAssetAccount(Utils.uniqueRandomStringGenerator("ASSET_", 5));
+        feePenaltyAccount = accountHelper.createAssetAccount(Utils.uniqueRandomStringGenerator("FEE_PENALTY_", 5));
+        expenseAccount = accountHelper.createExpenseAccount(Utils.uniqueRandomStringGenerator("EXPENSE_", 5));
+        incomeAccount = accountHelper.createIncomeAccount(Utils.uniqueRandomStringGenerator("INCOME_", 5));
+        overpaymentAccount = accountHelper.createLiabilityAccount(Utils.uniqueRandomStringGenerator("OVERPAYMENT_", 5));
+        officeHelper = new FeignOfficeHelper(FineractFeignClientHelper.getFineractFeignClient());
+        reportHelper = new FeignReportHelper(FineractFeignClientHelper.getFineractFeignClient());
     }
 
     @Test
     public void saleActiveLoanToExternalAssetOwnerWithCancelAndBuybackADayLater() {
         try {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2020-03-02");
+            setInitialBusinessDate(LocalDate.parse("2020-03-02"));
 
-            ExternalEventHelper.deleteAllExternalEvents(REQUEST_SPEC, new ResponseSpecBuilder().expectStatusCode(Matchers.is(204)).build());
-            ExternalEventHelper.changeEventState(REQUEST_SPEC, RESPONSE_SPEC, "LoanOwnershipTransferBusinessEvent", true);
+            externalEventHelper.deleteAllExternalEvents();
+            externalEventHelper.enableBusinessEvent(LOAN_OWNERSHIP_TRANSFER_EVENT);
 
-            Integer clientID = createClient();
-            Integer loanID = createLoanForClient(clientID);
-            addPenaltyForLoan(loanID, "10");
+            Long clientId = createClient();
+            Long loanId = createLoanForClient(clientId);
+            addPenaltyForLoan(loanId, PENALTY_AMOUNT);
 
-            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanID, "2020-03-02");
-            validateResponse(saleTransferResponse, loanID);
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanId, "2020-03-02");
+            validateResponse(saleTransferResponse, loanId);
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
                             "9999-12-31", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
                             new BigDecimal("0.000000")));
             getAndValidateThereIsNoActiveMapping(saleTransferResponse.getResourceExternalId());
-            PageExternalTransferData retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            PageExternalTransferData retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
             retrieveResponse.getContent().forEach(transfer -> getAndValidateThereIsNoJournalEntriesForTransfer(transfer.getTransferId()));
 
             EXTERNAL_ASSET_OWNER_HELPER.cancelTransferByTransferExternalId(saleTransferResponse.getResourceExternalId());
 
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
                             "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
@@ -208,10 +192,10 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
                             new BigDecimal("0.000000")));
             PostInitiateTransferResponse oldSaleTransferResponse = saleTransferResponse;
-            saleTransferResponse = createSaleTransfer(loanID, "2020-03-02");
-            validateResponse(saleTransferResponse, loanID);
+            saleTransferResponse = createSaleTransfer(loanId, "2020-03-02");
+            validateResponse(saleTransferResponse, loanId);
 
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, oldSaleTransferResponse.getResourceExternalId(), "2020-03-02",
                             "2020-03-02", "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
@@ -226,7 +210,7 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
                             new BigDecimal("0.000000")));
 
             updateBusinessDateAndExecuteCOBJob("2020-03-03");
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, oldSaleTransferResponse.getResourceExternalId(), "2020-03-02",
                             "2020-03-02", "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
@@ -244,35 +228,35 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
                             new BigDecimal("0.000000")));
 
-            List<ExternalEventResponse> allExternalEvents = ExternalEventHelper.getAllExternalEvents(REQUEST_SPEC, RESPONSE_SPEC);
-            Assertions.assertEquals(1, allExternalEvents.size());
-            Assertions.assertEquals("LoanOwnershipTransferBusinessEvent", allExternalEvents.get(0).getType());
-            Assertions.assertEquals(Long.valueOf(loanID), allExternalEvents.get(0).getAggregateRootId());
+            List<ExternalEventResponse> allExternalEvents = externalEventHelper.getAllExternalEvents();
+            assertEquals(1, allExternalEvents.size());
+            assertEquals(LOAN_OWNERSHIP_TRANSFER_EVENT, allExternalEvents.get(0).getType());
+            assertEquals(loanId, allExternalEvents.get(0).getAggregateRootId());
 
-            ExternalEventHelper.deleteAllExternalEvents(REQUEST_SPEC, new ResponseSpecBuilder().expectStatusCode(Matchers.is(204)).build());
-            ExternalEventHelper.changeEventState(REQUEST_SPEC, RESPONSE_SPEC, "LoanOwnershipTransferBusinessEvent", true);
+            externalEventHelper.deleteAllExternalEvents();
+            externalEventHelper.enableBusinessEvent(LOAN_OWNERSHIP_TRANSFER_EVENT);
 
-            getAndValidateThereIsActiveMapping(loanID);
-            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            getAndValidateThereIsActiveMapping(loanId);
+            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
             LocalDate expectedDate = LocalDate.of(2020, 3, 2);
             int initial = 2;
             getAndValidateThereIsJournalEntriesForTransfer(retrieveResponse.getContent().get(initial + 1).getTransferId(),
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(15757.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(10.000000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) TRANSFER_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(15767.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(15757.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(10.000000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) TRANSFER_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(15767.420000), expectedDate, expectedDate));
+                    ExpectedJournalEntryData.expected(assetAccountId(), creditEntryTypeId(), BigDecimal.valueOf(15757.420000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), creditEntryTypeId(), BigDecimal.valueOf(10.000000),
+                            expectedDate, expectedDate),
+                    ExpectedJournalEntryData.expected(transferAccountId(), debitEntryTypeId(), BigDecimal.valueOf(15767.420000),
+                            expectedDate, expectedDate),
+                    ExpectedJournalEntryData.expected(assetAccountId(), debitEntryTypeId(), BigDecimal.valueOf(15757.420000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), debitEntryTypeId(), BigDecimal.valueOf(10.000000),
+                            expectedDate, expectedDate),
+                    ExpectedJournalEntryData.expected(transferAccountId(), creditEntryTypeId(), BigDecimal.valueOf(15767.420000),
+                            expectedDate, expectedDate));
 
-            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanID, "2020-03-03");
-            validateResponse(buybackTransferResponse, loanID);
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanId, "2020-03-03");
+            validateResponse(buybackTransferResponse, loanId);
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, oldSaleTransferResponse.getResourceExternalId(), "2020-03-02",
                             "2020-03-02", "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
@@ -293,25 +277,24 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
                             "2020-03-03", "9999-12-31", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
                             new BigDecimal("0.000000")));
-            getAndValidateThereIsActiveMapping(loanID);
-            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            getAndValidateThereIsActiveMapping(loanId);
+            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
             getAndValidateThereIsNoJournalEntriesForTransfer(retrieveResponse.getContent().get(initial + 2).getTransferId());
 
-            LOAN_TRANSACTION_HELPER.makeLoanRepayment((long) loanID, new PostLoansLoanIdTransactionsRequest().dateFormat("dd MMMM yyyy")
-                    .transactionDate(dateFormatter.format(expectedDate)).locale("en").transactionAmount(5.0));
+            makePartialRepayment(loanId, expectedDate);
             LocalDate repaymentSubmittedOnDate = expectedDate.plusDays(1);
             getAndValidateOwnerJournalEntries(ownerExternalId,
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(15757.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(10.000000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(5.000000), expectedDate, repaymentSubmittedOnDate),
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(5.000000), expectedDate, repaymentSubmittedOnDate));
+                    ExpectedJournalEntryData.expected(assetAccountId(), debitEntryTypeId(), BigDecimal.valueOf(15757.420000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), debitEntryTypeId(), BigDecimal.valueOf(10.000000),
+                            expectedDate, expectedDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), creditEntryTypeId(), BigDecimal.valueOf(5.000000),
+                            expectedDate, repaymentSubmittedOnDate),
+                    ExpectedJournalEntryData.expected(assetAccountId(), debitEntryTypeId(), BigDecimal.valueOf(5.000000), expectedDate,
+                            repaymentSubmittedOnDate));
 
             updateBusinessDateAndExecuteCOBJob("2020-03-04");
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, oldSaleTransferResponse.getResourceExternalId(), "2020-03-02",
                             "2020-03-02", "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
@@ -333,39 +316,39 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
                             new BigDecimal("757.420000"), new BigDecimal("5.000000"), new BigDecimal("0.000000"),
                             new BigDecimal("0.000000")));
             getAndValidateThereIsNoActiveMapping(saleTransferResponse.getResourceExternalId());
-            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
             expectedDate = LocalDate.of(2020, 3, 3);
             getAndValidateThereIsJournalEntriesForTransfer(retrieveResponse.getContent().get(initial + 2).getTransferId(),
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(15757.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(5.000000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) TRANSFER_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(15762.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(15757.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(5.000000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) TRANSFER_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(15762.420000), expectedDate, expectedDate));
+                    ExpectedJournalEntryData.expected(assetAccountId(), debitEntryTypeId(), BigDecimal.valueOf(15757.420000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), debitEntryTypeId(), BigDecimal.valueOf(5.000000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(transferAccountId(), creditEntryTypeId(), BigDecimal.valueOf(15762.420000),
+                            expectedDate, expectedDate),
+                    ExpectedJournalEntryData.expected(assetAccountId(), creditEntryTypeId(), BigDecimal.valueOf(15757.420000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), creditEntryTypeId(), BigDecimal.valueOf(5.000000),
+                            expectedDate, expectedDate),
+                    ExpectedJournalEntryData.expected(transferAccountId(), debitEntryTypeId(), BigDecimal.valueOf(15762.420000),
+                            expectedDate, expectedDate));
             LocalDate previousDayDate = LocalDate.of(2020, 3, 2);
             getAndValidateOwnerJournalEntries(ownerExternalId,
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(15757.420000), previousDayDate, previousDayDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(10.000000), previousDayDate, previousDayDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(5.000000), previousDayDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(5.000000), previousDayDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(9.680000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) INCOME_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(9.680000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(15757.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(5.000000), expectedDate, expectedDate));
+                    ExpectedJournalEntryData.expected(assetAccountId(), debitEntryTypeId(), BigDecimal.valueOf(15757.420000),
+                            previousDayDate, previousDayDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), debitEntryTypeId(), BigDecimal.valueOf(10.000000),
+                            previousDayDate, previousDayDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), creditEntryTypeId(), BigDecimal.valueOf(5.000000),
+                            previousDayDate, expectedDate),
+                    ExpectedJournalEntryData.expected(assetAccountId(), debitEntryTypeId(), BigDecimal.valueOf(5.000000), previousDayDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(assetAccountId(), debitEntryTypeId(), BigDecimal.valueOf(9.680000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(incomeAccountId(), creditEntryTypeId(), BigDecimal.valueOf(9.680000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(assetAccountId(), creditEntryTypeId(), BigDecimal.valueOf(15757.420000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), creditEntryTypeId(), BigDecimal.valueOf(5.000000),
+                            expectedDate, expectedDate));
         } finally {
             cleanUpAndRestoreBusinessDate();
         }
@@ -375,24 +358,24 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
     public void saleActiveLoanToExternalAssetOwnerAndBuybackADayLater() {
         try {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2020-03-02");
-            Integer clientID = createClient();
-            Integer loanID = createLoanForClient(clientID);
-            addPenaltyForLoan(loanID, "10");
+            setInitialBusinessDate(LocalDate.parse("2020-03-02"));
+            Long clientId = createClient();
+            Long loanId = createLoanForClient(clientId);
+            addPenaltyForLoan(loanId, PENALTY_AMOUNT);
 
-            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanID, "2020-03-02");
-            validateResponse(saleTransferResponse, loanID);
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanId, "2020-03-02");
+            validateResponse(saleTransferResponse, loanId);
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
                             "9999-12-31", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
                             new BigDecimal("0.000000")));
             getAndValidateThereIsNoActiveMapping(saleTransferResponse.getResourceExternalId());
-            PageExternalTransferData retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            PageExternalTransferData retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
             retrieveResponse.getContent().forEach(transfer -> getAndValidateThereIsNoJournalEntriesForTransfer(transfer.getTransferId()));
 
             updateBusinessDateAndExecuteCOBJob("2020-03-03");
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
                             "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
@@ -401,26 +384,26 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
                             "9999-12-31", true, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
                             new BigDecimal("0.000000")));
-            getAndValidateThereIsActiveMapping(loanID);
-            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            getAndValidateThereIsActiveMapping(loanId);
+            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
             LocalDate expectedDate = LocalDate.of(2020, 3, 2);
             getAndValidateThereIsJournalEntriesForTransfer(retrieveResponse.getContent().get(1).getTransferId(),
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(15757.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(10.000000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) TRANSFER_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(15767.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(15757.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(10.000000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) TRANSFER_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(15767.420000), expectedDate, expectedDate));
+                    ExpectedJournalEntryData.expected(assetAccountId(), creditEntryTypeId(), BigDecimal.valueOf(15757.420000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), creditEntryTypeId(), BigDecimal.valueOf(10.000000),
+                            expectedDate, expectedDate),
+                    ExpectedJournalEntryData.expected(transferAccountId(), debitEntryTypeId(), BigDecimal.valueOf(15767.420000),
+                            expectedDate, expectedDate),
+                    ExpectedJournalEntryData.expected(assetAccountId(), debitEntryTypeId(), BigDecimal.valueOf(15757.420000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), debitEntryTypeId(), BigDecimal.valueOf(10.000000),
+                            expectedDate, expectedDate),
+                    ExpectedJournalEntryData.expected(transferAccountId(), creditEntryTypeId(), BigDecimal.valueOf(15767.420000),
+                            expectedDate, expectedDate));
 
-            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanID, "2020-03-03");
-            validateResponse(buybackTransferResponse, loanID);
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanId, "2020-03-03");
+            validateResponse(buybackTransferResponse, loanId);
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
                             "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
@@ -433,25 +416,24 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
                             "2020-03-03", "9999-12-31", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
                             new BigDecimal("0.000000")));
-            getAndValidateThereIsActiveMapping(loanID);
-            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            getAndValidateThereIsActiveMapping(loanId);
+            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
             getAndValidateThereIsNoJournalEntriesForTransfer(retrieveResponse.getContent().get(2).getTransferId());
 
-            LOAN_TRANSACTION_HELPER.makeLoanRepayment((long) loanID, new PostLoansLoanIdTransactionsRequest().dateFormat("dd MMMM yyyy")
-                    .transactionDate(dateFormatter.format(expectedDate)).locale("en").transactionAmount(5.0));
+            makePartialRepayment(loanId, expectedDate);
             LocalDate repaymentSubmittedOnDate = expectedDate.plusDays(1);
             getAndValidateOwnerJournalEntries(ownerExternalId,
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(15757.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(10.000000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(5.000000), expectedDate, repaymentSubmittedOnDate),
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(5.000000), expectedDate, repaymentSubmittedOnDate));
+                    ExpectedJournalEntryData.expected(assetAccountId(), debitEntryTypeId(), BigDecimal.valueOf(15757.420000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), debitEntryTypeId(), BigDecimal.valueOf(10.000000),
+                            expectedDate, expectedDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), creditEntryTypeId(), BigDecimal.valueOf(5.000000),
+                            expectedDate, repaymentSubmittedOnDate),
+                    ExpectedJournalEntryData.expected(assetAccountId(), debitEntryTypeId(), BigDecimal.valueOf(5.000000), expectedDate,
+                            repaymentSubmittedOnDate));
 
             updateBusinessDateAndExecuteCOBJob("2020-03-04");
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
                             "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
@@ -465,39 +447,39 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
                             new BigDecimal("757.420000"), new BigDecimal("5.000000"), new BigDecimal("0.000000"),
                             new BigDecimal("0.000000")));
             getAndValidateThereIsNoActiveMapping(saleTransferResponse.getResourceExternalId());
-            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
             expectedDate = LocalDate.of(2020, 3, 3);
             getAndValidateThereIsJournalEntriesForTransfer(retrieveResponse.getContent().get(2).getTransferId(),
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(15757.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(5.000000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) TRANSFER_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(15762.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(15757.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(5.000000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) TRANSFER_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(15762.420000), expectedDate, expectedDate));
+                    ExpectedJournalEntryData.expected(assetAccountId(), debitEntryTypeId(), BigDecimal.valueOf(15757.420000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), debitEntryTypeId(), BigDecimal.valueOf(5.000000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(transferAccountId(), creditEntryTypeId(), BigDecimal.valueOf(15762.420000),
+                            expectedDate, expectedDate),
+                    ExpectedJournalEntryData.expected(assetAccountId(), creditEntryTypeId(), BigDecimal.valueOf(15757.420000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), creditEntryTypeId(), BigDecimal.valueOf(5.000000),
+                            expectedDate, expectedDate),
+                    ExpectedJournalEntryData.expected(transferAccountId(), debitEntryTypeId(), BigDecimal.valueOf(15762.420000),
+                            expectedDate, expectedDate));
             LocalDate previousDayDate = LocalDate.of(2020, 3, 2);
             getAndValidateOwnerJournalEntries(ownerExternalId,
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(15757.420000), previousDayDate, previousDayDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(10.000000), previousDayDate, previousDayDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(5.000000), previousDayDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(5.000000), previousDayDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(9.680000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) INCOME_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(9.680000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(15757.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(5.000000), expectedDate, expectedDate));
+                    ExpectedJournalEntryData.expected(assetAccountId(), debitEntryTypeId(), BigDecimal.valueOf(15757.420000),
+                            previousDayDate, previousDayDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), debitEntryTypeId(), BigDecimal.valueOf(10.000000),
+                            previousDayDate, previousDayDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), creditEntryTypeId(), BigDecimal.valueOf(5.000000),
+                            previousDayDate, expectedDate),
+                    ExpectedJournalEntryData.expected(assetAccountId(), debitEntryTypeId(), BigDecimal.valueOf(5.000000), previousDayDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(assetAccountId(), debitEntryTypeId(), BigDecimal.valueOf(9.680000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(incomeAccountId(), creditEntryTypeId(), BigDecimal.valueOf(9.680000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(assetAccountId(), creditEntryTypeId(), BigDecimal.valueOf(15757.420000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), creditEntryTypeId(), BigDecimal.valueOf(5.000000),
+                            expectedDate, expectedDate));
         } finally {
             cleanUpAndRestoreBusinessDate();
         }
@@ -507,24 +489,24 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
     public void saleOverpaidLoanToExternalAssetOwnerAndBuybackADayLater() {
         try {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2020-03-02");
-            Integer clientID = createClient();
-            Integer loanID = createLoanForClient(clientID);
-            addPenaltyForLoan(loanID, "10");
+            setInitialBusinessDate(LocalDate.parse("2020-03-02"));
+            Long clientId = createClient();
+            Long loanId = createLoanForClient(clientId);
+            addPenaltyForLoan(loanId, PENALTY_AMOUNT);
 
-            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanID, "2020-03-02");
-            validateResponse(saleTransferResponse, loanID);
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanId, "2020-03-02");
+            validateResponse(saleTransferResponse, loanId);
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
                             "9999-12-31", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
                             new BigDecimal("0.000000")));
             getAndValidateThereIsNoActiveMapping(saleTransferResponse.getResourceExternalId());
-            PageExternalTransferData retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            PageExternalTransferData retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
             retrieveResponse.getContent().forEach(transfer -> getAndValidateThereIsNoJournalEntriesForTransfer(transfer.getTransferId()));
 
             updateBusinessDateAndExecuteCOBJob("2020-03-03");
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
                             "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
@@ -533,26 +515,26 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
                             "9999-12-31", true, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
                             new BigDecimal("0.000000")));
-            getAndValidateThereIsActiveMapping(loanID);
-            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            getAndValidateThereIsActiveMapping(loanId);
+            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
             LocalDate expectedDate = LocalDate.of(2020, 3, 2);
             getAndValidateThereIsJournalEntriesForTransfer(retrieveResponse.getContent().get(1).getTransferId(),
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(15757.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(10.000000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) TRANSFER_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(15767.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(15757.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(10.000000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) TRANSFER_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(15767.420000), expectedDate, expectedDate));
+                    ExpectedJournalEntryData.expected(assetAccountId(), creditEntryTypeId(), BigDecimal.valueOf(15757.420000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), creditEntryTypeId(), BigDecimal.valueOf(10.000000),
+                            expectedDate, expectedDate),
+                    ExpectedJournalEntryData.expected(transferAccountId(), debitEntryTypeId(), BigDecimal.valueOf(15767.420000),
+                            expectedDate, expectedDate),
+                    ExpectedJournalEntryData.expected(assetAccountId(), debitEntryTypeId(), BigDecimal.valueOf(15757.420000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), debitEntryTypeId(), BigDecimal.valueOf(10.000000),
+                            expectedDate, expectedDate),
+                    ExpectedJournalEntryData.expected(transferAccountId(), creditEntryTypeId(), BigDecimal.valueOf(15767.420000),
+                            expectedDate, expectedDate));
 
-            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanID, "2020-03-03");
-            validateResponse(buybackTransferResponse, loanID);
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanId, "2020-03-03");
+            validateResponse(buybackTransferResponse, loanId);
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
                             "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
@@ -565,23 +547,25 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
                             "2020-03-03", "9999-12-31", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
                             new BigDecimal("0.000000")));
-            getAndValidateThereIsActiveMapping(loanID);
-            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            getAndValidateThereIsActiveMapping(loanId);
+            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
             getAndValidateThereIsNoJournalEntriesForTransfer(retrieveResponse.getContent().get(2).getTransferId());
 
-            LOAN_TRANSACTION_HELPER.makeLoanRepayment((long) loanID, new PostLoansLoanIdTransactionsRequest().dateFormat("dd MMMM yyyy")
-                    .transactionDate(dateFormatter.format(expectedDate)).locale("en").transactionAmount(15777.42));
+            transactionHelper.makeLoanRepayment(loanId,
+                    new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                            .transactionDate(dateTimeFormatter.format(expectedDate)).locale(LoanTestData.LOCALE)
+                            .transactionAmount(FULL_PLUS_OVERPAYMENT_REPAYMENT_AMOUNT));
             LocalDate repaymentSubmittedOnDate = expectedDate.plusDays(1);
             getAndValidateOwnerJournalEntries(ownerExternalId,
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(15757.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(10.000000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) OVERPAYMENT_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(10.000000), repaymentSubmittedOnDate, repaymentSubmittedOnDate));
+                    ExpectedJournalEntryData.expected(assetAccountId(), debitEntryTypeId(), BigDecimal.valueOf(15757.420000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), debitEntryTypeId(), BigDecimal.valueOf(10.000000),
+                            expectedDate, expectedDate),
+                    ExpectedJournalEntryData.expected(overpaymentAccountId(), debitEntryTypeId(), BigDecimal.valueOf(10.000000),
+                            repaymentSubmittedOnDate, repaymentSubmittedOnDate));
 
             updateBusinessDateAndExecuteCOBJob("2020-03-04");
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
                             "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
@@ -595,25 +579,25 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
                             new BigDecimal("0.000000"), new BigDecimal("0.000000"), new BigDecimal("0.000000"),
                             new BigDecimal("10.000000")));
             getAndValidateThereIsNoActiveMapping(saleTransferResponse.getResourceExternalId());
-            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
             expectedDate = LocalDate.of(2020, 3, 3);
             getAndValidateThereIsJournalEntriesForTransfer(retrieveResponse.getContent().get(2).getTransferId(),
-                    ExpectedJournalEntryData.expected((long) OVERPAYMENT_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(10.000000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) TRANSFER_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(10.000000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) OVERPAYMENT_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(10.000000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) TRANSFER_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(10.000000), expectedDate, expectedDate));
+                    ExpectedJournalEntryData.expected(overpaymentAccountId(), debitEntryTypeId(), BigDecimal.valueOf(10.000000),
+                            expectedDate, expectedDate),
+                    ExpectedJournalEntryData.expected(transferAccountId(), creditEntryTypeId(), BigDecimal.valueOf(10.000000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(overpaymentAccountId(), creditEntryTypeId(), BigDecimal.valueOf(10.000000),
+                            expectedDate, expectedDate),
+                    ExpectedJournalEntryData.expected(transferAccountId(), debitEntryTypeId(), BigDecimal.valueOf(10.000000), expectedDate,
+                            expectedDate));
             LocalDate previousDayDate = LocalDate.of(2020, 3, 2);
             getAndValidateOwnerJournalEntries(ownerExternalId,
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(15757.420000), previousDayDate, previousDayDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(10.000000), previousDayDate, previousDayDate),
-                    ExpectedJournalEntryData.expected((long) OVERPAYMENT_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(10.000000), expectedDate, expectedDate));
+                    ExpectedJournalEntryData.expected(assetAccountId(), debitEntryTypeId(), BigDecimal.valueOf(15757.420000),
+                            previousDayDate, previousDayDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), debitEntryTypeId(), BigDecimal.valueOf(10.000000),
+                            previousDayDate, previousDayDate),
+                    ExpectedJournalEntryData.expected(overpaymentAccountId(), debitEntryTypeId(), BigDecimal.valueOf(10.000000),
+                            expectedDate, expectedDate));
         } finally {
             cleanUpAndRestoreBusinessDate();
         }
@@ -623,14 +607,15 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
     public void saleIsNotAllowedWhenTransferIsAlreadyPending() {
         try {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2020-03-02");
-            Integer clientID = createClient();
-            Integer loanID = createLoanForClient(clientID);
+            setInitialBusinessDate(LocalDate.parse("2020-03-02"));
+            Long clientId = createClient();
+            Long loanId = createLoanForClient(clientId);
 
-            createSaleTransfer(loanID, "2020-03-02");
+            createSaleTransfer(loanId, "2020-03-02");
 
             CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                    () -> createSaleTransfer(loanID, "2020-03-02"));
+                    () -> createSaleTransfer(loanId, "2020-03-02"));
+            assertEquals(FORBIDDEN, exception.getStatus());
             assertTrue(exception.getMessage().contains("External asset owner transfer is already in PENDING state for this loan"));
         } finally {
             cleanUpAndRestoreBusinessDate();
@@ -641,19 +626,19 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
     public void saleIsNotAllowedWhenLoanIsNotActive() {
         try {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2020-03-02");
-            Integer clientID = createClient();
-            Integer loanID = createLoanForClient(clientID);
+            setInitialBusinessDate(LocalDate.parse("2020-03-02"));
+            Long clientId = createClient();
+            Long loanId = createLoanForClient(clientId);
 
             updateBusinessDateAndExecuteCOBJob("2020-03-04");
 
-            LOAN_TRANSACTION_HELPER.makeRepayment("04 March 2020", 16000.0f, loanID);
+            makeRepayment("04 March 2020", OVERPAYING_REPAYMENT_AMOUNT, loanId);
 
-            HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            LoanStatus loanStatus = LoanStatus.fromInt((Integer) loanStatusHashMap.get("id"));
+            LoanStatus loanStatus = LoanStatus.fromInt(getLoanDetails(loanId).getStatus().getId().intValue());
 
             CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                    () -> createSaleTransfer(loanID, "2020-03-02"));
+                    () -> createSaleTransfer(loanId, "2020-03-02"));
+            assertEquals(FORBIDDEN, exception.getStatus());
             assertTrue(exception.getMessage().contains(String.format("Loan status %s is not valid for transfer.", loanStatus)));
         } finally {
             cleanUpAndRestoreBusinessDate();
@@ -664,16 +649,16 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
     public void saleIsDeclinedWhenLoanIsCancelled() {
         try {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2020-03-02");
-            Integer clientID = createClient();
-            Integer loanID = createLoanForClient(clientID);
+            setInitialBusinessDate(LocalDate.parse("2020-03-02"));
+            Long clientId = createClient();
+            Long loanId = createLoanForClient(clientId);
 
-            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanID, "2020-03-06");
+            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanId, "2020-03-06");
             updateBusinessDateAndExecuteCOBJob("2020-03-04");
 
-            LOAN_TRANSACTION_HELPER.writeOffLoan("04 March 2020", loanID);
+            writeOffLoan("04 March 2020", loanId);
 
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-06", "2020-03-02",
                             "2020-03-04"),
                     ExpectedExternalTransferData.expected(DECLINED, saleTransferResponse.getResourceExternalId(), "2020-03-06",
@@ -687,17 +672,17 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
     public void buybackIsExecutedWhenLoanIsCancelled() {
         try {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2020-03-02");
-            Integer clientID = createClient();
-            Integer loanID = createLoanForClient(clientID);
+            setInitialBusinessDate(LocalDate.parse("2020-03-02"));
+            Long clientId = createClient();
+            Long loanId = createLoanForClient(clientId);
 
-            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanID, "2020-03-04");
+            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanId, "2020-03-04");
             updateBusinessDateAndExecuteCOBJob("2020-03-05");
-            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanID, "2020-03-06");
+            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanId, "2020-03-06");
 
-            LOAN_TRANSACTION_HELPER.writeOffLoan("04 March 2020", loanID);
+            writeOffLoan("04 March 2020", loanId);
 
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-04", "2020-03-02",
                             "2020-03-04"),
                     ExpectedExternalTransferData.expected(ACTIVE, saleTransferResponse.getResourceExternalId(), "2020-03-04", "2020-03-05",
@@ -718,16 +703,16 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
     public void buybackAndSaleIsCancelledWhenLoanIsCancelled() {
         try {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2020-03-02");
-            Integer clientID = createClient();
-            Integer loanID = createLoanForClient(clientID);
+            setInitialBusinessDate(LocalDate.parse("2020-03-02"));
+            Long clientId = createClient();
+            Long loanId = createLoanForClient(clientId);
 
-            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanID, "2020-03-04");
-            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanID, "2020-03-06");
+            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanId, "2020-03-04");
+            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanId, "2020-03-06");
 
-            LOAN_TRANSACTION_HELPER.writeOffLoan("02 March 2020", loanID);
+            writeOffLoan("02 March 2020", loanId);
 
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-04", "2020-03-02",
                             "2020-03-02"),
                     ExpectedExternalTransferData.expected(BUYBACK, buybackTransferResponse.getResourceExternalId(), "2020-03-06",
@@ -745,16 +730,16 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
     public void sameDayBuybackAndSaleIsCancelledWhenLoanIsCancelled() {
         try {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2020-03-02");
-            Integer clientID = createClient();
-            Integer loanID = createLoanForClient(clientID);
+            setInitialBusinessDate(LocalDate.parse("2020-03-02"));
+            Long clientId = createClient();
+            Long loanId = createLoanForClient(clientId);
 
-            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanID, "2020-03-03");
-            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanID, "2020-03-03");
+            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanId, "2020-03-03");
+            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanId, "2020-03-03");
 
-            LOAN_TRANSACTION_HELPER.writeOffLoan("02 March 2020", loanID);
+            writeOffLoan("02 March 2020", loanId);
 
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-03", "2020-03-02",
                             "2020-03-02"),
                     ExpectedExternalTransferData.expected(BUYBACK, buybackTransferResponse.getResourceExternalId(), "2020-03-03",
@@ -772,16 +757,16 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
     public void saleAndBuybackOnTheSameDay() {
         try {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2020-03-02");
-            Integer clientID = createClient();
-            Integer loanID = createLoanForClient(clientID);
+            setInitialBusinessDate(LocalDate.parse("2020-03-02"));
+            Long clientId = createClient();
+            Long loanId = createLoanForClient(clientId);
 
-            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanID, "2020-03-02");
-            validateResponse(saleTransferResponse, loanID);
-            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanID, "2020-03-02");
-            validateResponse(buybackTransferResponse, loanID);
+            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanId, "2020-03-02");
+            validateResponse(saleTransferResponse, loanId);
+            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanId, "2020-03-02");
+            validateResponse(buybackTransferResponse, loanId);
 
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
                             "9999-12-31", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
@@ -795,7 +780,7 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
 
             updateBusinessDateAndExecuteCOBJob("2020-03-03");
 
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
                             "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
@@ -812,7 +797,7 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
                             "2020-03-02", "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
                             new BigDecimal("0.000000")));
-            getAndValidateThereIsNoActiveMapping((long) loanID);
+            getAndValidateThereIsNoActiveMapping(loanId);
         } finally {
             cleanUpAndRestoreBusinessDate();
         }
@@ -822,14 +807,14 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
     public void saleAndBuybackMultipleTimes() {
         try {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2020-03-02");
-            Integer clientID = createClient();
-            Integer loanID = createLoanForClient(clientID);
+            setInitialBusinessDate(LocalDate.parse("2020-03-02"));
+            Long clientId = createClient();
+            Long loanId = createLoanForClient(clientId);
 
-            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanID, "2020-03-04");
-            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanID, "2020-03-04");
+            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanId, "2020-03-04");
+            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanId, "2020-03-04");
 
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-04", "2020-03-02",
                             "9999-12-31", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
@@ -840,11 +825,13 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
                             new BigDecimal("0.000000")));
 
             CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                    () -> createSaleTransfer(loanID, "2020-03-04"));
+                    () -> createSaleTransfer(loanId, "2020-03-04"));
+            assertEquals(FORBIDDEN, exception.getStatus());
             assertTrue(exception.getMessage().contains("This loan cannot be sold, there is already an in progress transfer"));
 
             CallFailedRuntimeException exception2 = assertThrows(CallFailedRuntimeException.class,
-                    () -> createBuybackTransfer(loanID, "2020-03-04"));
+                    () -> createBuybackTransfer(loanId, "2020-03-04"));
+            assertEquals(FORBIDDEN, exception2.getStatus());
             assertTrue(exception2.getMessage()
                     .contains("This loan cannot be bought back, external asset owner buyback transfer is already in progress"));
         } finally {
@@ -856,47 +843,54 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
     public void buybackExceptionHandling() {
         try {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2020-03-02");
+            setInitialBusinessDate(LocalDate.parse("2020-03-02"));
 
-            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class, () -> createBuybackTransfer(1, null));
+            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
+                    () -> createBuybackTransfer(FeignOfficeHelper.HEAD_OFFICE_ID, null));
+            assertEquals(BAD_REQUEST, exception.getStatus());
             assertTrue(exception.getMessage().contains("The parameter `settlementDate` is mandatory."));
 
             CallFailedRuntimeException exception2 = assertThrows(CallFailedRuntimeException.class, () -> {
-                Integer clientID = createClient();
-                Integer loanID = createLoanForClient(clientID);
-                createBuybackTransfer(loanID, "1970-01-01");
+                Long clientId = createClient();
+                Long loanId = createLoanForClient(clientId);
+                createBuybackTransfer(loanId, "1970-01-01");
             });
+            assertEquals(FORBIDDEN, exception2.getStatus());
             assertTrue(exception2.getMessage().contains("Settlement date cannot be in the past"));
 
             CallFailedRuntimeException exception3 = assertThrows(CallFailedRuntimeException.class, () -> {
-                Integer clientID = createClient();
-                Integer loanID = createLoanForClient(clientID);
-                createSaleTransfer(loanID, "2020-03-03");
-                createBuybackTransfer(loanID, "2020-03-02");
+                Long clientId = createClient();
+                Long loanId = createLoanForClient(clientId);
+                createSaleTransfer(loanId, "2020-03-03");
+                createBuybackTransfer(loanId, "2020-03-02");
             });
+            assertEquals(FORBIDDEN, exception3.getStatus());
             assertTrue(exception3.getMessage().contains(
                     "This loan cannot be bought back, settlement date is earlier than effective transfer settlement date: 2020-03-03"));
 
             CallFailedRuntimeException exception4 = assertThrows(CallFailedRuntimeException.class, () -> {
-                Integer clientID = createClient();
-                Integer loanID = createLoanForClient(clientID);
-                createBuybackTransfer(loanID, "2020-03-03");
+                Long clientId = createClient();
+                Long loanId = createLoanForClient(clientId);
+                createBuybackTransfer(loanId, "2020-03-03");
             });
+            assertEquals(FORBIDDEN, exception4.getStatus());
             assertTrue(exception4.getMessage().contains("This loan cannot be bought back, it is not owned by an external asset owner"));
 
             CallFailedRuntimeException exception5 = assertThrows(CallFailedRuntimeException.class,
-                    () -> createBuybackTransfer(-1, "2020-03-03"));
+                    () -> createBuybackTransfer(-1L, "2020-03-03"));
+            assertEquals(NOT_FOUND, exception5.getStatus());
             assertTrue(exception5.getMessage().contains("Loan with identifier -1 does not exist"));
 
             String externalId = UUID.randomUUID().toString();
             String transferExternalGroupId = UUID.randomUUID().toString();
 
             CallFailedRuntimeException exception6 = assertThrows(CallFailedRuntimeException.class, () -> {
-                Integer clientID = createClient();
-                Integer loanID = createLoanForClient(clientID);
-                createSaleTransfer(loanID, "2020-03-03", externalId, transferExternalGroupId, "1", "1.0");
-                createBuybackTransfer(loanID, "2020-03-02", externalId);
+                Long clientId = createClient();
+                Long loanId = createLoanForClient(clientId);
+                createSaleTransfer(loanId, "2020-03-03", externalId, transferExternalGroupId, "1", "1.0");
+                createBuybackTransfer(loanId, "2020-03-02", externalId);
             });
+            assertEquals(FORBIDDEN, exception6.getStatus());
             assertTrue(exception6.getMessage()
                     .contains(String.format("Already existing an asset transfer with the provided transfer external id: %s", externalId)));
         } finally {
@@ -908,45 +902,53 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
     public void saleExceptionHandling() {
         try {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2020-03-02");
-            Integer clientID = createClient();
-            Integer loanID = createLoanForClient(clientID);
+            setInitialBusinessDate(LocalDate.parse("2020-03-02"));
+            Long clientId = createClient();
+            Long loanId = createLoanForClient(clientId);
 
-            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class, () -> createSaleTransfer(loanID, null));
+            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class, () -> createSaleTransfer(loanId, null));
+            assertEquals(BAD_REQUEST, exception.getStatus());
             assertTrue(exception.getMessage().contains("The parameter `settlementDate` is mandatory."));
 
-            CallFailedRuntimeException exception2 = assertThrows(CallFailedRuntimeException.class, () -> createSaleTransfer(loanID,
+            CallFailedRuntimeException exception2 = assertThrows(CallFailedRuntimeException.class, () -> createSaleTransfer(loanId,
                     "2020-03-02", UUID.randomUUID().toString(), UUID.randomUUID().toString(), null, "1.0"));
+            assertEquals(BAD_REQUEST, exception2.getStatus());
             assertTrue(exception2.getMessage().contains("The parameter `ownerExternalId` is mandatory."));
 
             CallFailedRuntimeException exception3 = assertThrows(CallFailedRuntimeException.class,
-                    () -> createSaleTransfer(loanID, "2020-03-02", null, UUID.randomUUID().toString(), UUID.randomUUID().toString(), null));
+                    () -> createSaleTransfer(loanId, "2020-03-02", null, UUID.randomUUID().toString(), UUID.randomUUID().toString(), null));
+            assertEquals(BAD_REQUEST, exception3.getStatus());
             assertTrue(exception3.getMessage().contains("The parameter `purchasePriceRatio` is mandatory."));
 
             CallFailedRuntimeException exception4 = assertThrows(CallFailedRuntimeException.class,
-                    () -> createSaleTransfer(loanID, "1970-01-01"));
+                    () -> createSaleTransfer(loanId, "1970-01-01"));
+            assertEquals(FORBIDDEN, exception4.getStatus());
             assertTrue(exception4.getMessage().contains("Settlement date cannot be in the past"));
 
             CallFailedRuntimeException exception5 = assertThrows(CallFailedRuntimeException.class, () -> {
-                createSaleTransfer(loanID, "2020-03-03");
-                createBuybackTransfer(loanID, "2020-03-04");
-                createSaleTransfer(loanID, "2020-03-05");
+                createSaleTransfer(loanId, "2020-03-03");
+                createBuybackTransfer(loanId, "2020-03-04");
+                createSaleTransfer(loanId, "2020-03-05");
             });
+            assertEquals(FORBIDDEN, exception5.getStatus());
             assertTrue(exception5.getMessage().contains("This loan cannot be sold, there is already an in progress transfer"));
+
             // Owner-to-owner transfer: selling a loan that is already owned by an external asset owner should
             // succeed at API time (a new PENDING is created; the actual ownership switch happens in COB)
-            Integer loanIDForOwnerTransfer = createLoanForClient(clientID);
-            createSaleTransfer(loanIDForOwnerTransfer, "2020-03-03");
+            Long loanIdForOwnerTransfer = createLoanForClient(clientId);
+            createSaleTransfer(loanIdForOwnerTransfer, "2020-03-03");
             updateBusinessDateAndExecuteCOBJob("2020-03-04");
-            PostInitiateTransferResponse ownerToOwnerSaleResponse = createSaleTransfer(loanIDForOwnerTransfer, "2020-03-05");
+            PostInitiateTransferResponse ownerToOwnerSaleResponse = createSaleTransfer(loanIdForOwnerTransfer, "2020-03-05");
             assertNotNull(ownerToOwnerSaleResponse.getResourceId());
+
             String externalId = UUID.randomUUID().toString();
             String transferExternalGroupId = UUID.randomUUID().toString();
             CallFailedRuntimeException exception7 = assertThrows(CallFailedRuntimeException.class, () -> {
-                Integer loanID2 = createLoanForClient(clientID);
-                createSaleTransfer(loanID2, "2020-03-05", externalId, transferExternalGroupId, "1", "1.0");
-                createSaleTransfer(loanID2, "2020-03-05", externalId, transferExternalGroupId, "1", "1.0");
+                Long anotherLoanId = createLoanForClient(clientId);
+                createSaleTransfer(anotherLoanId, "2020-03-05", externalId, transferExternalGroupId, "1", "1.0");
+                createSaleTransfer(anotherLoanId, "2020-03-05", externalId, transferExternalGroupId, "1", "1.0");
             });
+            assertEquals(FORBIDDEN, exception7.getStatus());
             assertTrue(exception7.getMessage()
                     .contains(String.format("Already existing an asset transfer with the provided transfer external id: %s", externalId)));
         } finally {
@@ -955,32 +957,32 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
     }
 
     @Test
-    public void transactionSummaryReportWithAssetOwner() throws IOException {
+    public void transactionSummaryReportWithAssetOwner() {
         try {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2020-03-02");
+            setInitialBusinessDate(LocalDate.parse("2020-03-02"));
 
-            ExternalEventHelper.deleteAllExternalEvents(REQUEST_SPEC, new ResponseSpecBuilder().expectStatusCode(Matchers.is(204)).build());
-            ExternalEventHelper.changeEventState(REQUEST_SPEC, RESPONSE_SPEC, "LoanOwnershipTransferBusinessEvent", true);
+            externalEventHelper.deleteAllExternalEvents();
+            externalEventHelper.enableBusinessEvent(LOAN_OWNERSHIP_TRANSFER_EVENT);
 
-            final Integer officeId = OFFICE_HELPER.createOffice(LocalDate.of(2020, 1, 1)).getResourceId().intValue();
-            final var clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC, "1 January 2020", officeId.toString());
-            final var loanID = createLoanForClient(clientID);
-            addPenaltyForLoan(loanID, "10");
+            Long officeId = officeHelper.createOffice(LocalDate.of(2020, 1, 1)).getResourceId();
+            Long clientId = createClientInOffice(officeId);
+            Long loanId = createLoanForClient(clientId);
+            addPenaltyForLoan(loanId, PENALTY_AMOUNT);
 
-            final var saleTransferResponse = createSaleTransfer(loanID, "2020-03-02");
-            validateResponse(saleTransferResponse, loanID);
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanId, "2020-03-02");
+            validateResponse(saleTransferResponse, loanId);
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
                             "9999-12-31", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
                             new BigDecimal("0.000000")));
             getAndValidateThereIsNoActiveMapping(saleTransferResponse.getResourceExternalId());
-            var retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            PageExternalTransferData retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
             retrieveResponse.getContent().forEach(transfer -> getAndValidateThereIsNoJournalEntriesForTransfer(transfer.getTransferId()));
 
             updateBusinessDateAndExecuteCOBJob("2020-03-03");
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
                             "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
@@ -990,20 +992,18 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
                             new BigDecimal("0.000000")));
 
-            final var allExternalEvents = ExternalEventHelper.getAllExternalEvents(REQUEST_SPEC, RESPONSE_SPEC);
-            List<ExternalEventResponse> loanOwnershipTransferBusinessEvents = allExternalEvents.stream()
-                    .filter(e -> e.getType().equals("LoanOwnershipTransferBusinessEvent")).toList();
-            Assertions.assertEquals(1, loanOwnershipTransferBusinessEvents.size());
-            Assertions.assertEquals(Long.valueOf(loanID), loanOwnershipTransferBusinessEvents.get(0).getAggregateRootId());
+            List<ExternalEventResponse> loanOwnershipTransferBusinessEvents = externalEventHelper.getAllExternalEvents().stream()
+                    .filter(event -> LOAN_OWNERSHIP_TRANSFER_EVENT.equals(event.getType())).toList();
+            assertEquals(1, loanOwnershipTransferBusinessEvents.size());
+            assertEquals(loanId, loanOwnershipTransferBusinessEvents.get(0).getAggregateRootId());
 
-            getAndValidateThereIsActiveMapping(loanID);
+            getAndValidateThereIsActiveMapping(loanId);
 
-            final var expectedDate = LocalDate.of(2020, 3, 2);
-            final var initial = 0;
+            LocalDate repaymentDate = LocalDate.of(2020, 3, 2);
 
-            final var buybackTransferResponse = createBuybackTransfer(loanID, "2020-03-03");
-            validateResponse(buybackTransferResponse, loanID);
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanId, "2020-03-03");
+            validateResponse(buybackTransferResponse, loanId);
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
                             "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
@@ -1016,15 +1016,14 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
                             "2020-03-03", "9999-12-31", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
                             new BigDecimal("0.000000")));
-            getAndValidateThereIsActiveMapping(loanID);
-            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
-            getAndValidateThereIsNoJournalEntriesForTransfer(retrieveResponse.getContent().get(initial + 2).getTransferId());
+            getAndValidateThereIsActiveMapping(loanId);
+            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
+            getAndValidateThereIsNoJournalEntriesForTransfer(retrieveResponse.getContent().get(2).getTransferId());
 
-            LOAN_TRANSACTION_HELPER.makeLoanRepayment((long) loanID, new PostLoansLoanIdTransactionsRequest().dateFormat("dd MMMM yyyy")
-                    .transactionDate(dateFormatter.format(expectedDate)).locale("en").transactionAmount(5.0));
+            makePartialRepayment(loanId, repaymentDate);
 
             updateBusinessDateAndExecuteCOBJob("2020-03-04");
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
                             "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
@@ -1038,267 +1037,109 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
                             new BigDecimal("757.420000"), new BigDecimal("5.000000"), new BigDecimal("0.000000"),
                             new BigDecimal("0.000000")));
             getAndValidateThereIsNoActiveMapping(saleTransferResponse.getResourceExternalId());
-            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
 
-            final var reportResult = reportHelper.runReport("Transaction Summary Report with Asset Owner",
-                    Map.of("R_endDate", "2020-03-03", "R_officeId", officeId.toString(), "output-type", "CSV"));
+            RunReportsResponse report = runTransactionSummaryReport("2020-03-03", officeId);
 
-            assertNotNull(reportResult.body());
-            final var csvContent = reportResult.body().string();
-            final var jsonPath = JsonPath.from(csvContent);
-
-            assertNotNull(jsonPath.getString("columnHeaders[0].columnType"));
-            assertNotNull(jsonPath.getString("columnHeaders[0].columnDisplayType"));
-            assertFalse(jsonPath.getBoolean("columnHeaders[0].isColumnNullable"));
-
-            assertNotNull(jsonPath.getString("columnHeaders[1].columnType"));
-            assertNotNull(jsonPath.getString("columnHeaders[1].columnDisplayType"));
-            assertFalse(jsonPath.getBoolean("columnHeaders[1].isColumnNullable"));
-
-            assertNotNull(jsonPath.getString("columnHeaders[2].columnType"));
-            assertNotNull(jsonPath.getString("columnHeaders[2].columnDisplayType"));
-            assertFalse(jsonPath.getBoolean("columnHeaders[2].isColumnNullable"));
-
-            assertNotNull(jsonPath.getString("columnHeaders[3].columnType"));
-            assertNotNull(jsonPath.getString("columnHeaders[3].columnDisplayType"));
-            assertFalse(jsonPath.getBoolean("columnHeaders[3].isColumnNullable"));
-
-            assertNotNull(jsonPath.getString("columnHeaders[4].columnType"));
-            assertNotNull(jsonPath.getString("columnHeaders[4].columnDisplayType"));
-            assertFalse(jsonPath.getBoolean("columnHeaders[4].isColumnNullable"));
-
-            assertNotNull(jsonPath.getString("columnHeaders[5].columnType"));
-            assertNotNull(jsonPath.getString("columnHeaders[5].columnDisplayType"));
-            assertFalse(jsonPath.getBoolean("columnHeaders[5].isColumnNullable"));
-
-            assertNotNull(jsonPath.getString("columnHeaders[6].columnType"));
-            assertNotNull(jsonPath.getString("columnHeaders[6].columnDisplayType"));
-            assertFalse(jsonPath.getBoolean("columnHeaders[6].isColumnNullable"));
-
-            assertNotNull(jsonPath.getString("columnHeaders[7].columnType"));
-            assertNotNull(jsonPath.getString("columnHeaders[7].columnDisplayType"));
-            assertFalse(jsonPath.getBoolean("columnHeaders[7].isColumnNullable"));
-
-            assertNotNull(jsonPath.getString("columnHeaders[8].columnType"));
-            assertNotNull(jsonPath.getString("columnHeaders[8].columnDisplayType"));
-            assertFalse(jsonPath.getBoolean("columnHeaders[8].isColumnNullable"));
-
-            assertNotNull(jsonPath.getString("columnHeaders[9].columnType"));
-            assertNotNull(jsonPath.getString("columnHeaders[9].columnDisplayType"));
-            assertFalse(jsonPath.getBoolean("columnHeaders[9].isColumnNullable"));
-
-            assertNotNull(jsonPath.getString("columnHeaders[10].columnType"));
-            assertNotNull(jsonPath.getString("columnHeaders[10].columnDisplayType"));
-            assertFalse(jsonPath.getBoolean("columnHeaders[10].isColumnNullable"));
+            assertEquals(REPORT_COLUMN_COUNT, report.getColumnHeaders().size());
+            for (ResultsetColumnHeaderData columnHeader : report.getColumnHeaders()) {
+                assertNotNull(columnHeader.getColumnType());
+                assertNotNull(columnHeader.getColumnDisplayType());
+                assertFalse(columnHeader.getIsColumnNullable());
+            }
 
             assertNotNull(retrieveResponse.getContent().get(0).getOwner());
-            final var ownerId = retrieveResponse.getContent().get(0).getOwner().getExternalId();
+            String ownerId = retrieveResponse.getContent().get(0).getOwner().getExternalId();
             assertNotNull(retrieveResponse.getContent().get(2).getPreviousOwner());
-            final var previousOwnerId = retrieveResponse.getContent().get(2).getPreviousOwner().getExternalId();
+            String previousOwnerId = retrieveResponse.getContent().get(2).getPreviousOwner().getExternalId();
 
-            assertEquals("2020-03-03", jsonPath.getString("data[0].row[0]"));
-            assertTrue(jsonPath.getString("data[0].row[1]").matches("^LOAN_PRODUCT_.{6}$"));
-            assertEquals("Apply Charges", jsonPath.getString("data[0].row[2]"));
-            assertNull(jsonPath.getString("data[0].row[3]"));
-            assertEquals("", jsonPath.getString("data[0].row[4]"));
-            assertFalse(jsonPath.getBoolean("data[0].row[5]"));
-            assertEquals("Interest", jsonPath.getString("data[0].row[6]"));
-            assertNull(jsonPath.getString("data[0].row[7]"));
-            assertEquals(9.68, jsonPath.getDouble("data[0].row[8]"), 0.01);
-            assertEquals(ownerId, jsonPath.getString("data[0].row[9]"));
-            assertNull(jsonPath.getString("data[0].row[10]"));
-
-            assertEquals("2020-03-03", jsonPath.getString("data[1].row[0]"));
-            assertTrue(jsonPath.getString("data[1].row[1]").matches("^LOAN_PRODUCT_.{6}$"));
-            assertEquals("Asset Buyback", jsonPath.getString("data[1].row[2]"));
-            assertNull(jsonPath.getString("data[1].row[3]"));
-            assertEquals("", jsonPath.getString("data[1].row[4]"));
-            assertFalse(jsonPath.getBoolean("data[1].row[5]"));
-            assertEquals("Interest", jsonPath.getString("data[1].row[6]"));
-            assertNull(jsonPath.getString("data[1].row[7]"));
-            assertEquals(-757.42, jsonPath.getDouble("data[1].row[8]"), 0.01);
-            assertNull(jsonPath.getString("data[1].row[9]"));
-            assertEquals(previousOwnerId, jsonPath.getString("data[1].row[10]"));
-
-            assertEquals("2020-03-03", jsonPath.getString("data[2].row[0]"));
-            assertTrue(jsonPath.getString("data[2].row[1]").matches("^LOAN_PRODUCT_.{6}$"));
-            assertEquals("Asset Buyback", jsonPath.getString("data[2].row[2]"));
-            assertNull(jsonPath.getString("data[2].row[3]"));
-            assertEquals("", jsonPath.getString("data[2].row[4]"));
-            assertFalse(jsonPath.getBoolean("data[2].row[5]"));
-            assertEquals("Penalty", jsonPath.getString("data[2].row[6]"));
-            assertNull(jsonPath.getString("data[2].row[7]"));
-            assertEquals(-5.00, jsonPath.getDouble("data[2].row[8]"), 0.01);
-            assertNull(jsonPath.getString("data[2].row[9]"));
-            assertEquals(previousOwnerId, jsonPath.getString("data[2].row[10]"));
-
-            assertEquals("2020-03-03", jsonPath.getString("data[3].row[0]"));
-            assertTrue(jsonPath.getString("data[3].row[1]").matches("^LOAN_PRODUCT_.{6}$"));
-            assertEquals("Asset Buyback", jsonPath.getString("data[3].row[2]"));
-            assertNull(jsonPath.getString("data[3].row[3]"));
-            assertEquals("", jsonPath.getString("data[3].row[4]"));
-            assertFalse(jsonPath.getBoolean("data[3].row[5]"));
-            assertEquals("Principal", jsonPath.getString("data[3].row[6]"));
-            assertNull(jsonPath.getString("data[3].row[7]"));
-            assertEquals(-15000.00, jsonPath.getDouble("data[3].row[8]"), 0.01);
-            assertNull(jsonPath.getString("data[3].row[9]"));
-            assertEquals(previousOwnerId, jsonPath.getString("data[3].row[10]"));
-
-            assertEquals("2020-03-03", jsonPath.getString("data[4].row[0]"));
-            assertTrue(jsonPath.getString("data[4].row[1]").matches("^LOAN_PRODUCT_.{6}$"));
-            assertEquals("Repayment", jsonPath.getString("data[4].row[2]"));
-            assertNull(jsonPath.getString("data[4].row[3]"));
-            assertEquals("", jsonPath.getString("data[4].row[4]"));
-            assertFalse(jsonPath.getBoolean("data[4].row[5]"));
-            assertEquals("Fees", jsonPath.getString("data[4].row[6]"));
-            assertNull(jsonPath.getString("data[4].row[7]"));
-            assertEquals(0.00, jsonPath.getDouble("data[4].row[8]"), 0.01);
-            assertEquals(ownerId, jsonPath.getString("data[4].row[9]"));
-            assertNull(jsonPath.getString("data[4].row[10]"));
-
-            assertEquals("2020-03-03", jsonPath.getString("data[5].row[0]"));
-            assertTrue(jsonPath.getString("data[5].row[1]").matches("^LOAN_PRODUCT_.{6}$"));
-            assertEquals("Repayment", jsonPath.getString("data[5].row[2]"));
-            assertNull(jsonPath.getString("data[5].row[3]"));
-            assertEquals("", jsonPath.getString("data[5].row[4]"));
-            assertFalse(jsonPath.getBoolean("data[5].row[5]"));
-            assertEquals("Interest", jsonPath.getString("data[5].row[6]"));
-            assertNull(jsonPath.getString("data[5].row[7]"));
-            assertEquals(0.00, jsonPath.getDouble("data[5].row[8]"), 0.01);
-            assertEquals(ownerId, jsonPath.getString("data[5].row[9]"));
-            assertNull(jsonPath.getString("data[5].row[10]"));
-
-            assertEquals("2020-03-03", jsonPath.getString("data[6].row[0]"));
-            assertTrue(jsonPath.getString("data[6].row[1]").matches("^LOAN_PRODUCT_.{6}$"));
-            assertEquals("Repayment", jsonPath.getString("data[6].row[2]"));
-            assertNull(jsonPath.getString("data[6].row[3]"));
-            assertEquals("", jsonPath.getString("data[6].row[4]"));
-            assertFalse(jsonPath.getBoolean("data[6].row[5]"));
-            assertEquals("Penalty", jsonPath.getString("data[6].row[6]"));
-            assertNull(jsonPath.getString("data[6].row[7]"));
-            assertEquals(-5.00, jsonPath.getDouble("data[6].row[8]"), 0.01);
-            assertEquals(ownerId, jsonPath.getString("data[6].row[9]"));
-            assertNull(jsonPath.getString("data[6].row[10]"));
-
-            assertEquals("2020-03-03", jsonPath.getString("data[7].row[0]"));
-            assertTrue(jsonPath.getString("data[7].row[1]").matches("^LOAN_PRODUCT_.{6}$"));
-            assertEquals("Repayment", jsonPath.getString("data[7].row[2]"));
-            assertNull(jsonPath.getString("data[7].row[3]"));
-            assertEquals("", jsonPath.getString("data[7].row[4]"));
-            assertFalse(jsonPath.getBoolean("data[7].row[5]"));
-            assertEquals("Principal", jsonPath.getString("data[7].row[6]"));
-            assertNull(jsonPath.getString("data[7].row[7]"));
-            assertEquals(0.00, jsonPath.getDouble("data[7].row[8]"), 0.01);
-            assertEquals(ownerId, jsonPath.getString("data[7].row[9]"));
-            assertNull(jsonPath.getString("data[7].row[10]"));
-
-            assertEquals("2020-03-03", jsonPath.getString("data[8].row[0]"));
-            assertTrue(jsonPath.getString("data[8].row[1]").matches("^LOAN_PRODUCT_.{6}$"));
-            assertEquals("Repayment", jsonPath.getString("data[8].row[2]"));
-            assertNull(jsonPath.getString("data[8].row[3]"));
-            assertEquals("", jsonPath.getString("data[8].row[4]"));
-            assertFalse(jsonPath.getBoolean("data[8].row[5]"));
-            assertEquals("Unallocated Credit (UNC)", jsonPath.getString("data[8].row[6]"));
-            assertNull(jsonPath.getString("data[8].row[7]"));
-            assertEquals(0.00, jsonPath.getDouble("data[8].row[8]"), 0.01);
-            assertEquals(ownerId, jsonPath.getString("data[8].row[9]"));
-            assertNull(jsonPath.getString("data[8].row[10]"));
+            List<List<Object>> rows = report.getData().stream().map(row -> row.getRow()).toList();
+            assertEquals(9, rows.size());
+            assertReportRow(rows.get(0), "2020-03-03", APPLY_CHARGES_TRANSACTION, INTEREST_ALLOCATION, 9.68, ownerId, null);
+            assertReportRow(rows.get(1), "2020-03-03", ASSET_BUYBACK_TRANSACTION, INTEREST_ALLOCATION, -757.42, null, previousOwnerId);
+            assertReportRow(rows.get(2), "2020-03-03", ASSET_BUYBACK_TRANSACTION, PENALTY_ALLOCATION, -5.00, null, previousOwnerId);
+            assertReportRow(rows.get(3), "2020-03-03", ASSET_BUYBACK_TRANSACTION, PRINCIPAL_ALLOCATION, -15000.00, null, previousOwnerId);
+            assertReportRow(rows.get(4), "2020-03-03", REPAYMENT_TRANSACTION, FEES_ALLOCATION, 0.00, ownerId, null);
+            assertReportRow(rows.get(5), "2020-03-03", REPAYMENT_TRANSACTION, INTEREST_ALLOCATION, 0.00, ownerId, null);
+            assertReportRow(rows.get(6), "2020-03-03", REPAYMENT_TRANSACTION, PENALTY_ALLOCATION, -5.00, ownerId, null);
+            assertReportRow(rows.get(7), "2020-03-03", REPAYMENT_TRANSACTION, PRINCIPAL_ALLOCATION, 0.00, ownerId, null);
+            assertReportRow(rows.get(8), "2020-03-03", REPAYMENT_TRANSACTION, UNALLOCATED_CREDIT_ALLOCATION, 0.00, ownerId, null);
         } finally {
-            ExternalEventHelper.deleteAllExternalEvents(REQUEST_SPEC, new ResponseSpecBuilder().expectStatusCode(Matchers.is(204)).build());
+            externalEventHelper.deleteAllExternalEvents();
             cleanUpAndRestoreBusinessDate();
         }
     }
 
     @Test
-    public void transactionSummaryReportWithAssetOwner_CheckFromAssetOwnerIdForBuyback() throws IOException {
+    public void transactionSummaryReportWithAssetOwnerCheckFromAssetOwnerIdForBuyback() {
         try {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2023-08-16");
+            setInitialBusinessDate(LocalDate.parse("2023-08-16"));
 
-            ExternalEventHelper.deleteAllExternalEvents(REQUEST_SPEC, new ResponseSpecBuilder().expectStatusCode(Matchers.is(204)).build());
-            ExternalEventHelper.changeEventState(REQUEST_SPEC, RESPONSE_SPEC, "LoanOwnershipTransferBusinessEvent", true);
+            externalEventHelper.deleteAllExternalEvents();
+            externalEventHelper.enableBusinessEvent(LOAN_OWNERSHIP_TRANSFER_EVENT);
 
-            final Integer officeId = OFFICE_HELPER.createOffice(LocalDate.of(2020, 1, 1)).getResourceId().intValue();
-            final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC, "1 January 2020", officeId.toString());
-            final Integer loanID = createLoanForClient(clientID);
+            Long officeId = officeHelper.createOffice(LocalDate.of(2020, 1, 1)).getResourceId();
+            Long clientId = createClientInOffice(officeId);
+            Long loanId = createLoanForClient(clientId);
 
             // Create first sale transfer
-            final PostInitiateTransferResponse firstSaleTransferResponse = createSaleTransfer(loanID, "2023-08-16");
-            validateResponse(firstSaleTransferResponse, loanID);
+            PostInitiateTransferResponse firstSaleTransferResponse = createSaleTransfer(loanId, "2023-08-16");
+            validateResponse(firstSaleTransferResponse, loanId);
 
             // Verify the transfer is PENDING initially
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
-                    ExpectedExternalTransferData.expected(PENDING, firstSaleTransferResponse.getResourceExternalId(), "2023-08-16",
-                            "2023-08-16", "9999-12-31", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
-                            new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
-                            new BigDecimal("0.000000")));
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId, ExpectedExternalTransferData.expected(PENDING,
+                    firstSaleTransferResponse.getResourceExternalId(), "2023-08-16", "2023-08-16", "9999-12-31"));
 
             // Execute COB job on the next day to activate the transfer
             updateBusinessDateAndExecuteCOBJob("2023-08-17");
 
             // Verify the transfer is ACTIVE after COB job
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, firstSaleTransferResponse.getResourceExternalId(), "2023-08-16",
-                            "2023-08-16", "2023-08-16", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
-                            new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
-                            new BigDecimal("0.000000")),
+                            "2023-08-16", "2023-08-16"),
                     ExpectedExternalTransferData.expected(ACTIVE, firstSaleTransferResponse.getResourceExternalId(), "2023-08-16",
                             "2023-08-17", "9999-12-31", true, new BigDecimal("15914.980000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("157.560000"), new BigDecimal("0.000000"),
                             new BigDecimal("0.000000")));
 
             // Get the owner ID of the first transfer for later verification
-            PageExternalTransferData retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            PageExternalTransferData retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
             assertNotNull(retrieveResponse.getContent().get(1).getOwner());
-            final String firstOwnerId = retrieveResponse.getContent().get(1).getOwner().getExternalId();
+            String firstOwnerId = retrieveResponse.getContent().get(1).getOwner().getExternalId();
             assertNull(retrieveResponse.getContent().get(1).getPreviousOwner(), "First sale transfer should not have previous_owner_id");
 
             // Create buyback transfer
             updateBusinessDateAndExecuteCOBJob("2023-08-18");
-            final PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanID, "2023-08-18");
-            validateResponse(buybackTransferResponse, loanID);
+            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanId, "2023-08-18");
+            validateResponse(buybackTransferResponse, loanId);
 
             // Execute COB job to process buyback
             updateBusinessDateAndExecuteCOBJob("2023-08-19");
 
             // Verify buyback has previous_owner_id set
-            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
             assertNotNull(retrieveResponse.getContent().get(2).getPreviousOwner());
             assertEquals(firstOwnerId, retrieveResponse.getContent().get(2).getPreviousOwner().getExternalId(),
                     "Buyback transfer should have previous_owner_id set to first owner");
 
             // Run report on settlement date of buyback to check that from_asset_owner_id is populated
-            final Response<ResponseBody> reportResult = reportHelper.runReport("Transaction Summary Report with Asset Owner",
-                    Map.of("R_endDate", "2023-08-18", "R_officeId", officeId.toString(), "output-type", "CSV"));
+            RunReportsResponse report = runTransactionSummaryReport("2023-08-18", officeId);
 
-            assertNotNull(reportResult.body());
-            final String csvContent = reportResult.body().string();
-            final JsonPath jsonPath = JsonPath.from(csvContent);
-
-            // Find Asset Buyback entries to verify from_asset_owner_id is populated
-            final List<Map<String, Object>> buybackRows = new ArrayList<>();
-            final int dataSize = jsonPath.getInt("data.size()");
-            for (int i = 0; i < dataSize; i++) {
-                final String transactionType = jsonPath.getString("data[" + i + "].row[2]");
-                final String transactionDate = jsonPath.getString("data[" + i + "].row[0]");
-                // Find Asset Buyback entries for the buyback date
-                if ("Asset Buyback".equals(transactionType) && "2023-08-18".equals(transactionDate)) {
-                    buybackRows.add(jsonPath.getMap("data[" + i + "]"));
-                }
-            }
+            List<List<Object>> buybackRows = report.getData().stream().map(row -> row.getRow())
+                    .filter(row -> ASSET_BUYBACK_TRANSACTION.equals(row.get(TRANSACTION_TYPE_COLUMN))
+                            && "2023-08-18".equals(row.get(TRANSACTION_DATE_COLUMN)))
+                    .toList();
 
             // Verify that Asset Buyback entries exist
             assertFalse(buybackRows.isEmpty(), "Asset Buyback entries should exist in the report");
-
-            // Verify that from_asset_owner_id is populated with previous_owner_id for buyback
-            for (Map<String, Object> row : buybackRows) {
-                final List<Object> rowData = (List<Object>) row.get("row");
-                assertNotNull(rowData.get(10), "from_asset_owner_id should be populated for buyback transfer");
-                assertEquals(firstOwnerId, rowData.get(10),
+            for (List<Object> row : buybackRows) {
+                // Verify that from_asset_owner_id is populated with previous_owner_id for buyback
+                assertEquals(firstOwnerId, row.get(FROM_ASSET_OWNER_ID_COLUMN),
                         "from_asset_owner_id should equal the first owner's external ID for buyback transfer");
             }
         } finally {
-            ExternalEventHelper.deleteAllExternalEvents(REQUEST_SPEC, new ResponseSpecBuilder().expectStatusCode(Matchers.is(204)).build());
+            externalEventHelper.deleteAllExternalEvents();
             cleanUpAndRestoreBusinessDate();
         }
     }
@@ -1306,63 +1147,43 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
     @Test
     public void addManualJournalEntriesWithAssetExternalization() {
         runAt("10 April 2025", () -> {
+            Account glAccountDebit = accountHelper.createAssetAccount(Utils.uniqueRandomStringGenerator("MANUAL_DEBIT_", 5));
+            Account glAccountCredit = accountHelper.createLiabilityAccount(Utils.uniqueRandomStringGenerator("MANUAL_CREDIT_", 5));
+            String externalAssetOwner = Utils.uniqueRandomStringGenerator("ASSET_EXTERNAL_", 5);
 
-            final Account glAccountDebit = accountHelper.createAssetAccount();
-            final Account glAccountCredit = accountHelper.createLiabilityAccount();
-            final String externalAssetOwner = Utils.uniqueRandomStringGenerator("ASSET_EXTERNAL_", 5);
+            CallFailedRuntimeException unknownOwnerException = assertThrows(CallFailedRuntimeException.class,
+                    () -> journalHelper.createJournalEntry(manualJournalEntry(glAccountDebit, glAccountCredit, externalAssetOwner)));
+            assertEquals(NOT_FOUND, unknownOwnerException.getStatus());
+            assertTrue(unknownOwnerException.getMessage().contains("External asset owner with external id:"));
 
-            CallFailedRuntimeException callFailedRuntimeException = Assertions.assertThrows(CallFailedRuntimeException.class,
-                    () -> JournalEntryHelper.createJournalEntry("", new JournalEntryCommand().amount(BigDecimal.TEN).officeId(1L)
-                            .currencyCode("USD").locale("en").dateFormat("uuuu-MM-dd").transactionDate(LocalDate.of(2024, 1, 1))
-                            .addCreditsItem(new SingleDebitOrCreditEntryCommand().glAccountId(glAccountDebit.getAccountID().longValue())
-                                    .amount(BigDecimal.TEN))
-                            .addDebitsItem(new SingleDebitOrCreditEntryCommand().glAccountId(glAccountCredit.getAccountID().longValue())
-                                    .amount(BigDecimal.TEN))
-                            .externalAssetOwner(externalAssetOwner)));
-            Assertions.assertTrue(callFailedRuntimeException.getMessage().contains("External asset owner with external id:"));
+            Long clientId = createClient();
+            String operationDate = "10 April 2025";
 
-            final Integer clientId = ClientHelper.createClient(requestSpec, responseSpec);
-            final String operationDate = "10 April 2025";
+            Long loanProductId = createLoanProduct(manualEntryLoanProduct());
+            Long loanId = applyForLoan(
+                    applyLoanRequest(clientId, loanProductId, operationDate, MANUAL_ENTRY_LOAN_PRINCIPAL, MANUAL_ENTRY_LOAN_REPAYMENTS,
+                            request -> request
+                                    .transactionProcessingStrategyCode(
+                                            LoanTestData.TransactionProcessingStrategyCode.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)
+                                    .interestRatePerPeriod(BigDecimal.valueOf(MANUAL_ENTRY_LOAN_INTEREST_RATE))));
+            approveLoan(loanId, approveLoanRequest(MANUAL_ENTRY_LOAN_PRINCIPAL, operationDate));
+            disburseLoan(loanId, operationDate, MANUAL_ENTRY_LOAN_PRINCIPAL);
 
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(
-                    createOnePeriod30DaysPeriodicAccrualProductWithAdvancedPaymentAllocationAndInterestRecalculation(12.0, 4));
-
-            final PostLoansRequest applicationRequest = applyLoanRequest(clientId.longValue(), loanProductResponse.getResourceId(),
-                    operationDate, 1000.0, 4).transactionProcessingStrategyCode("advanced-payment-allocation-strategy")//
-                    .interestRatePerPeriod(BigDecimal.valueOf(12.0));
-
-            final PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
-            final Long loanId = loanResponse.getLoanId();
-
-            loanTransactionHelper.approveLoan(loanId, new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000.0))
-                    .dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
-
-            loanTransactionHelper.disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
-
-            PostInitiateTransferResponse transferResponse = EXTERNAL_ASSET_OWNER_HELPER.initiateTransferByLoanId(loanId, "sale",
-                    new ExternalAssetOwnerRequest().settlementDate("2025-04-20").dateFormat("yyyy-MM-dd").locale("en")
-                            .transferExternalId(externalAssetOwner).transferExternalGroupId(null).ownerExternalId(externalAssetOwner)
-                            .purchasePriceRatio("0.90"));
+            PostInitiateTransferResponse transferResponse = EXTERNAL_ASSET_OWNER_HELPER.initiateTransferByLoanId(loanId, SALE_COMMAND,
+                    new ExternalAssetOwnerRequest().settlementDate("2025-04-20").dateFormat(DATE_FORMAT_ISO).locale(LoanTestData.LOCALE)
+                            .transferExternalId(externalAssetOwner).ownerExternalId(externalAssetOwner).purchasePriceRatio("0.90"));
             assertEquals(externalAssetOwner, transferResponse.getResourceExternalId());
 
-            final PostJournalEntriesResponse journalEntriesResponse = JournalEntryHelper.createJournalEntry("",
-                    new JournalEntryCommand().amount(BigDecimal.TEN).officeId(1L).currencyCode("USD").locale("en").dateFormat("uuuu-MM-dd")
-                            .transactionDate(LocalDate.of(2024, 1, 1))
-                            .addCreditsItem(new SingleDebitOrCreditEntryCommand().glAccountId(glAccountDebit.getAccountID().longValue())
-                                    .amount(BigDecimal.TEN))
-                            .addDebitsItem(new SingleDebitOrCreditEntryCommand().glAccountId(glAccountCredit.getAccountID().longValue())
-                                    .amount(BigDecimal.TEN))
-                            .externalAssetOwner(externalAssetOwner));
+            PostJournalEntriesResponse journalEntriesResponse = journalHelper
+                    .createJournalEntry(manualJournalEntry(glAccountDebit, glAccountCredit, externalAssetOwner));
 
-            final GetJournalEntriesTransactionIdResponse journalEntriesTransactionIdResponse = JournalEntryHelper
-                    .retrieveJournalEntryByTransactionId(journalEntriesResponse.getTransactionId());
-            Assertions.assertNotNull(journalEntriesTransactionIdResponse);
-            assertEquals(2, journalEntriesTransactionIdResponse.getPageItems().size());
-            JournalEntryTransactionItem journalEntryItem = journalEntriesTransactionIdResponse.getPageItems().get(0);
-            assertEquals(externalAssetOwner, journalEntryItem.getExternalAssetOwner());
-            journalEntryItem = journalEntriesTransactionIdResponse.getPageItems().get(1);
-            assertEquals(externalAssetOwner, journalEntryItem.getExternalAssetOwner());
+            GetJournalEntriesTransactionIdResponse journalEntries = journalHelper
+                    .getJournalEntriesByTransactionId(journalEntriesResponse.getTransactionId());
+            assertNotNull(journalEntries);
+            assertEquals(2, journalEntries.getPageItems().size());
+            for (JournalEntryTransactionItem journalEntryItem : journalEntries.getPageItems()) {
+                assertEquals(externalAssetOwner, journalEntryItem.getExternalAssetOwner());
+            }
         });
     }
 
@@ -1370,36 +1191,30 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
     public void saleTransferWithSameOwnerExternalIdInParallelShouldNotFail() {
         try {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2020-03-02");
+            setInitialBusinessDate(LocalDate.parse("2020-03-02"));
 
-            final int threadCount = 10;
-            final String sharedOwnerExternalId = UUID.randomUUID().toString();
+            String sharedOwnerExternalId = UUID.randomUUID().toString();
 
-            final List<Integer> loanIDs = new ArrayList<>();
-            for (int i = 0; i < threadCount; i++) {
-                Integer clientID = createClient();
-                Integer loanID = createLoanForClient(clientID);
-                loanIDs.add(loanID);
+            List<Long> loanIds = new ArrayList<>();
+            for (int i = 0; i < PARALLEL_SALE_THREAD_COUNT; i++) {
+                loanIds.add(createLoanForClient(createClient()));
             }
 
-            final ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
-            final CountDownLatch startLatch = new CountDownLatch(1);
-            final CountDownLatch doneLatch = new CountDownLatch(threadCount);
-            final List<PostInitiateTransferResponse> results = Collections.synchronizedList(new ArrayList<>());
-            final List<Exception> exceptions = Collections.synchronizedList(new ArrayList<>());
+            ExecutorService executorService = Executors.newFixedThreadPool(PARALLEL_SALE_THREAD_COUNT);
+            CountDownLatch startLatch = new CountDownLatch(1);
+            CountDownLatch doneLatch = new CountDownLatch(PARALLEL_SALE_THREAD_COUNT);
+            List<PostInitiateTransferResponse> results = Collections.synchronizedList(new ArrayList<>());
+            List<Exception> exceptions = Collections.synchronizedList(new ArrayList<>());
 
-            for (int i = 0; i < threadCount; i++) {
-                final Integer loanID = loanIDs.get(i);
+            for (Long loanId : loanIds) {
                 executorService.execute(() -> {
                     try {
                         startLatch.await();
-                        PostInitiateTransferResponse response = EXTERNAL_ASSET_OWNER_HELPER.initiateTransferByLoanId(loanID.longValue(),
-                                "sale",
-                                new ExternalAssetOwnerRequest().settlementDate("2020-03-02").dateFormat("yyyy-MM-dd").locale("en")
-                                        .transferExternalId(UUID.randomUUID().toString())
+                        results.add(EXTERNAL_ASSET_OWNER_HELPER.initiateTransferByLoanId(loanId, SALE_COMMAND,
+                                new ExternalAssetOwnerRequest().settlementDate("2020-03-02").dateFormat(DATE_FORMAT_ISO)
+                                        .locale(LoanTestData.LOCALE).transferExternalId(UUID.randomUUID().toString())
                                         .transferExternalGroupId(UUID.randomUUID().toString()).ownerExternalId(sharedOwnerExternalId)
-                                        .purchasePriceRatio("1.0"));
-                        results.add(response);
+                                        .purchasePriceRatio("1.0")));
                     } catch (Exception e) {
                         exceptions.add(e);
                     } finally {
@@ -1409,21 +1224,22 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
             }
 
             startLatch.countDown();
-            assertTrue(doneLatch.await(30, TimeUnit.SECONDS), "All threads should complete within timeout");
+            assertTrue(doneLatch.await(PARALLEL_SALE_TIMEOUT_SECONDS, TimeUnit.SECONDS), "All threads should complete within timeout");
             executorService.shutdown();
-            assertTrue(executorService.awaitTermination(10, TimeUnit.SECONDS), "ExecutorService should terminate");
+            assertTrue(executorService.awaitTermination(EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                    "ExecutorService should terminate");
 
             assertTrue(exceptions.isEmpty(),
-                    "Expected no exceptions but got " + exceptions.size() + ": " + exceptions.stream().map(Throwable::getMessage).toList());
-            assertEquals(threadCount, results.size(), "All transfers should succeed");
+                    "Expected no exceptions but got " + exceptions.size() + ": " + exceptions.stream().map(Exception::getMessage).toList());
+            assertEquals(PARALLEL_SALE_THREAD_COUNT, results.size(), "All transfers should succeed");
             results.forEach(response -> {
                 assertNotNull(response.getResourceId());
                 assertNotNull(response.getResourceExternalId());
             });
 
-            // Verify all transfers reference the same owner
-            for (Integer loanID : loanIDs) {
-                PageExternalTransferData transfers = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            for (Long loanId : loanIds) {
+                // Verify all transfers reference the same owner
+                PageExternalTransferData transfers = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
                 assertEquals(1, transfers.getTotalElements());
                 assertNotNull(transfers.getContent());
                 assertNotNull(transfers.getContent().getFirst().getOwner());
@@ -1438,290 +1254,174 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
         }
     }
 
-    private void updateBusinessDateAndExecuteCOBJob(String date) {
-        BusinessDateHelper.updateBusinessDate(BUSINESS_DATE, LocalDate.parse(date));
-        SchedulerJobHelper.executeAndAwaitJob("Loan COB");
+    private Long createLoanForClient(Long clientId) {
+        Long overdueFeeChargeId = chargesHelper.createLoanOverdueFeePercentageOfAmountAndInterest(OVERDUE_FEE_PERCENTAGE).getResourceId();
+        return createLoanForClient(clientId, LOAN_SUBMITTED_ON_DATE, assetOwnerLoanProduct(overdueFeeChargeId));
     }
 
-    private PostInitiateTransferResponse createSaleTransfer(Integer loanID, String settlementDate) {
-        String transferExternalId = UUID.randomUUID().toString();
-        String transferExternalGroupId = UUID.randomUUID().toString();
-        ownerExternalId = UUID.randomUUID().toString();
-        return createSaleTransfer(loanID, settlementDate, transferExternalId, transferExternalGroupId, ownerExternalId, "1.0");
+    /**
+     * The transferrable loan product, booked against a single asset account plus a dedicated fee/penalty asset account,
+     * so every sale, buyback and repayment journal entry can be attributed to exactly one of them.
+     */
+    private PostLoanProductsRequest assetOwnerLoanProduct(Long overdueFeeChargeId) {
+        return withPeriodicAccrualAccounting(transferrableLoanProduct(), assetAccount, expenseAccount, incomeAccount, overpaymentAccount)//
+                .receivableFeeAccountId(feePenaltyAccountId())//
+                .receivablePenaltyAccountId(feePenaltyAccountId())//
+                .charges(List.of(new LoanProductChargeData().id(overdueFeeChargeId)));
     }
 
-    private PostInitiateTransferResponse createSaleTransfer(Integer loanID, String settlementDate, String transferExternalId,
-            String transferExternalGroupId, String ownerExternalId, String purchasePriceRatio) {
-        PostInitiateTransferResponse saleResponse = EXTERNAL_ASSET_OWNER_HELPER.initiateTransferByLoanId(loanID.longValue(), "sale",
-                new ExternalAssetOwnerRequest().settlementDate(settlementDate).dateFormat("yyyy-MM-dd").locale("en")
-                        .transferExternalId(transferExternalId).transferExternalGroupId(transferExternalGroupId)
-                        .ownerExternalId(ownerExternalId).purchasePriceRatio(purchasePriceRatio));
-        assertEquals(transferExternalId, saleResponse.getResourceExternalId());
-        return saleResponse;
+    private PostLoanProductsRequest manualEntryLoanProduct() {
+        return onePeriod30DaysPeriodicAccrualWithAdvancedAllocation()//
+                .principal(MANUAL_ENTRY_LOAN_PRINCIPAL)//
+                .numberOfRepayments(MANUAL_ENTRY_LOAN_REPAYMENTS)//
+                .interestRatePerPeriod(MANUAL_ENTRY_LOAN_INTEREST_RATE)//
+                .enableDownPayment(false)//
+                .isInterestRecalculationEnabled(true)//
+                .interestRecalculationCompoundingMethod(LoanTestData.InterestRecalculationCompoundingMethod.NONE)//
+                .rescheduleStrategyMethod(LoanTestData.RescheduleStrategyMethod.ADJUST_LAST_UNPAID_PERIOD)//
+                .recalculationRestFrequencyType(LoanTestData.RecalculationRestFrequencyType.SAME_AS_REPAYMENT_PERIOD)//
+                .preClosureInterestCalculationStrategy(PRE_CLOSURE_INTEREST_CALCULATION_TILL_PRE_CLOSE_DATE)//
+                .allowPartialPeriodInterestCalculation(true);
     }
 
-    private PostInitiateTransferResponse createBuybackTransfer(Integer loanID, String settlementDate) {
-        String transferExternalId = UUID.randomUUID().toString();
-        return createBuybackTransfer(loanID, settlementDate, transferExternalId);
+    private JournalEntryCommand manualJournalEntry(Account debitAccount, Account creditAccount, String externalAssetOwner) {
+        return new JournalEntryCommand().amount(BigDecimal.TEN).officeId(FeignOfficeHelper.HEAD_OFFICE_ID).currencyCode("USD")
+                .locale(LoanTestData.LOCALE).dateFormat(MANUAL_JOURNAL_ENTRY_DATE_FORMAT).transactionDate(LocalDate.of(2024, 1, 1))
+                .addCreditsItem(
+                        new SingleDebitOrCreditEntryCommand().glAccountId(debitAccount.getAccountID().longValue()).amount(BigDecimal.TEN))
+                .addDebitsItem(
+                        new SingleDebitOrCreditEntryCommand().glAccountId(creditAccount.getAccountID().longValue()).amount(BigDecimal.TEN))
+                .externalAssetOwner(externalAssetOwner);
     }
 
-    private PostInitiateTransferResponse createBuybackTransfer(Integer loanID, String settlementDate, String transferExternalId) {
-        PostInitiateTransferResponse saleResponse = EXTERNAL_ASSET_OWNER_HELPER.initiateTransferByLoanId(loanID.longValue(), "buyback",
-                new ExternalAssetOwnerRequest().settlementDate(settlementDate).dateFormat("yyyy-MM-dd").locale("en")
+    private Long createClientInOffice(Long officeId) {
+        return clientHelper.createClient(ClientHelper.defaultClientCreationRequest().officeId(officeId).activationDate("01 January 2020"))
+                .getClientId();
+    }
+
+    private void makePartialRepayment(Long loanId, LocalDate transactionDate) {
+        transactionHelper.makeLoanRepayment(loanId,
+                new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                        .transactionDate(dateTimeFormatter.format(transactionDate)).locale(LoanTestData.LOCALE)
+                        .transactionAmount(PARTIAL_REPAYMENT_AMOUNT));
+    }
+
+    private RunReportsResponse runTransactionSummaryReport(String endDate, Long officeId) {
+        return reportHelper.runReport(TRANSACTION_SUMMARY_REPORT,
+                Map.of("R_endDate", endDate, "R_officeId", officeId.toString(), "output-type", "CSV"));
+    }
+
+    private void assertReportRow(List<Object> row, String transactionDate, String transactionType, String allocationType, double amount,
+            String assetOwnerId, String fromAssetOwnerId) {
+        assertEquals(transactionDate, row.get(TRANSACTION_DATE_COLUMN));
+        assertTrue(((String) row.get(PRODUCT_NAME_COLUMN)).matches(LOAN_PRODUCT_NAME_PATTERN));
+        assertEquals(transactionType, row.get(TRANSACTION_TYPE_COLUMN));
+        assertNull(row.get(PAYMENT_TYPE_COLUMN));
+        assertEquals("", row.get(CHARGE_TYPE_COLUMN));
+        assertNotReversed(row.get(REVERSED_COLUMN));
+        assertEquals(allocationType, row.get(ALLOCATION_TYPE_COLUMN));
+        assertNull(row.get(CHARGE_OFF_REASON_COLUMN));
+        assertEquals(amount, ((Number) row.get(AMOUNT_COLUMN)).doubleValue(), AMOUNT_TOLERANCE);
+        assertEquals(assetOwnerId, row.get(ASSET_OWNER_ID_COLUMN));
+        assertEquals(fromAssetOwnerId, row.get(FROM_ASSET_OWNER_ID_COLUMN));
+        assertNull(row.get(ORIGINATOR_EXTERNAL_IDS_COLUMN));
+    }
+
+    /**
+     * The report's "reversed" column is a database boolean, which the databases we test against do not agree on:
+     * PostgreSQL reports it as {@code false} while MySQL and MariaDB report a {@code tinyint} {@code 0}. Accept either
+     * rather than pinning the assertion to one database.
+     */
+    private void assertNotReversed(Object reversed) {
+        boolean notReversed = reversed instanceof Number number ? number.intValue() == 0 : Boolean.FALSE.equals(reversed);
+        assertTrue(notReversed, "Expected a non-reversed transaction, but the report reported reversed=" + reversed);
+    }
+
+    private PostInitiateTransferResponse createBuybackTransfer(Long loanId, String settlementDate) {
+        return createBuybackTransfer(loanId, settlementDate, UUID.randomUUID().toString());
+    }
+
+    private PostInitiateTransferResponse createBuybackTransfer(Long loanId, String settlementDate, String transferExternalId) {
+        PostInitiateTransferResponse buybackResponse = EXTERNAL_ASSET_OWNER_HELPER.initiateTransferByLoanId(loanId, BUYBACK_COMMAND,
+                new ExternalAssetOwnerRequest().settlementDate(settlementDate).dateFormat(DATE_FORMAT_ISO).locale(LoanTestData.LOCALE)
                         .transferExternalId(transferExternalId));
-        assertEquals(transferExternalId, saleResponse.getResourceExternalId());
-        return saleResponse;
-    }
-
-    private void addPenaltyForLoan(Integer loanID, String amount) {
-        // Add Charge Penalty
-        Integer penalty = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, amount, true));
-        Integer penalty1LoanChargeId = LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID,
-                LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "02 March 2020", amount));
-        assertNotNull(penalty1LoanChargeId);
-    }
-
-    private void setInitialBusinessDate(String date) {
-        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                new PutGlobalConfigurationsRequest().enabled(true));
-        BusinessDateHelper.updateBusinessDate(BUSINESS_DATE, LocalDate.parse(date));
-    }
-
-    private void cleanUpAndRestoreBusinessDate() {
-        REQUEST_SPEC = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        REQUEST_SPEC.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        REQUEST_SPEC.header("Fineract-Platform-TenantId", "default");
-        RESPONSE_SPEC = new ResponseSpecBuilder().expectStatusCode(200).build();
-        BusinessDateHelper.updateBusinessDate(BUSINESS_DATE, TODAYS_DATE);
-        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                new PutGlobalConfigurationsRequest().enabled(false));
-        globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, false);
-    }
-
-    @NonNull
-    private Integer createClient() {
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        Assertions.assertNotNull(clientID);
-        return clientID;
-    }
-
-    @NonNull
-    private Integer createLoanForClient(Integer clientID) {
-        Integer overdueFeeChargeId = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
-        Assertions.assertNotNull(overdueFeeChargeId);
-
-        Integer loanProductID = createLoanProduct(overdueFeeChargeId.toString());
-        Assertions.assertNotNull(loanProductID);
-        HashMap loanStatusHashMap;
-
-        Integer loanID = applyForLoanApplication(clientID.toString(), loanProductID.toString(), "1 March 2020");
-
-        Assertions.assertNotNull(loanID);
-
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
-
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("01 March 2020", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("02 March 2020", loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-        return loanID;
-    }
-
-    private Integer createLoanProduct(final String chargeId) {
-
-        final String loanProductJSON = new LoanProductTestBuilder().withPrincipal("15,000.00").withNumberOfRepayments("4")
-                .withRepaymentAfterEvery("1").withRepaymentTypeAsMonth().withinterestRatePerPeriod("1")
-                .withAccountingRulePeriodicAccrual(new Account[] { ASSET_ACCOUNT, EXPENSE_ACCOUNT, INCOME_ACCOUNT, OVERPAYMENT_ACCOUNT })
-                .withInterestRateFrequencyTypeAsMonths().withAmortizationTypeAsEqualInstallments().withInterestTypeAsDecliningBalance()
-                .withFeeAndPenaltyAssetAccount(FEE_PENALTY_ACCOUNT).build(chargeId);
-        return LOAN_TRANSACTION_HELPER.getLoanProductId(loanProductJSON);
-    }
-
-    private Integer applyForLoanApplication(final String clientID, final String loanProductID, final String date) {
-        List<HashMap> collaterals = new ArrayList<>();
-        Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
-        Assertions.assertNotNull(collateralId);
-        Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC, clientID, collateralId);
-        Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
-
-        String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal("15,000.00").withLoanTermFrequency("4")
-                .withLoanTermFrequencyAsMonths().withNumberOfRepayments("4").withRepaymentEveryAfter("1")
-                .withRepaymentFrequencyTypeAsMonths().withInterestRatePerPeriod("2").withAmortizationTypeAsEqualInstallments()
-                .withInterestTypeAsDecliningBalance().withInterestCalculationPeriodTypeSameAsRepaymentPeriod()
-                .withExpectedDisbursementDate(date).withSubmittedOnDate(date).withCollaterals(collaterals).withInArrearsTolerance("0")
-                .withPrincipalGrace("0").withInterestGrace("0").build(clientID, loanProductID, null);
-        return LOAN_TRANSACTION_HELPER.getLoanId(loanApplicationJSON);
-    }
-
-    private void addCollaterals(List<HashMap> collaterals, Integer collateralId, BigDecimal quantity) {
-        collaterals.add(collaterals(collateralId, quantity));
-    }
-
-    private HashMap<String, String> collaterals(Integer collateralId, BigDecimal quantity) {
-        HashMap<String, String> collateral = new HashMap<>(2);
-        collateral.put("clientCollateralId", collateralId.toString());
-        collateral.put("quantity", quantity.toString());
-        return collateral;
-    }
-
-    private void getAndValidateExternalAssetOwnerTransferByLoan(Integer loanID, ExpectedExternalTransferData... expectedItems) {
-        PageExternalTransferData retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
-        assertEquals(expectedItems.length, retrieveResponse.getNumberOfElements());
-
-        for (ExpectedExternalTransferData expected : expectedItems) {
-            assertNotNull(retrieveResponse.getContent());
-            Optional<ExternalTransferData> first = retrieveResponse.getContent().stream()
-                    .filter(e -> Objects.equals(e.getTransferExternalId(), expected.transferExternalId)
-                            && Objects.equals(e.getStatus(), expected.status))
-                    .findFirst();
-            assertTrue(first.isPresent());
-            ExternalTransferData etd = first.get();
-            assertEquals(expected.transferExternalId, etd.getTransferExternalId());
-
-            assertEquals(expected.status, etd.getStatus());
-            assertEquals(LocalDate.parse(expected.settlementDate), etd.getSettlementDate());
-            assertEquals(LocalDate.parse(expected.effectiveFrom), etd.getEffectiveFrom());
-            assertEquals(LocalDate.parse(expected.effectiveTo), etd.getEffectiveTo());
-            if (!expected.detailsExpected) {
-                assertNull(etd.getDetails());
-            } else {
-                assertNotNull(etd.getDetails());
-                assertEquals(expected.totalOutstanding, etd.getDetails().getTotalOutstanding());
-                assertEquals(expected.totalPrincipalOutstanding, etd.getDetails().getTotalPrincipalOutstanding());
-                assertEquals(expected.totalInterestOutstanding, etd.getDetails().getTotalInterestOutstanding());
-                assertEquals(expected.totalPenaltyOutstanding, etd.getDetails().getTotalPenaltyChargesOutstanding());
-                assertEquals(expected.totalFeeOutstanding, etd.getDetails().getTotalFeeChargesOutstanding());
-                assertEquals(expected.totalOverpaid, etd.getDetails().getTotalOverpaid());
-            }
-            if (expected.subStatus != null) {
-                assertEquals(expected.subStatus, etd.getSubStatus());
-            }
-        }
-    }
-
-    private void getAndValidateThereIsActiveMapping(Integer loanID) {
-        ExternalTransferData activeTransfer = EXTERNAL_ASSET_OWNER_HELPER.retrieveActiveTransferByLoanId((long) loanID);
-        assertNotNull(activeTransfer);
-        ExternalTransferData retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue()).getContent()
-                .stream().filter(transfer -> ExternalTransferData.StatusEnum.ACTIVE.equals(transfer.getStatus())).findFirst().get();
-        assertEquals(retrieveResponse.getTransferId(), activeTransfer.getTransferId());
+        assertEquals(transferExternalId, buybackResponse.getResourceExternalId());
+        return buybackResponse;
     }
 
     private void getAndValidateThereIsNoActiveMapping(Long loanId) {
-        ExternalTransferData activeTransfer = EXTERNAL_ASSET_OWNER_HELPER.retrieveActiveTransferByLoanId(loanId);
-        assertNull(activeTransfer);
+        assertNull(EXTERNAL_ASSET_OWNER_HELPER.retrieveActiveTransferByLoanId(loanId));
     }
 
     private void getAndValidateThereIsNoActiveMapping(String transferExternalId) {
-        ExternalTransferData activeTransfer = EXTERNAL_ASSET_OWNER_HELPER.retrieveActiveTransferByTransferExternalId(transferExternalId);
-        assertNull(activeTransfer);
-    }
-
-    private void validateResponse(PostInitiateTransferResponse transferResponse, Integer loanID) {
-        assertNotNull(transferResponse);
-        assertNotNull(transferResponse.getResourceId());
-        assertNotNull(transferResponse.getResourceExternalId());
-        assertNotNull(transferResponse.getSubResourceId());
-        assertEquals((long) loanID, transferResponse.getSubResourceId());
-        assertNotNull(transferResponse.getSubResourceExternalId());
-        assertNull(transferResponse.getChanges());
+        assertNull(EXTERNAL_ASSET_OWNER_HELPER.retrieveActiveTransferByTransferExternalId(transferExternalId));
     }
 
     private void getAndValidateOwnerJournalEntries(String ownerExternalId, ExpectedJournalEntryData... expectedItems) {
         ExternalOwnerJournalEntryData result = EXTERNAL_ASSET_OWNER_HELPER.retrieveJournalEntriesOfOwner(ownerExternalId);
         assertNotNull(result);
         assertEquals(expectedItems.length, result.getJournalEntryData().getTotalElements());
-        int i = 0;
         assertEquals(ownerExternalId, result.getOwnerData().getExternalId());
-        for (ExpectedJournalEntryData expectedJournalEntryData : expectedItems) {
-            assertTrue(expectedJournalEntryData.amount.compareTo(result.getJournalEntryData().getContent().get(i).getAmount()) == 0);
-            assertEquals(expectedJournalEntryData.entryTypeId, result.getJournalEntryData().getContent().get(i).getEntryType().getId());
-            assertEquals(expectedJournalEntryData.glAccountId, result.getJournalEntryData().getContent().get(i).getGlAccountId());
-            assertEquals(expectedJournalEntryData.transactionDate, result.getJournalEntryData().getContent().get(i).getTransactionDate());
-            assertEquals(expectedJournalEntryData.submittedOnDate, result.getJournalEntryData().getContent().get(i).getSubmittedOnDate());
-            i++;
-        }
+        assertJournalEntriesMatch(result.getJournalEntryData().getContent(), expectedItems);
     }
 
     private void getAndValidateThereIsJournalEntriesForTransfer(Long transferId, ExpectedJournalEntryData... expectedItems) {
         ExternalOwnerTransferJournalEntryData result = EXTERNAL_ASSET_OWNER_HELPER.retrieveJournalEntriesOfTransfer(transferId);
         assertNotNull(result);
-        long totalElements = result.getJournalEntryData().getTotalElements();
-        assertEquals(expectedItems.length, totalElements);
-        int i = 0;
+        assertEquals(expectedItems.length, result.getJournalEntryData().getTotalElements());
         assertEquals(transferId, result.getTransferData().getTransferId());
-        for (ExpectedJournalEntryData expectedJournalEntryData : expectedItems) {
-            assertTrue(expectedJournalEntryData.amount.compareTo(result.getJournalEntryData().getContent().get(i).getAmount()) == 0);
-            assertEquals(expectedJournalEntryData.entryTypeId, result.getJournalEntryData().getContent().get(i).getEntryType().getId());
-            assertEquals(expectedJournalEntryData.glAccountId, result.getJournalEntryData().getContent().get(i).getGlAccountId());
-            assertEquals(expectedJournalEntryData.transactionDate, result.getJournalEntryData().getContent().get(i).getTransactionDate());
-            assertEquals(expectedJournalEntryData.submittedOnDate, result.getJournalEntryData().getContent().get(i).getSubmittedOnDate());
-            i++;
+        assertJournalEntriesMatch(result.getJournalEntryData().getContent(), expectedItems);
+    }
+
+    private void assertJournalEntriesMatch(List<JournalEntryData> actualItems, ExpectedJournalEntryData... expectedItems) {
+        for (int i = 0; i < expectedItems.length; i++) {
+            ExpectedJournalEntryData expected = expectedItems[i];
+            JournalEntryData actual = actualItems.get(i);
+            assertEquals(0, expected.amount.compareTo(actual.getAmount()));
+            assertEquals(expected.entryTypeId, actual.getEntryType().getId());
+            assertEquals(expected.glAccountId, actual.getGlAccountId());
+            assertEquals(expected.transactionDate, actual.getTransactionDate());
+            assertEquals(expected.submittedOnDate, actual.getSubmittedOnDate());
         }
     }
 
     private void getAndValidateThereIsNoJournalEntriesForTransfer(Long transferId) {
-        ExternalOwnerTransferJournalEntryData result = EXTERNAL_ASSET_OWNER_HELPER.retrieveJournalEntriesOfTransfer(transferId);
-        assertNull(result.getJournalEntryData());
+        assertNull(EXTERNAL_ASSET_OWNER_HELPER.retrieveJournalEntriesOfTransfer(transferId).getJournalEntryData());
+    }
+
+    private static Long assetAccountId() {
+        return assetAccount.getAccountID().longValue();
+    }
+
+    private static Long feePenaltyAccountId() {
+        return feePenaltyAccount.getAccountID().longValue();
+    }
+
+    private static Long incomeAccountId() {
+        return incomeAccount.getAccountID().longValue();
+    }
+
+    private static Long overpaymentAccountId() {
+        return overpaymentAccount.getAccountID().longValue();
+    }
+
+    private static Long transferAccountId() {
+        return transferAccount.getAccountID().longValue();
+    }
+
+    private static Long debitEntryTypeId() {
+        return (long) JournalEntryType.DEBIT.getValue();
+    }
+
+    private static Long creditEntryTypeId() {
+        return (long) JournalEntryType.CREDIT.getValue();
     }
 
     @RequiredArgsConstructor
-    public static class ExpectedExternalTransferData {
-
-        private final ExternalTransferData.StatusEnum status;
-
-        private final String transferExternalId;
-
-        private final String settlementDate;
-
-        private final String effectiveFrom;
-        private final String effectiveTo;
-        private final ExternalTransferData.SubStatusEnum subStatus;
-        private final boolean detailsExpected;
-
-        private final BigDecimal totalOutstanding;
-        private final BigDecimal totalPrincipalOutstanding;
-        private final BigDecimal totalInterestOutstanding;
-        private final BigDecimal totalPenaltyOutstanding;
-        private final BigDecimal totalFeeOutstanding;
-        private final BigDecimal totalOverpaid;
-
-        static ExpectedExternalTransferData expected(ExternalTransferData.StatusEnum status, String transferExternalId,
-                String settlementDate, String effectiveFrom, String effectiveTo, boolean detailsExpected, BigDecimal totalOutstanding,
-                BigDecimal totalPrincipalOutstanding, BigDecimal totalInterestOutstanding, BigDecimal totalPenaltyOutstanding,
-                BigDecimal totalFeeOutstanding, BigDecimal totalOverpaid) {
-            return new ExpectedExternalTransferData(status, transferExternalId, settlementDate, effectiveFrom, effectiveTo, null,
-                    detailsExpected, totalOutstanding, totalPrincipalOutstanding, totalInterestOutstanding, totalPenaltyOutstanding,
-                    totalFeeOutstanding, totalOverpaid);
-        }
-
-        static ExpectedExternalTransferData expected(ExternalTransferData.StatusEnum status, String transferExternalId,
-                String settlementDate, String effectiveFrom, String effectiveTo) {
-            return new ExpectedExternalTransferData(status, transferExternalId, settlementDate, effectiveFrom, effectiveTo, null, false,
-                    null, null, null, null, null, null);
-        }
-
-        static ExpectedExternalTransferData expected(ExternalTransferData.StatusEnum status, String transferExternalId,
-                String settlementDate, String effectiveFrom, String effectiveTo, ExternalTransferData.SubStatusEnum subStatus) {
-            return new ExpectedExternalTransferData(status, transferExternalId, settlementDate, effectiveFrom, effectiveTo, subStatus,
-                    false, null, null, null, null, null, null);
-        }
-    }
-
-    @RequiredArgsConstructor
-    public static class ExpectedJournalEntryData {
+    private static final class ExpectedJournalEntryData {
 
         private final Long glAccountId;
-
         private final Long entryTypeId;
-
         private final BigDecimal amount;
         private final LocalDate transactionDate;
         private final LocalDate submittedOnDate;
@@ -1730,6 +1430,5 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
                 LocalDate submittedOnDate) {
             return new ExpectedJournalEntryData(glAccountId, entryTypeId, amount, transactionDate, submittedOnDate);
         }
-
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/investor/externalassetowner/InitiateExternalAssetOwnerTransferTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/investor/externalassetowner/InitiateExternalAssetOwnerTransferTest.java
@@ -26,7 +26,6 @@ import static org.apache.fineract.client.models.ExternalTransferData.StatusEnum.
 import static org.apache.fineract.client.models.ExternalTransferData.SubStatusEnum.BALANCE_ZERO;
 import static org.apache.fineract.client.models.ExternalTransferData.SubStatusEnum.SAMEDAY_TRANSFERS;
 import static org.apache.fineract.client.models.ExternalTransferData.SubStatusEnum.UNSOLD;
-import static org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType.BUSINESS_DATE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -34,171 +33,154 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.builder.ResponseSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.path.json.JsonPath;
-import io.restassured.specification.RequestSpecification;
-import io.restassured.specification.ResponseSpecification;
-import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
-import okhttp3.ResponseBody;
-import org.apache.fineract.accounting.common.AccountingConstants;
 import org.apache.fineract.accounting.journalentry.domain.JournalEntryType;
+import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
 import org.apache.fineract.client.models.ExternalAssetOwnerRequest;
 import org.apache.fineract.client.models.ExternalOwnerJournalEntryData;
 import org.apache.fineract.client.models.ExternalOwnerTransferJournalEntryData;
-import org.apache.fineract.client.models.ExternalTransferData;
-import org.apache.fineract.client.models.GetFinancialActivityAccountsResponse;
 import org.apache.fineract.client.models.GetJournalEntriesTransactionIdResponse;
 import org.apache.fineract.client.models.JournalEntryCommand;
+import org.apache.fineract.client.models.JournalEntryData;
 import org.apache.fineract.client.models.JournalEntryTransactionItem;
+import org.apache.fineract.client.models.LoanProductChargeData;
 import org.apache.fineract.client.models.PageExternalTransferData;
-import org.apache.fineract.client.models.PostFinancialActivityAccountsRequest;
 import org.apache.fineract.client.models.PostInitiateTransferResponse;
 import org.apache.fineract.client.models.PostJournalEntriesResponse;
-import org.apache.fineract.client.models.PostLoanProductsResponse;
-import org.apache.fineract.client.models.PostLoansLoanIdRequest;
+import org.apache.fineract.client.models.PostLoanProductsRequest;
 import org.apache.fineract.client.models.PostLoansLoanIdTransactionsRequest;
-import org.apache.fineract.client.models.PostLoansRequest;
-import org.apache.fineract.client.models.PostLoansResponse;
-import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
+import org.apache.fineract.client.models.ResultsetColumnHeaderData;
+import org.apache.fineract.client.models.RunReportsResponse;
 import org.apache.fineract.client.models.SingleDebitOrCreditEntryCommand;
-import org.apache.fineract.client.util.CallFailedRuntimeException;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
 import org.apache.fineract.infrastructure.event.external.data.ExternalEventResponse;
-import org.apache.fineract.integrationtests.BaseLoanIntegrationTest;
-import org.apache.fineract.integrationtests.common.BusinessDateHelper;
-import org.apache.fineract.integrationtests.common.BusinessStepHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignOfficeHelper;
+import org.apache.fineract.integrationtests.client.feign.helpers.FeignReportHelper;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
 import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.CollateralManagementHelper;
-import org.apache.fineract.integrationtests.common.ExternalAssetOwnerHelper;
-import org.apache.fineract.integrationtests.common.OfficeHelper;
-import org.apache.fineract.integrationtests.common.SchedulerJobHelper;
+import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.common.accounting.Account;
-import org.apache.fineract.integrationtests.common.accounting.AccountHelper;
-import org.apache.fineract.integrationtests.common.accounting.FinancialActivityAccountHelper;
-import org.apache.fineract.integrationtests.common.accounting.JournalEntryHelper;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
-import org.apache.fineract.integrationtests.common.externalevents.ExternalEventHelper;
 import org.apache.fineract.integrationtests.common.externalevents.ExternalEventsExtension;
-import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanProductTestBuilder;
-import org.apache.fineract.integrationtests.common.loans.LoanStatusChecker;
-import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
-import org.apache.fineract.integrationtests.common.report.ReportHelper;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanStatus;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.lang.NonNull;
-import retrofit2.Response;
 
-@SuppressWarnings("rawtypes")
 @ExtendWith({ ExternalEventsExtension.class })
-public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationTest {
+public class InitiateExternalAssetOwnerTransferTest extends ExternalAssetOwnerTransferTest {
 
-    private static ResponseSpecification RESPONSE_SPEC;
-    private static RequestSpecification REQUEST_SPEC;
-    private static Account ASSET_ACCOUNT;
-    private static Account FEE_PENALTY_ACCOUNT;
-    private static Account TRANSFER_ACCOUNT;
-    private static Account EXPENSE_ACCOUNT;
-    private static Account INCOME_ACCOUNT;
-    private static Account OVERPAYMENT_ACCOUNT;
-    private static FinancialActivityAccountHelper FINANCIAL_ACTIVITY_ACCOUNT_HELPER;
-    private static ExternalAssetOwnerHelper EXTERNAL_ASSET_OWNER_HELPER;
-    private static LoanTransactionHelper LOAN_TRANSACTION_HELPER;
-    private static SchedulerJobHelper SCHEDULER_JOB_HELPER;
-    private static OfficeHelper OFFICE_HELPER;
-    private static LocalDate TODAYS_DATE;
-    public String ownerExternalId;
-    private static ReportHelper reportHelper;
-    private final DateTimeFormatter dateFormatter = new DateTimeFormatterBuilder().appendPattern("dd MMMM yyyy").toFormatter();
+    private static final String LOAN_OWNERSHIP_TRANSFER_EVENT = "LoanOwnershipTransferBusinessEvent";
+    private static final String TRANSACTION_SUMMARY_REPORT = "Transaction Summary Report with Asset Owner";
+    private static final String SALE_COMMAND = "sale";
+    private static final String BUYBACK_COMMAND = "buyback";
+
+    private static final String LOAN_SUBMITTED_ON_DATE = "02 March 2020";
+    private static final String PENALTY_AMOUNT = "10";
+    private static final double OVERDUE_FEE_PERCENTAGE = 1.0;
+    private static final double PARTIAL_REPAYMENT_AMOUNT = 5.0;
+    private static final double FULL_PLUS_OVERPAYMENT_REPAYMENT_AMOUNT = 15777.42;
+    private static final float OVERPAYING_REPAYMENT_AMOUNT = 16000.0f;
+
+    private static final int BAD_REQUEST = 400;
+    private static final int FORBIDDEN = 403;
+    private static final int NOT_FOUND = 404;
+
+    private static final int PARALLEL_SALE_THREAD_COUNT = 10;
+    private static final int PARALLEL_SALE_TIMEOUT_SECONDS = 30;
+    private static final int EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS = 10;
+
+    /**
+     * Columns of the {@value #TRANSACTION_SUMMARY_REPORT} generic result set, in the order the report projects them.
+     */
+    private static final int REPORT_COLUMN_COUNT = 12;
+    private static final int TRANSACTION_DATE_COLUMN = 0;
+    private static final int PRODUCT_NAME_COLUMN = 1;
+    private static final int TRANSACTION_TYPE_COLUMN = 2;
+    private static final int PAYMENT_TYPE_COLUMN = 3;
+    private static final int CHARGE_TYPE_COLUMN = 4;
+    private static final int REVERSED_COLUMN = 5;
+    private static final int ALLOCATION_TYPE_COLUMN = 6;
+    private static final int CHARGE_OFF_REASON_COLUMN = 7;
+    private static final int AMOUNT_COLUMN = 8;
+    private static final int ASSET_OWNER_ID_COLUMN = 9;
+    private static final int FROM_ASSET_OWNER_ID_COLUMN = 10;
+    private static final int ORIGINATOR_EXTERNAL_IDS_COLUMN = 11;
+
+    private static final String LOAN_PRODUCT_NAME_PATTERN = "^LOAN_PRODUCT_.{6}$";
+    private static final String APPLY_CHARGES_TRANSACTION = "Apply Charges";
+    private static final String ASSET_BUYBACK_TRANSACTION = "Asset Buyback";
+    private static final String REPAYMENT_TRANSACTION = "Repayment";
+    private static final String PRINCIPAL_ALLOCATION = "Principal";
+    private static final String INTEREST_ALLOCATION = "Interest";
+    private static final String FEES_ALLOCATION = "Fees";
+    private static final String PENALTY_ALLOCATION = "Penalty";
+    private static final String UNALLOCATED_CREDIT_ALLOCATION = "Unallocated Credit (UNC)";
+    private static final double AMOUNT_TOLERANCE = 0.01;
+
+    private static final String MANUAL_JOURNAL_ENTRY_DATE_FORMAT = "uuuu-MM-dd";
+    private static final double MANUAL_ENTRY_LOAN_PRINCIPAL = 1000.0;
+    private static final int MANUAL_ENTRY_LOAN_REPAYMENTS = 4;
+    private static final double MANUAL_ENTRY_LOAN_INTEREST_RATE = 12.0;
+    private static final int PRE_CLOSURE_INTEREST_CALCULATION_TILL_PRE_CLOSE_DATE = 1;
+
+    private static Account assetAccount;
+    private static Account feePenaltyAccount;
+    private static Account expenseAccount;
+    private static Account incomeAccount;
+    private static Account overpaymentAccount;
+    private static FeignOfficeHelper officeHelper;
+    private static FeignReportHelper reportHelper;
 
     @BeforeAll
-    public static void setupInvestorBusinessStep() {
-        Utils.initializeRESTAssured();
-        REQUEST_SPEC = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        REQUEST_SPEC.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        RESPONSE_SPEC = new ResponseSpecBuilder().expectStatusCode(200).build();
-        AccountHelper accountHelper = new AccountHelper(REQUEST_SPEC, RESPONSE_SPEC);
-        EXTERNAL_ASSET_OWNER_HELPER = new ExternalAssetOwnerHelper();
-        SCHEDULER_JOB_HELPER = new SchedulerJobHelper(REQUEST_SPEC);
-        FINANCIAL_ACTIVITY_ACCOUNT_HELPER = new FinancialActivityAccountHelper(REQUEST_SPEC);
-        LOAN_TRANSACTION_HELPER = new LoanTransactionHelper(REQUEST_SPEC, RESPONSE_SPEC);
-        OFFICE_HELPER = new OfficeHelper();
-
-        TODAYS_DATE = Utils.getLocalDateOfTenant();
-        new BusinessStepHelper().updateSteps("LOAN_CLOSE_OF_BUSINESS", "APPLY_CHARGE_TO_OVERDUE_LOANS", "LOAN_DELINQUENCY_CLASSIFICATION",
-                "CHECK_LOAN_REPAYMENT_DUE", "CHECK_LOAN_REPAYMENT_OVERDUE", "UPDATE_LOAN_ARREARS_AGING", "ADD_PERIODIC_ACCRUAL_ENTRIES",
-                "EXTERNAL_ASSET_OWNER_TRANSFER");
-
-        ASSET_ACCOUNT = accountHelper.createAssetAccount();
-        FEE_PENALTY_ACCOUNT = accountHelper.createAssetAccount();
-        TRANSFER_ACCOUNT = accountHelper.createAssetAccount();
-        EXPENSE_ACCOUNT = accountHelper.createExpenseAccount();
-        INCOME_ACCOUNT = accountHelper.createIncomeAccount();
-        OVERPAYMENT_ACCOUNT = accountHelper.createLiabilityAccount();
-
-        setProperFinancialActivity(TRANSFER_ACCOUNT);
-        reportHelper = new ReportHelper();
-    }
-
-    private static void setProperFinancialActivity(Account transferAccount) {
-        List<GetFinancialActivityAccountsResponse> financialMappings = FINANCIAL_ACTIVITY_ACCOUNT_HELPER.getAllFinancialActivityAccounts();
-        financialMappings.forEach(mapping -> FINANCIAL_ACTIVITY_ACCOUNT_HELPER.deleteFinancialActivityAccount(mapping.getId()));
-        FINANCIAL_ACTIVITY_ACCOUNT_HELPER.createFinancialActivityAccount(new PostFinancialActivityAccountsRequest()
-                .financialActivityId((long) AccountingConstants.FinancialActivity.ASSET_TRANSFER.getValue())
-                .glAccountId((long) transferAccount.getAccountID()));
+    public static void setupAssetOwnerAccounts() {
+        assetAccount = accountHelper.createAssetAccount(Utils.uniqueRandomStringGenerator("ASSET_", 5));
+        feePenaltyAccount = accountHelper.createAssetAccount(Utils.uniqueRandomStringGenerator("FEE_PENALTY_", 5));
+        expenseAccount = accountHelper.createExpenseAccount(Utils.uniqueRandomStringGenerator("EXPENSE_", 5));
+        incomeAccount = accountHelper.createIncomeAccount(Utils.uniqueRandomStringGenerator("INCOME_", 5));
+        overpaymentAccount = accountHelper.createLiabilityAccount(Utils.uniqueRandomStringGenerator("OVERPAYMENT_", 5));
+        officeHelper = new FeignOfficeHelper(FineractFeignClientHelper.getFineractFeignClient());
+        reportHelper = new FeignReportHelper(FineractFeignClientHelper.getFineractFeignClient());
     }
 
     @Test
     public void saleActiveLoanToExternalAssetOwnerWithCancelAndBuybackADayLater() {
         try {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2020-03-02");
+            setInitialBusinessDate(LocalDate.parse("2020-03-02"));
 
-            ExternalEventHelper.deleteAllExternalEvents(REQUEST_SPEC, new ResponseSpecBuilder().expectStatusCode(Matchers.is(204)).build());
-            ExternalEventHelper.changeEventState(REQUEST_SPEC, RESPONSE_SPEC, "LoanOwnershipTransferBusinessEvent", true);
+            externalEventHelper.deleteAllExternalEvents();
+            externalEventHelper.enableBusinessEvent(LOAN_OWNERSHIP_TRANSFER_EVENT);
 
-            Integer clientID = createClient();
-            Integer loanID = createLoanForClient(clientID);
-            addPenaltyForLoan(loanID, "10");
+            Long clientId = createClient();
+            Long loanId = createLoanForClient(clientId);
+            addPenaltyForLoan(loanId, PENALTY_AMOUNT);
 
-            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanID, "2020-03-02");
-            validateResponse(saleTransferResponse, loanID);
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanId, "2020-03-02");
+            validateResponse(saleTransferResponse, loanId);
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
                             "9999-12-31", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
                             new BigDecimal("0.000000")));
             getAndValidateThereIsNoActiveMapping(saleTransferResponse.getResourceExternalId());
-            PageExternalTransferData retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            PageExternalTransferData retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
             retrieveResponse.getContent().forEach(transfer -> getAndValidateThereIsNoJournalEntriesForTransfer(transfer.getTransferId()));
 
             EXTERNAL_ASSET_OWNER_HELPER.cancelTransferByTransferExternalId(saleTransferResponse.getResourceExternalId());
 
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
                             "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
@@ -208,10 +190,10 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
                             new BigDecimal("0.000000")));
             PostInitiateTransferResponse oldSaleTransferResponse = saleTransferResponse;
-            saleTransferResponse = createSaleTransfer(loanID, "2020-03-02");
-            validateResponse(saleTransferResponse, loanID);
+            saleTransferResponse = createSaleTransfer(loanId, "2020-03-02");
+            validateResponse(saleTransferResponse, loanId);
 
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, oldSaleTransferResponse.getResourceExternalId(), "2020-03-02",
                             "2020-03-02", "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
@@ -226,7 +208,7 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
                             new BigDecimal("0.000000")));
 
             updateBusinessDateAndExecuteCOBJob("2020-03-03");
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, oldSaleTransferResponse.getResourceExternalId(), "2020-03-02",
                             "2020-03-02", "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
@@ -244,35 +226,35 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
                             new BigDecimal("0.000000")));
 
-            List<ExternalEventResponse> allExternalEvents = ExternalEventHelper.getAllExternalEvents(REQUEST_SPEC, RESPONSE_SPEC);
-            Assertions.assertEquals(1, allExternalEvents.size());
-            Assertions.assertEquals("LoanOwnershipTransferBusinessEvent", allExternalEvents.get(0).getType());
-            Assertions.assertEquals(Long.valueOf(loanID), allExternalEvents.get(0).getAggregateRootId());
+            List<ExternalEventResponse> allExternalEvents = externalEventHelper.getAllExternalEvents();
+            assertEquals(1, allExternalEvents.size());
+            assertEquals(LOAN_OWNERSHIP_TRANSFER_EVENT, allExternalEvents.get(0).getType());
+            assertEquals(loanId, allExternalEvents.get(0).getAggregateRootId());
 
-            ExternalEventHelper.deleteAllExternalEvents(REQUEST_SPEC, new ResponseSpecBuilder().expectStatusCode(Matchers.is(204)).build());
-            ExternalEventHelper.changeEventState(REQUEST_SPEC, RESPONSE_SPEC, "LoanOwnershipTransferBusinessEvent", true);
+            externalEventHelper.deleteAllExternalEvents();
+            externalEventHelper.enableBusinessEvent(LOAN_OWNERSHIP_TRANSFER_EVENT);
 
-            getAndValidateThereIsActiveMapping(loanID);
-            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            getAndValidateThereIsActiveMapping(loanId);
+            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
             LocalDate expectedDate = LocalDate.of(2020, 3, 2);
             int initial = 2;
             getAndValidateThereIsJournalEntriesForTransfer(retrieveResponse.getContent().get(initial + 1).getTransferId(),
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(15757.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(10.000000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) TRANSFER_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(15767.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(15757.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(10.000000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) TRANSFER_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(15767.420000), expectedDate, expectedDate));
+                    ExpectedJournalEntryData.expected(assetAccountId(), creditEntryTypeId(), BigDecimal.valueOf(15757.420000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), creditEntryTypeId(), BigDecimal.valueOf(10.000000),
+                            expectedDate, expectedDate),
+                    ExpectedJournalEntryData.expected(transferAccountId(), debitEntryTypeId(), BigDecimal.valueOf(15767.420000),
+                            expectedDate, expectedDate),
+                    ExpectedJournalEntryData.expected(assetAccountId(), debitEntryTypeId(), BigDecimal.valueOf(15757.420000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), debitEntryTypeId(), BigDecimal.valueOf(10.000000),
+                            expectedDate, expectedDate),
+                    ExpectedJournalEntryData.expected(transferAccountId(), creditEntryTypeId(), BigDecimal.valueOf(15767.420000),
+                            expectedDate, expectedDate));
 
-            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanID, "2020-03-03");
-            validateResponse(buybackTransferResponse, loanID);
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanId, "2020-03-03");
+            validateResponse(buybackTransferResponse, loanId);
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, oldSaleTransferResponse.getResourceExternalId(), "2020-03-02",
                             "2020-03-02", "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
@@ -293,25 +275,24 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
                             "2020-03-03", "9999-12-31", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
                             new BigDecimal("0.000000")));
-            getAndValidateThereIsActiveMapping(loanID);
-            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            getAndValidateThereIsActiveMapping(loanId);
+            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
             getAndValidateThereIsNoJournalEntriesForTransfer(retrieveResponse.getContent().get(initial + 2).getTransferId());
 
-            LOAN_TRANSACTION_HELPER.makeLoanRepayment((long) loanID, new PostLoansLoanIdTransactionsRequest().dateFormat("dd MMMM yyyy")
-                    .transactionDate(dateFormatter.format(expectedDate)).locale("en").transactionAmount(5.0));
+            makePartialRepayment(loanId, expectedDate);
             LocalDate repaymentSubmittedOnDate = expectedDate.plusDays(1);
             getAndValidateOwnerJournalEntries(ownerExternalId,
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(15757.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(10.000000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(5.000000), expectedDate, repaymentSubmittedOnDate),
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(5.000000), expectedDate, repaymentSubmittedOnDate));
+                    ExpectedJournalEntryData.expected(assetAccountId(), debitEntryTypeId(), BigDecimal.valueOf(15757.420000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), debitEntryTypeId(), BigDecimal.valueOf(10.000000),
+                            expectedDate, expectedDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), creditEntryTypeId(), BigDecimal.valueOf(5.000000),
+                            expectedDate, repaymentSubmittedOnDate),
+                    ExpectedJournalEntryData.expected(assetAccountId(), debitEntryTypeId(), BigDecimal.valueOf(5.000000), expectedDate,
+                            repaymentSubmittedOnDate));
 
             updateBusinessDateAndExecuteCOBJob("2020-03-04");
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, oldSaleTransferResponse.getResourceExternalId(), "2020-03-02",
                             "2020-03-02", "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
@@ -333,39 +314,39 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
                             new BigDecimal("757.420000"), new BigDecimal("5.000000"), new BigDecimal("0.000000"),
                             new BigDecimal("0.000000")));
             getAndValidateThereIsNoActiveMapping(saleTransferResponse.getResourceExternalId());
-            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
             expectedDate = LocalDate.of(2020, 3, 3);
             getAndValidateThereIsJournalEntriesForTransfer(retrieveResponse.getContent().get(initial + 2).getTransferId(),
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(15757.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(5.000000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) TRANSFER_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(15762.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(15757.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(5.000000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) TRANSFER_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(15762.420000), expectedDate, expectedDate));
+                    ExpectedJournalEntryData.expected(assetAccountId(), debitEntryTypeId(), BigDecimal.valueOf(15757.420000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), debitEntryTypeId(), BigDecimal.valueOf(5.000000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(transferAccountId(), creditEntryTypeId(), BigDecimal.valueOf(15762.420000),
+                            expectedDate, expectedDate),
+                    ExpectedJournalEntryData.expected(assetAccountId(), creditEntryTypeId(), BigDecimal.valueOf(15757.420000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), creditEntryTypeId(), BigDecimal.valueOf(5.000000),
+                            expectedDate, expectedDate),
+                    ExpectedJournalEntryData.expected(transferAccountId(), debitEntryTypeId(), BigDecimal.valueOf(15762.420000),
+                            expectedDate, expectedDate));
             LocalDate previousDayDate = LocalDate.of(2020, 3, 2);
             getAndValidateOwnerJournalEntries(ownerExternalId,
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(15757.420000), previousDayDate, previousDayDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(10.000000), previousDayDate, previousDayDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(5.000000), previousDayDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(5.000000), previousDayDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(9.680000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) INCOME_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(9.680000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(15757.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(5.000000), expectedDate, expectedDate));
+                    ExpectedJournalEntryData.expected(assetAccountId(), debitEntryTypeId(), BigDecimal.valueOf(15757.420000),
+                            previousDayDate, previousDayDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), debitEntryTypeId(), BigDecimal.valueOf(10.000000),
+                            previousDayDate, previousDayDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), creditEntryTypeId(), BigDecimal.valueOf(5.000000),
+                            previousDayDate, expectedDate),
+                    ExpectedJournalEntryData.expected(assetAccountId(), debitEntryTypeId(), BigDecimal.valueOf(5.000000), previousDayDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(assetAccountId(), debitEntryTypeId(), BigDecimal.valueOf(9.680000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(incomeAccountId(), creditEntryTypeId(), BigDecimal.valueOf(9.680000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(assetAccountId(), creditEntryTypeId(), BigDecimal.valueOf(15757.420000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), creditEntryTypeId(), BigDecimal.valueOf(5.000000),
+                            expectedDate, expectedDate));
         } finally {
             cleanUpAndRestoreBusinessDate();
         }
@@ -375,24 +356,24 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
     public void saleActiveLoanToExternalAssetOwnerAndBuybackADayLater() {
         try {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2020-03-02");
-            Integer clientID = createClient();
-            Integer loanID = createLoanForClient(clientID);
-            addPenaltyForLoan(loanID, "10");
+            setInitialBusinessDate(LocalDate.parse("2020-03-02"));
+            Long clientId = createClient();
+            Long loanId = createLoanForClient(clientId);
+            addPenaltyForLoan(loanId, PENALTY_AMOUNT);
 
-            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanID, "2020-03-02");
-            validateResponse(saleTransferResponse, loanID);
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanId, "2020-03-02");
+            validateResponse(saleTransferResponse, loanId);
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
                             "9999-12-31", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
                             new BigDecimal("0.000000")));
             getAndValidateThereIsNoActiveMapping(saleTransferResponse.getResourceExternalId());
-            PageExternalTransferData retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            PageExternalTransferData retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
             retrieveResponse.getContent().forEach(transfer -> getAndValidateThereIsNoJournalEntriesForTransfer(transfer.getTransferId()));
 
             updateBusinessDateAndExecuteCOBJob("2020-03-03");
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
                             "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
@@ -401,26 +382,26 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
                             "9999-12-31", true, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
                             new BigDecimal("0.000000")));
-            getAndValidateThereIsActiveMapping(loanID);
-            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            getAndValidateThereIsActiveMapping(loanId);
+            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
             LocalDate expectedDate = LocalDate.of(2020, 3, 2);
             getAndValidateThereIsJournalEntriesForTransfer(retrieveResponse.getContent().get(1).getTransferId(),
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(15757.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(10.000000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) TRANSFER_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(15767.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(15757.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(10.000000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) TRANSFER_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(15767.420000), expectedDate, expectedDate));
+                    ExpectedJournalEntryData.expected(assetAccountId(), creditEntryTypeId(), BigDecimal.valueOf(15757.420000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), creditEntryTypeId(), BigDecimal.valueOf(10.000000),
+                            expectedDate, expectedDate),
+                    ExpectedJournalEntryData.expected(transferAccountId(), debitEntryTypeId(), BigDecimal.valueOf(15767.420000),
+                            expectedDate, expectedDate),
+                    ExpectedJournalEntryData.expected(assetAccountId(), debitEntryTypeId(), BigDecimal.valueOf(15757.420000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), debitEntryTypeId(), BigDecimal.valueOf(10.000000),
+                            expectedDate, expectedDate),
+                    ExpectedJournalEntryData.expected(transferAccountId(), creditEntryTypeId(), BigDecimal.valueOf(15767.420000),
+                            expectedDate, expectedDate));
 
-            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanID, "2020-03-03");
-            validateResponse(buybackTransferResponse, loanID);
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanId, "2020-03-03");
+            validateResponse(buybackTransferResponse, loanId);
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
                             "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
@@ -433,25 +414,24 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
                             "2020-03-03", "9999-12-31", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
                             new BigDecimal("0.000000")));
-            getAndValidateThereIsActiveMapping(loanID);
-            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            getAndValidateThereIsActiveMapping(loanId);
+            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
             getAndValidateThereIsNoJournalEntriesForTransfer(retrieveResponse.getContent().get(2).getTransferId());
 
-            LOAN_TRANSACTION_HELPER.makeLoanRepayment((long) loanID, new PostLoansLoanIdTransactionsRequest().dateFormat("dd MMMM yyyy")
-                    .transactionDate(dateFormatter.format(expectedDate)).locale("en").transactionAmount(5.0));
+            makePartialRepayment(loanId, expectedDate);
             LocalDate repaymentSubmittedOnDate = expectedDate.plusDays(1);
             getAndValidateOwnerJournalEntries(ownerExternalId,
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(15757.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(10.000000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(5.000000), expectedDate, repaymentSubmittedOnDate),
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(5.000000), expectedDate, repaymentSubmittedOnDate));
+                    ExpectedJournalEntryData.expected(assetAccountId(), debitEntryTypeId(), BigDecimal.valueOf(15757.420000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), debitEntryTypeId(), BigDecimal.valueOf(10.000000),
+                            expectedDate, expectedDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), creditEntryTypeId(), BigDecimal.valueOf(5.000000),
+                            expectedDate, repaymentSubmittedOnDate),
+                    ExpectedJournalEntryData.expected(assetAccountId(), debitEntryTypeId(), BigDecimal.valueOf(5.000000), expectedDate,
+                            repaymentSubmittedOnDate));
 
             updateBusinessDateAndExecuteCOBJob("2020-03-04");
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
                             "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
@@ -465,39 +445,39 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
                             new BigDecimal("757.420000"), new BigDecimal("5.000000"), new BigDecimal("0.000000"),
                             new BigDecimal("0.000000")));
             getAndValidateThereIsNoActiveMapping(saleTransferResponse.getResourceExternalId());
-            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
             expectedDate = LocalDate.of(2020, 3, 3);
             getAndValidateThereIsJournalEntriesForTransfer(retrieveResponse.getContent().get(2).getTransferId(),
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(15757.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(5.000000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) TRANSFER_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(15762.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(15757.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(5.000000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) TRANSFER_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(15762.420000), expectedDate, expectedDate));
+                    ExpectedJournalEntryData.expected(assetAccountId(), debitEntryTypeId(), BigDecimal.valueOf(15757.420000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), debitEntryTypeId(), BigDecimal.valueOf(5.000000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(transferAccountId(), creditEntryTypeId(), BigDecimal.valueOf(15762.420000),
+                            expectedDate, expectedDate),
+                    ExpectedJournalEntryData.expected(assetAccountId(), creditEntryTypeId(), BigDecimal.valueOf(15757.420000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), creditEntryTypeId(), BigDecimal.valueOf(5.000000),
+                            expectedDate, expectedDate),
+                    ExpectedJournalEntryData.expected(transferAccountId(), debitEntryTypeId(), BigDecimal.valueOf(15762.420000),
+                            expectedDate, expectedDate));
             LocalDate previousDayDate = LocalDate.of(2020, 3, 2);
             getAndValidateOwnerJournalEntries(ownerExternalId,
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(15757.420000), previousDayDate, previousDayDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(10.000000), previousDayDate, previousDayDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(5.000000), previousDayDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(5.000000), previousDayDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(9.680000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) INCOME_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(9.680000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(15757.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(5.000000), expectedDate, expectedDate));
+                    ExpectedJournalEntryData.expected(assetAccountId(), debitEntryTypeId(), BigDecimal.valueOf(15757.420000),
+                            previousDayDate, previousDayDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), debitEntryTypeId(), BigDecimal.valueOf(10.000000),
+                            previousDayDate, previousDayDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), creditEntryTypeId(), BigDecimal.valueOf(5.000000),
+                            previousDayDate, expectedDate),
+                    ExpectedJournalEntryData.expected(assetAccountId(), debitEntryTypeId(), BigDecimal.valueOf(5.000000), previousDayDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(assetAccountId(), debitEntryTypeId(), BigDecimal.valueOf(9.680000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(incomeAccountId(), creditEntryTypeId(), BigDecimal.valueOf(9.680000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(assetAccountId(), creditEntryTypeId(), BigDecimal.valueOf(15757.420000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), creditEntryTypeId(), BigDecimal.valueOf(5.000000),
+                            expectedDate, expectedDate));
         } finally {
             cleanUpAndRestoreBusinessDate();
         }
@@ -507,24 +487,24 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
     public void saleOverpaidLoanToExternalAssetOwnerAndBuybackADayLater() {
         try {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2020-03-02");
-            Integer clientID = createClient();
-            Integer loanID = createLoanForClient(clientID);
-            addPenaltyForLoan(loanID, "10");
+            setInitialBusinessDate(LocalDate.parse("2020-03-02"));
+            Long clientId = createClient();
+            Long loanId = createLoanForClient(clientId);
+            addPenaltyForLoan(loanId, PENALTY_AMOUNT);
 
-            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanID, "2020-03-02");
-            validateResponse(saleTransferResponse, loanID);
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanId, "2020-03-02");
+            validateResponse(saleTransferResponse, loanId);
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
                             "9999-12-31", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
                             new BigDecimal("0.000000")));
             getAndValidateThereIsNoActiveMapping(saleTransferResponse.getResourceExternalId());
-            PageExternalTransferData retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            PageExternalTransferData retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
             retrieveResponse.getContent().forEach(transfer -> getAndValidateThereIsNoJournalEntriesForTransfer(transfer.getTransferId()));
 
             updateBusinessDateAndExecuteCOBJob("2020-03-03");
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
                             "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
@@ -533,26 +513,26 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
                             "9999-12-31", true, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
                             new BigDecimal("0.000000")));
-            getAndValidateThereIsActiveMapping(loanID);
-            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            getAndValidateThereIsActiveMapping(loanId);
+            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
             LocalDate expectedDate = LocalDate.of(2020, 3, 2);
             getAndValidateThereIsJournalEntriesForTransfer(retrieveResponse.getContent().get(1).getTransferId(),
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(15757.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(10.000000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) TRANSFER_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(15767.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(15757.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(10.000000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) TRANSFER_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(15767.420000), expectedDate, expectedDate));
+                    ExpectedJournalEntryData.expected(assetAccountId(), creditEntryTypeId(), BigDecimal.valueOf(15757.420000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), creditEntryTypeId(), BigDecimal.valueOf(10.000000),
+                            expectedDate, expectedDate),
+                    ExpectedJournalEntryData.expected(transferAccountId(), debitEntryTypeId(), BigDecimal.valueOf(15767.420000),
+                            expectedDate, expectedDate),
+                    ExpectedJournalEntryData.expected(assetAccountId(), debitEntryTypeId(), BigDecimal.valueOf(15757.420000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), debitEntryTypeId(), BigDecimal.valueOf(10.000000),
+                            expectedDate, expectedDate),
+                    ExpectedJournalEntryData.expected(transferAccountId(), creditEntryTypeId(), BigDecimal.valueOf(15767.420000),
+                            expectedDate, expectedDate));
 
-            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanID, "2020-03-03");
-            validateResponse(buybackTransferResponse, loanID);
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanId, "2020-03-03");
+            validateResponse(buybackTransferResponse, loanId);
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
                             "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
@@ -565,23 +545,25 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
                             "2020-03-03", "9999-12-31", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
                             new BigDecimal("0.000000")));
-            getAndValidateThereIsActiveMapping(loanID);
-            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            getAndValidateThereIsActiveMapping(loanId);
+            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
             getAndValidateThereIsNoJournalEntriesForTransfer(retrieveResponse.getContent().get(2).getTransferId());
 
-            LOAN_TRANSACTION_HELPER.makeLoanRepayment((long) loanID, new PostLoansLoanIdTransactionsRequest().dateFormat("dd MMMM yyyy")
-                    .transactionDate(dateFormatter.format(expectedDate)).locale("en").transactionAmount(15777.42));
+            transactionHelper.makeLoanRepayment(loanId,
+                    new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                            .transactionDate(dateTimeFormatter.format(expectedDate)).locale(LoanTestData.LOCALE)
+                            .transactionAmount(FULL_PLUS_OVERPAYMENT_REPAYMENT_AMOUNT));
             LocalDate repaymentSubmittedOnDate = expectedDate.plusDays(1);
             getAndValidateOwnerJournalEntries(ownerExternalId,
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(15757.420000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(10.000000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) OVERPAYMENT_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(10.000000), repaymentSubmittedOnDate, repaymentSubmittedOnDate));
+                    ExpectedJournalEntryData.expected(assetAccountId(), debitEntryTypeId(), BigDecimal.valueOf(15757.420000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), debitEntryTypeId(), BigDecimal.valueOf(10.000000),
+                            expectedDate, expectedDate),
+                    ExpectedJournalEntryData.expected(overpaymentAccountId(), debitEntryTypeId(), BigDecimal.valueOf(10.000000),
+                            repaymentSubmittedOnDate, repaymentSubmittedOnDate));
 
             updateBusinessDateAndExecuteCOBJob("2020-03-04");
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
                             "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
@@ -595,25 +577,25 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
                             new BigDecimal("0.000000"), new BigDecimal("0.000000"), new BigDecimal("0.000000"),
                             new BigDecimal("10.000000")));
             getAndValidateThereIsNoActiveMapping(saleTransferResponse.getResourceExternalId());
-            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
             expectedDate = LocalDate.of(2020, 3, 3);
             getAndValidateThereIsJournalEntriesForTransfer(retrieveResponse.getContent().get(2).getTransferId(),
-                    ExpectedJournalEntryData.expected((long) OVERPAYMENT_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(10.000000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) TRANSFER_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(10.000000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) OVERPAYMENT_ACCOUNT.getAccountID(), (long) JournalEntryType.CREDIT.getValue(),
-                            BigDecimal.valueOf(10.000000), expectedDate, expectedDate),
-                    ExpectedJournalEntryData.expected((long) TRANSFER_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(10.000000), expectedDate, expectedDate));
+                    ExpectedJournalEntryData.expected(overpaymentAccountId(), debitEntryTypeId(), BigDecimal.valueOf(10.000000),
+                            expectedDate, expectedDate),
+                    ExpectedJournalEntryData.expected(transferAccountId(), creditEntryTypeId(), BigDecimal.valueOf(10.000000), expectedDate,
+                            expectedDate),
+                    ExpectedJournalEntryData.expected(overpaymentAccountId(), creditEntryTypeId(), BigDecimal.valueOf(10.000000),
+                            expectedDate, expectedDate),
+                    ExpectedJournalEntryData.expected(transferAccountId(), debitEntryTypeId(), BigDecimal.valueOf(10.000000), expectedDate,
+                            expectedDate));
             LocalDate previousDayDate = LocalDate.of(2020, 3, 2);
             getAndValidateOwnerJournalEntries(ownerExternalId,
-                    ExpectedJournalEntryData.expected((long) ASSET_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(15757.420000), previousDayDate, previousDayDate),
-                    ExpectedJournalEntryData.expected((long) FEE_PENALTY_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(10.000000), previousDayDate, previousDayDate),
-                    ExpectedJournalEntryData.expected((long) OVERPAYMENT_ACCOUNT.getAccountID(), (long) JournalEntryType.DEBIT.getValue(),
-                            BigDecimal.valueOf(10.000000), expectedDate, expectedDate));
+                    ExpectedJournalEntryData.expected(assetAccountId(), debitEntryTypeId(), BigDecimal.valueOf(15757.420000),
+                            previousDayDate, previousDayDate),
+                    ExpectedJournalEntryData.expected(feePenaltyAccountId(), debitEntryTypeId(), BigDecimal.valueOf(10.000000),
+                            previousDayDate, previousDayDate),
+                    ExpectedJournalEntryData.expected(overpaymentAccountId(), debitEntryTypeId(), BigDecimal.valueOf(10.000000),
+                            expectedDate, expectedDate));
         } finally {
             cleanUpAndRestoreBusinessDate();
         }
@@ -623,14 +605,15 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
     public void saleIsNotAllowedWhenTransferIsAlreadyPending() {
         try {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2020-03-02");
-            Integer clientID = createClient();
-            Integer loanID = createLoanForClient(clientID);
+            setInitialBusinessDate(LocalDate.parse("2020-03-02"));
+            Long clientId = createClient();
+            Long loanId = createLoanForClient(clientId);
 
-            createSaleTransfer(loanID, "2020-03-02");
+            createSaleTransfer(loanId, "2020-03-02");
 
             CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                    () -> createSaleTransfer(loanID, "2020-03-02"));
+                    () -> createSaleTransfer(loanId, "2020-03-02"));
+            assertEquals(FORBIDDEN, exception.getStatus());
             assertTrue(exception.getMessage().contains("External asset owner transfer is already in PENDING state for this loan"));
         } finally {
             cleanUpAndRestoreBusinessDate();
@@ -641,19 +624,19 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
     public void saleIsNotAllowedWhenLoanIsNotActive() {
         try {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2020-03-02");
-            Integer clientID = createClient();
-            Integer loanID = createLoanForClient(clientID);
+            setInitialBusinessDate(LocalDate.parse("2020-03-02"));
+            Long clientId = createClient();
+            Long loanId = createLoanForClient(clientId);
 
             updateBusinessDateAndExecuteCOBJob("2020-03-04");
 
-            LOAN_TRANSACTION_HELPER.makeRepayment("04 March 2020", 16000.0f, loanID);
+            makeRepayment("04 March 2020", OVERPAYING_REPAYMENT_AMOUNT, loanId);
 
-            HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-            LoanStatus loanStatus = LoanStatus.fromInt((Integer) loanStatusHashMap.get("id"));
+            LoanStatus loanStatus = LoanStatus.fromInt(getLoanDetails(loanId).getStatus().getId().intValue());
 
             CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                    () -> createSaleTransfer(loanID, "2020-03-02"));
+                    () -> createSaleTransfer(loanId, "2020-03-02"));
+            assertEquals(FORBIDDEN, exception.getStatus());
             assertTrue(exception.getMessage().contains(String.format("Loan status %s is not valid for transfer.", loanStatus)));
         } finally {
             cleanUpAndRestoreBusinessDate();
@@ -664,16 +647,16 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
     public void saleIsDeclinedWhenLoanIsCancelled() {
         try {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2020-03-02");
-            Integer clientID = createClient();
-            Integer loanID = createLoanForClient(clientID);
+            setInitialBusinessDate(LocalDate.parse("2020-03-02"));
+            Long clientId = createClient();
+            Long loanId = createLoanForClient(clientId);
 
-            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanID, "2020-03-06");
+            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanId, "2020-03-06");
             updateBusinessDateAndExecuteCOBJob("2020-03-04");
 
-            LOAN_TRANSACTION_HELPER.writeOffLoan("04 March 2020", loanID);
+            writeOffLoan("04 March 2020", loanId);
 
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-06", "2020-03-02",
                             "2020-03-04"),
                     ExpectedExternalTransferData.expected(DECLINED, saleTransferResponse.getResourceExternalId(), "2020-03-06",
@@ -687,17 +670,17 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
     public void buybackIsExecutedWhenLoanIsCancelled() {
         try {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2020-03-02");
-            Integer clientID = createClient();
-            Integer loanID = createLoanForClient(clientID);
+            setInitialBusinessDate(LocalDate.parse("2020-03-02"));
+            Long clientId = createClient();
+            Long loanId = createLoanForClient(clientId);
 
-            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanID, "2020-03-04");
+            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanId, "2020-03-04");
             updateBusinessDateAndExecuteCOBJob("2020-03-05");
-            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanID, "2020-03-06");
+            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanId, "2020-03-06");
 
-            LOAN_TRANSACTION_HELPER.writeOffLoan("04 March 2020", loanID);
+            writeOffLoan("04 March 2020", loanId);
 
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-04", "2020-03-02",
                             "2020-03-04"),
                     ExpectedExternalTransferData.expected(ACTIVE, saleTransferResponse.getResourceExternalId(), "2020-03-04", "2020-03-05",
@@ -718,16 +701,16 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
     public void buybackAndSaleIsCancelledWhenLoanIsCancelled() {
         try {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2020-03-02");
-            Integer clientID = createClient();
-            Integer loanID = createLoanForClient(clientID);
+            setInitialBusinessDate(LocalDate.parse("2020-03-02"));
+            Long clientId = createClient();
+            Long loanId = createLoanForClient(clientId);
 
-            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanID, "2020-03-04");
-            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanID, "2020-03-06");
+            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanId, "2020-03-04");
+            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanId, "2020-03-06");
 
-            LOAN_TRANSACTION_HELPER.writeOffLoan("02 March 2020", loanID);
+            writeOffLoan("02 March 2020", loanId);
 
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-04", "2020-03-02",
                             "2020-03-02"),
                     ExpectedExternalTransferData.expected(BUYBACK, buybackTransferResponse.getResourceExternalId(), "2020-03-06",
@@ -745,16 +728,16 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
     public void sameDayBuybackAndSaleIsCancelledWhenLoanIsCancelled() {
         try {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2020-03-02");
-            Integer clientID = createClient();
-            Integer loanID = createLoanForClient(clientID);
+            setInitialBusinessDate(LocalDate.parse("2020-03-02"));
+            Long clientId = createClient();
+            Long loanId = createLoanForClient(clientId);
 
-            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanID, "2020-03-03");
-            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanID, "2020-03-03");
+            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanId, "2020-03-03");
+            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanId, "2020-03-03");
 
-            LOAN_TRANSACTION_HELPER.writeOffLoan("02 March 2020", loanID);
+            writeOffLoan("02 March 2020", loanId);
 
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-03", "2020-03-02",
                             "2020-03-02"),
                     ExpectedExternalTransferData.expected(BUYBACK, buybackTransferResponse.getResourceExternalId(), "2020-03-03",
@@ -772,16 +755,16 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
     public void saleAndBuybackOnTheSameDay() {
         try {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2020-03-02");
-            Integer clientID = createClient();
-            Integer loanID = createLoanForClient(clientID);
+            setInitialBusinessDate(LocalDate.parse("2020-03-02"));
+            Long clientId = createClient();
+            Long loanId = createLoanForClient(clientId);
 
-            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanID, "2020-03-02");
-            validateResponse(saleTransferResponse, loanID);
-            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanID, "2020-03-02");
-            validateResponse(buybackTransferResponse, loanID);
+            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanId, "2020-03-02");
+            validateResponse(saleTransferResponse, loanId);
+            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanId, "2020-03-02");
+            validateResponse(buybackTransferResponse, loanId);
 
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
                             "9999-12-31", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
@@ -795,7 +778,7 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
 
             updateBusinessDateAndExecuteCOBJob("2020-03-03");
 
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
                             "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
@@ -812,7 +795,7 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
                             "2020-03-02", "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
                             new BigDecimal("0.000000")));
-            getAndValidateThereIsNoActiveMapping((long) loanID);
+            getAndValidateThereIsNoActiveMapping(loanId);
         } finally {
             cleanUpAndRestoreBusinessDate();
         }
@@ -822,14 +805,14 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
     public void saleAndBuybackMultipleTimes() {
         try {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2020-03-02");
-            Integer clientID = createClient();
-            Integer loanID = createLoanForClient(clientID);
+            setInitialBusinessDate(LocalDate.parse("2020-03-02"));
+            Long clientId = createClient();
+            Long loanId = createLoanForClient(clientId);
 
-            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanID, "2020-03-04");
-            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanID, "2020-03-04");
+            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanId, "2020-03-04");
+            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanId, "2020-03-04");
 
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-04", "2020-03-02",
                             "9999-12-31", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
@@ -840,11 +823,13 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
                             new BigDecimal("0.000000")));
 
             CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
-                    () -> createSaleTransfer(loanID, "2020-03-04"));
+                    () -> createSaleTransfer(loanId, "2020-03-04"));
+            assertEquals(FORBIDDEN, exception.getStatus());
             assertTrue(exception.getMessage().contains("This loan cannot be sold, there is already an in progress transfer"));
 
             CallFailedRuntimeException exception2 = assertThrows(CallFailedRuntimeException.class,
-                    () -> createBuybackTransfer(loanID, "2020-03-04"));
+                    () -> createBuybackTransfer(loanId, "2020-03-04"));
+            assertEquals(FORBIDDEN, exception2.getStatus());
             assertTrue(exception2.getMessage()
                     .contains("This loan cannot be bought back, external asset owner buyback transfer is already in progress"));
         } finally {
@@ -856,47 +841,54 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
     public void buybackExceptionHandling() {
         try {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2020-03-02");
+            setInitialBusinessDate(LocalDate.parse("2020-03-02"));
 
-            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class, () -> createBuybackTransfer(1, null));
+            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
+                    () -> createBuybackTransfer(FeignOfficeHelper.HEAD_OFFICE_ID, null));
+            assertEquals(BAD_REQUEST, exception.getStatus());
             assertTrue(exception.getMessage().contains("The parameter `settlementDate` is mandatory."));
 
             CallFailedRuntimeException exception2 = assertThrows(CallFailedRuntimeException.class, () -> {
-                Integer clientID = createClient();
-                Integer loanID = createLoanForClient(clientID);
-                createBuybackTransfer(loanID, "1970-01-01");
+                Long clientId = createClient();
+                Long loanId = createLoanForClient(clientId);
+                createBuybackTransfer(loanId, "1970-01-01");
             });
+            assertEquals(FORBIDDEN, exception2.getStatus());
             assertTrue(exception2.getMessage().contains("Settlement date cannot be in the past"));
 
             CallFailedRuntimeException exception3 = assertThrows(CallFailedRuntimeException.class, () -> {
-                Integer clientID = createClient();
-                Integer loanID = createLoanForClient(clientID);
-                createSaleTransfer(loanID, "2020-03-03");
-                createBuybackTransfer(loanID, "2020-03-02");
+                Long clientId = createClient();
+                Long loanId = createLoanForClient(clientId);
+                createSaleTransfer(loanId, "2020-03-03");
+                createBuybackTransfer(loanId, "2020-03-02");
             });
+            assertEquals(FORBIDDEN, exception3.getStatus());
             assertTrue(exception3.getMessage().contains(
                     "This loan cannot be bought back, settlement date is earlier than effective transfer settlement date: 2020-03-03"));
 
             CallFailedRuntimeException exception4 = assertThrows(CallFailedRuntimeException.class, () -> {
-                Integer clientID = createClient();
-                Integer loanID = createLoanForClient(clientID);
-                createBuybackTransfer(loanID, "2020-03-03");
+                Long clientId = createClient();
+                Long loanId = createLoanForClient(clientId);
+                createBuybackTransfer(loanId, "2020-03-03");
             });
+            assertEquals(FORBIDDEN, exception4.getStatus());
             assertTrue(exception4.getMessage().contains("This loan cannot be bought back, it is not owned by an external asset owner"));
 
             CallFailedRuntimeException exception5 = assertThrows(CallFailedRuntimeException.class,
-                    () -> createBuybackTransfer(-1, "2020-03-03"));
+                    () -> createBuybackTransfer(-1L, "2020-03-03"));
+            assertEquals(NOT_FOUND, exception5.getStatus());
             assertTrue(exception5.getMessage().contains("Loan with identifier -1 does not exist"));
 
             String externalId = UUID.randomUUID().toString();
             String transferExternalGroupId = UUID.randomUUID().toString();
 
             CallFailedRuntimeException exception6 = assertThrows(CallFailedRuntimeException.class, () -> {
-                Integer clientID = createClient();
-                Integer loanID = createLoanForClient(clientID);
-                createSaleTransfer(loanID, "2020-03-03", externalId, transferExternalGroupId, "1", "1.0");
-                createBuybackTransfer(loanID, "2020-03-02", externalId);
+                Long clientId = createClient();
+                Long loanId = createLoanForClient(clientId);
+                createSaleTransfer(loanId, "2020-03-03", externalId, transferExternalGroupId, "1", "1.0");
+                createBuybackTransfer(loanId, "2020-03-02", externalId);
             });
+            assertEquals(FORBIDDEN, exception6.getStatus());
             assertTrue(exception6.getMessage()
                     .contains(String.format("Already existing an asset transfer with the provided transfer external id: %s", externalId)));
         } finally {
@@ -908,45 +900,53 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
     public void saleExceptionHandling() {
         try {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2020-03-02");
-            Integer clientID = createClient();
-            Integer loanID = createLoanForClient(clientID);
+            setInitialBusinessDate(LocalDate.parse("2020-03-02"));
+            Long clientId = createClient();
+            Long loanId = createLoanForClient(clientId);
 
-            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class, () -> createSaleTransfer(loanID, null));
+            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class, () -> createSaleTransfer(loanId, null));
+            assertEquals(BAD_REQUEST, exception.getStatus());
             assertTrue(exception.getMessage().contains("The parameter `settlementDate` is mandatory."));
 
-            CallFailedRuntimeException exception2 = assertThrows(CallFailedRuntimeException.class, () -> createSaleTransfer(loanID,
+            CallFailedRuntimeException exception2 = assertThrows(CallFailedRuntimeException.class, () -> createSaleTransfer(loanId,
                     "2020-03-02", UUID.randomUUID().toString(), UUID.randomUUID().toString(), null, "1.0"));
+            assertEquals(BAD_REQUEST, exception2.getStatus());
             assertTrue(exception2.getMessage().contains("The parameter `ownerExternalId` is mandatory."));
 
             CallFailedRuntimeException exception3 = assertThrows(CallFailedRuntimeException.class,
-                    () -> createSaleTransfer(loanID, "2020-03-02", null, UUID.randomUUID().toString(), UUID.randomUUID().toString(), null));
+                    () -> createSaleTransfer(loanId, "2020-03-02", null, UUID.randomUUID().toString(), UUID.randomUUID().toString(), null));
+            assertEquals(BAD_REQUEST, exception3.getStatus());
             assertTrue(exception3.getMessage().contains("The parameter `purchasePriceRatio` is mandatory."));
 
             CallFailedRuntimeException exception4 = assertThrows(CallFailedRuntimeException.class,
-                    () -> createSaleTransfer(loanID, "1970-01-01"));
+                    () -> createSaleTransfer(loanId, "1970-01-01"));
+            assertEquals(FORBIDDEN, exception4.getStatus());
             assertTrue(exception4.getMessage().contains("Settlement date cannot be in the past"));
 
             CallFailedRuntimeException exception5 = assertThrows(CallFailedRuntimeException.class, () -> {
-                createSaleTransfer(loanID, "2020-03-03");
-                createBuybackTransfer(loanID, "2020-03-04");
-                createSaleTransfer(loanID, "2020-03-05");
+                createSaleTransfer(loanId, "2020-03-03");
+                createBuybackTransfer(loanId, "2020-03-04");
+                createSaleTransfer(loanId, "2020-03-05");
             });
+            assertEquals(FORBIDDEN, exception5.getStatus());
             assertTrue(exception5.getMessage().contains("This loan cannot be sold, there is already an in progress transfer"));
+
             // Owner-to-owner transfer: selling a loan that is already owned by an external asset owner should
             // succeed at API time (a new PENDING is created; the actual ownership switch happens in COB)
-            Integer loanIDForOwnerTransfer = createLoanForClient(clientID);
-            createSaleTransfer(loanIDForOwnerTransfer, "2020-03-03");
+            Long loanIdForOwnerTransfer = createLoanForClient(clientId);
+            createSaleTransfer(loanIdForOwnerTransfer, "2020-03-03");
             updateBusinessDateAndExecuteCOBJob("2020-03-04");
-            PostInitiateTransferResponse ownerToOwnerSaleResponse = createSaleTransfer(loanIDForOwnerTransfer, "2020-03-05");
+            PostInitiateTransferResponse ownerToOwnerSaleResponse = createSaleTransfer(loanIdForOwnerTransfer, "2020-03-05");
             assertNotNull(ownerToOwnerSaleResponse.getResourceId());
+
             String externalId = UUID.randomUUID().toString();
             String transferExternalGroupId = UUID.randomUUID().toString();
             CallFailedRuntimeException exception7 = assertThrows(CallFailedRuntimeException.class, () -> {
-                Integer loanID2 = createLoanForClient(clientID);
-                createSaleTransfer(loanID2, "2020-03-05", externalId, transferExternalGroupId, "1", "1.0");
-                createSaleTransfer(loanID2, "2020-03-05", externalId, transferExternalGroupId, "1", "1.0");
+                Long anotherLoanId = createLoanForClient(clientId);
+                createSaleTransfer(anotherLoanId, "2020-03-05", externalId, transferExternalGroupId, "1", "1.0");
+                createSaleTransfer(anotherLoanId, "2020-03-05", externalId, transferExternalGroupId, "1", "1.0");
             });
+            assertEquals(FORBIDDEN, exception7.getStatus());
             assertTrue(exception7.getMessage()
                     .contains(String.format("Already existing an asset transfer with the provided transfer external id: %s", externalId)));
         } finally {
@@ -955,32 +955,32 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
     }
 
     @Test
-    public void transactionSummaryReportWithAssetOwner() throws IOException {
+    public void transactionSummaryReportWithAssetOwner() {
         try {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2020-03-02");
+            setInitialBusinessDate(LocalDate.parse("2020-03-02"));
 
-            ExternalEventHelper.deleteAllExternalEvents(REQUEST_SPEC, new ResponseSpecBuilder().expectStatusCode(Matchers.is(204)).build());
-            ExternalEventHelper.changeEventState(REQUEST_SPEC, RESPONSE_SPEC, "LoanOwnershipTransferBusinessEvent", true);
+            externalEventHelper.deleteAllExternalEvents();
+            externalEventHelper.enableBusinessEvent(LOAN_OWNERSHIP_TRANSFER_EVENT);
 
-            final Integer officeId = OFFICE_HELPER.createOffice(LocalDate.of(2020, 1, 1)).getResourceId().intValue();
-            final var clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC, "1 January 2020", officeId.toString());
-            final var loanID = createLoanForClient(clientID);
-            addPenaltyForLoan(loanID, "10");
+            Long officeId = officeHelper.createOffice(LocalDate.of(2020, 1, 1)).getResourceId();
+            Long clientId = createClientInOffice(officeId);
+            Long loanId = createLoanForClient(clientId);
+            addPenaltyForLoan(loanId, PENALTY_AMOUNT);
 
-            final var saleTransferResponse = createSaleTransfer(loanID, "2020-03-02");
-            validateResponse(saleTransferResponse, loanID);
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanId, "2020-03-02");
+            validateResponse(saleTransferResponse, loanId);
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
                             "9999-12-31", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
                             new BigDecimal("0.000000")));
             getAndValidateThereIsNoActiveMapping(saleTransferResponse.getResourceExternalId());
-            var retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            PageExternalTransferData retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
             retrieveResponse.getContent().forEach(transfer -> getAndValidateThereIsNoJournalEntriesForTransfer(transfer.getTransferId()));
 
             updateBusinessDateAndExecuteCOBJob("2020-03-03");
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
                             "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
@@ -990,20 +990,18 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
                             new BigDecimal("0.000000")));
 
-            final var allExternalEvents = ExternalEventHelper.getAllExternalEvents(REQUEST_SPEC, RESPONSE_SPEC);
-            List<ExternalEventResponse> loanOwnershipTransferBusinessEvents = allExternalEvents.stream()
-                    .filter(e -> e.getType().equals("LoanOwnershipTransferBusinessEvent")).toList();
-            Assertions.assertEquals(1, loanOwnershipTransferBusinessEvents.size());
-            Assertions.assertEquals(Long.valueOf(loanID), loanOwnershipTransferBusinessEvents.get(0).getAggregateRootId());
+            List<ExternalEventResponse> loanOwnershipTransferBusinessEvents = externalEventHelper.getAllExternalEvents().stream()
+                    .filter(event -> LOAN_OWNERSHIP_TRANSFER_EVENT.equals(event.getType())).toList();
+            assertEquals(1, loanOwnershipTransferBusinessEvents.size());
+            assertEquals(loanId, loanOwnershipTransferBusinessEvents.get(0).getAggregateRootId());
 
-            getAndValidateThereIsActiveMapping(loanID);
+            getAndValidateThereIsActiveMapping(loanId);
 
-            final var expectedDate = LocalDate.of(2020, 3, 2);
-            final var initial = 0;
+            LocalDate repaymentDate = LocalDate.of(2020, 3, 2);
 
-            final var buybackTransferResponse = createBuybackTransfer(loanID, "2020-03-03");
-            validateResponse(buybackTransferResponse, loanID);
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanId, "2020-03-03");
+            validateResponse(buybackTransferResponse, loanId);
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
                             "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
@@ -1016,15 +1014,14 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
                             "2020-03-03", "9999-12-31", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
                             new BigDecimal("0.000000")));
-            getAndValidateThereIsActiveMapping(loanID);
-            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
-            getAndValidateThereIsNoJournalEntriesForTransfer(retrieveResponse.getContent().get(initial + 2).getTransferId());
+            getAndValidateThereIsActiveMapping(loanId);
+            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
+            getAndValidateThereIsNoJournalEntriesForTransfer(retrieveResponse.getContent().get(2).getTransferId());
 
-            LOAN_TRANSACTION_HELPER.makeLoanRepayment((long) loanID, new PostLoansLoanIdTransactionsRequest().dateFormat("dd MMMM yyyy")
-                    .transactionDate(dateFormatter.format(expectedDate)).locale("en").transactionAmount(5.0));
+            makePartialRepayment(loanId, repaymentDate);
 
             updateBusinessDateAndExecuteCOBJob("2020-03-04");
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, saleTransferResponse.getResourceExternalId(), "2020-03-02", "2020-03-02",
                             "2020-03-02", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
@@ -1038,267 +1035,98 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
                             new BigDecimal("757.420000"), new BigDecimal("5.000000"), new BigDecimal("0.000000"),
                             new BigDecimal("0.000000")));
             getAndValidateThereIsNoActiveMapping(saleTransferResponse.getResourceExternalId());
-            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
 
-            final var reportResult = reportHelper.runReport("Transaction Summary Report with Asset Owner",
-                    Map.of("R_endDate", "2020-03-03", "R_officeId", officeId.toString(), "output-type", "CSV"));
+            RunReportsResponse report = runTransactionSummaryReport("2020-03-03", officeId);
 
-            assertNotNull(reportResult.body());
-            final var csvContent = reportResult.body().string();
-            final var jsonPath = JsonPath.from(csvContent);
-
-            assertNotNull(jsonPath.getString("columnHeaders[0].columnType"));
-            assertNotNull(jsonPath.getString("columnHeaders[0].columnDisplayType"));
-            assertFalse(jsonPath.getBoolean("columnHeaders[0].isColumnNullable"));
-
-            assertNotNull(jsonPath.getString("columnHeaders[1].columnType"));
-            assertNotNull(jsonPath.getString("columnHeaders[1].columnDisplayType"));
-            assertFalse(jsonPath.getBoolean("columnHeaders[1].isColumnNullable"));
-
-            assertNotNull(jsonPath.getString("columnHeaders[2].columnType"));
-            assertNotNull(jsonPath.getString("columnHeaders[2].columnDisplayType"));
-            assertFalse(jsonPath.getBoolean("columnHeaders[2].isColumnNullable"));
-
-            assertNotNull(jsonPath.getString("columnHeaders[3].columnType"));
-            assertNotNull(jsonPath.getString("columnHeaders[3].columnDisplayType"));
-            assertFalse(jsonPath.getBoolean("columnHeaders[3].isColumnNullable"));
-
-            assertNotNull(jsonPath.getString("columnHeaders[4].columnType"));
-            assertNotNull(jsonPath.getString("columnHeaders[4].columnDisplayType"));
-            assertFalse(jsonPath.getBoolean("columnHeaders[4].isColumnNullable"));
-
-            assertNotNull(jsonPath.getString("columnHeaders[5].columnType"));
-            assertNotNull(jsonPath.getString("columnHeaders[5].columnDisplayType"));
-            assertFalse(jsonPath.getBoolean("columnHeaders[5].isColumnNullable"));
-
-            assertNotNull(jsonPath.getString("columnHeaders[6].columnType"));
-            assertNotNull(jsonPath.getString("columnHeaders[6].columnDisplayType"));
-            assertFalse(jsonPath.getBoolean("columnHeaders[6].isColumnNullable"));
-
-            assertNotNull(jsonPath.getString("columnHeaders[7].columnType"));
-            assertNotNull(jsonPath.getString("columnHeaders[7].columnDisplayType"));
-            assertFalse(jsonPath.getBoolean("columnHeaders[7].isColumnNullable"));
-
-            assertNotNull(jsonPath.getString("columnHeaders[8].columnType"));
-            assertNotNull(jsonPath.getString("columnHeaders[8].columnDisplayType"));
-            assertFalse(jsonPath.getBoolean("columnHeaders[8].isColumnNullable"));
-
-            assertNotNull(jsonPath.getString("columnHeaders[9].columnType"));
-            assertNotNull(jsonPath.getString("columnHeaders[9].columnDisplayType"));
-            assertFalse(jsonPath.getBoolean("columnHeaders[9].isColumnNullable"));
-
-            assertNotNull(jsonPath.getString("columnHeaders[10].columnType"));
-            assertNotNull(jsonPath.getString("columnHeaders[10].columnDisplayType"));
-            assertFalse(jsonPath.getBoolean("columnHeaders[10].isColumnNullable"));
+            assertEquals(REPORT_COLUMN_COUNT, report.getColumnHeaders().size());
+            for (ResultsetColumnHeaderData columnHeader : report.getColumnHeaders()) {
+                assertNotNull(columnHeader.getColumnType());
+                assertNotNull(columnHeader.getColumnDisplayType());
+                assertFalse(columnHeader.getIsColumnNullable());
+            }
 
             assertNotNull(retrieveResponse.getContent().get(0).getOwner());
-            final var ownerId = retrieveResponse.getContent().get(0).getOwner().getExternalId();
+            String ownerId = retrieveResponse.getContent().get(0).getOwner().getExternalId();
             assertNotNull(retrieveResponse.getContent().get(2).getPreviousOwner());
-            final var previousOwnerId = retrieveResponse.getContent().get(2).getPreviousOwner().getExternalId();
+            String previousOwnerId = retrieveResponse.getContent().get(2).getPreviousOwner().getExternalId();
 
-            assertEquals("2020-03-03", jsonPath.getString("data[0].row[0]"));
-            assertTrue(jsonPath.getString("data[0].row[1]").matches("^LOAN_PRODUCT_.{6}$"));
-            assertEquals("Apply Charges", jsonPath.getString("data[0].row[2]"));
-            assertNull(jsonPath.getString("data[0].row[3]"));
-            assertEquals("", jsonPath.getString("data[0].row[4]"));
-            assertFalse(jsonPath.getBoolean("data[0].row[5]"));
-            assertEquals("Interest", jsonPath.getString("data[0].row[6]"));
-            assertNull(jsonPath.getString("data[0].row[7]"));
-            assertEquals(9.68, jsonPath.getDouble("data[0].row[8]"), 0.01);
-            assertEquals(ownerId, jsonPath.getString("data[0].row[9]"));
-            assertNull(jsonPath.getString("data[0].row[10]"));
-
-            assertEquals("2020-03-03", jsonPath.getString("data[1].row[0]"));
-            assertTrue(jsonPath.getString("data[1].row[1]").matches("^LOAN_PRODUCT_.{6}$"));
-            assertEquals("Asset Buyback", jsonPath.getString("data[1].row[2]"));
-            assertNull(jsonPath.getString("data[1].row[3]"));
-            assertEquals("", jsonPath.getString("data[1].row[4]"));
-            assertFalse(jsonPath.getBoolean("data[1].row[5]"));
-            assertEquals("Interest", jsonPath.getString("data[1].row[6]"));
-            assertNull(jsonPath.getString("data[1].row[7]"));
-            assertEquals(-757.42, jsonPath.getDouble("data[1].row[8]"), 0.01);
-            assertNull(jsonPath.getString("data[1].row[9]"));
-            assertEquals(previousOwnerId, jsonPath.getString("data[1].row[10]"));
-
-            assertEquals("2020-03-03", jsonPath.getString("data[2].row[0]"));
-            assertTrue(jsonPath.getString("data[2].row[1]").matches("^LOAN_PRODUCT_.{6}$"));
-            assertEquals("Asset Buyback", jsonPath.getString("data[2].row[2]"));
-            assertNull(jsonPath.getString("data[2].row[3]"));
-            assertEquals("", jsonPath.getString("data[2].row[4]"));
-            assertFalse(jsonPath.getBoolean("data[2].row[5]"));
-            assertEquals("Penalty", jsonPath.getString("data[2].row[6]"));
-            assertNull(jsonPath.getString("data[2].row[7]"));
-            assertEquals(-5.00, jsonPath.getDouble("data[2].row[8]"), 0.01);
-            assertNull(jsonPath.getString("data[2].row[9]"));
-            assertEquals(previousOwnerId, jsonPath.getString("data[2].row[10]"));
-
-            assertEquals("2020-03-03", jsonPath.getString("data[3].row[0]"));
-            assertTrue(jsonPath.getString("data[3].row[1]").matches("^LOAN_PRODUCT_.{6}$"));
-            assertEquals("Asset Buyback", jsonPath.getString("data[3].row[2]"));
-            assertNull(jsonPath.getString("data[3].row[3]"));
-            assertEquals("", jsonPath.getString("data[3].row[4]"));
-            assertFalse(jsonPath.getBoolean("data[3].row[5]"));
-            assertEquals("Principal", jsonPath.getString("data[3].row[6]"));
-            assertNull(jsonPath.getString("data[3].row[7]"));
-            assertEquals(-15000.00, jsonPath.getDouble("data[3].row[8]"), 0.01);
-            assertNull(jsonPath.getString("data[3].row[9]"));
-            assertEquals(previousOwnerId, jsonPath.getString("data[3].row[10]"));
-
-            assertEquals("2020-03-03", jsonPath.getString("data[4].row[0]"));
-            assertTrue(jsonPath.getString("data[4].row[1]").matches("^LOAN_PRODUCT_.{6}$"));
-            assertEquals("Repayment", jsonPath.getString("data[4].row[2]"));
-            assertNull(jsonPath.getString("data[4].row[3]"));
-            assertEquals("", jsonPath.getString("data[4].row[4]"));
-            assertFalse(jsonPath.getBoolean("data[4].row[5]"));
-            assertEquals("Fees", jsonPath.getString("data[4].row[6]"));
-            assertNull(jsonPath.getString("data[4].row[7]"));
-            assertEquals(0.00, jsonPath.getDouble("data[4].row[8]"), 0.01);
-            assertEquals(ownerId, jsonPath.getString("data[4].row[9]"));
-            assertNull(jsonPath.getString("data[4].row[10]"));
-
-            assertEquals("2020-03-03", jsonPath.getString("data[5].row[0]"));
-            assertTrue(jsonPath.getString("data[5].row[1]").matches("^LOAN_PRODUCT_.{6}$"));
-            assertEquals("Repayment", jsonPath.getString("data[5].row[2]"));
-            assertNull(jsonPath.getString("data[5].row[3]"));
-            assertEquals("", jsonPath.getString("data[5].row[4]"));
-            assertFalse(jsonPath.getBoolean("data[5].row[5]"));
-            assertEquals("Interest", jsonPath.getString("data[5].row[6]"));
-            assertNull(jsonPath.getString("data[5].row[7]"));
-            assertEquals(0.00, jsonPath.getDouble("data[5].row[8]"), 0.01);
-            assertEquals(ownerId, jsonPath.getString("data[5].row[9]"));
-            assertNull(jsonPath.getString("data[5].row[10]"));
-
-            assertEquals("2020-03-03", jsonPath.getString("data[6].row[0]"));
-            assertTrue(jsonPath.getString("data[6].row[1]").matches("^LOAN_PRODUCT_.{6}$"));
-            assertEquals("Repayment", jsonPath.getString("data[6].row[2]"));
-            assertNull(jsonPath.getString("data[6].row[3]"));
-            assertEquals("", jsonPath.getString("data[6].row[4]"));
-            assertFalse(jsonPath.getBoolean("data[6].row[5]"));
-            assertEquals("Penalty", jsonPath.getString("data[6].row[6]"));
-            assertNull(jsonPath.getString("data[6].row[7]"));
-            assertEquals(-5.00, jsonPath.getDouble("data[6].row[8]"), 0.01);
-            assertEquals(ownerId, jsonPath.getString("data[6].row[9]"));
-            assertNull(jsonPath.getString("data[6].row[10]"));
-
-            assertEquals("2020-03-03", jsonPath.getString("data[7].row[0]"));
-            assertTrue(jsonPath.getString("data[7].row[1]").matches("^LOAN_PRODUCT_.{6}$"));
-            assertEquals("Repayment", jsonPath.getString("data[7].row[2]"));
-            assertNull(jsonPath.getString("data[7].row[3]"));
-            assertEquals("", jsonPath.getString("data[7].row[4]"));
-            assertFalse(jsonPath.getBoolean("data[7].row[5]"));
-            assertEquals("Principal", jsonPath.getString("data[7].row[6]"));
-            assertNull(jsonPath.getString("data[7].row[7]"));
-            assertEquals(0.00, jsonPath.getDouble("data[7].row[8]"), 0.01);
-            assertEquals(ownerId, jsonPath.getString("data[7].row[9]"));
-            assertNull(jsonPath.getString("data[7].row[10]"));
-
-            assertEquals("2020-03-03", jsonPath.getString("data[8].row[0]"));
-            assertTrue(jsonPath.getString("data[8].row[1]").matches("^LOAN_PRODUCT_.{6}$"));
-            assertEquals("Repayment", jsonPath.getString("data[8].row[2]"));
-            assertNull(jsonPath.getString("data[8].row[3]"));
-            assertEquals("", jsonPath.getString("data[8].row[4]"));
-            assertFalse(jsonPath.getBoolean("data[8].row[5]"));
-            assertEquals("Unallocated Credit (UNC)", jsonPath.getString("data[8].row[6]"));
-            assertNull(jsonPath.getString("data[8].row[7]"));
-            assertEquals(0.00, jsonPath.getDouble("data[8].row[8]"), 0.01);
-            assertEquals(ownerId, jsonPath.getString("data[8].row[9]"));
-            assertNull(jsonPath.getString("data[8].row[10]"));
+            List<List<Object>> rows = report.getData().stream().map(row -> row.getRow()).toList();
+            assertEquals(9, rows.size());
+            assertReportRow(rows.get(0), "2020-03-03", APPLY_CHARGES_TRANSACTION, INTEREST_ALLOCATION, 9.68, ownerId, null);
+            assertReportRow(rows.get(1), "2020-03-03", ASSET_BUYBACK_TRANSACTION, INTEREST_ALLOCATION, -757.42, null, previousOwnerId);
+            assertReportRow(rows.get(2), "2020-03-03", ASSET_BUYBACK_TRANSACTION, PENALTY_ALLOCATION, -5.00, null, previousOwnerId);
+            assertReportRow(rows.get(3), "2020-03-03", ASSET_BUYBACK_TRANSACTION, PRINCIPAL_ALLOCATION, -15000.00, null, previousOwnerId);
+            assertReportRow(rows.get(4), "2020-03-03", REPAYMENT_TRANSACTION, FEES_ALLOCATION, 0.00, ownerId, null);
+            assertReportRow(rows.get(5), "2020-03-03", REPAYMENT_TRANSACTION, INTEREST_ALLOCATION, 0.00, ownerId, null);
+            assertReportRow(rows.get(6), "2020-03-03", REPAYMENT_TRANSACTION, PENALTY_ALLOCATION, -5.00, ownerId, null);
+            assertReportRow(rows.get(7), "2020-03-03", REPAYMENT_TRANSACTION, PRINCIPAL_ALLOCATION, 0.00, ownerId, null);
+            assertReportRow(rows.get(8), "2020-03-03", REPAYMENT_TRANSACTION, UNALLOCATED_CREDIT_ALLOCATION, 0.00, ownerId, null);
         } finally {
-            ExternalEventHelper.deleteAllExternalEvents(REQUEST_SPEC, new ResponseSpecBuilder().expectStatusCode(Matchers.is(204)).build());
+            externalEventHelper.deleteAllExternalEvents();
             cleanUpAndRestoreBusinessDate();
         }
     }
 
     @Test
-    public void transactionSummaryReportWithAssetOwner_CheckFromAssetOwnerIdForBuyback() throws IOException {
+    public void transactionSummaryReportWithAssetOwnerCheckFromAssetOwnerIdForBuyback() {
         try {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2023-08-16");
+            setInitialBusinessDate(LocalDate.parse("2023-08-16"));
 
-            ExternalEventHelper.deleteAllExternalEvents(REQUEST_SPEC, new ResponseSpecBuilder().expectStatusCode(Matchers.is(204)).build());
-            ExternalEventHelper.changeEventState(REQUEST_SPEC, RESPONSE_SPEC, "LoanOwnershipTransferBusinessEvent", true);
+            externalEventHelper.deleteAllExternalEvents();
+            externalEventHelper.enableBusinessEvent(LOAN_OWNERSHIP_TRANSFER_EVENT);
 
-            final Integer officeId = OFFICE_HELPER.createOffice(LocalDate.of(2020, 1, 1)).getResourceId().intValue();
-            final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC, "1 January 2020", officeId.toString());
-            final Integer loanID = createLoanForClient(clientID);
+            Long officeId = officeHelper.createOffice(LocalDate.of(2020, 1, 1)).getResourceId();
+            Long clientId = createClientInOffice(officeId);
+            Long loanId = createLoanForClient(clientId);
 
-            // Create first sale transfer
-            final PostInitiateTransferResponse firstSaleTransferResponse = createSaleTransfer(loanID, "2023-08-16");
-            validateResponse(firstSaleTransferResponse, loanID);
+            PostInitiateTransferResponse firstSaleTransferResponse = createSaleTransfer(loanId, "2023-08-16");
+            validateResponse(firstSaleTransferResponse, loanId);
 
-            // Verify the transfer is PENDING initially
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
-                    ExpectedExternalTransferData.expected(PENDING, firstSaleTransferResponse.getResourceExternalId(), "2023-08-16",
-                            "2023-08-16", "9999-12-31", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
-                            new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
-                            new BigDecimal("0.000000")));
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId, ExpectedExternalTransferData.expected(PENDING,
+                    firstSaleTransferResponse.getResourceExternalId(), "2023-08-16", "2023-08-16", "9999-12-31"));
 
-            // Execute COB job on the next day to activate the transfer
             updateBusinessDateAndExecuteCOBJob("2023-08-17");
 
-            // Verify the transfer is ACTIVE after COB job
-            getAndValidateExternalAssetOwnerTransferByLoan(loanID,
+            getAndValidateExternalAssetOwnerTransferByLoan(loanId,
                     ExpectedExternalTransferData.expected(PENDING, firstSaleTransferResponse.getResourceExternalId(), "2023-08-16",
-                            "2023-08-16", "2023-08-16", false, new BigDecimal("15767.420000"), new BigDecimal("15000.000000"),
-                            new BigDecimal("757.420000"), new BigDecimal("10.000000"), new BigDecimal("0.000000"),
-                            new BigDecimal("0.000000")),
+                            "2023-08-16", "2023-08-16"),
                     ExpectedExternalTransferData.expected(ACTIVE, firstSaleTransferResponse.getResourceExternalId(), "2023-08-16",
                             "2023-08-17", "9999-12-31", true, new BigDecimal("15914.980000"), new BigDecimal("15000.000000"),
                             new BigDecimal("757.420000"), new BigDecimal("157.560000"), new BigDecimal("0.000000"),
                             new BigDecimal("0.000000")));
 
-            // Get the owner ID of the first transfer for later verification
-            PageExternalTransferData retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            PageExternalTransferData retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
             assertNotNull(retrieveResponse.getContent().get(1).getOwner());
-            final String firstOwnerId = retrieveResponse.getContent().get(1).getOwner().getExternalId();
+            String firstOwnerId = retrieveResponse.getContent().get(1).getOwner().getExternalId();
             assertNull(retrieveResponse.getContent().get(1).getPreviousOwner(), "First sale transfer should not have previous_owner_id");
 
-            // Create buyback transfer
             updateBusinessDateAndExecuteCOBJob("2023-08-18");
-            final PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanID, "2023-08-18");
-            validateResponse(buybackTransferResponse, loanID);
+            PostInitiateTransferResponse buybackTransferResponse = createBuybackTransfer(loanId, "2023-08-18");
+            validateResponse(buybackTransferResponse, loanId);
 
-            // Execute COB job to process buyback
             updateBusinessDateAndExecuteCOBJob("2023-08-19");
 
-            // Verify buyback has previous_owner_id set
-            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
             assertNotNull(retrieveResponse.getContent().get(2).getPreviousOwner());
             assertEquals(firstOwnerId, retrieveResponse.getContent().get(2).getPreviousOwner().getExternalId(),
                     "Buyback transfer should have previous_owner_id set to first owner");
 
-            // Run report on settlement date of buyback to check that from_asset_owner_id is populated
-            final Response<ResponseBody> reportResult = reportHelper.runReport("Transaction Summary Report with Asset Owner",
-                    Map.of("R_endDate", "2023-08-18", "R_officeId", officeId.toString(), "output-type", "CSV"));
+            RunReportsResponse report = runTransactionSummaryReport("2023-08-18", officeId);
 
-            assertNotNull(reportResult.body());
-            final String csvContent = reportResult.body().string();
-            final JsonPath jsonPath = JsonPath.from(csvContent);
+            List<List<Object>> buybackRows = report.getData().stream().map(row -> row.getRow())
+                    .filter(row -> ASSET_BUYBACK_TRANSACTION.equals(row.get(TRANSACTION_TYPE_COLUMN))
+                            && "2023-08-18".equals(row.get(TRANSACTION_DATE_COLUMN)))
+                    .toList();
 
-            // Find Asset Buyback entries to verify from_asset_owner_id is populated
-            final List<Map<String, Object>> buybackRows = new ArrayList<>();
-            final int dataSize = jsonPath.getInt("data.size()");
-            for (int i = 0; i < dataSize; i++) {
-                final String transactionType = jsonPath.getString("data[" + i + "].row[2]");
-                final String transactionDate = jsonPath.getString("data[" + i + "].row[0]");
-                // Find Asset Buyback entries for the buyback date
-                if ("Asset Buyback".equals(transactionType) && "2023-08-18".equals(transactionDate)) {
-                    buybackRows.add(jsonPath.getMap("data[" + i + "]"));
-                }
-            }
-
-            // Verify that Asset Buyback entries exist
             assertFalse(buybackRows.isEmpty(), "Asset Buyback entries should exist in the report");
-
-            // Verify that from_asset_owner_id is populated with previous_owner_id for buyback
-            for (Map<String, Object> row : buybackRows) {
-                final List<Object> rowData = (List<Object>) row.get("row");
-                assertNotNull(rowData.get(10), "from_asset_owner_id should be populated for buyback transfer");
-                assertEquals(firstOwnerId, rowData.get(10),
+            for (List<Object> row : buybackRows) {
+                assertEquals(firstOwnerId, row.get(FROM_ASSET_OWNER_ID_COLUMN),
                         "from_asset_owner_id should equal the first owner's external ID for buyback transfer");
             }
         } finally {
-            ExternalEventHelper.deleteAllExternalEvents(REQUEST_SPEC, new ResponseSpecBuilder().expectStatusCode(Matchers.is(204)).build());
+            externalEventHelper.deleteAllExternalEvents();
             cleanUpAndRestoreBusinessDate();
         }
     }
@@ -1306,63 +1134,43 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
     @Test
     public void addManualJournalEntriesWithAssetExternalization() {
         runAt("10 April 2025", () -> {
+            Account glAccountDebit = accountHelper.createAssetAccount(Utils.uniqueRandomStringGenerator("MANUAL_DEBIT_", 5));
+            Account glAccountCredit = accountHelper.createLiabilityAccount(Utils.uniqueRandomStringGenerator("MANUAL_CREDIT_", 5));
+            String externalAssetOwner = Utils.uniqueRandomStringGenerator("ASSET_EXTERNAL_", 5);
 
-            final Account glAccountDebit = accountHelper.createAssetAccount();
-            final Account glAccountCredit = accountHelper.createLiabilityAccount();
-            final String externalAssetOwner = Utils.uniqueRandomStringGenerator("ASSET_EXTERNAL_", 5);
+            CallFailedRuntimeException unknownOwnerException = assertThrows(CallFailedRuntimeException.class,
+                    () -> journalHelper.createJournalEntry(manualJournalEntry(glAccountDebit, glAccountCredit, externalAssetOwner)));
+            assertEquals(NOT_FOUND, unknownOwnerException.getStatus());
+            assertTrue(unknownOwnerException.getMessage().contains("External asset owner with external id:"));
 
-            CallFailedRuntimeException callFailedRuntimeException = Assertions.assertThrows(CallFailedRuntimeException.class,
-                    () -> JournalEntryHelper.createJournalEntry("", new JournalEntryCommand().amount(BigDecimal.TEN).officeId(1L)
-                            .currencyCode("USD").locale("en").dateFormat("uuuu-MM-dd").transactionDate(LocalDate.of(2024, 1, 1))
-                            .addCreditsItem(new SingleDebitOrCreditEntryCommand().glAccountId(glAccountDebit.getAccountID().longValue())
-                                    .amount(BigDecimal.TEN))
-                            .addDebitsItem(new SingleDebitOrCreditEntryCommand().glAccountId(glAccountCredit.getAccountID().longValue())
-                                    .amount(BigDecimal.TEN))
-                            .externalAssetOwner(externalAssetOwner)));
-            Assertions.assertTrue(callFailedRuntimeException.getMessage().contains("External asset owner with external id:"));
+            Long clientId = createClient();
+            String operationDate = "10 April 2025";
 
-            final Integer clientId = ClientHelper.createClient(requestSpec, responseSpec);
-            final String operationDate = "10 April 2025";
+            Long loanProductId = createLoanProduct(manualEntryLoanProduct());
+            Long loanId = applyForLoan(
+                    applyLoanRequest(clientId, loanProductId, operationDate, MANUAL_ENTRY_LOAN_PRINCIPAL, MANUAL_ENTRY_LOAN_REPAYMENTS,
+                            request -> request
+                                    .transactionProcessingStrategyCode(
+                                            LoanTestData.TransactionProcessingStrategyCode.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)
+                                    .interestRatePerPeriod(BigDecimal.valueOf(MANUAL_ENTRY_LOAN_INTEREST_RATE))));
+            approveLoan(loanId, approveLoanRequest(MANUAL_ENTRY_LOAN_PRINCIPAL, operationDate));
+            disburseLoan(loanId, operationDate, MANUAL_ENTRY_LOAN_PRINCIPAL);
 
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(
-                    createOnePeriod30DaysPeriodicAccrualProductWithAdvancedPaymentAllocationAndInterestRecalculation(12.0, 4));
-
-            final PostLoansRequest applicationRequest = applyLoanRequest(clientId.longValue(), loanProductResponse.getResourceId(),
-                    operationDate, 1000.0, 4).transactionProcessingStrategyCode("advanced-payment-allocation-strategy")//
-                    .interestRatePerPeriod(BigDecimal.valueOf(12.0));
-
-            final PostLoansResponse loanResponse = loanTransactionHelper.applyLoan(applicationRequest);
-            final Long loanId = loanResponse.getLoanId();
-
-            loanTransactionHelper.approveLoan(loanId, new PostLoansLoanIdRequest().approvedLoanAmount(BigDecimal.valueOf(1000.0))
-                    .dateFormat(DATETIME_PATTERN).approvedOnDate(operationDate).locale("en"));
-
-            loanTransactionHelper.disburseLoan(loanId, new PostLoansLoanIdRequest().actualDisbursementDate(operationDate)
-                    .dateFormat(DATETIME_PATTERN).transactionAmount(BigDecimal.valueOf(1000.0)).locale("en"));
-
-            PostInitiateTransferResponse transferResponse = EXTERNAL_ASSET_OWNER_HELPER.initiateTransferByLoanId(loanId, "sale",
-                    new ExternalAssetOwnerRequest().settlementDate("2025-04-20").dateFormat("yyyy-MM-dd").locale("en")
-                            .transferExternalId(externalAssetOwner).transferExternalGroupId(null).ownerExternalId(externalAssetOwner)
-                            .purchasePriceRatio("0.90"));
+            PostInitiateTransferResponse transferResponse = EXTERNAL_ASSET_OWNER_HELPER.initiateTransferByLoanId(loanId, SALE_COMMAND,
+                    new ExternalAssetOwnerRequest().settlementDate("2025-04-20").dateFormat(DATE_FORMAT_ISO).locale(LoanTestData.LOCALE)
+                            .transferExternalId(externalAssetOwner).ownerExternalId(externalAssetOwner).purchasePriceRatio("0.90"));
             assertEquals(externalAssetOwner, transferResponse.getResourceExternalId());
 
-            final PostJournalEntriesResponse journalEntriesResponse = JournalEntryHelper.createJournalEntry("",
-                    new JournalEntryCommand().amount(BigDecimal.TEN).officeId(1L).currencyCode("USD").locale("en").dateFormat("uuuu-MM-dd")
-                            .transactionDate(LocalDate.of(2024, 1, 1))
-                            .addCreditsItem(new SingleDebitOrCreditEntryCommand().glAccountId(glAccountDebit.getAccountID().longValue())
-                                    .amount(BigDecimal.TEN))
-                            .addDebitsItem(new SingleDebitOrCreditEntryCommand().glAccountId(glAccountCredit.getAccountID().longValue())
-                                    .amount(BigDecimal.TEN))
-                            .externalAssetOwner(externalAssetOwner));
+            PostJournalEntriesResponse journalEntriesResponse = journalHelper
+                    .createJournalEntry(manualJournalEntry(glAccountDebit, glAccountCredit, externalAssetOwner));
 
-            final GetJournalEntriesTransactionIdResponse journalEntriesTransactionIdResponse = JournalEntryHelper
-                    .retrieveJournalEntryByTransactionId(journalEntriesResponse.getTransactionId());
-            Assertions.assertNotNull(journalEntriesTransactionIdResponse);
-            assertEquals(2, journalEntriesTransactionIdResponse.getPageItems().size());
-            JournalEntryTransactionItem journalEntryItem = journalEntriesTransactionIdResponse.getPageItems().get(0);
-            assertEquals(externalAssetOwner, journalEntryItem.getExternalAssetOwner());
-            journalEntryItem = journalEntriesTransactionIdResponse.getPageItems().get(1);
-            assertEquals(externalAssetOwner, journalEntryItem.getExternalAssetOwner());
+            GetJournalEntriesTransactionIdResponse journalEntries = journalHelper
+                    .getJournalEntriesByTransactionId(journalEntriesResponse.getTransactionId());
+            assertNotNull(journalEntries);
+            assertEquals(2, journalEntries.getPageItems().size());
+            for (JournalEntryTransactionItem journalEntryItem : journalEntries.getPageItems()) {
+                assertEquals(externalAssetOwner, journalEntryItem.getExternalAssetOwner());
+            }
         });
     }
 
@@ -1370,36 +1178,30 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
     public void saleTransferWithSameOwnerExternalIdInParallelShouldNotFail() {
         try {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
-            setInitialBusinessDate("2020-03-02");
+            setInitialBusinessDate(LocalDate.parse("2020-03-02"));
 
-            final int threadCount = 10;
-            final String sharedOwnerExternalId = UUID.randomUUID().toString();
+            String sharedOwnerExternalId = UUID.randomUUID().toString();
 
-            final List<Integer> loanIDs = new ArrayList<>();
-            for (int i = 0; i < threadCount; i++) {
-                Integer clientID = createClient();
-                Integer loanID = createLoanForClient(clientID);
-                loanIDs.add(loanID);
+            List<Long> loanIds = new ArrayList<>();
+            for (int i = 0; i < PARALLEL_SALE_THREAD_COUNT; i++) {
+                loanIds.add(createLoanForClient(createClient()));
             }
 
-            final ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
-            final CountDownLatch startLatch = new CountDownLatch(1);
-            final CountDownLatch doneLatch = new CountDownLatch(threadCount);
-            final List<PostInitiateTransferResponse> results = Collections.synchronizedList(new ArrayList<>());
-            final List<Exception> exceptions = Collections.synchronizedList(new ArrayList<>());
+            ExecutorService executorService = Executors.newFixedThreadPool(PARALLEL_SALE_THREAD_COUNT);
+            CountDownLatch startLatch = new CountDownLatch(1);
+            CountDownLatch doneLatch = new CountDownLatch(PARALLEL_SALE_THREAD_COUNT);
+            List<PostInitiateTransferResponse> results = Collections.synchronizedList(new ArrayList<>());
+            List<Exception> exceptions = Collections.synchronizedList(new ArrayList<>());
 
-            for (int i = 0; i < threadCount; i++) {
-                final Integer loanID = loanIDs.get(i);
+            for (Long loanId : loanIds) {
                 executorService.execute(() -> {
                     try {
                         startLatch.await();
-                        PostInitiateTransferResponse response = EXTERNAL_ASSET_OWNER_HELPER.initiateTransferByLoanId(loanID.longValue(),
-                                "sale",
-                                new ExternalAssetOwnerRequest().settlementDate("2020-03-02").dateFormat("yyyy-MM-dd").locale("en")
-                                        .transferExternalId(UUID.randomUUID().toString())
+                        results.add(EXTERNAL_ASSET_OWNER_HELPER.initiateTransferByLoanId(loanId, SALE_COMMAND,
+                                new ExternalAssetOwnerRequest().settlementDate("2020-03-02").dateFormat(DATE_FORMAT_ISO)
+                                        .locale(LoanTestData.LOCALE).transferExternalId(UUID.randomUUID().toString())
                                         .transferExternalGroupId(UUID.randomUUID().toString()).ownerExternalId(sharedOwnerExternalId)
-                                        .purchasePriceRatio("1.0"));
-                        results.add(response);
+                                        .purchasePriceRatio("1.0")));
                     } catch (Exception e) {
                         exceptions.add(e);
                     } finally {
@@ -1409,21 +1211,21 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
             }
 
             startLatch.countDown();
-            assertTrue(doneLatch.await(30, TimeUnit.SECONDS), "All threads should complete within timeout");
+            assertTrue(doneLatch.await(PARALLEL_SALE_TIMEOUT_SECONDS, TimeUnit.SECONDS), "All threads should complete within timeout");
             executorService.shutdown();
-            assertTrue(executorService.awaitTermination(10, TimeUnit.SECONDS), "ExecutorService should terminate");
+            assertTrue(executorService.awaitTermination(EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                    "ExecutorService should terminate");
 
             assertTrue(exceptions.isEmpty(),
-                    "Expected no exceptions but got " + exceptions.size() + ": " + exceptions.stream().map(Throwable::getMessage).toList());
-            assertEquals(threadCount, results.size(), "All transfers should succeed");
+                    "Expected no exceptions but got " + exceptions.size() + ": " + exceptions.stream().map(Exception::getMessage).toList());
+            assertEquals(PARALLEL_SALE_THREAD_COUNT, results.size(), "All transfers should succeed");
             results.forEach(response -> {
                 assertNotNull(response.getResourceId());
                 assertNotNull(response.getResourceExternalId());
             });
 
-            // Verify all transfers reference the same owner
-            for (Integer loanID : loanIDs) {
-                PageExternalTransferData transfers = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
+            for (Long loanId : loanIds) {
+                PageExternalTransferData transfers = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanId);
                 assertEquals(1, transfers.getTotalElements());
                 assertNotNull(transfers.getContent());
                 assertNotNull(transfers.getContent().getFirst().getOwner());
@@ -1438,290 +1240,174 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
         }
     }
 
-    private void updateBusinessDateAndExecuteCOBJob(String date) {
-        BusinessDateHelper.updateBusinessDate(BUSINESS_DATE, LocalDate.parse(date));
-        SCHEDULER_JOB_HELPER.executeAndAwaitJob("Loan COB");
+    private Long createLoanForClient(Long clientId) {
+        Long overdueFeeChargeId = chargesHelper.createLoanOverdueFeePercentageOfAmountAndInterest(OVERDUE_FEE_PERCENTAGE).getResourceId();
+        return createLoanForClient(clientId, LOAN_SUBMITTED_ON_DATE, assetOwnerLoanProduct(overdueFeeChargeId));
     }
 
-    private PostInitiateTransferResponse createSaleTransfer(Integer loanID, String settlementDate) {
-        String transferExternalId = UUID.randomUUID().toString();
-        String transferExternalGroupId = UUID.randomUUID().toString();
-        ownerExternalId = UUID.randomUUID().toString();
-        return createSaleTransfer(loanID, settlementDate, transferExternalId, transferExternalGroupId, ownerExternalId, "1.0");
+    /**
+     * The transferrable loan product, booked against a single asset account plus a dedicated fee/penalty asset account,
+     * so every sale, buyback and repayment journal entry can be attributed to exactly one of them.
+     */
+    private PostLoanProductsRequest assetOwnerLoanProduct(Long overdueFeeChargeId) {
+        return withPeriodicAccrualAccounting(transferrableLoanProduct(), assetAccount, expenseAccount, incomeAccount, overpaymentAccount)//
+                .receivableFeeAccountId(feePenaltyAccountId())//
+                .receivablePenaltyAccountId(feePenaltyAccountId())//
+                .charges(List.of(new LoanProductChargeData().id(overdueFeeChargeId)));
     }
 
-    private PostInitiateTransferResponse createSaleTransfer(Integer loanID, String settlementDate, String transferExternalId,
-            String transferExternalGroupId, String ownerExternalId, String purchasePriceRatio) {
-        PostInitiateTransferResponse saleResponse = EXTERNAL_ASSET_OWNER_HELPER.initiateTransferByLoanId(loanID.longValue(), "sale",
-                new ExternalAssetOwnerRequest().settlementDate(settlementDate).dateFormat("yyyy-MM-dd").locale("en")
-                        .transferExternalId(transferExternalId).transferExternalGroupId(transferExternalGroupId)
-                        .ownerExternalId(ownerExternalId).purchasePriceRatio(purchasePriceRatio));
-        assertEquals(transferExternalId, saleResponse.getResourceExternalId());
-        return saleResponse;
+    private PostLoanProductsRequest manualEntryLoanProduct() {
+        return onePeriod30DaysPeriodicAccrualWithAdvancedAllocation()//
+                .principal(MANUAL_ENTRY_LOAN_PRINCIPAL)//
+                .numberOfRepayments(MANUAL_ENTRY_LOAN_REPAYMENTS)//
+                .interestRatePerPeriod(MANUAL_ENTRY_LOAN_INTEREST_RATE)//
+                .enableDownPayment(false)//
+                .isInterestRecalculationEnabled(true)//
+                .interestRecalculationCompoundingMethod(LoanTestData.InterestRecalculationCompoundingMethod.NONE)//
+                .rescheduleStrategyMethod(LoanTestData.RescheduleStrategyMethod.ADJUST_LAST_UNPAID_PERIOD)//
+                .recalculationRestFrequencyType(LoanTestData.RecalculationRestFrequencyType.SAME_AS_REPAYMENT_PERIOD)//
+                .preClosureInterestCalculationStrategy(PRE_CLOSURE_INTEREST_CALCULATION_TILL_PRE_CLOSE_DATE)//
+                .allowPartialPeriodInterestCalculation(true);
     }
 
-    private PostInitiateTransferResponse createBuybackTransfer(Integer loanID, String settlementDate) {
-        String transferExternalId = UUID.randomUUID().toString();
-        return createBuybackTransfer(loanID, settlementDate, transferExternalId);
+    private JournalEntryCommand manualJournalEntry(Account debitAccount, Account creditAccount, String externalAssetOwner) {
+        return new JournalEntryCommand().amount(BigDecimal.TEN).officeId(FeignOfficeHelper.HEAD_OFFICE_ID).currencyCode("USD")
+                .locale(LoanTestData.LOCALE).dateFormat(MANUAL_JOURNAL_ENTRY_DATE_FORMAT).transactionDate(LocalDate.of(2024, 1, 1))
+                .addCreditsItem(
+                        new SingleDebitOrCreditEntryCommand().glAccountId(debitAccount.getAccountID().longValue()).amount(BigDecimal.TEN))
+                .addDebitsItem(
+                        new SingleDebitOrCreditEntryCommand().glAccountId(creditAccount.getAccountID().longValue()).amount(BigDecimal.TEN))
+                .externalAssetOwner(externalAssetOwner);
     }
 
-    private PostInitiateTransferResponse createBuybackTransfer(Integer loanID, String settlementDate, String transferExternalId) {
-        PostInitiateTransferResponse saleResponse = EXTERNAL_ASSET_OWNER_HELPER.initiateTransferByLoanId(loanID.longValue(), "buyback",
-                new ExternalAssetOwnerRequest().settlementDate(settlementDate).dateFormat("yyyy-MM-dd").locale("en")
+    private Long createClientInOffice(Long officeId) {
+        return clientHelper.createClient(ClientHelper.defaultClientCreationRequest().officeId(officeId).activationDate("01 January 2020"))
+                .getClientId();
+    }
+
+    private void makePartialRepayment(Long loanId, LocalDate transactionDate) {
+        transactionHelper.makeLoanRepayment(loanId,
+                new PostLoansLoanIdTransactionsRequest().dateFormat(DATETIME_PATTERN)
+                        .transactionDate(dateTimeFormatter.format(transactionDate)).locale(LoanTestData.LOCALE)
+                        .transactionAmount(PARTIAL_REPAYMENT_AMOUNT));
+    }
+
+    private RunReportsResponse runTransactionSummaryReport(String endDate, Long officeId) {
+        return reportHelper.runReport(TRANSACTION_SUMMARY_REPORT,
+                Map.of("R_endDate", endDate, "R_officeId", officeId.toString(), "output-type", "CSV"));
+    }
+
+    private void assertReportRow(List<Object> row, String transactionDate, String transactionType, String allocationType, double amount,
+            String assetOwnerId, String fromAssetOwnerId) {
+        assertEquals(transactionDate, row.get(TRANSACTION_DATE_COLUMN));
+        assertTrue(((String) row.get(PRODUCT_NAME_COLUMN)).matches(LOAN_PRODUCT_NAME_PATTERN));
+        assertEquals(transactionType, row.get(TRANSACTION_TYPE_COLUMN));
+        assertNull(row.get(PAYMENT_TYPE_COLUMN));
+        assertEquals("", row.get(CHARGE_TYPE_COLUMN));
+        assertNotReversed(row.get(REVERSED_COLUMN));
+        assertEquals(allocationType, row.get(ALLOCATION_TYPE_COLUMN));
+        assertNull(row.get(CHARGE_OFF_REASON_COLUMN));
+        assertEquals(amount, ((Number) row.get(AMOUNT_COLUMN)).doubleValue(), AMOUNT_TOLERANCE);
+        assertEquals(assetOwnerId, row.get(ASSET_OWNER_ID_COLUMN));
+        assertEquals(fromAssetOwnerId, row.get(FROM_ASSET_OWNER_ID_COLUMN));
+        assertNull(row.get(ORIGINATOR_EXTERNAL_IDS_COLUMN));
+    }
+
+    /**
+     * The report's "reversed" column is a database boolean, which the databases we test against do not agree on:
+     * PostgreSQL reports it as {@code false} while MySQL and MariaDB report a {@code tinyint} {@code 0}. Accept either
+     * rather than pinning the assertion to one database.
+     */
+    private void assertNotReversed(Object reversed) {
+        boolean notReversed = reversed instanceof Number number ? number.intValue() == 0 : Boolean.FALSE.equals(reversed);
+        assertTrue(notReversed, "Expected a non-reversed transaction, but the report reported reversed=" + reversed);
+    }
+
+    private PostInitiateTransferResponse createBuybackTransfer(Long loanId, String settlementDate) {
+        return createBuybackTransfer(loanId, settlementDate, UUID.randomUUID().toString());
+    }
+
+    private PostInitiateTransferResponse createBuybackTransfer(Long loanId, String settlementDate, String transferExternalId) {
+        PostInitiateTransferResponse buybackResponse = EXTERNAL_ASSET_OWNER_HELPER.initiateTransferByLoanId(loanId, BUYBACK_COMMAND,
+                new ExternalAssetOwnerRequest().settlementDate(settlementDate).dateFormat(DATE_FORMAT_ISO).locale(LoanTestData.LOCALE)
                         .transferExternalId(transferExternalId));
-        assertEquals(transferExternalId, saleResponse.getResourceExternalId());
-        return saleResponse;
-    }
-
-    private void addPenaltyForLoan(Integer loanID, String amount) {
-        // Add Charge Penalty
-        Integer penalty = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanSpecifiedDueDateJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, amount, true));
-        Integer penalty1LoanChargeId = LOAN_TRANSACTION_HELPER.addChargesForLoan(loanID,
-                LoanTransactionHelper.getSpecifiedDueDateChargesForLoanAsJSON(String.valueOf(penalty), "02 March 2020", amount));
-        assertNotNull(penalty1LoanChargeId);
-    }
-
-    private void setInitialBusinessDate(String date) {
-        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                new PutGlobalConfigurationsRequest().enabled(true));
-        BusinessDateHelper.updateBusinessDate(BUSINESS_DATE, LocalDate.parse(date));
-    }
-
-    private void cleanUpAndRestoreBusinessDate() {
-        REQUEST_SPEC = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
-        REQUEST_SPEC.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
-        REQUEST_SPEC.header("Fineract-Platform-TenantId", "default");
-        RESPONSE_SPEC = new ResponseSpecBuilder().expectStatusCode(200).build();
-        BusinessDateHelper.updateBusinessDate(BUSINESS_DATE, TODAYS_DATE);
-        globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
-                new PutGlobalConfigurationsRequest().enabled(false));
-        globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, false);
-    }
-
-    @NonNull
-    private Integer createClient() {
-        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
-        Assertions.assertNotNull(clientID);
-        return clientID;
-    }
-
-    @NonNull
-    private Integer createLoanForClient(Integer clientID) {
-        Integer overdueFeeChargeId = ChargesHelper.createCharges(REQUEST_SPEC, RESPONSE_SPEC,
-                ChargesHelper.getLoanOverdueFeeJSONWithCalculationTypePercentage("1"));
-        Assertions.assertNotNull(overdueFeeChargeId);
-
-        Integer loanProductID = createLoanProduct(overdueFeeChargeId.toString());
-        Assertions.assertNotNull(loanProductID);
-        HashMap loanStatusHashMap;
-
-        Integer loanID = applyForLoanApplication(clientID.toString(), loanProductID.toString(), "1 March 2020");
-
-        Assertions.assertNotNull(loanID);
-
-        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
-
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.approveLoan("01 March 2020", loanID);
-        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
-
-        String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
-        loanStatusHashMap = LOAN_TRANSACTION_HELPER.disburseLoanWithNetDisbursalAmount("02 March 2020", loanID,
-                JsonPath.from(loanDetails).get("netDisbursalAmount").toString());
-        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
-        return loanID;
-    }
-
-    private Integer createLoanProduct(final String chargeId) {
-
-        final String loanProductJSON = new LoanProductTestBuilder().withPrincipal("15,000.00").withNumberOfRepayments("4")
-                .withRepaymentAfterEvery("1").withRepaymentTypeAsMonth().withinterestRatePerPeriod("1")
-                .withAccountingRulePeriodicAccrual(new Account[] { ASSET_ACCOUNT, EXPENSE_ACCOUNT, INCOME_ACCOUNT, OVERPAYMENT_ACCOUNT })
-                .withInterestRateFrequencyTypeAsMonths().withAmortizationTypeAsEqualInstallments().withInterestTypeAsDecliningBalance()
-                .withFeeAndPenaltyAssetAccount(FEE_PENALTY_ACCOUNT).build(chargeId);
-        return LOAN_TRANSACTION_HELPER.getLoanProductId(loanProductJSON);
-    }
-
-    private Integer applyForLoanApplication(final String clientID, final String loanProductID, final String date) {
-        List<HashMap> collaterals = new ArrayList<>();
-        Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
-        Assertions.assertNotNull(collateralId);
-        Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC, clientID, collateralId);
-        Assertions.assertNotNull(clientCollateralId);
-        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(1));
-
-        String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal("15,000.00").withLoanTermFrequency("4")
-                .withLoanTermFrequencyAsMonths().withNumberOfRepayments("4").withRepaymentEveryAfter("1")
-                .withRepaymentFrequencyTypeAsMonths().withInterestRatePerPeriod("2").withAmortizationTypeAsEqualInstallments()
-                .withInterestTypeAsDecliningBalance().withInterestCalculationPeriodTypeSameAsRepaymentPeriod()
-                .withExpectedDisbursementDate(date).withSubmittedOnDate(date).withCollaterals(collaterals).withInArrearsTolerance("0")
-                .withPrincipalGrace("0").withInterestGrace("0").build(clientID, loanProductID, null);
-        return LOAN_TRANSACTION_HELPER.getLoanId(loanApplicationJSON);
-    }
-
-    private void addCollaterals(List<HashMap> collaterals, Integer collateralId, BigDecimal quantity) {
-        collaterals.add(collaterals(collateralId, quantity));
-    }
-
-    private HashMap<String, String> collaterals(Integer collateralId, BigDecimal quantity) {
-        HashMap<String, String> collateral = new HashMap<>(2);
-        collateral.put("clientCollateralId", collateralId.toString());
-        collateral.put("quantity", quantity.toString());
-        return collateral;
-    }
-
-    private void getAndValidateExternalAssetOwnerTransferByLoan(Integer loanID, ExpectedExternalTransferData... expectedItems) {
-        PageExternalTransferData retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue());
-        assertEquals(expectedItems.length, retrieveResponse.getNumberOfElements());
-
-        for (ExpectedExternalTransferData expected : expectedItems) {
-            assertNotNull(retrieveResponse.getContent());
-            Optional<ExternalTransferData> first = retrieveResponse.getContent().stream()
-                    .filter(e -> Objects.equals(e.getTransferExternalId(), expected.transferExternalId)
-                            && Objects.equals(e.getStatus(), expected.status))
-                    .findFirst();
-            assertTrue(first.isPresent());
-            ExternalTransferData etd = first.get();
-            assertEquals(expected.transferExternalId, etd.getTransferExternalId());
-
-            assertEquals(expected.status, etd.getStatus());
-            assertEquals(LocalDate.parse(expected.settlementDate), etd.getSettlementDate());
-            assertEquals(LocalDate.parse(expected.effectiveFrom), etd.getEffectiveFrom());
-            assertEquals(LocalDate.parse(expected.effectiveTo), etd.getEffectiveTo());
-            if (!expected.detailsExpected) {
-                assertNull(etd.getDetails());
-            } else {
-                assertNotNull(etd.getDetails());
-                assertEquals(expected.totalOutstanding, etd.getDetails().getTotalOutstanding());
-                assertEquals(expected.totalPrincipalOutstanding, etd.getDetails().getTotalPrincipalOutstanding());
-                assertEquals(expected.totalInterestOutstanding, etd.getDetails().getTotalInterestOutstanding());
-                assertEquals(expected.totalPenaltyOutstanding, etd.getDetails().getTotalPenaltyChargesOutstanding());
-                assertEquals(expected.totalFeeOutstanding, etd.getDetails().getTotalFeeChargesOutstanding());
-                assertEquals(expected.totalOverpaid, etd.getDetails().getTotalOverpaid());
-            }
-            if (expected.subStatus != null) {
-                assertEquals(expected.subStatus, etd.getSubStatus());
-            }
-        }
-    }
-
-    private void getAndValidateThereIsActiveMapping(Integer loanID) {
-        ExternalTransferData activeTransfer = EXTERNAL_ASSET_OWNER_HELPER.retrieveActiveTransferByLoanId((long) loanID);
-        assertNotNull(activeTransfer);
-        ExternalTransferData retrieveResponse = EXTERNAL_ASSET_OWNER_HELPER.retrieveTransfersByLoanId(loanID.longValue()).getContent()
-                .stream().filter(transfer -> ExternalTransferData.StatusEnum.ACTIVE.equals(transfer.getStatus())).findFirst().get();
-        assertEquals(retrieveResponse.getTransferId(), activeTransfer.getTransferId());
+        assertEquals(transferExternalId, buybackResponse.getResourceExternalId());
+        return buybackResponse;
     }
 
     private void getAndValidateThereIsNoActiveMapping(Long loanId) {
-        ExternalTransferData activeTransfer = EXTERNAL_ASSET_OWNER_HELPER.retrieveActiveTransferByLoanId(loanId);
-        assertNull(activeTransfer);
+        assertNull(EXTERNAL_ASSET_OWNER_HELPER.retrieveActiveTransferByLoanId(loanId));
     }
 
     private void getAndValidateThereIsNoActiveMapping(String transferExternalId) {
-        ExternalTransferData activeTransfer = EXTERNAL_ASSET_OWNER_HELPER.retrieveActiveTransferByTransferExternalId(transferExternalId);
-        assertNull(activeTransfer);
-    }
-
-    private void validateResponse(PostInitiateTransferResponse transferResponse, Integer loanID) {
-        assertNotNull(transferResponse);
-        assertNotNull(transferResponse.getResourceId());
-        assertNotNull(transferResponse.getResourceExternalId());
-        assertNotNull(transferResponse.getSubResourceId());
-        assertEquals((long) loanID, transferResponse.getSubResourceId());
-        assertNotNull(transferResponse.getSubResourceExternalId());
-        assertNull(transferResponse.getChanges());
+        assertNull(EXTERNAL_ASSET_OWNER_HELPER.retrieveActiveTransferByTransferExternalId(transferExternalId));
     }
 
     private void getAndValidateOwnerJournalEntries(String ownerExternalId, ExpectedJournalEntryData... expectedItems) {
         ExternalOwnerJournalEntryData result = EXTERNAL_ASSET_OWNER_HELPER.retrieveJournalEntriesOfOwner(ownerExternalId);
         assertNotNull(result);
         assertEquals(expectedItems.length, result.getJournalEntryData().getTotalElements());
-        int i = 0;
         assertEquals(ownerExternalId, result.getOwnerData().getExternalId());
-        for (ExpectedJournalEntryData expectedJournalEntryData : expectedItems) {
-            assertTrue(expectedJournalEntryData.amount.compareTo(result.getJournalEntryData().getContent().get(i).getAmount()) == 0);
-            assertEquals(expectedJournalEntryData.entryTypeId, result.getJournalEntryData().getContent().get(i).getEntryType().getId());
-            assertEquals(expectedJournalEntryData.glAccountId, result.getJournalEntryData().getContent().get(i).getGlAccountId());
-            assertEquals(expectedJournalEntryData.transactionDate, result.getJournalEntryData().getContent().get(i).getTransactionDate());
-            assertEquals(expectedJournalEntryData.submittedOnDate, result.getJournalEntryData().getContent().get(i).getSubmittedOnDate());
-            i++;
-        }
+        assertJournalEntriesMatch(result.getJournalEntryData().getContent(), expectedItems);
     }
 
     private void getAndValidateThereIsJournalEntriesForTransfer(Long transferId, ExpectedJournalEntryData... expectedItems) {
         ExternalOwnerTransferJournalEntryData result = EXTERNAL_ASSET_OWNER_HELPER.retrieveJournalEntriesOfTransfer(transferId);
         assertNotNull(result);
-        long totalElements = result.getJournalEntryData().getTotalElements();
-        assertEquals(expectedItems.length, totalElements);
-        int i = 0;
+        assertEquals(expectedItems.length, result.getJournalEntryData().getTotalElements());
         assertEquals(transferId, result.getTransferData().getTransferId());
-        for (ExpectedJournalEntryData expectedJournalEntryData : expectedItems) {
-            assertTrue(expectedJournalEntryData.amount.compareTo(result.getJournalEntryData().getContent().get(i).getAmount()) == 0);
-            assertEquals(expectedJournalEntryData.entryTypeId, result.getJournalEntryData().getContent().get(i).getEntryType().getId());
-            assertEquals(expectedJournalEntryData.glAccountId, result.getJournalEntryData().getContent().get(i).getGlAccountId());
-            assertEquals(expectedJournalEntryData.transactionDate, result.getJournalEntryData().getContent().get(i).getTransactionDate());
-            assertEquals(expectedJournalEntryData.submittedOnDate, result.getJournalEntryData().getContent().get(i).getSubmittedOnDate());
-            i++;
+        assertJournalEntriesMatch(result.getJournalEntryData().getContent(), expectedItems);
+    }
+
+    private void assertJournalEntriesMatch(List<JournalEntryData> actualItems, ExpectedJournalEntryData... expectedItems) {
+        for (int i = 0; i < expectedItems.length; i++) {
+            ExpectedJournalEntryData expected = expectedItems[i];
+            JournalEntryData actual = actualItems.get(i);
+            assertEquals(0, expected.amount.compareTo(actual.getAmount()));
+            assertEquals(expected.entryTypeId, actual.getEntryType().getId());
+            assertEquals(expected.glAccountId, actual.getGlAccountId());
+            assertEquals(expected.transactionDate, actual.getTransactionDate());
+            assertEquals(expected.submittedOnDate, actual.getSubmittedOnDate());
         }
     }
 
     private void getAndValidateThereIsNoJournalEntriesForTransfer(Long transferId) {
-        ExternalOwnerTransferJournalEntryData result = EXTERNAL_ASSET_OWNER_HELPER.retrieveJournalEntriesOfTransfer(transferId);
-        assertNull(result.getJournalEntryData());
+        assertNull(EXTERNAL_ASSET_OWNER_HELPER.retrieveJournalEntriesOfTransfer(transferId).getJournalEntryData());
+    }
+
+    private static Long assetAccountId() {
+        return assetAccount.getAccountID().longValue();
+    }
+
+    private static Long feePenaltyAccountId() {
+        return feePenaltyAccount.getAccountID().longValue();
+    }
+
+    private static Long incomeAccountId() {
+        return incomeAccount.getAccountID().longValue();
+    }
+
+    private static Long overpaymentAccountId() {
+        return overpaymentAccount.getAccountID().longValue();
+    }
+
+    private static Long transferAccountId() {
+        return transferAccount.getAccountID().longValue();
+    }
+
+    private static Long debitEntryTypeId() {
+        return (long) JournalEntryType.DEBIT.getValue();
+    }
+
+    private static Long creditEntryTypeId() {
+        return (long) JournalEntryType.CREDIT.getValue();
     }
 
     @RequiredArgsConstructor
-    public static class ExpectedExternalTransferData {
-
-        private final ExternalTransferData.StatusEnum status;
-
-        private final String transferExternalId;
-
-        private final String settlementDate;
-
-        private final String effectiveFrom;
-        private final String effectiveTo;
-        private final ExternalTransferData.SubStatusEnum subStatus;
-        private final boolean detailsExpected;
-
-        private final BigDecimal totalOutstanding;
-        private final BigDecimal totalPrincipalOutstanding;
-        private final BigDecimal totalInterestOutstanding;
-        private final BigDecimal totalPenaltyOutstanding;
-        private final BigDecimal totalFeeOutstanding;
-        private final BigDecimal totalOverpaid;
-
-        static ExpectedExternalTransferData expected(ExternalTransferData.StatusEnum status, String transferExternalId,
-                String settlementDate, String effectiveFrom, String effectiveTo, boolean detailsExpected, BigDecimal totalOutstanding,
-                BigDecimal totalPrincipalOutstanding, BigDecimal totalInterestOutstanding, BigDecimal totalPenaltyOutstanding,
-                BigDecimal totalFeeOutstanding, BigDecimal totalOverpaid) {
-            return new ExpectedExternalTransferData(status, transferExternalId, settlementDate, effectiveFrom, effectiveTo, null,
-                    detailsExpected, totalOutstanding, totalPrincipalOutstanding, totalInterestOutstanding, totalPenaltyOutstanding,
-                    totalFeeOutstanding, totalOverpaid);
-        }
-
-        static ExpectedExternalTransferData expected(ExternalTransferData.StatusEnum status, String transferExternalId,
-                String settlementDate, String effectiveFrom, String effectiveTo) {
-            return new ExpectedExternalTransferData(status, transferExternalId, settlementDate, effectiveFrom, effectiveTo, null, false,
-                    null, null, null, null, null, null);
-        }
-
-        static ExpectedExternalTransferData expected(ExternalTransferData.StatusEnum status, String transferExternalId,
-                String settlementDate, String effectiveFrom, String effectiveTo, ExternalTransferData.SubStatusEnum subStatus) {
-            return new ExpectedExternalTransferData(status, transferExternalId, settlementDate, effectiveFrom, effectiveTo, subStatus,
-                    false, null, null, null, null, null, null);
-        }
-    }
-
-    @RequiredArgsConstructor
-    public static class ExpectedJournalEntryData {
+    private static final class ExpectedJournalEntryData {
 
         private final Long glAccountId;
-
         private final Long entryTypeId;
-
         private final BigDecimal amount;
         private final LocalDate transactionDate;
         private final LocalDate submittedOnDate;
@@ -1730,6 +1416,5 @@ public class InitiateExternalAssetOwnerTransferTest extends BaseLoanIntegrationT
                 LocalDate submittedOnDate) {
             return new ExpectedJournalEntryData(glAccountId, entryTypeId, amount, transactionDate, submittedOnDate);
         }
-
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/investor/externalassetowner/SearchExternalAssetOwnerTransferTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/investor/externalassetowner/SearchExternalAssetOwnerTransferTest.java
@@ -46,8 +46,8 @@ public class SearchExternalAssetOwnerTransferTest extends ExternalAssetOwnerTran
         try {
             globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.ENABLE_AUTO_GENERATED_EXTERNAL_ID, true);
             setInitialBusinessDate(LocalDate.of(2020, 2, 29));
-            Integer clientID = createClient();
-            Integer loanID = createLoanForClient(clientID, "29 February 2020");
+            Long clientID = createClient();
+            Long loanID = createLoanForClient(clientID, "29 February 2020");
             addPenaltyForLoan(loanID, "10");
 
             PostInitiateTransferResponse saleTransferResponse = createSaleTransfer(loanID, baseDate);

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/loan/LoanApiIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/loan/LoanApiIntegrationTest.java
@@ -23,121 +23,74 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
 import org.apache.fineract.client.models.GetLoansResponse;
 import org.apache.fineract.client.models.PostLoanProductsRequest;
-import org.apache.fineract.client.models.PostLoanProductsResponse;
-import org.apache.fineract.client.models.PostLoansLoanIdResponse;
 import org.apache.fineract.client.models.PostLoansRequest;
-import org.apache.fineract.client.models.PostLoansResponse;
-import org.apache.fineract.integrationtests.BaseLoanIntegrationTest;
-import org.apache.fineract.integrationtests.common.ClientHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
 import org.junit.jupiter.api.Test;
 
-public class LoanApiIntegrationTest extends BaseLoanIntegrationTest {
+public class LoanApiIntegrationTest extends FeignLoanTestBase {
+
+    private static final String LOAN_DATE = "01 January 2023";
+
+    private PostLoanProductsRequest commonProduct(int numberOfRepayments, int repaymentEvery) {
+        return createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct().numberOfRepayments(numberOfRepayments)
+                .repaymentEvery(repaymentEvery).installmentAmountInMultiplesOf(null)
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS_L)
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE).interestRatePerPeriod(10.0)
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.DAILY)
+                .interestRecalculationCompoundingMethod(LoanTestData.InterestRecalculationCompoundingMethod.NONE)
+                .rescheduleStrategyMethod(LoanTestData.RescheduleStrategyMethod.ADJUST_LAST_UNPAID_PERIOD)
+                .isInterestRecalculationEnabled(true).recalculationRestFrequencyInterval(1)
+                .recalculationRestFrequencyType(LoanTestData.RecalculationRestFrequencyType.DAILY)
+                .rescheduleStrategyMethod(LoanTestData.RescheduleStrategyMethod.REDUCE_EMI_AMOUNT)
+                .allowPartialPeriodInterestCalculation(false).disallowExpectedDisbursements(false)
+                .allowApprovedDisbursedAmountsOverApplied(false).overAppliedNumber(null).overAppliedCalculationType(null)
+                .multiDisburseLoan(null);
+    }
+
+    private PostLoansRequest commonApplication(Long clientId, Long loanProductId, int numberOfRepayments, int repaymentEvery,
+            double amount) {
+        return applyLoanRequest(clientId, loanProductId, LOAN_DATE, amount, numberOfRepayments).repaymentEvery(repaymentEvery)
+                .interestRatePerPeriod(BigDecimal.valueOf(10.0)).loanTermFrequency(numberOfRepayments)
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)
+                .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS).interestType(LoanTestData.InterestType.DECLINING_BALANCE)
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.DAILY);
+    }
 
     @Test
     public void test_retrieveLoansByClientId_Works() {
         AtomicLong createdLoanId = new AtomicLong();
         AtomicLong createdLoanId2 = new AtomicLong();
-        Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
-        Long clientId2 = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+        Long clientId = createClient();
+        Long clientId2 = createClient();
 
-        runAt("01 January 2023", () -> {
-            // Create Client
+        int numberOfRepayments = 3;
+        int repaymentEvery = 1;
+        double amount = 5000.0;
 
-            int numberOfRepayments = 3;
-            int repaymentEvery = 1;
+        // Create Client
+        runAt(LOAN_DATE, () -> {
+            Long loanProductId = createLoanProduct(commonProduct(numberOfRepayments, repaymentEvery));
+            Long loanProductId2 = createLoanProduct(commonProduct(numberOfRepayments, repaymentEvery));
 
             // Create Loan Products
-            PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct() //
-                    .numberOfRepayments(numberOfRepayments) //
-                    .repaymentEvery(repaymentEvery) //
-                    .installmentAmountInMultiplesOf(null) //
-                    .repaymentFrequencyType(RepaymentFrequencyType.MONTHS.longValue()) //
-                    .interestType(InterestType.DECLINING_BALANCE)//
-                    .interestRatePerPeriod(10.0)//
-                    .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY)//
-                    .interestRecalculationCompoundingMethod(InterestRecalculationCompoundingMethod.NONE)//
-                    .rescheduleStrategyMethod(RescheduleStrategyMethod.ADJUST_LAST_UNPAID_PERIOD)//
-                    .isInterestRecalculationEnabled(true)//
-                    .recalculationRestFrequencyInterval(1)//
-                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY)//
-                    .rescheduleStrategyMethod(RescheduleStrategyMethod.REDUCE_EMI_AMOUNT)//
-                    .allowPartialPeriodInterestCalculation(false)//
-                    .disallowExpectedDisbursements(false)//
-                    .allowApprovedDisbursedAmountsOverApplied(false)//
-                    .overAppliedNumber(null)//
-                    .overAppliedCalculationType(null)//
-                    .multiDisburseLoan(null);//
+            Long loanId = approveLoan(applyForLoan(commonApplication(clientId, loanProductId, numberOfRepayments, repaymentEvery, amount)),
+                    approveLoanRequest(amount, LOAN_DATE)).getLoanId();
+            Long loanId2 = approveLoan(
+                    applyForLoan(commonApplication(clientId2, loanProductId2, numberOfRepayments, repaymentEvery, amount)),
+                    approveLoanRequest(amount, LOAN_DATE)).getLoanId();
 
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-            Long loanProductId = loanProductResponse.getResourceId();
-
-            PostLoanProductsRequest product2 = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct() //
-                    .numberOfRepayments(numberOfRepayments) //
-                    .repaymentEvery(repaymentEvery) //
-                    .installmentAmountInMultiplesOf(null) //
-                    .repaymentFrequencyType(RepaymentFrequencyType.MONTHS.longValue()) //
-                    .interestType(InterestType.DECLINING_BALANCE)//
-                    .interestRatePerPeriod(10.0)//
-                    .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY)//
-                    .interestRecalculationCompoundingMethod(InterestRecalculationCompoundingMethod.NONE)//
-                    .rescheduleStrategyMethod(RescheduleStrategyMethod.ADJUST_LAST_UNPAID_PERIOD)//
-                    .isInterestRecalculationEnabled(true)//
-                    .recalculationRestFrequencyInterval(1)//
-                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY)//
-                    .rescheduleStrategyMethod(RescheduleStrategyMethod.REDUCE_EMI_AMOUNT)//
-                    .allowPartialPeriodInterestCalculation(false)//
-                    .disallowExpectedDisbursements(false)//
-                    .allowApprovedDisbursedAmountsOverApplied(false)//
-                    .overAppliedNumber(null)//
-                    .overAppliedCalculationType(null)//
-                    .multiDisburseLoan(null);//
-
-            PostLoanProductsResponse loanProductResponse2 = loanProductHelper.createLoanProduct(product2);
-            Long loanProductId2 = loanProductResponse2.getResourceId();
-
-            // Apply and Approve Loan
-            double amount = 5000.0;
-
-            PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "01 January 2023", amount, numberOfRepayments)//
-                    .repaymentEvery(repaymentEvery)//
-                    .interestRatePerPeriod(BigDecimal.valueOf(10.0))//
-                    .loanTermFrequency(numberOfRepayments)//
-                    .repaymentFrequencyType(RepaymentFrequencyType.MONTHS)//
-                    .loanTermFrequencyType(RepaymentFrequencyType.MONTHS)//
-                    .interestType(InterestType.DECLINING_BALANCE)//
-                    .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY);//
-
-            PostLoansRequest applicationRequest2 = applyLoanRequest(clientId2, loanProductId2, "01 January 2023", amount,
-                    numberOfRepayments)//
-                    .repaymentEvery(repaymentEvery)//
-                    .interestRatePerPeriod(BigDecimal.valueOf(10.0))//
-                    .loanTermFrequency(numberOfRepayments)//
-                    .repaymentFrequencyType(RepaymentFrequencyType.MONTHS)//
-                    .loanTermFrequencyType(RepaymentFrequencyType.MONTHS)//
-                    .interestType(InterestType.DECLINING_BALANCE)//
-                    .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY);//
-
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applicationRequest);
-            PostLoansResponse postLoansResponse2 = loanTransactionHelper.applyLoan(applicationRequest2);
-
-            PostLoansLoanIdResponse approvedLoanResult = loanTransactionHelper.approveLoan(postLoansResponse.getResourceId(),
-                    approveLoanRequest(amount, "01 January 2023"));
-
-            PostLoansLoanIdResponse approvedLoanResult2 = loanTransactionHelper.approveLoan(postLoansResponse2.getResourceId(),
-                    approveLoanRequest(amount, "01 January 2023"));
-
-            Long loanId = approvedLoanResult.getLoanId();
-            Long loanId2 = approvedLoanResult2.getLoanId();
             createdLoanId.getAndSet(loanId);
             createdLoanId2.getAndSet(loanId2);
 
+            disburseLoan(loanId, BigDecimal.valueOf(amount), LOAN_DATE);
             // disburse Loan
-            disburseLoan(loanId, BigDecimal.valueOf(amount), "01 January 2023");
-            disburseLoan(loanId2, BigDecimal.valueOf(amount), "01 January 2023");
+            disburseLoan(loanId2, BigDecimal.valueOf(amount), LOAN_DATE);
         });
+
         runAt("01 February 2023", () -> {
             long loanId = createdLoanId.get();
-            GetLoansResponse loansLoanIdResponse = loanTransactionHelper.retrieveAllLoans(null, null, clientId);
+            GetLoansResponse loansLoanIdResponse = retrieveAllLoans(null, null, clientId);
             assertThat(loansLoanIdResponse.getPageItems()).isNotNull();
             assertThat(loansLoanIdResponse.getPageItems().size()).isEqualTo(1);
             Long loanIdFromResponse = loansLoanIdResponse.getPageItems().iterator().next().getId();
@@ -149,65 +102,29 @@ public class LoanApiIntegrationTest extends BaseLoanIntegrationTest {
     public void test_retrieveLoansWithSummary_Works() {
         AtomicLong createdLoanId = new AtomicLong();
 
-        runAt("01 January 2023", () -> {
-            // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+        int numberOfRepayments = 3;
+        int repaymentEvery = 1;
+        // Create Client
+        double amount = 5000.0;
 
-            int numberOfRepayments = 3;
-            int repaymentEvery = 1;
-
+        runAt(LOAN_DATE, () -> {
+            Long clientId = createClient();
             // Create Loan Product
-            PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct() //
-                    .numberOfRepayments(numberOfRepayments) //
-                    .repaymentEvery(repaymentEvery) //
-                    .installmentAmountInMultiplesOf(null) //
-                    .repaymentFrequencyType(RepaymentFrequencyType.MONTHS.longValue()) //
-                    .interestType(InterestType.DECLINING_BALANCE)//
-                    .interestRatePerPeriod(10.0)//
-                    .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY)//
-                    .interestRecalculationCompoundingMethod(InterestRecalculationCompoundingMethod.NONE)//
-                    .rescheduleStrategyMethod(RescheduleStrategyMethod.ADJUST_LAST_UNPAID_PERIOD)//
-                    .isInterestRecalculationEnabled(true)//
-                    .recalculationRestFrequencyInterval(1)//
-                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY)//
-                    .rescheduleStrategyMethod(RescheduleStrategyMethod.REDUCE_EMI_AMOUNT)//
-                    .allowPartialPeriodInterestCalculation(false)//
-                    .disallowExpectedDisbursements(false)//
-                    .allowApprovedDisbursedAmountsOverApplied(false)//
-                    .overAppliedNumber(null)//
-                    .overAppliedCalculationType(null)//
-                    .multiDisburseLoan(null);//
-
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-            Long loanProductId = loanProductResponse.getResourceId();
+            Long loanProductId = createLoanProduct(commonProduct(numberOfRepayments, repaymentEvery));
 
             // Apply and Approve Loan
-            double amount = 5000.0;
-
-            PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "01 January 2023", amount, numberOfRepayments)//
-                    .repaymentEvery(repaymentEvery)//
-                    .interestRatePerPeriod(BigDecimal.valueOf(10.0))//
-                    .loanTermFrequency(numberOfRepayments)//
-                    .repaymentFrequencyType(RepaymentFrequencyType.MONTHS)//
-                    .loanTermFrequencyType(RepaymentFrequencyType.MONTHS)//
-                    .interestType(InterestType.DECLINING_BALANCE)//
-                    .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY);//
-
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applicationRequest);
-
-            PostLoansLoanIdResponse approvedLoanResult = loanTransactionHelper.approveLoan(postLoansResponse.getResourceId(),
-                    approveLoanRequest(amount, "01 January 2023"));
-
-            Long loanId = approvedLoanResult.getLoanId();
+            Long loanId = approveLoan(applyForLoan(commonApplication(clientId, loanProductId, numberOfRepayments, repaymentEvery, amount)),
+                    approveLoanRequest(amount, LOAN_DATE)).getLoanId();
             createdLoanId.getAndSet(loanId);
 
             // disburse Loan
-            disburseLoan(loanId, BigDecimal.valueOf(amount), "01 January 2023");
+            disburseLoan(loanId, BigDecimal.valueOf(amount), LOAN_DATE);
         });
+
         runAt("01 February 2023", () -> {
             long loanId = createdLoanId.get();
-            GetLoansLoanIdResponse loanResponse = loanTransactionHelper.getLoanDetails(loanId);
-            GetLoansResponse loansLoanIdResponse = loanTransactionHelper.retrieveAllLoans(loanResponse.getAccountNo(), "summary", null);
+            GetLoansLoanIdResponse loanResponse = getLoanDetails(loanId);
+            GetLoansResponse loansLoanIdResponse = retrieveAllLoans(loanResponse.getAccountNo(), "summary", null);
             BigDecimal totalUnpaidPayableDueInterest = loansLoanIdResponse.getPageItems().iterator().next().getSummary()
                     .getTotalUnpaidPayableDueInterest();
             assertThat(totalUnpaidPayableDueInterest).isEqualByComparingTo(BigDecimal.valueOf(509.59));
@@ -217,83 +134,30 @@ public class LoanApiIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void test_retrieveLoansWithSummaryForMultipleLoans_Works() {
         AtomicLong createdClientId = new AtomicLong();
-        AtomicLong createdLoanId = new AtomicLong();
-        AtomicLong createdLoanId2 = new AtomicLong();
 
-        runAt("01 January 2023", () -> {
-            // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+        int numberOfRepayments = 3;
+        int repaymentEvery = 1;
+        // Create Client
+        double amount = 5000.0;
+
+        runAt(LOAN_DATE, () -> {
+            Long clientId = createClient();
             createdClientId.getAndSet(clientId);
-            int numberOfRepayments = 3;
-            int repaymentEvery = 1;
+            Long loanProductId = createLoanProduct(commonProduct(numberOfRepayments, repaymentEvery));
 
             // Create Loan Product
-            PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct() //
-                    .numberOfRepayments(numberOfRepayments) //
-                    .repaymentEvery(repaymentEvery) //
-                    .installmentAmountInMultiplesOf(null) //
-                    .repaymentFrequencyType(RepaymentFrequencyType.MONTHS.longValue()) //
-                    .interestType(InterestType.DECLINING_BALANCE)//
-                    .interestRatePerPeriod(10.0)//
-                    .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY)//
-                    .interestRecalculationCompoundingMethod(InterestRecalculationCompoundingMethod.NONE)//
-                    .rescheduleStrategyMethod(RescheduleStrategyMethod.ADJUST_LAST_UNPAID_PERIOD)//
-                    .isInterestRecalculationEnabled(true)//
-                    .recalculationRestFrequencyInterval(1)//
-                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY)//
-                    .rescheduleStrategyMethod(RescheduleStrategyMethod.REDUCE_EMI_AMOUNT)//
-                    .allowPartialPeriodInterestCalculation(false)//
-                    .disallowExpectedDisbursements(false)//
-                    .allowApprovedDisbursedAmountsOverApplied(false)//
-                    .overAppliedNumber(null)//
-                    .overAppliedCalculationType(null)//
-                    .multiDisburseLoan(null);//
+            Long loanId = approveLoan(applyForLoan(commonApplication(clientId, loanProductId, numberOfRepayments, repaymentEvery, amount)),
+                    approveLoanRequest(amount, LOAN_DATE)).getLoanId();
+            Long loanId2 = approveLoan(applyForLoan(commonApplication(clientId, loanProductId, numberOfRepayments, repaymentEvery, amount)),
+                    approveLoanRequest(amount, LOAN_DATE)).getLoanId();
 
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-            Long loanProductId = loanProductResponse.getResourceId();
-
-            // Apply and Approve Loan
-            double amount = 5000.0;
-
-            PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "01 January 2023", amount, numberOfRepayments)//
-                    .repaymentEvery(repaymentEvery)//
-                    .interestRatePerPeriod(BigDecimal.valueOf(10.0))//
-                    .loanTermFrequency(numberOfRepayments)//
-                    .repaymentFrequencyType(RepaymentFrequencyType.MONTHS)//
-                    .loanTermFrequencyType(RepaymentFrequencyType.MONTHS)//
-                    .interestType(InterestType.DECLINING_BALANCE)//
-                    .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY);//
-
-            PostLoansRequest applicationRequest2 = applyLoanRequest(clientId, loanProductId, "01 January 2023", amount, numberOfRepayments)//
-                    .repaymentEvery(repaymentEvery)//
-                    .interestRatePerPeriod(BigDecimal.valueOf(10.0))//
-                    .loanTermFrequency(numberOfRepayments)//
-                    .repaymentFrequencyType(RepaymentFrequencyType.MONTHS)//
-                    .loanTermFrequencyType(RepaymentFrequencyType.MONTHS)//
-                    .interestType(InterestType.DECLINING_BALANCE)//
-                    .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY);//
-
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applicationRequest);
-            PostLoansResponse postLoansResponse2 = loanTransactionHelper.applyLoan(applicationRequest2);
-
-            PostLoansLoanIdResponse approvedLoanResult = loanTransactionHelper.approveLoan(postLoansResponse.getResourceId(),
-                    approveLoanRequest(amount, "01 January 2023"));
-
-            PostLoansLoanIdResponse approvedLoanResult2 = loanTransactionHelper.approveLoan(postLoansResponse2.getResourceId(),
-                    approveLoanRequest(amount, "01 January 2023"));
-
-            Long loanId = approvedLoanResult.getLoanId();
-            createdLoanId.getAndSet(loanId);
-            Long loanId2 = approvedLoanResult2.getLoanId();
-            createdLoanId2.getAndSet(loanId2);
-
-            // disburse Loan
-            disburseLoan(loanId, BigDecimal.valueOf(amount), "01 January 2023");
-            disburseLoan(loanId2, BigDecimal.valueOf(amount), "01 January 2023");
+            disburseLoan(loanId, BigDecimal.valueOf(amount), LOAN_DATE);
+            disburseLoan(loanId2, BigDecimal.valueOf(amount), LOAN_DATE);
         });
+
         runAt("01 February 2023", () -> {
-            GetLoansResponse loansLoanIdResponse = loanTransactionHelper.retrieveAllLoans(null, "summary", createdClientId.get());
-            loansLoanIdResponse.getPageItems().stream().forEach(r -> {
+            GetLoansResponse loansLoanIdResponse = retrieveAllLoans(null, "summary", createdClientId.get());
+            loansLoanIdResponse.getPageItems().forEach(r -> {
                 BigDecimal totalUnpaidPayableDueInterest = r.getSummary().getTotalUnpaidPayableDueInterest();
                 assertThat(totalUnpaidPayableDueInterest).isEqualByComparingTo(BigDecimal.valueOf(509.59));
             });
@@ -304,62 +168,26 @@ public class LoanApiIntegrationTest extends BaseLoanIntegrationTest {
     public void test_retrieveLoansWithSummaryWithoutDisbursement_Works() {
         AtomicLong createdLoanId = new AtomicLong();
 
-        runAt("01 January 2023", () -> {
-            // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+        int numberOfRepayments = 3;
+        int repaymentEvery = 1;
+        // Create Client
+        double amount = 5000.0;
 
-            int numberOfRepayments = 3;
-            int repaymentEvery = 1;
-
+        runAt(LOAN_DATE, () -> {
+            Long clientId = createClient();
             // Create Loan Product
-            PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct() //
-                    .numberOfRepayments(numberOfRepayments) //
-                    .repaymentEvery(repaymentEvery) //
-                    .installmentAmountInMultiplesOf(null) //
-                    .repaymentFrequencyType(RepaymentFrequencyType.MONTHS.longValue()) //
-                    .interestType(InterestType.DECLINING_BALANCE)//
-                    .interestRatePerPeriod(10.0)//
-                    .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY)//
-                    .interestRecalculationCompoundingMethod(InterestRecalculationCompoundingMethod.NONE)//
-                    .rescheduleStrategyMethod(RescheduleStrategyMethod.ADJUST_LAST_UNPAID_PERIOD)//
-                    .isInterestRecalculationEnabled(true)//
-                    .recalculationRestFrequencyInterval(1)//
-                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY)//
-                    .rescheduleStrategyMethod(RescheduleStrategyMethod.REDUCE_EMI_AMOUNT)//
-                    .allowPartialPeriodInterestCalculation(false)//
-                    .disallowExpectedDisbursements(false)//
-                    .allowApprovedDisbursedAmountsOverApplied(false)//
-                    .overAppliedNumber(null)//
-                    .overAppliedCalculationType(null)//
-                    .multiDisburseLoan(null);//
-
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-            Long loanProductId = loanProductResponse.getResourceId();
+            Long loanProductId = createLoanProduct(commonProduct(numberOfRepayments, repaymentEvery));
 
             // Apply and Approve Loan
-            double amount = 5000.0;
-
-            PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "01 January 2023", amount, numberOfRepayments)//
-                    .repaymentEvery(repaymentEvery)//
-                    .interestRatePerPeriod(BigDecimal.valueOf(10.0))//
-                    .loanTermFrequency(numberOfRepayments)//
-                    .repaymentFrequencyType(RepaymentFrequencyType.MONTHS)//
-                    .loanTermFrequencyType(RepaymentFrequencyType.MONTHS)//
-                    .interestType(InterestType.DECLINING_BALANCE)//
-                    .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY);//
-
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applicationRequest);
-
-            PostLoansLoanIdResponse approvedLoanResult = loanTransactionHelper.approveLoan(postLoansResponse.getResourceId(),
-                    approveLoanRequest(amount, "01 January 2023"));
-
-            Long loanId = approvedLoanResult.getLoanId();
+            Long loanId = approveLoan(applyForLoan(commonApplication(clientId, loanProductId, numberOfRepayments, repaymentEvery, amount)),
+                    approveLoanRequest(amount, LOAN_DATE)).getLoanId();
             createdLoanId.getAndSet(loanId);
         });
+
         runAt("01 February 2023", () -> {
             long loanId = createdLoanId.get();
-            GetLoansLoanIdResponse loanResponse = loanTransactionHelper.getLoanDetails(loanId);
-            GetLoansResponse loansLoanIdResponse = loanTransactionHelper.retrieveAllLoans(loanResponse.getAccountNo(), "summary", null);
+            GetLoansLoanIdResponse loanResponse = getLoanDetails(loanId);
+            GetLoansResponse loansLoanIdResponse = retrieveAllLoans(loanResponse.getAccountNo(), "summary", null);
             assertThat(loansLoanIdResponse.getPageItems()).isNotNull();
             assertThat(loansLoanIdResponse.getPageItems().iterator().next().getSummary()).isNull();
         });

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/loan/LoanApiIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/loan/LoanApiIntegrationTest.java
@@ -23,121 +23,71 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.apache.fineract.client.models.GetLoansLoanIdResponse;
 import org.apache.fineract.client.models.GetLoansResponse;
 import org.apache.fineract.client.models.PostLoanProductsRequest;
-import org.apache.fineract.client.models.PostLoanProductsResponse;
-import org.apache.fineract.client.models.PostLoansLoanIdResponse;
 import org.apache.fineract.client.models.PostLoansRequest;
-import org.apache.fineract.client.models.PostLoansResponse;
-import org.apache.fineract.integrationtests.BaseLoanIntegrationTest;
-import org.apache.fineract.integrationtests.common.ClientHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
 import org.junit.jupiter.api.Test;
 
-public class LoanApiIntegrationTest extends BaseLoanIntegrationTest {
+public class LoanApiIntegrationTest extends FeignLoanTestBase {
+
+    private static final String LOAN_DATE = "01 January 2023";
+
+    private PostLoanProductsRequest commonProduct(int numberOfRepayments, int repaymentEvery) {
+        return createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct().numberOfRepayments(numberOfRepayments)
+                .repaymentEvery(repaymentEvery).installmentAmountInMultiplesOf(null)
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS_L)
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE).interestRatePerPeriod(10.0)
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.DAILY)
+                .interestRecalculationCompoundingMethod(LoanTestData.InterestRecalculationCompoundingMethod.NONE)
+                .rescheduleStrategyMethod(LoanTestData.RescheduleStrategyMethod.ADJUST_LAST_UNPAID_PERIOD)
+                .isInterestRecalculationEnabled(true).recalculationRestFrequencyInterval(1)
+                .recalculationRestFrequencyType(LoanTestData.RecalculationRestFrequencyType.DAILY)
+                .rescheduleStrategyMethod(LoanTestData.RescheduleStrategyMethod.REDUCE_EMI_AMOUNT)
+                .allowPartialPeriodInterestCalculation(false).disallowExpectedDisbursements(false)
+                .allowApprovedDisbursedAmountsOverApplied(false).overAppliedNumber(null).overAppliedCalculationType(null)
+                .multiDisburseLoan(null);
+    }
+
+    private PostLoansRequest commonApplication(Long clientId, Long loanProductId, int numberOfRepayments, int repaymentEvery,
+            double amount) {
+        return applyLoanRequest(clientId, loanProductId, LOAN_DATE, amount, numberOfRepayments).repaymentEvery(repaymentEvery)
+                .interestRatePerPeriod(BigDecimal.valueOf(10.0)).loanTermFrequency(numberOfRepayments)
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS)
+                .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.MONTHS).interestType(LoanTestData.InterestType.DECLINING_BALANCE)
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.DAILY);
+    }
 
     @Test
     public void test_retrieveLoansByClientId_Works() {
         AtomicLong createdLoanId = new AtomicLong();
         AtomicLong createdLoanId2 = new AtomicLong();
-        Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
-        Long clientId2 = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+        Long clientId = createClient();
+        Long clientId2 = createClient();
 
-        runAt("01 January 2023", () -> {
-            // Create Client
+        int numberOfRepayments = 3;
+        int repaymentEvery = 1;
+        double amount = 5000.0;
 
-            int numberOfRepayments = 3;
-            int repaymentEvery = 1;
+        runAt(LOAN_DATE, () -> {
+            Long loanProductId = createLoanProduct(commonProduct(numberOfRepayments, repaymentEvery));
+            Long loanProductId2 = createLoanProduct(commonProduct(numberOfRepayments, repaymentEvery));
 
-            // Create Loan Products
-            PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct() //
-                    .numberOfRepayments(numberOfRepayments) //
-                    .repaymentEvery(repaymentEvery) //
-                    .installmentAmountInMultiplesOf(null) //
-                    .repaymentFrequencyType(RepaymentFrequencyType.MONTHS.longValue()) //
-                    .interestType(InterestType.DECLINING_BALANCE)//
-                    .interestRatePerPeriod(10.0)//
-                    .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY)//
-                    .interestRecalculationCompoundingMethod(InterestRecalculationCompoundingMethod.NONE)//
-                    .rescheduleStrategyMethod(RescheduleStrategyMethod.ADJUST_LAST_UNPAID_PERIOD)//
-                    .isInterestRecalculationEnabled(true)//
-                    .recalculationRestFrequencyInterval(1)//
-                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY)//
-                    .rescheduleStrategyMethod(RescheduleStrategyMethod.REDUCE_EMI_AMOUNT)//
-                    .allowPartialPeriodInterestCalculation(false)//
-                    .disallowExpectedDisbursements(false)//
-                    .allowApprovedDisbursedAmountsOverApplied(false)//
-                    .overAppliedNumber(null)//
-                    .overAppliedCalculationType(null)//
-                    .multiDisburseLoan(null);//
+            Long loanId = approveLoan(applyForLoan(commonApplication(clientId, loanProductId, numberOfRepayments, repaymentEvery, amount)),
+                    approveLoanRequest(amount, LOAN_DATE)).getLoanId();
+            Long loanId2 = approveLoan(
+                    applyForLoan(commonApplication(clientId2, loanProductId2, numberOfRepayments, repaymentEvery, amount)),
+                    approveLoanRequest(amount, LOAN_DATE)).getLoanId();
 
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-            Long loanProductId = loanProductResponse.getResourceId();
-
-            PostLoanProductsRequest product2 = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct() //
-                    .numberOfRepayments(numberOfRepayments) //
-                    .repaymentEvery(repaymentEvery) //
-                    .installmentAmountInMultiplesOf(null) //
-                    .repaymentFrequencyType(RepaymentFrequencyType.MONTHS.longValue()) //
-                    .interestType(InterestType.DECLINING_BALANCE)//
-                    .interestRatePerPeriod(10.0)//
-                    .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY)//
-                    .interestRecalculationCompoundingMethod(InterestRecalculationCompoundingMethod.NONE)//
-                    .rescheduleStrategyMethod(RescheduleStrategyMethod.ADJUST_LAST_UNPAID_PERIOD)//
-                    .isInterestRecalculationEnabled(true)//
-                    .recalculationRestFrequencyInterval(1)//
-                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY)//
-                    .rescheduleStrategyMethod(RescheduleStrategyMethod.REDUCE_EMI_AMOUNT)//
-                    .allowPartialPeriodInterestCalculation(false)//
-                    .disallowExpectedDisbursements(false)//
-                    .allowApprovedDisbursedAmountsOverApplied(false)//
-                    .overAppliedNumber(null)//
-                    .overAppliedCalculationType(null)//
-                    .multiDisburseLoan(null);//
-
-            PostLoanProductsResponse loanProductResponse2 = loanProductHelper.createLoanProduct(product2);
-            Long loanProductId2 = loanProductResponse2.getResourceId();
-
-            // Apply and Approve Loan
-            double amount = 5000.0;
-
-            PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "01 January 2023", amount, numberOfRepayments)//
-                    .repaymentEvery(repaymentEvery)//
-                    .interestRatePerPeriod(BigDecimal.valueOf(10.0))//
-                    .loanTermFrequency(numberOfRepayments)//
-                    .repaymentFrequencyType(RepaymentFrequencyType.MONTHS)//
-                    .loanTermFrequencyType(RepaymentFrequencyType.MONTHS)//
-                    .interestType(InterestType.DECLINING_BALANCE)//
-                    .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY);//
-
-            PostLoansRequest applicationRequest2 = applyLoanRequest(clientId2, loanProductId2, "01 January 2023", amount,
-                    numberOfRepayments)//
-                    .repaymentEvery(repaymentEvery)//
-                    .interestRatePerPeriod(BigDecimal.valueOf(10.0))//
-                    .loanTermFrequency(numberOfRepayments)//
-                    .repaymentFrequencyType(RepaymentFrequencyType.MONTHS)//
-                    .loanTermFrequencyType(RepaymentFrequencyType.MONTHS)//
-                    .interestType(InterestType.DECLINING_BALANCE)//
-                    .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY);//
-
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applicationRequest);
-            PostLoansResponse postLoansResponse2 = loanTransactionHelper.applyLoan(applicationRequest2);
-
-            PostLoansLoanIdResponse approvedLoanResult = loanTransactionHelper.approveLoan(postLoansResponse.getResourceId(),
-                    approveLoanRequest(amount, "01 January 2023"));
-
-            PostLoansLoanIdResponse approvedLoanResult2 = loanTransactionHelper.approveLoan(postLoansResponse2.getResourceId(),
-                    approveLoanRequest(amount, "01 January 2023"));
-
-            Long loanId = approvedLoanResult.getLoanId();
-            Long loanId2 = approvedLoanResult2.getLoanId();
             createdLoanId.getAndSet(loanId);
             createdLoanId2.getAndSet(loanId2);
 
-            // disburse Loan
-            disburseLoan(loanId, BigDecimal.valueOf(amount), "01 January 2023");
-            disburseLoan(loanId2, BigDecimal.valueOf(amount), "01 January 2023");
+            disburseLoan(loanId, BigDecimal.valueOf(amount), LOAN_DATE);
+            disburseLoan(loanId2, BigDecimal.valueOf(amount), LOAN_DATE);
         });
+
         runAt("01 February 2023", () -> {
             long loanId = createdLoanId.get();
-            GetLoansResponse loansLoanIdResponse = loanTransactionHelper.retrieveAllLoans(null, null, clientId);
+            GetLoansResponse loansLoanIdResponse = retrieveAllLoans(null, null, clientId);
             assertThat(loansLoanIdResponse.getPageItems()).isNotNull();
             assertThat(loansLoanIdResponse.getPageItems().size()).isEqualTo(1);
             Long loanIdFromResponse = loansLoanIdResponse.getPageItems().iterator().next().getId();
@@ -149,65 +99,25 @@ public class LoanApiIntegrationTest extends BaseLoanIntegrationTest {
     public void test_retrieveLoansWithSummary_Works() {
         AtomicLong createdLoanId = new AtomicLong();
 
-        runAt("01 January 2023", () -> {
-            // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+        int numberOfRepayments = 3;
+        int repaymentEvery = 1;
+        double amount = 5000.0;
 
-            int numberOfRepayments = 3;
-            int repaymentEvery = 1;
+        runAt(LOAN_DATE, () -> {
+            Long clientId = createClient();
+            Long loanProductId = createLoanProduct(commonProduct(numberOfRepayments, repaymentEvery));
 
-            // Create Loan Product
-            PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct() //
-                    .numberOfRepayments(numberOfRepayments) //
-                    .repaymentEvery(repaymentEvery) //
-                    .installmentAmountInMultiplesOf(null) //
-                    .repaymentFrequencyType(RepaymentFrequencyType.MONTHS.longValue()) //
-                    .interestType(InterestType.DECLINING_BALANCE)//
-                    .interestRatePerPeriod(10.0)//
-                    .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY)//
-                    .interestRecalculationCompoundingMethod(InterestRecalculationCompoundingMethod.NONE)//
-                    .rescheduleStrategyMethod(RescheduleStrategyMethod.ADJUST_LAST_UNPAID_PERIOD)//
-                    .isInterestRecalculationEnabled(true)//
-                    .recalculationRestFrequencyInterval(1)//
-                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY)//
-                    .rescheduleStrategyMethod(RescheduleStrategyMethod.REDUCE_EMI_AMOUNT)//
-                    .allowPartialPeriodInterestCalculation(false)//
-                    .disallowExpectedDisbursements(false)//
-                    .allowApprovedDisbursedAmountsOverApplied(false)//
-                    .overAppliedNumber(null)//
-                    .overAppliedCalculationType(null)//
-                    .multiDisburseLoan(null);//
-
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-            Long loanProductId = loanProductResponse.getResourceId();
-
-            // Apply and Approve Loan
-            double amount = 5000.0;
-
-            PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "01 January 2023", amount, numberOfRepayments)//
-                    .repaymentEvery(repaymentEvery)//
-                    .interestRatePerPeriod(BigDecimal.valueOf(10.0))//
-                    .loanTermFrequency(numberOfRepayments)//
-                    .repaymentFrequencyType(RepaymentFrequencyType.MONTHS)//
-                    .loanTermFrequencyType(RepaymentFrequencyType.MONTHS)//
-                    .interestType(InterestType.DECLINING_BALANCE)//
-                    .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY);//
-
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applicationRequest);
-
-            PostLoansLoanIdResponse approvedLoanResult = loanTransactionHelper.approveLoan(postLoansResponse.getResourceId(),
-                    approveLoanRequest(amount, "01 January 2023"));
-
-            Long loanId = approvedLoanResult.getLoanId();
+            Long loanId = approveLoan(applyForLoan(commonApplication(clientId, loanProductId, numberOfRepayments, repaymentEvery, amount)),
+                    approveLoanRequest(amount, LOAN_DATE)).getLoanId();
             createdLoanId.getAndSet(loanId);
 
-            // disburse Loan
-            disburseLoan(loanId, BigDecimal.valueOf(amount), "01 January 2023");
+            disburseLoan(loanId, BigDecimal.valueOf(amount), LOAN_DATE);
         });
+
         runAt("01 February 2023", () -> {
             long loanId = createdLoanId.get();
-            GetLoansLoanIdResponse loanResponse = loanTransactionHelper.getLoanDetails(loanId);
-            GetLoansResponse loansLoanIdResponse = loanTransactionHelper.retrieveAllLoans(loanResponse.getAccountNo(), "summary", null);
+            GetLoansLoanIdResponse loanResponse = getLoanDetails(loanId);
+            GetLoansResponse loansLoanIdResponse = retrieveAllLoans(loanResponse.getAccountNo(), "summary", null);
             BigDecimal totalUnpaidPayableDueInterest = loansLoanIdResponse.getPageItems().iterator().next().getSummary()
                     .getTotalUnpaidPayableDueInterest();
             assertThat(totalUnpaidPayableDueInterest).isEqualByComparingTo(BigDecimal.valueOf(509.59));
@@ -217,83 +127,28 @@ public class LoanApiIntegrationTest extends BaseLoanIntegrationTest {
     @Test
     public void test_retrieveLoansWithSummaryForMultipleLoans_Works() {
         AtomicLong createdClientId = new AtomicLong();
-        AtomicLong createdLoanId = new AtomicLong();
-        AtomicLong createdLoanId2 = new AtomicLong();
 
-        runAt("01 January 2023", () -> {
-            // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+        int numberOfRepayments = 3;
+        int repaymentEvery = 1;
+        double amount = 5000.0;
+
+        runAt(LOAN_DATE, () -> {
+            Long clientId = createClient();
             createdClientId.getAndSet(clientId);
-            int numberOfRepayments = 3;
-            int repaymentEvery = 1;
+            Long loanProductId = createLoanProduct(commonProduct(numberOfRepayments, repaymentEvery));
 
-            // Create Loan Product
-            PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct() //
-                    .numberOfRepayments(numberOfRepayments) //
-                    .repaymentEvery(repaymentEvery) //
-                    .installmentAmountInMultiplesOf(null) //
-                    .repaymentFrequencyType(RepaymentFrequencyType.MONTHS.longValue()) //
-                    .interestType(InterestType.DECLINING_BALANCE)//
-                    .interestRatePerPeriod(10.0)//
-                    .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY)//
-                    .interestRecalculationCompoundingMethod(InterestRecalculationCompoundingMethod.NONE)//
-                    .rescheduleStrategyMethod(RescheduleStrategyMethod.ADJUST_LAST_UNPAID_PERIOD)//
-                    .isInterestRecalculationEnabled(true)//
-                    .recalculationRestFrequencyInterval(1)//
-                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY)//
-                    .rescheduleStrategyMethod(RescheduleStrategyMethod.REDUCE_EMI_AMOUNT)//
-                    .allowPartialPeriodInterestCalculation(false)//
-                    .disallowExpectedDisbursements(false)//
-                    .allowApprovedDisbursedAmountsOverApplied(false)//
-                    .overAppliedNumber(null)//
-                    .overAppliedCalculationType(null)//
-                    .multiDisburseLoan(null);//
+            Long loanId = approveLoan(applyForLoan(commonApplication(clientId, loanProductId, numberOfRepayments, repaymentEvery, amount)),
+                    approveLoanRequest(amount, LOAN_DATE)).getLoanId();
+            Long loanId2 = approveLoan(applyForLoan(commonApplication(clientId, loanProductId, numberOfRepayments, repaymentEvery, amount)),
+                    approveLoanRequest(amount, LOAN_DATE)).getLoanId();
 
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-            Long loanProductId = loanProductResponse.getResourceId();
-
-            // Apply and Approve Loan
-            double amount = 5000.0;
-
-            PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "01 January 2023", amount, numberOfRepayments)//
-                    .repaymentEvery(repaymentEvery)//
-                    .interestRatePerPeriod(BigDecimal.valueOf(10.0))//
-                    .loanTermFrequency(numberOfRepayments)//
-                    .repaymentFrequencyType(RepaymentFrequencyType.MONTHS)//
-                    .loanTermFrequencyType(RepaymentFrequencyType.MONTHS)//
-                    .interestType(InterestType.DECLINING_BALANCE)//
-                    .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY);//
-
-            PostLoansRequest applicationRequest2 = applyLoanRequest(clientId, loanProductId, "01 January 2023", amount, numberOfRepayments)//
-                    .repaymentEvery(repaymentEvery)//
-                    .interestRatePerPeriod(BigDecimal.valueOf(10.0))//
-                    .loanTermFrequency(numberOfRepayments)//
-                    .repaymentFrequencyType(RepaymentFrequencyType.MONTHS)//
-                    .loanTermFrequencyType(RepaymentFrequencyType.MONTHS)//
-                    .interestType(InterestType.DECLINING_BALANCE)//
-                    .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY);//
-
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applicationRequest);
-            PostLoansResponse postLoansResponse2 = loanTransactionHelper.applyLoan(applicationRequest2);
-
-            PostLoansLoanIdResponse approvedLoanResult = loanTransactionHelper.approveLoan(postLoansResponse.getResourceId(),
-                    approveLoanRequest(amount, "01 January 2023"));
-
-            PostLoansLoanIdResponse approvedLoanResult2 = loanTransactionHelper.approveLoan(postLoansResponse2.getResourceId(),
-                    approveLoanRequest(amount, "01 January 2023"));
-
-            Long loanId = approvedLoanResult.getLoanId();
-            createdLoanId.getAndSet(loanId);
-            Long loanId2 = approvedLoanResult2.getLoanId();
-            createdLoanId2.getAndSet(loanId2);
-
-            // disburse Loan
-            disburseLoan(loanId, BigDecimal.valueOf(amount), "01 January 2023");
-            disburseLoan(loanId2, BigDecimal.valueOf(amount), "01 January 2023");
+            disburseLoan(loanId, BigDecimal.valueOf(amount), LOAN_DATE);
+            disburseLoan(loanId2, BigDecimal.valueOf(amount), LOAN_DATE);
         });
+
         runAt("01 February 2023", () -> {
-            GetLoansResponse loansLoanIdResponse = loanTransactionHelper.retrieveAllLoans(null, "summary", createdClientId.get());
-            loansLoanIdResponse.getPageItems().stream().forEach(r -> {
+            GetLoansResponse loansLoanIdResponse = retrieveAllLoans(null, "summary", createdClientId.get());
+            loansLoanIdResponse.getPageItems().forEach(r -> {
                 BigDecimal totalUnpaidPayableDueInterest = r.getSummary().getTotalUnpaidPayableDueInterest();
                 assertThat(totalUnpaidPayableDueInterest).isEqualByComparingTo(BigDecimal.valueOf(509.59));
             });
@@ -304,62 +159,23 @@ public class LoanApiIntegrationTest extends BaseLoanIntegrationTest {
     public void test_retrieveLoansWithSummaryWithoutDisbursement_Works() {
         AtomicLong createdLoanId = new AtomicLong();
 
-        runAt("01 January 2023", () -> {
-            // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+        int numberOfRepayments = 3;
+        int repaymentEvery = 1;
+        double amount = 5000.0;
 
-            int numberOfRepayments = 3;
-            int repaymentEvery = 1;
+        runAt(LOAN_DATE, () -> {
+            Long clientId = createClient();
+            Long loanProductId = createLoanProduct(commonProduct(numberOfRepayments, repaymentEvery));
 
-            // Create Loan Product
-            PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct() //
-                    .numberOfRepayments(numberOfRepayments) //
-                    .repaymentEvery(repaymentEvery) //
-                    .installmentAmountInMultiplesOf(null) //
-                    .repaymentFrequencyType(RepaymentFrequencyType.MONTHS.longValue()) //
-                    .interestType(InterestType.DECLINING_BALANCE)//
-                    .interestRatePerPeriod(10.0)//
-                    .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY)//
-                    .interestRecalculationCompoundingMethod(InterestRecalculationCompoundingMethod.NONE)//
-                    .rescheduleStrategyMethod(RescheduleStrategyMethod.ADJUST_LAST_UNPAID_PERIOD)//
-                    .isInterestRecalculationEnabled(true)//
-                    .recalculationRestFrequencyInterval(1)//
-                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY)//
-                    .rescheduleStrategyMethod(RescheduleStrategyMethod.REDUCE_EMI_AMOUNT)//
-                    .allowPartialPeriodInterestCalculation(false)//
-                    .disallowExpectedDisbursements(false)//
-                    .allowApprovedDisbursedAmountsOverApplied(false)//
-                    .overAppliedNumber(null)//
-                    .overAppliedCalculationType(null)//
-                    .multiDisburseLoan(null);//
-
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-            Long loanProductId = loanProductResponse.getResourceId();
-
-            // Apply and Approve Loan
-            double amount = 5000.0;
-
-            PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "01 January 2023", amount, numberOfRepayments)//
-                    .repaymentEvery(repaymentEvery)//
-                    .interestRatePerPeriod(BigDecimal.valueOf(10.0))//
-                    .loanTermFrequency(numberOfRepayments)//
-                    .repaymentFrequencyType(RepaymentFrequencyType.MONTHS)//
-                    .loanTermFrequencyType(RepaymentFrequencyType.MONTHS)//
-                    .interestType(InterestType.DECLINING_BALANCE)//
-                    .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY);//
-
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applicationRequest);
-
-            PostLoansLoanIdResponse approvedLoanResult = loanTransactionHelper.approveLoan(postLoansResponse.getResourceId(),
-                    approveLoanRequest(amount, "01 January 2023"));
-
-            Long loanId = approvedLoanResult.getLoanId();
+            Long loanId = approveLoan(applyForLoan(commonApplication(clientId, loanProductId, numberOfRepayments, repaymentEvery, amount)),
+                    approveLoanRequest(amount, LOAN_DATE)).getLoanId();
             createdLoanId.getAndSet(loanId);
         });
+
         runAt("01 February 2023", () -> {
             long loanId = createdLoanId.get();
-            GetLoansLoanIdResponse loanResponse = loanTransactionHelper.getLoanDetails(loanId);
-            GetLoansResponse loansLoanIdResponse = loanTransactionHelper.retrieveAllLoans(loanResponse.getAccountNo(), "summary", null);
+            GetLoansLoanIdResponse loanResponse = getLoanDetails(loanId);
+            GetLoansResponse loansLoanIdResponse = retrieveAllLoans(loanResponse.getAccountNo(), "summary", null);
             assertThat(loansLoanIdResponse.getPageItems()).isNotNull();
             assertThat(loansLoanIdResponse.getPageItems().iterator().next().getSummary()).isNull();
         });

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/loan/penalty/LoanPenaltyBackdatedTransactionTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/loan/penalty/LoanPenaltyBackdatedTransactionTest.java
@@ -21,25 +21,26 @@ package org.apache.fineract.integrationtests.loan.penalty;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
+import org.apache.fineract.client.models.ChargeRequest;
 import org.apache.fineract.client.models.LoanProductChargeData;
 import org.apache.fineract.client.models.PostLoanProductsRequest;
-import org.apache.fineract.client.models.PostLoanProductsResponse;
-import org.apache.fineract.client.models.PostLoansLoanIdResponse;
 import org.apache.fineract.client.models.PostLoansRequest;
-import org.apache.fineract.client.models.PostLoansResponse;
 import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
-import org.apache.fineract.integrationtests.BaseLoanIntegrationTest;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.SchedulerJobHelper;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.modules.ChargeRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
+import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 
 @Order(2)
-public class LoanPenaltyBackdatedTransactionTest extends BaseLoanIntegrationTest {
+public class LoanPenaltyBackdatedTransactionTest extends FeignLoanTestBase {
+
+    // PeriodFrequencyType.DAYS
+    private static final String FEE_FREQUENCY_DAYS = "0";
 
     @BeforeEach
     public void before() {
@@ -59,62 +60,8 @@ public class LoanPenaltyBackdatedTransactionTest extends BaseLoanIntegrationTest
         AtomicReference<Long> aLoanId = new AtomicReference<>();
 
         runAt("01 January 2023", () -> {
-            // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
-
-            int numberOfRepayments = 3;
-            int repaymentEvery = 4;
-
-            // Create charges
-            double chargeAmount = 1.0;
-            Long chargeId = createOverduePenaltyPercentageCharge(chargeAmount, ChargesHelper.CHARGE_FEE_FREQUENCY_DAYS, 1);
-
-            // Create Loan Product
-            PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct() //
-                    .graceOnArrearsAgeing(0).numberOfRepayments(numberOfRepayments) //
-                    .repaymentEvery(repaymentEvery) //
-                    .installmentAmountInMultiplesOf(null) //
-                    .repaymentFrequencyType(RepaymentFrequencyType.DAYS.longValue()) //
-                    .interestType(InterestType.DECLINING_BALANCE)//
-                    .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY)//
-                    .interestRecalculationCompoundingMethod(InterestRecalculationCompoundingMethod.NONE)//
-                    .rescheduleStrategyMethod(RescheduleStrategyMethod.ADJUST_LAST_UNPAID_PERIOD)//
-                    .isInterestRecalculationEnabled(true)//
-                    .recalculationRestFrequencyInterval(1)//
-                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY)//
-                    .rescheduleStrategyMethod(RescheduleStrategyMethod.REDUCE_EMI_AMOUNT)//
-                    .allowPartialPeriodInterestCalculation(false)//
-                    .disallowExpectedDisbursements(false)//
-                    .allowApprovedDisbursedAmountsOverApplied(false)//
-                    .overAppliedNumber(null)//
-                    .overAppliedCalculationType(null)//
-                    .multiDisburseLoan(null)//
-                    .charges(List.of(new LoanProductChargeData().id(chargeId)));//
-
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-            Long loanProductId = loanProductResponse.getResourceId();
-
-            // Apply and Approve Loan
-            double amount = 5000.0;
-
-            PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "01 January 2023", amount, numberOfRepayments)//
-                    .repaymentEvery(repaymentEvery)//
-                    .loanTermFrequency(numberOfRepayments * repaymentEvery)//
-                    .repaymentFrequencyType(RepaymentFrequencyType.DAYS)//
-                    .loanTermFrequencyType(RepaymentFrequencyType.DAYS)//
-                    .interestType(InterestType.DECLINING_BALANCE)//
-                    .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY);
-
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applicationRequest);
-
-            PostLoansLoanIdResponse approvedLoanResult = loanTransactionHelper.approveLoan(postLoansResponse.getResourceId(),
-                    approveLoanRequest(amount, "01 January 2023"));
-
-            aLoanId.getAndSet(approvedLoanResult.getLoanId());
-            Long loanId = aLoanId.get();
-
-            // disburse Loan
-            disburseLoan(loanId, BigDecimal.valueOf(5000.0), "01 January 2023");
+            Long loanId = createBackdatedPenaltyLoan();
+            aLoanId.set(loanId);
 
             // verify transactions
             verifyTransactions(loanId, //
@@ -125,8 +72,8 @@ public class LoanPenaltyBackdatedTransactionTest extends BaseLoanIntegrationTest
         runAt("09 January 2023", () -> {
             Long loanId = aLoanId.get();
             // run accrual posting
-            SchedulerJobHelper.executeAndAwaitJob("Apply penalty to overdue loans");
-            SchedulerJobHelper.executeAndAwaitJob("Add Accrual Transactions");
+            schedulerHelper.executeAndAwaitJob("Apply penalty to overdue loans");
+            schedulerHelper.executeAndAwaitJob("Add Accrual Transactions");
 
             // verify transactions
             verifyTransactions(loanId, //
@@ -150,8 +97,8 @@ public class LoanPenaltyBackdatedTransactionTest extends BaseLoanIntegrationTest
             deactivateOverdueLoanCharges(loanId, "07 January 2023");
 
             // run accrual posting
-            SchedulerJobHelper.executeAndAwaitJob("Apply penalty to overdue loans");
-            SchedulerJobHelper.executeAndAwaitJob("Add Accrual Transactions");
+            schedulerHelper.executeAndAwaitJob("Apply penalty to overdue loans");
+            schedulerHelper.executeAndAwaitJob("Add Accrual Transactions");
 
             // verify transactions
             verifyTransactions(loanId, //
@@ -169,62 +116,8 @@ public class LoanPenaltyBackdatedTransactionTest extends BaseLoanIntegrationTest
         AtomicReference<Long> aLoanId = new AtomicReference<>();
 
         runAt("01 January 2023", () -> {
-            // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
-
-            int numberOfRepayments = 3;
-            int repaymentEvery = 4;
-
-            // Create charges
-            double chargeAmount = 1.0;
-            Long chargeId = createOverduePenaltyPercentageCharge(chargeAmount, ChargesHelper.CHARGE_FEE_FREQUENCY_DAYS, 1);
-
-            // Create Loan Product
-            PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct() //
-                    .graceOnArrearsAgeing(0).numberOfRepayments(numberOfRepayments) //
-                    .repaymentEvery(repaymentEvery) //
-                    .installmentAmountInMultiplesOf(null) //
-                    .repaymentFrequencyType(RepaymentFrequencyType.DAYS.longValue()) //
-                    .interestType(InterestType.DECLINING_BALANCE)//
-                    .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY)//
-                    .interestRecalculationCompoundingMethod(InterestRecalculationCompoundingMethod.NONE)//
-                    .rescheduleStrategyMethod(RescheduleStrategyMethod.ADJUST_LAST_UNPAID_PERIOD)//
-                    .isInterestRecalculationEnabled(true)//
-                    .recalculationRestFrequencyInterval(1)//
-                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY)//
-                    .rescheduleStrategyMethod(RescheduleStrategyMethod.REDUCE_EMI_AMOUNT)//
-                    .allowPartialPeriodInterestCalculation(false)//
-                    .disallowExpectedDisbursements(false)//
-                    .allowApprovedDisbursedAmountsOverApplied(false)//
-                    .overAppliedNumber(null)//
-                    .overAppliedCalculationType(null)//
-                    .multiDisburseLoan(null)//
-                    .charges(List.of(new LoanProductChargeData().id(chargeId)));//
-
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-            Long loanProductId = loanProductResponse.getResourceId();
-
-            // Apply and Approve Loan
-            double amount = 5000.0;
-
-            PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "01 January 2023", amount, numberOfRepayments)//
-                    .repaymentEvery(repaymentEvery)//
-                    .loanTermFrequency(numberOfRepayments * repaymentEvery)//
-                    .repaymentFrequencyType(RepaymentFrequencyType.DAYS)//
-                    .loanTermFrequencyType(RepaymentFrequencyType.DAYS)//
-                    .interestType(InterestType.DECLINING_BALANCE)//
-                    .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY);
-
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applicationRequest);
-
-            PostLoansLoanIdResponse approvedLoanResult = loanTransactionHelper.approveLoan(postLoansResponse.getResourceId(),
-                    approveLoanRequest(amount, "01 January 2023"));
-
-            aLoanId.getAndSet(approvedLoanResult.getLoanId());
-            Long loanId = aLoanId.get();
-
-            // disburse Loan
-            disburseLoan(loanId, BigDecimal.valueOf(5000.0), "01 January 2023");
+            Long loanId = createBackdatedPenaltyLoan();
+            aLoanId.set(loanId);
 
             // verify transactions
             verifyTransactions(loanId, //
@@ -236,8 +129,8 @@ public class LoanPenaltyBackdatedTransactionTest extends BaseLoanIntegrationTest
             Long loanId = aLoanId.get();
 
             // run accrual posting
-            SchedulerJobHelper.executeAndAwaitJob("Apply penalty to overdue loans");
-            SchedulerJobHelper.executeAndAwaitJob("Add Accrual Transactions");
+            schedulerHelper.executeAndAwaitJob("Apply penalty to overdue loans");
+            schedulerHelper.executeAndAwaitJob("Add Accrual Transactions");
 
             // verify transactions
             verifyTransactions(loanId, //
@@ -261,8 +154,8 @@ public class LoanPenaltyBackdatedTransactionTest extends BaseLoanIntegrationTest
             deactivateOverdueLoanCharges(loanId, "05 January 2023");
 
             // run accrual posting
-            SchedulerJobHelper.executeAndAwaitJob("Apply penalty to overdue loans");
-            SchedulerJobHelper.executeAndAwaitJob("Add Accrual Transactions");
+            schedulerHelper.executeAndAwaitJob("Apply penalty to overdue loans");
+            schedulerHelper.executeAndAwaitJob("Add Accrual Transactions");
 
             // verify transactions
             verifyTransactions(loanId, //
@@ -281,62 +174,9 @@ public class LoanPenaltyBackdatedTransactionTest extends BaseLoanIntegrationTest
         AtomicReference<Long> aLoanId = new AtomicReference<>();
 
         runAt("01 January 2023", () -> {
+            Long loanId = createBackdatedPenaltyLoan();
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
-
-            int numberOfRepayments = 3;
-            int repaymentEvery = 4;
-
-            // Create charges
-            double chargeAmount = 1.0;
-            Long chargeId = createOverduePenaltyPercentageCharge(chargeAmount, ChargesHelper.CHARGE_FEE_FREQUENCY_DAYS, 1);
-
-            // Create Loan Product
-            PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct() //
-                    .graceOnArrearsAgeing(0).numberOfRepayments(numberOfRepayments) //
-                    .repaymentEvery(repaymentEvery) //
-                    .installmentAmountInMultiplesOf(null) //
-                    .repaymentFrequencyType(RepaymentFrequencyType.DAYS.longValue()) //
-                    .interestType(InterestType.DECLINING_BALANCE)//
-                    .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY)//
-                    .interestRecalculationCompoundingMethod(InterestRecalculationCompoundingMethod.NONE)//
-                    .rescheduleStrategyMethod(RescheduleStrategyMethod.ADJUST_LAST_UNPAID_PERIOD)//
-                    .isInterestRecalculationEnabled(true)//
-                    .recalculationRestFrequencyInterval(1)//
-                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY)//
-                    .rescheduleStrategyMethod(RescheduleStrategyMethod.REDUCE_EMI_AMOUNT)//
-                    .allowPartialPeriodInterestCalculation(false)//
-                    .disallowExpectedDisbursements(false)//
-                    .allowApprovedDisbursedAmountsOverApplied(false)//
-                    .overAppliedNumber(null)//
-                    .overAppliedCalculationType(null)//
-                    .multiDisburseLoan(null)//
-                    .charges(List.of(new LoanProductChargeData().id(chargeId)));//
-
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-            Long loanProductId = loanProductResponse.getResourceId();
-
-            // Apply and Approve Loan
-            double amount = 5000.0;
-
-            PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "01 January 2023", amount, numberOfRepayments)//
-                    .repaymentEvery(repaymentEvery)//
-                    .loanTermFrequency(numberOfRepayments * repaymentEvery)//
-                    .repaymentFrequencyType(RepaymentFrequencyType.DAYS)//
-                    .loanTermFrequencyType(RepaymentFrequencyType.DAYS)//
-                    .interestType(InterestType.DECLINING_BALANCE)//
-                    .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY);
-
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applicationRequest);
-
-            PostLoansLoanIdResponse approvedLoanResult = loanTransactionHelper.approveLoan(postLoansResponse.getResourceId(),
-                    approveLoanRequest(amount, "01 January 2023"));
-
-            aLoanId.getAndSet(approvedLoanResult.getLoanId());
-            Long loanId = aLoanId.get();
-
-            // disburse Loan
-            disburseLoan(loanId, BigDecimal.valueOf(5000.0), "01 January 2023");
+            aLoanId.set(loanId);
 
             // verify transactions
             verifyTransactions(loanId, //
@@ -348,8 +188,8 @@ public class LoanPenaltyBackdatedTransactionTest extends BaseLoanIntegrationTest
             Long loanId = aLoanId.get();
 
             // run accrual posting
-            SchedulerJobHelper.executeAndAwaitJob("Apply penalty to overdue loans");
-            SchedulerJobHelper.executeAndAwaitJob("Add Accrual Transactions");
+            schedulerHelper.executeAndAwaitJob("Apply penalty to overdue loans");
+            schedulerHelper.executeAndAwaitJob("Add Accrual Transactions");
 
             // verify transactions
             verifyTransactions(loanId, //
@@ -373,8 +213,8 @@ public class LoanPenaltyBackdatedTransactionTest extends BaseLoanIntegrationTest
             deactivateOverdueLoanCharges(loanId, "07 January 2023");
 
             // run accrual posting
-            SchedulerJobHelper.executeAndAwaitJob("Apply penalty to overdue loans");
-            SchedulerJobHelper.executeAndAwaitJob("Add Accrual Transactions");
+            schedulerHelper.executeAndAwaitJob("Apply penalty to overdue loans");
+            schedulerHelper.executeAndAwaitJob("Add Accrual Transactions");
 
             // verify transactions
             verifyTransactions(loanId, //
@@ -402,5 +242,66 @@ public class LoanPenaltyBackdatedTransactionTest extends BaseLoanIntegrationTest
                     transaction(1000.0, "Repayment", "10 January 2023", 3047.0, 969.67, 0.0, 0.0, 30.33, 0.0, 0.0) //
             );
         });
+    }
+
+    private Long createBackdatedPenaltyLoan() {
+        // Create Client
+        Long clientId = createClient();
+
+        int numberOfRepayments = 3;
+        int repaymentEvery = 4;
+
+        // Create charges
+        double chargeAmount = 1.0;
+        Long chargeId = createOverduePenaltyPercentageCharge(chargeAmount, FEE_FREQUENCY_DAYS, 1);
+
+        // Create Loan Product
+        PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct() //
+                .graceOnArrearsAgeing(0).numberOfRepayments(numberOfRepayments) //
+                .repaymentEvery(repaymentEvery) //
+                .installmentAmountInMultiplesOf(null) //
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.DAYS_L) //
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE)//
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.DAILY)//
+                .interestRecalculationCompoundingMethod(LoanTestData.InterestRecalculationCompoundingMethod.NONE)//
+                .isInterestRecalculationEnabled(true)//
+                .recalculationRestFrequencyInterval(1)//
+                .recalculationRestFrequencyType(LoanTestData.RecalculationRestFrequencyType.DAILY)//
+                .rescheduleStrategyMethod(LoanTestData.RescheduleStrategyMethod.REDUCE_EMI_AMOUNT)//
+                .allowPartialPeriodInterestCalculation(false)//
+                .disallowExpectedDisbursements(false)//
+                .allowApprovedDisbursedAmountsOverApplied(false)//
+                .overAppliedNumber(null)//
+                .overAppliedCalculationType(null)//
+                .multiDisburseLoan(null)//
+                .charges(List.of(new LoanProductChargeData().id(chargeId)));//
+
+        Long loanProductId = createLoanProduct(product);
+
+        // Apply and Approve Loan
+        double amount = 5000.0;
+
+        PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "01 January 2023", amount, numberOfRepayments)//
+                .repaymentEvery(repaymentEvery)//
+                .loanTermFrequency(numberOfRepayments * repaymentEvery)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.DAYS)//
+                .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.DAYS)//
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE)//
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.DAILY);
+
+        Long loanId = applyForLoan(applicationRequest);
+        approveLoan(loanId, approveLoanRequest(amount, "01 January 2023"));
+
+        // disburse Loan
+        disburseLoan(loanId, BigDecimal.valueOf(5000.0), "01 January 2023");
+        return loanId;
+    }
+
+    private Long createOverduePenaltyPercentageCharge(double percentageAmount, String feeFrequency, int feeInterval) {
+        ChargeRequest chargeRequest = ChargeRequestBuilders.loanOverdueFee(percentageAmount)//
+                .chargeCalculationType(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST.getValue())//
+                .feeFrequency(feeFrequency)//
+                .feeInterval(String.valueOf(feeInterval));
+        return chargesHelper.createCharge(chargeRequest).getResourceId();
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/loan/penalty/LoanPenaltyBackdatedTransactionTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/loan/penalty/LoanPenaltyBackdatedTransactionTest.java
@@ -21,22 +21,24 @@ package org.apache.fineract.integrationtests.loan.penalty;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
+import org.apache.fineract.client.models.ChargeRequest;
 import org.apache.fineract.client.models.LoanProductChargeData;
 import org.apache.fineract.client.models.PostLoanProductsRequest;
-import org.apache.fineract.client.models.PostLoanProductsResponse;
-import org.apache.fineract.client.models.PostLoansLoanIdResponse;
 import org.apache.fineract.client.models.PostLoansRequest;
-import org.apache.fineract.client.models.PostLoansResponse;
 import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
 import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
-import org.apache.fineract.integrationtests.BaseLoanIntegrationTest;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.modules.ChargeRequestBuilders;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData;
+import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class LoanPenaltyBackdatedTransactionTest extends BaseLoanIntegrationTest {
+public class LoanPenaltyBackdatedTransactionTest extends FeignLoanTestBase {
+
+    // PeriodFrequencyType.DAYS
+    private static final String FEE_FREQUENCY_DAYS = "0";
 
     @BeforeEach
     public void before() {
@@ -56,62 +58,8 @@ public class LoanPenaltyBackdatedTransactionTest extends BaseLoanIntegrationTest
         AtomicReference<Long> aLoanId = new AtomicReference<>();
 
         runAt("01 January 2023", () -> {
-            // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
-
-            int numberOfRepayments = 3;
-            int repaymentEvery = 4;
-
-            // Create charges
-            double chargeAmount = 1.0;
-            Long chargeId = createOverduePenaltyPercentageCharge(chargeAmount, ChargesHelper.CHARGE_FEE_FREQUENCY_DAYS, 1);
-
-            // Create Loan Product
-            PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct() //
-                    .graceOnArrearsAgeing(0).numberOfRepayments(numberOfRepayments) //
-                    .repaymentEvery(repaymentEvery) //
-                    .installmentAmountInMultiplesOf(null) //
-                    .repaymentFrequencyType(RepaymentFrequencyType.DAYS.longValue()) //
-                    .interestType(InterestType.DECLINING_BALANCE)//
-                    .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY)//
-                    .interestRecalculationCompoundingMethod(InterestRecalculationCompoundingMethod.NONE)//
-                    .rescheduleStrategyMethod(RescheduleStrategyMethod.ADJUST_LAST_UNPAID_PERIOD)//
-                    .isInterestRecalculationEnabled(true)//
-                    .recalculationRestFrequencyInterval(1)//
-                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY)//
-                    .rescheduleStrategyMethod(RescheduleStrategyMethod.REDUCE_EMI_AMOUNT)//
-                    .allowPartialPeriodInterestCalculation(false)//
-                    .disallowExpectedDisbursements(false)//
-                    .allowApprovedDisbursedAmountsOverApplied(false)//
-                    .overAppliedNumber(null)//
-                    .overAppliedCalculationType(null)//
-                    .multiDisburseLoan(null)//
-                    .charges(List.of(new LoanProductChargeData().id(chargeId)));//
-
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-            Long loanProductId = loanProductResponse.getResourceId();
-
-            // Apply and Approve Loan
-            double amount = 5000.0;
-
-            PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "01 January 2023", amount, numberOfRepayments)//
-                    .repaymentEvery(repaymentEvery)//
-                    .loanTermFrequency(numberOfRepayments * repaymentEvery)//
-                    .repaymentFrequencyType(RepaymentFrequencyType.DAYS)//
-                    .loanTermFrequencyType(RepaymentFrequencyType.DAYS)//
-                    .interestType(InterestType.DECLINING_BALANCE)//
-                    .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY);
-
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applicationRequest);
-
-            PostLoansLoanIdResponse approvedLoanResult = loanTransactionHelper.approveLoan(postLoansResponse.getResourceId(),
-                    approveLoanRequest(amount, "01 January 2023"));
-
-            aLoanId.getAndSet(approvedLoanResult.getLoanId());
-            Long loanId = aLoanId.get();
-
-            // disburse Loan
-            disburseLoan(loanId, BigDecimal.valueOf(5000.0), "01 January 2023");
+            Long loanId = createBackdatedPenaltyLoan();
+            aLoanId.set(loanId);
 
             // verify transactions
             verifyTransactions(loanId, //
@@ -122,8 +70,8 @@ public class LoanPenaltyBackdatedTransactionTest extends BaseLoanIntegrationTest
         runAt("09 January 2023", () -> {
             Long loanId = aLoanId.get();
             // run accrual posting
-            schedulerJobHelper.executeAndAwaitJob("Apply penalty to overdue loans");
-            schedulerJobHelper.executeAndAwaitJob("Add Accrual Transactions");
+            schedulerHelper.executeAndAwaitJob("Apply penalty to overdue loans");
+            schedulerHelper.executeAndAwaitJob("Add Accrual Transactions");
 
             // verify transactions
             verifyTransactions(loanId, //
@@ -147,8 +95,8 @@ public class LoanPenaltyBackdatedTransactionTest extends BaseLoanIntegrationTest
             deactivateOverdueLoanCharges(loanId, "07 January 2023");
 
             // run accrual posting
-            schedulerJobHelper.executeAndAwaitJob("Apply penalty to overdue loans");
-            schedulerJobHelper.executeAndAwaitJob("Add Accrual Transactions");
+            schedulerHelper.executeAndAwaitJob("Apply penalty to overdue loans");
+            schedulerHelper.executeAndAwaitJob("Add Accrual Transactions");
 
             // verify transactions
             verifyTransactions(loanId, //
@@ -166,62 +114,8 @@ public class LoanPenaltyBackdatedTransactionTest extends BaseLoanIntegrationTest
         AtomicReference<Long> aLoanId = new AtomicReference<>();
 
         runAt("01 January 2023", () -> {
-            // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
-
-            int numberOfRepayments = 3;
-            int repaymentEvery = 4;
-
-            // Create charges
-            double chargeAmount = 1.0;
-            Long chargeId = createOverduePenaltyPercentageCharge(chargeAmount, ChargesHelper.CHARGE_FEE_FREQUENCY_DAYS, 1);
-
-            // Create Loan Product
-            PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct() //
-                    .graceOnArrearsAgeing(0).numberOfRepayments(numberOfRepayments) //
-                    .repaymentEvery(repaymentEvery) //
-                    .installmentAmountInMultiplesOf(null) //
-                    .repaymentFrequencyType(RepaymentFrequencyType.DAYS.longValue()) //
-                    .interestType(InterestType.DECLINING_BALANCE)//
-                    .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY)//
-                    .interestRecalculationCompoundingMethod(InterestRecalculationCompoundingMethod.NONE)//
-                    .rescheduleStrategyMethod(RescheduleStrategyMethod.ADJUST_LAST_UNPAID_PERIOD)//
-                    .isInterestRecalculationEnabled(true)//
-                    .recalculationRestFrequencyInterval(1)//
-                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY)//
-                    .rescheduleStrategyMethod(RescheduleStrategyMethod.REDUCE_EMI_AMOUNT)//
-                    .allowPartialPeriodInterestCalculation(false)//
-                    .disallowExpectedDisbursements(false)//
-                    .allowApprovedDisbursedAmountsOverApplied(false)//
-                    .overAppliedNumber(null)//
-                    .overAppliedCalculationType(null)//
-                    .multiDisburseLoan(null)//
-                    .charges(List.of(new LoanProductChargeData().id(chargeId)));//
-
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-            Long loanProductId = loanProductResponse.getResourceId();
-
-            // Apply and Approve Loan
-            double amount = 5000.0;
-
-            PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "01 January 2023", amount, numberOfRepayments)//
-                    .repaymentEvery(repaymentEvery)//
-                    .loanTermFrequency(numberOfRepayments * repaymentEvery)//
-                    .repaymentFrequencyType(RepaymentFrequencyType.DAYS)//
-                    .loanTermFrequencyType(RepaymentFrequencyType.DAYS)//
-                    .interestType(InterestType.DECLINING_BALANCE)//
-                    .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY);
-
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applicationRequest);
-
-            PostLoansLoanIdResponse approvedLoanResult = loanTransactionHelper.approveLoan(postLoansResponse.getResourceId(),
-                    approveLoanRequest(amount, "01 January 2023"));
-
-            aLoanId.getAndSet(approvedLoanResult.getLoanId());
-            Long loanId = aLoanId.get();
-
-            // disburse Loan
-            disburseLoan(loanId, BigDecimal.valueOf(5000.0), "01 January 2023");
+            Long loanId = createBackdatedPenaltyLoan();
+            aLoanId.set(loanId);
 
             // verify transactions
             verifyTransactions(loanId, //
@@ -233,8 +127,8 @@ public class LoanPenaltyBackdatedTransactionTest extends BaseLoanIntegrationTest
             Long loanId = aLoanId.get();
 
             // run accrual posting
-            schedulerJobHelper.executeAndAwaitJob("Apply penalty to overdue loans");
-            schedulerJobHelper.executeAndAwaitJob("Add Accrual Transactions");
+            schedulerHelper.executeAndAwaitJob("Apply penalty to overdue loans");
+            schedulerHelper.executeAndAwaitJob("Add Accrual Transactions");
 
             // verify transactions
             verifyTransactions(loanId, //
@@ -258,8 +152,8 @@ public class LoanPenaltyBackdatedTransactionTest extends BaseLoanIntegrationTest
             deactivateOverdueLoanCharges(loanId, "05 January 2023");
 
             // run accrual posting
-            schedulerJobHelper.executeAndAwaitJob("Apply penalty to overdue loans");
-            schedulerJobHelper.executeAndAwaitJob("Add Accrual Transactions");
+            schedulerHelper.executeAndAwaitJob("Apply penalty to overdue loans");
+            schedulerHelper.executeAndAwaitJob("Add Accrual Transactions");
 
             // verify transactions
             verifyTransactions(loanId, //
@@ -278,62 +172,8 @@ public class LoanPenaltyBackdatedTransactionTest extends BaseLoanIntegrationTest
         AtomicReference<Long> aLoanId = new AtomicReference<>();
 
         runAt("01 January 2023", () -> {
-            // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
-
-            int numberOfRepayments = 3;
-            int repaymentEvery = 4;
-
-            // Create charges
-            double chargeAmount = 1.0;
-            Long chargeId = createOverduePenaltyPercentageCharge(chargeAmount, ChargesHelper.CHARGE_FEE_FREQUENCY_DAYS, 1);
-
-            // Create Loan Product
-            PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct() //
-                    .graceOnArrearsAgeing(0).numberOfRepayments(numberOfRepayments) //
-                    .repaymentEvery(repaymentEvery) //
-                    .installmentAmountInMultiplesOf(null) //
-                    .repaymentFrequencyType(RepaymentFrequencyType.DAYS.longValue()) //
-                    .interestType(InterestType.DECLINING_BALANCE)//
-                    .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY)//
-                    .interestRecalculationCompoundingMethod(InterestRecalculationCompoundingMethod.NONE)//
-                    .rescheduleStrategyMethod(RescheduleStrategyMethod.ADJUST_LAST_UNPAID_PERIOD)//
-                    .isInterestRecalculationEnabled(true)//
-                    .recalculationRestFrequencyInterval(1)//
-                    .recalculationRestFrequencyType(RecalculationRestFrequencyType.DAILY)//
-                    .rescheduleStrategyMethod(RescheduleStrategyMethod.REDUCE_EMI_AMOUNT)//
-                    .allowPartialPeriodInterestCalculation(false)//
-                    .disallowExpectedDisbursements(false)//
-                    .allowApprovedDisbursedAmountsOverApplied(false)//
-                    .overAppliedNumber(null)//
-                    .overAppliedCalculationType(null)//
-                    .multiDisburseLoan(null)//
-                    .charges(List.of(new LoanProductChargeData().id(chargeId)));//
-
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-            Long loanProductId = loanProductResponse.getResourceId();
-
-            // Apply and Approve Loan
-            double amount = 5000.0;
-
-            PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "01 January 2023", amount, numberOfRepayments)//
-                    .repaymentEvery(repaymentEvery)//
-                    .loanTermFrequency(numberOfRepayments * repaymentEvery)//
-                    .repaymentFrequencyType(RepaymentFrequencyType.DAYS)//
-                    .loanTermFrequencyType(RepaymentFrequencyType.DAYS)//
-                    .interestType(InterestType.DECLINING_BALANCE)//
-                    .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY);
-
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applicationRequest);
-
-            PostLoansLoanIdResponse approvedLoanResult = loanTransactionHelper.approveLoan(postLoansResponse.getResourceId(),
-                    approveLoanRequest(amount, "01 January 2023"));
-
-            aLoanId.getAndSet(approvedLoanResult.getLoanId());
-            Long loanId = aLoanId.get();
-
-            // disburse Loan
-            disburseLoan(loanId, BigDecimal.valueOf(5000.0), "01 January 2023");
+            Long loanId = createBackdatedPenaltyLoan();
+            aLoanId.set(loanId);
 
             // verify transactions
             verifyTransactions(loanId, //
@@ -345,8 +185,8 @@ public class LoanPenaltyBackdatedTransactionTest extends BaseLoanIntegrationTest
             Long loanId = aLoanId.get();
 
             // run accrual posting
-            schedulerJobHelper.executeAndAwaitJob("Apply penalty to overdue loans");
-            schedulerJobHelper.executeAndAwaitJob("Add Accrual Transactions");
+            schedulerHelper.executeAndAwaitJob("Apply penalty to overdue loans");
+            schedulerHelper.executeAndAwaitJob("Add Accrual Transactions");
 
             // verify transactions
             verifyTransactions(loanId, //
@@ -370,8 +210,8 @@ public class LoanPenaltyBackdatedTransactionTest extends BaseLoanIntegrationTest
             deactivateOverdueLoanCharges(loanId, "07 January 2023");
 
             // run accrual posting
-            schedulerJobHelper.executeAndAwaitJob("Apply penalty to overdue loans");
-            schedulerJobHelper.executeAndAwaitJob("Add Accrual Transactions");
+            schedulerHelper.executeAndAwaitJob("Apply penalty to overdue loans");
+            schedulerHelper.executeAndAwaitJob("Add Accrual Transactions");
 
             // verify transactions
             verifyTransactions(loanId, //
@@ -399,5 +239,65 @@ public class LoanPenaltyBackdatedTransactionTest extends BaseLoanIntegrationTest
                     transaction(1000.0, "Repayment", "10 January 2023", 3047.0, 969.67, 0.0, 0.0, 30.33, 0.0, 0.0) //
             );
         });
+    }
+
+    private Long createBackdatedPenaltyLoan() {
+        Long clientId = createClient();
+
+        int numberOfRepayments = 3;
+        int repaymentEvery = 4;
+
+        // Create charges
+        double chargeAmount = 1.0;
+        Long chargeId = createOverduePenaltyPercentageCharge(chargeAmount, FEE_FREQUENCY_DAYS, 1);
+
+        // Create Loan Product
+        PostLoanProductsRequest product = createOnePeriod30DaysLongNoInterestPeriodicAccrualProduct() //
+                .graceOnArrearsAgeing(0).numberOfRepayments(numberOfRepayments) //
+                .repaymentEvery(repaymentEvery) //
+                .installmentAmountInMultiplesOf(null) //
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.DAYS_L) //
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE)//
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.DAILY)//
+                .interestRecalculationCompoundingMethod(LoanTestData.InterestRecalculationCompoundingMethod.NONE)//
+                .isInterestRecalculationEnabled(true)//
+                .recalculationRestFrequencyInterval(1)//
+                .recalculationRestFrequencyType(LoanTestData.RecalculationRestFrequencyType.DAILY)//
+                .rescheduleStrategyMethod(LoanTestData.RescheduleStrategyMethod.REDUCE_EMI_AMOUNT)//
+                .allowPartialPeriodInterestCalculation(false)//
+                .disallowExpectedDisbursements(false)//
+                .allowApprovedDisbursedAmountsOverApplied(false)//
+                .overAppliedNumber(null)//
+                .overAppliedCalculationType(null)//
+                .multiDisburseLoan(null)//
+                .charges(List.of(new LoanProductChargeData().id(chargeId)));//
+
+        Long loanProductId = createLoanProduct(product);
+
+        // Apply and Approve Loan
+        double amount = 5000.0;
+
+        PostLoansRequest applicationRequest = applyLoanRequest(clientId, loanProductId, "01 January 2023", amount, numberOfRepayments)//
+                .repaymentEvery(repaymentEvery)//
+                .loanTermFrequency(numberOfRepayments * repaymentEvery)//
+                .repaymentFrequencyType(LoanTestData.RepaymentFrequencyType.DAYS)//
+                .loanTermFrequencyType(LoanTestData.RepaymentFrequencyType.DAYS)//
+                .interestType(LoanTestData.InterestType.DECLINING_BALANCE)//
+                .interestCalculationPeriodType(LoanTestData.InterestCalculationPeriodType.DAILY);
+
+        Long loanId = applyForLoan(applicationRequest);
+        approveLoan(loanId, approveLoanRequest(amount, "01 January 2023"));
+
+        // disburse Loan
+        disburseLoan(loanId, BigDecimal.valueOf(5000.0), "01 January 2023");
+        return loanId;
+    }
+
+    private Long createOverduePenaltyPercentageCharge(double percentageAmount, String feeFrequency, int feeInterval) {
+        ChargeRequest chargeRequest = ChargeRequestBuilders.loanOverdueFee(percentageAmount)//
+                .chargeCalculationType(ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST.getValue())//
+                .feeFrequency(feeFrequency)//
+                .feeInterval(String.valueOf(feeInterval));
+        return chargesHelper.createCharge(chargeRequest).getResourceId();
     }
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/loan/pointintime/LoanPointInTimeTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/loan/pointintime/LoanPointInTimeTest.java
@@ -18,8 +18,7 @@
  */
 package org.apache.fineract.integrationtests.loan.pointintime;
 
-import static org.apache.fineract.integrationtests.BaseLoanIntegrationTest.TransactionProcessingStrategyCode.ADVANCED_PAYMENT_ALLOCATION_STRATEGY;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.TransactionProcessingStrategyCode.ADVANCED_PAYMENT_ALLOCATION_STRATEGY;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -28,17 +27,20 @@ import org.apache.fineract.client.models.GetLoansLoanIdResponse;
 import org.apache.fineract.client.models.LoanPointInTimeData;
 import org.apache.fineract.client.models.LoanProductChargeData;
 import org.apache.fineract.client.models.PostLoanProductsRequest;
-import org.apache.fineract.client.models.PostLoanProductsResponse;
 import org.apache.fineract.client.models.PostLoansLoanIdResponse;
 import org.apache.fineract.client.models.PostLoansRequest;
 import org.apache.fineract.client.models.PostLoansRequestChargeData;
 import org.apache.fineract.client.models.PostLoansResponse;
-import org.apache.fineract.integrationtests.BaseLoanIntegrationTest;
-import org.apache.fineract.integrationtests.common.ClientHelper;
-import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
+import org.apache.fineract.integrationtests.client.feign.FeignLoanTestBase;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestCalculationPeriodType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestRecalculationCompoundingMethod;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.InterestType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.RecalculationRestFrequencyType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.RepaymentFrequencyType;
+import org.apache.fineract.integrationtests.client.feign.modules.LoanTestData.RescheduleStrategyMethod;
 import org.junit.jupiter.api.Test;
 
-public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
+public class LoanPointInTimeTest extends FeignLoanTestBase {
 
     @Test
     public void test_LoanPointInTimeDataWorks_ForPrincipalOutstandingCalculation() {
@@ -46,7 +48,7 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
 
         runAt("01 January 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             int numberOfRepayments = 3;
             int repaymentEvery = 1;
@@ -79,8 +81,7 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
                     .multiDisburseLoan(null)//
                     .charges(List.of(new LoanProductChargeData().id(charge1Id), new LoanProductChargeData().id(charge2Id)));//
 
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-            Long loanProductId = loanProductResponse.getResourceId();
+            Long loanProductId = createLoanProduct(product);
 
             // Apply and Approve Loan
             double amount = 5000.0;
@@ -97,9 +98,9 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
                             new PostLoansRequestChargeData().chargeId(charge2Id).amount(BigDecimal.valueOf(charge2Amount))//
             ));//
 
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse postLoansResponse = loanHelper.applyForLoan(applicationRequest);
 
-            PostLoansLoanIdResponse approvedLoanResult = loanTransactionHelper.approveLoan(postLoansResponse.getResourceId(),
+            PostLoansLoanIdResponse approvedLoanResult = approveLoan(postLoansResponse.getResourceId(),
                     approveLoanRequest(amount, "01 January 2023"));
 
             aLoanId.getAndSet(approvedLoanResult.getLoanId());
@@ -191,7 +192,7 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
 
         runAt("01 January 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             int numberOfRepayments = 3;
             int repaymentEvery = 1;
@@ -218,8 +219,7 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
                     .overAppliedCalculationType(null)//
                     .multiDisburseLoan(null);//
 
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-            Long loanProductId = loanProductResponse.getResourceId();
+            Long loanProductId = createLoanProduct(product);
 
             // Apply and Approve Loan
             double amount = 5000.0;
@@ -233,9 +233,9 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
                     .interestType(InterestType.DECLINING_BALANCE)//
                     .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY);//
 
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse postLoansResponse = loanHelper.applyForLoan(applicationRequest);
 
-            PostLoansLoanIdResponse approvedLoanResult = loanTransactionHelper.approveLoan(postLoansResponse.getResourceId(),
+            PostLoansLoanIdResponse approvedLoanResult = approveLoan(postLoansResponse.getResourceId(),
                     approveLoanRequest(amount, "01 January 2023"));
 
             aLoanId.getAndSet(approvedLoanResult.getLoanId());
@@ -356,7 +356,7 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
 
         runAt("01 January 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             int numberOfRepayments = 3;
             int repaymentEvery = 1;
@@ -382,8 +382,7 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
                     .overAppliedCalculationType(null)//
                     .currencyCode("USD").multiDisburseLoan(null);//
 
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-            Long loanProductId = loanProductResponse.getResourceId();
+            Long loanProductId = createLoanProduct(product);
 
             // Apply and Approve Loan
             double amount = 5000.0;
@@ -397,9 +396,9 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
                     .interestType(InterestType.DECLINING_BALANCE)//
                     .interestCalculationPeriodType(InterestCalculationPeriodType.DAILY);//
 
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse postLoansResponse = loanHelper.applyForLoan(applicationRequest);
 
-            PostLoansLoanIdResponse approvedLoanResult = loanTransactionHelper.approveLoan(postLoansResponse.getResourceId(),
+            PostLoansLoanIdResponse approvedLoanResult = approveLoan(postLoansResponse.getResourceId(),
                     approveLoanRequest(amount, "01 January 2023"));
 
             aLoanId.getAndSet(approvedLoanResult.getLoanId());
@@ -521,7 +520,7 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
 
         runAt("01 January 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             int numberOfRepayments = 3;
             int repaymentEvery = 1;
@@ -554,8 +553,7 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
                     .multiDisburseLoan(null)//
                     .charges(List.of(new LoanProductChargeData().id(charge1Id), new LoanProductChargeData().id(charge2Id)));//
 
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-            Long loanProductId = loanProductResponse.getResourceId();
+            Long loanProductId = createLoanProduct(product);
 
             // Apply and Approve Loan
             double amount = 5000.0;
@@ -572,13 +570,13 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
                             new PostLoansRequestChargeData().chargeId(charge2Id).amount(BigDecimal.valueOf(charge2Amount))//
             ));//
 
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applicationRequest);
-            PostLoansResponse postLoansResponse2 = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse postLoansResponse = loanHelper.applyForLoan(applicationRequest);
+            PostLoansResponse postLoansResponse2 = loanHelper.applyForLoan(applicationRequest);
 
-            PostLoansLoanIdResponse approvedLoanResult = loanTransactionHelper.approveLoan(postLoansResponse.getResourceId(),
+            PostLoansLoanIdResponse approvedLoanResult = approveLoan(postLoansResponse.getResourceId(),
                     approveLoanRequest(amount, "01 January 2023"));
 
-            PostLoansLoanIdResponse approvedLoanResult2 = loanTransactionHelper.approveLoan(postLoansResponse2.getResourceId(),
+            PostLoansLoanIdResponse approvedLoanResult2 = approveLoan(postLoansResponse2.getResourceId(),
                     approveLoanRequest(amount, "01 January 2023"));
 
             aLoanId.getAndSet(approvedLoanResult.getLoanId());
@@ -666,7 +664,7 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
 
         runAt("01 January 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             int numberOfRepayments = 3;
             int repaymentEvery = 1;
@@ -698,8 +696,7 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
                     .multiDisburseLoan(null)//
                     .charges(List.of(new LoanProductChargeData().id(charge1Id), new LoanProductChargeData().id(charge2Id)));//
 
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-            Long loanProductId = loanProductResponse.getResourceId();
+            Long loanProductId = createLoanProduct(product);
 
             // Apply and Approve Loan
             double amount = 5000.0;
@@ -716,9 +713,9 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
                             new PostLoansRequestChargeData().chargeId(charge2Id).amount(BigDecimal.valueOf(charge2Amount))//
             ));//
 
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse postLoansResponse = loanHelper.applyForLoan(applicationRequest);
 
-            PostLoansLoanIdResponse approvedLoanResult = loanTransactionHelper.approveLoan(postLoansResponse.getResourceId(),
+            PostLoansLoanIdResponse approvedLoanResult = approveLoan(postLoansResponse.getResourceId(),
                     approveLoanRequest(amount, "01 January 2023"));
 
             aLoanId.getAndSet(approvedLoanResult.getLoanId());
@@ -763,7 +760,7 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
 
         runAt("01 January 2023", () -> {
             // Create Client
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             int numberOfRepayments = 3;
             int repaymentEvery = 1;
@@ -796,8 +793,7 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
                     .multiDisburseLoan(null)//
                     .charges(List.of(new LoanProductChargeData().id(charge1Id), new LoanProductChargeData().id(charge2Id)));//
 
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-            Long loanProductId = loanProductResponse.getResourceId();
+            Long loanProductId = createLoanProduct(product);
 
             // Apply and Approve Loan
             double amount = 5000.0;
@@ -814,9 +810,9 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
                             new PostLoansRequestChargeData().chargeId(charge2Id).amount(BigDecimal.valueOf(charge2Amount))//
             ));//
 
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse postLoansResponse = loanHelper.applyForLoan(applicationRequest);
 
-            PostLoansLoanIdResponse approvedLoanResult = loanTransactionHelper.approveLoan(postLoansResponse.getResourceId(),
+            PostLoansLoanIdResponse approvedLoanResult = approveLoan(postLoansResponse.getResourceId(),
                     approveLoanRequest(amount, "01 January 2023"));
 
             aLoanId.getAndSet(approvedLoanResult.getLoanId());
@@ -868,7 +864,7 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
         double installmentFeeAmount = 100.0;
 
         runAt("01 October 2025", () -> {
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             int numberOfRepayments = 6;
             int repaymentEvery = 1;
@@ -887,8 +883,7 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
                     .overAppliedCalculationType(null).multiDisburseLoan(null)
                     .charges(List.of(new LoanProductChargeData().id(installmentFeeChargeId)));
 
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-            Long loanProductId = loanProductResponse.getResourceId();
+            Long loanProductId = createLoanProduct(product);
 
             double amount = 6000.0;
 
@@ -899,9 +894,9 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
                     .charges(List.of(new PostLoansRequestChargeData().chargeId(installmentFeeChargeId)
                             .amount(BigDecimal.valueOf(installmentFeeAmount))));
 
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse postLoansResponse = loanHelper.applyForLoan(applicationRequest);
 
-            PostLoansLoanIdResponse approvedLoanResult = loanTransactionHelper.approveLoan(postLoansResponse.getResourceId(),
+            PostLoansLoanIdResponse approvedLoanResult = approveLoan(postLoansResponse.getResourceId(),
                     approveLoanRequest(amount, "01 October 2025"));
 
             aLoanId.getAndSet(approvedLoanResult.getLoanId());
@@ -939,7 +934,7 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
                     transaction(1100.0, "Repayment", "01 November 2025"), transaction(1100.0, "Repayment", "01 December 2025"),
                     transaction(1100.0, "Repayment", "01 January 2026"));
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             BigDecimal regularApiFeeChargesPaid = loanDetails.getSummary().getFeeChargesPaid();
             BigDecimal regularApiFeeChargesCharged = loanDetails.getSummary().getFeeChargesCharged();
 
@@ -974,7 +969,7 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
         double installmentFeeAmount = 25.0;
 
         runAt("01 October 2023", () -> {
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             int numberOfRepayments = 2;
             int repaymentEvery = 1;
@@ -989,8 +984,7 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
                     .allowApprovedDisbursedAmountsOverApplied(false).overAppliedNumber(null).overAppliedCalculationType(null)
                     .multiDisburseLoan(null).charges(List.of(new LoanProductChargeData().id(installmentFeeChargeId)));
 
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-            Long loanProductId = loanProductResponse.getResourceId();
+            Long loanProductId = createLoanProduct(product);
 
             double amount = 2000.0;
 
@@ -1001,9 +995,9 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
                     .charges(List.of(new PostLoansRequestChargeData().chargeId(installmentFeeChargeId)
                             .amount(BigDecimal.valueOf(installmentFeeAmount))));
 
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse postLoansResponse = loanHelper.applyForLoan(applicationRequest);
 
-            PostLoansLoanIdResponse approvedLoanResult = loanTransactionHelper.approveLoan(postLoansResponse.getResourceId(),
+            PostLoansLoanIdResponse approvedLoanResult = approveLoan(postLoansResponse.getResourceId(),
                     approveLoanRequest(amount, "01 October 2023"));
 
             aLoanId.getAndSet(approvedLoanResult.getLoanId());
@@ -1030,7 +1024,7 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
             // Second repayment: 1000 principal + 25 fee = 1025 (loan should close)
             addRepaymentForLoan(loanId, 1025.0, "01 December 2023");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
 
             // Verify loan is closed
             assertThat(loanDetails.getStatus().getCode()).isEqualTo("loanStatusType.closed.obligations.met");
@@ -1077,7 +1071,7 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
         double installmentFeeAmount = 100.0;
 
         runAt("01 October 2025", () -> {
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             int numberOfRepayments = 6;
             int repaymentEvery = 1;
@@ -1096,8 +1090,7 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
                     .overAppliedCalculationType(null).multiDisburseLoan(null)
                     .charges(List.of(new LoanProductChargeData().id(installmentFeeChargeId)));
 
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-            Long loanProductId = loanProductResponse.getResourceId();
+            Long loanProductId = createLoanProduct(product);
 
             double amount = 6000.0;
 
@@ -1108,9 +1101,9 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
                     .charges(List.of(new PostLoansRequestChargeData().chargeId(installmentFeeChargeId)
                             .amount(BigDecimal.valueOf(installmentFeeAmount))));
 
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse postLoansResponse = loanHelper.applyForLoan(applicationRequest);
 
-            PostLoansLoanIdResponse approvedLoanResult = loanTransactionHelper.approveLoan(postLoansResponse.getResourceId(),
+            PostLoansLoanIdResponse approvedLoanResult = approveLoan(postLoansResponse.getResourceId(),
                     approveLoanRequest(amount, "01 October 2025"));
 
             aLoanId.getAndSet(approvedLoanResult.getLoanId());
@@ -1134,7 +1127,7 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
             addRepaymentForLoan(loanId, 1100.0, "01 January 2026");
 
             // Verify regular API values (full schedule)
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             BigDecimal regularApiFeeChargesCharged = loanDetails.getSummary().getFeeChargesCharged();
             assertThat(regularApiFeeChargesCharged).as("Regular API should show full fees (600)")
                     .isEqualByComparingTo(BigDecimal.valueOf(600.0));
@@ -1176,7 +1169,7 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
         double interestRatePerPeriod = 12.0;
 
         runAt("01 October 2025", () -> {
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             int numberOfRepayments = 4;
             int repaymentEvery = 1;
@@ -1191,8 +1184,7 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
                     .allowApprovedDisbursedAmountsOverApplied(false).overAppliedNumber(null).overAppliedCalculationType(null)
                     .multiDisburseLoan(null).charges(List.of(new LoanProductChargeData().id(installmentFeeChargeId)));
 
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-            Long loanProductId = loanProductResponse.getResourceId();
+            Long loanProductId = createLoanProduct(product);
 
             double amount = 4000.0;
 
@@ -1203,9 +1195,9 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
                     .interestRatePerPeriod(BigDecimal.valueOf(interestRatePerPeriod)).charges(List.of(new PostLoansRequestChargeData()
                             .chargeId(installmentFeeChargeId).amount(BigDecimal.valueOf(installmentFeeAmount))));
 
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse postLoansResponse = loanHelper.applyForLoan(applicationRequest);
 
-            PostLoansLoanIdResponse approvedLoanResult = loanTransactionHelper.approveLoan(postLoansResponse.getResourceId(),
+            PostLoansLoanIdResponse approvedLoanResult = approveLoan(postLoansResponse.getResourceId(),
                     approveLoanRequest(amount, "01 October 2025"));
 
             aLoanId.getAndSet(approvedLoanResult.getLoanId());
@@ -1227,7 +1219,7 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
         runAt("08 December 2025", () -> {
             Long loanId = aLoanId.get();
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             BigDecimal regularApiInterestCharged = loanDetails.getSummary().getInterestCharged();
             BigDecimal regularApiInterestPaid = loanDetails.getSummary().getInterestPaid();
             BigDecimal regularApiInterestOutstanding = loanDetails.getSummary().getInterestOutstanding();
@@ -1258,7 +1250,7 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
         double installmentPenaltyAmount = 25.0;
 
         runAt("01 October 2025", () -> {
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             int numberOfRepayments = 4;
             int repaymentEvery = 1;
@@ -1275,8 +1267,7 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
                     .multiDisburseLoan(null).charges(List.of(new LoanProductChargeData().id(installmentFeeChargeId),
                             new LoanProductChargeData().id(installmentPenaltyChargeId)));
 
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-            Long loanProductId = loanProductResponse.getResourceId();
+            Long loanProductId = createLoanProduct(product);
 
             double amount = 4000.0;
 
@@ -1290,9 +1281,9 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
                             new PostLoansRequestChargeData().chargeId(installmentPenaltyChargeId)
                                     .amount(BigDecimal.valueOf(installmentPenaltyAmount))));
 
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse postLoansResponse = loanHelper.applyForLoan(applicationRequest);
 
-            PostLoansLoanIdResponse approvedLoanResult = loanTransactionHelper.approveLoan(postLoansResponse.getResourceId(),
+            PostLoansLoanIdResponse approvedLoanResult = approveLoan(postLoansResponse.getResourceId(),
                     approveLoanRequest(amount, "01 October 2025"));
 
             aLoanId.getAndSet(approvedLoanResult.getLoanId());
@@ -1314,7 +1305,7 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
         runAt("08 December 2025", () -> {
             Long loanId = aLoanId.get();
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
             BigDecimal regularApiPenaltyCharged = loanDetails.getSummary().getPenaltyChargesCharged();
             BigDecimal regularApiPenaltyPaid = loanDetails.getSummary().getPenaltyChargesPaid();
             BigDecimal regularApiPenaltyOutstanding = loanDetails.getSummary().getPenaltyChargesOutstanding();
@@ -1345,7 +1336,7 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
         double installmentFeeAmount = 100.0;
 
         runAt("01 October 2025", () -> {
-            Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            Long clientId = createClient();
 
             int numberOfRepayments = 3;
             int repaymentEvery = 1;
@@ -1360,8 +1351,7 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
                     .allowApprovedDisbursedAmountsOverApplied(false).overAppliedNumber(null).overAppliedCalculationType(null)
                     .multiDisburseLoan(null).charges(List.of(new LoanProductChargeData().id(installmentFeeChargeId)));
 
-            PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(product);
-            Long loanProductId = loanProductResponse.getResourceId();
+            Long loanProductId = createLoanProduct(product);
 
             double amount = 3000.0;
 
@@ -1372,9 +1362,9 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
                     .charges(List.of(new PostLoansRequestChargeData().chargeId(installmentFeeChargeId)
                             .amount(BigDecimal.valueOf(installmentFeeAmount))));
 
-            PostLoansResponse postLoansResponse = loanTransactionHelper.applyLoan(applicationRequest);
+            PostLoansResponse postLoansResponse = loanHelper.applyForLoan(applicationRequest);
 
-            PostLoansLoanIdResponse approvedLoanResult = loanTransactionHelper.approveLoan(postLoansResponse.getResourceId(),
+            PostLoansLoanIdResponse approvedLoanResult = approveLoan(postLoansResponse.getResourceId(),
                     approveLoanRequest(amount, "01 October 2025"));
 
             aLoanId.getAndSet(approvedLoanResult.getLoanId());
@@ -1397,7 +1387,7 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
             Long loanId = aLoanId.get();
             addRepaymentForLoan(loanId, 1100.0, "01 January 2026");
 
-            GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse loanDetails = getLoanDetails(loanId);
 
             assertThat(loanDetails.getStatus().getCode()).isEqualTo("loanStatusType.closed.obligations.met");
         });
@@ -1405,7 +1395,7 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
         runAt("15 January 2026", () -> {
             Long loanId = aLoanId.get();
 
-            GetLoansLoanIdResponse regularApi = loanTransactionHelper.getLoanDetails(loanId);
+            GetLoansLoanIdResponse regularApi = getLoanDetails(loanId);
             LoanPointInTimeData pointInTimeApi = getPointInTimeData(loanId, "15 January 2026");
 
             assertThat(pointInTimeApi.getFee().getFeeChargesCharged())
@@ -1435,19 +1425,5 @@ public class LoanPointInTimeTest extends BaseLoanIntegrationTest {
                     .as("Closed loan: point-in-time totalOutstanding should match regular API")
                     .isEqualByComparingTo(regularApi.getSummary().getTotalOutstanding());
         });
-    }
-
-    private Long createInstallmentFeeCharge(double amount) {
-        Integer chargeId = ChargesHelper.createCharges(requestSpec, responseSpec,
-                ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, String.valueOf(amount), false));
-        assertNotNull(chargeId);
-        return chargeId.longValue();
-    }
-
-    private Long createInstallmentPenaltyCharge(double amount) {
-        Integer chargeId = ChargesHelper.createCharges(requestSpec, responseSpec,
-                ChargesHelper.getLoanInstallmentJSON(ChargesHelper.CHARGE_CALCULATION_TYPE_FLAT, String.valueOf(amount), true));
-        assertNotNull(chargeId);
-        return chargeId.longValue();
     }
 }


### PR DESCRIPTION
## What this PR does

fourth batch of the loan integration-test migration. It moves **54 test classes (655 test methods)** off REST-assured onto the typed Feign client.

None of those 54 classes reference REST-assured any more. With this merged, 151 integration-test classes run on the typed client.

99 files changed:

- 54 test classes (655 test methods)
- 2 shared base classes (`FeignLoanTestBase`, `BaseLoanIntegrationTest`)
- 34 shared Feign helpers and builders (16 of them new)

The tests assert the same things as before. This changes how they talk to the server, not what they check. The few assertions that did change are listed under "Bugs found" and each one is a fix.

## Commits

**26 commits**, each a group of related tests (loan charges, COB, external asset owner, delinquency, advanced payment allocation, and so on).

## What's covered

- **Client loan lifecycle** - charges of every calculation type, credit balance refund, external IDs, backdated disbursement, overpaid status, modifying approved amounts, floating-rate interest recalculation, date validation.
- **Close of Business (COB)** - partitioning, catch-up, inline COB, account locks.
- **External asset owner** - transfer, cancel, search, initiate/undisbursed.
- **Advanced Payment Allocation** - repayment schedules, interest refunds, charges, reprocessing.
- **Charges** - specific due date, after maturity, instalment fees, penalties, charge-off accounting.
- **Delinquency** - buckets, business events, classification.
- **Batch API, scheduler jobs, journal reversal, SQL-injection reporting.**

## Bugs found

The typed client is stricter than REST-assured, so a few real problems showed up:

- **Wrong charge calculation type.** `ChargeRequestBuilders` had `CHARGE_CALCULATION_TYPE_PERCENTAGE_AMOUNT_AND_INTEREST = 4`, but 4 is percent-of-interest. Percent-of-amount-and-interest is 3, which is what `ChargesHelper` uses and what the tests meant. Every test using that builder was charging on the wrong base and still passing, because the amounts were plausible. Now uses `ChargeCalculationType.PERCENT_OF_AMOUNT_AND_INTEREST`.
- **A comparison that could never be true.** In `testLoanCharges_INSTALMENT_FEE` the instalment numbers are `Long` (the request model requires it) but the schedule reports its period as an `Integer`. `Long.equals(Integer)` is always false, so the "this is the waived instalment" and "this is the paid instalment" branches never ran and the test compared against the wrong expected values. Now compared numerically.
- **A crash hidden in a helper.** `modifyLoanApplication` passed `command` through `Map.of(...)`, which rejects nulls. Three charge tests in `ClientLoanIntegrationTest` pass null here and were throwing `NullPointerException` before reaching the server. Now uses the typed query parameter, which drops a null.
- **A dropped product setting.** `LoanProductTestBuilder.withDisallowExpectedDisbursements(true)` also quietly turned on a 100% over-applied disbursement allowance. The migrated builder set it to `false`, which broke `chargeOff` because it disburses two 1000 tranches against a 1000 approval. Restored.
- **A COB step missing its prerequisite.** `CobPartitioningTest` registered the external-asset-owner COB step but had lost the `ASSET_TRANSFER` GL mapping that step needs. The step list is tenant-wide and never restored, so this broke an unrelated later test.
- **Weak assertions.** The SQL-injection tests caught bare `RuntimeException` as "the server rejected this", so a client-side connection failure counted as a pass. They also looked for "404" in the exception message, which includes the request path, so a report whose ID contained `404` hid a real failure. Both now check the HTTP status.
- **Interest calculation changed.** One charges test had moved from `SAME_AS_REPAYMENT_PERIOD` to `DAILY`. Reverted.
- **Locale changed.** Account transfers were posted with `en` instead of `en_GB`. Restored.
- **A reversal check that never fired.** `verifyTransactions` compared `manuallyReversed` with `Objects.equals(item.getManuallyReversed(), tr.reversed)`, but the API omits that field entirely for non-reversed transactions, so the comparison was `Objects.equals(null, false)` - always false, making the whole predicate unreachable. The check now treats null and false as the same state, and per review feedback it exists in **both** validators: `LoanTestValidators` (Feign) and `BaseLoanIntegrationTest` (REST-assured), where there was previously no check at all.

## Shared test infrastructure

- **`LoanChargeCommandsApi`** and **`ClientChargeCommandsApi`** (new). Two hand-written Feign nterfaces, bound to the *generated* response models, for the three request shapes the generated request models cannot express: a bodyless `?command=waive` POST (the generated client always serialises at least `{}`, which that endpoint answers with a 500), a locale-formatted decimal amount (`"50,05"`), and a client-charge amount with decimal places. No JSON is built by hand. Retyping the shared models instead was rejected: `PostLoansLoanIdChargesRequest.amount` has 118 call sites passing a number, and `PostClientsClientIdChargesRequest.amount` is an `Integer` whose correction is a breaking OpenAPI change (swagger-brake R010) that belongs in its own PR.
- **`LoanRequestBuilders`** - added a type-safe `paymentAllocationOrder(PaymentAllocationType...)` overload, replacing copies of the same private helper in individual tests.
- **`ChargeRequestBuilders`** - dropped its three local `CHARGE_CALCULATION_TYPE_*` constants. All call sites now use the `ChargeCalculationType` enum, so the name and the value can't drift apart again.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [ ] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).
- [ ] If merging this PR resolves a JIRA issue, I will mark that issue as resolved and set "Fix Version/s" appropriately.

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
