### PR TITLE
FINERACT-2702: Make client search case-insensitive

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/client/domain/search/SearchingClientRepositoryImpl.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/client/domain/search/SearchingClientRepositoryImpl.java
@@ -74,10 +74,12 @@ public class SearchingClientRepositoryImpl implements SearchingClientRepository 
             List<Predicate> predicates = new ArrayList<>();
             predicates.add(cb.like(o.get("hierarchy"), hierarchyLikeValue));
 
-            String searchLikeValue = "%" + searchText + "%";
-            predicates.add(cb.or(cb.like(r.get("accountNumber"), searchLikeValue), cb.like(r.get("displayName"), searchLikeValue),
-                    cb.like(r.get("externalId"), searchLikeValue), cb.like(r.get("mobileNo"), searchLikeValue),
-                    cb.like(identity.get("documentKey"), searchLikeValue)));
+            String searchLikeValue = "%" + searchText.toLowerCase() + "%";
+            predicates.add(cb.or(cb.like(cb.lower(r.get("accountNumber")), searchLikeValue),
+                    cb.like(cb.lower(r.get("displayName")), searchLikeValue),
+                    cb.like(cb.function("LOWER", String.class, r.get("externalId")), searchLikeValue),
+                    cb.like(cb.lower(r.get("mobileNo")), searchLikeValue),
+                    cb.like(cb.lower(identity.get("documentKey")), searchLikeValue)));
 
             return cb.and(predicates.toArray(new Predicate[0]));
         };

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/ClientSearchTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/ClientSearchTest.java
@@ -175,6 +175,24 @@ public class ClientSearchTest extends IntegrationTest {
     }
 
     @Test
+    public void testClientSearchWorks_ByExternalId_CaseInsensitive() {
+        // given
+        PostClientsRequest request1 = ClientHelper.defaultClientCreationRequest();
+        clientHelper.createClient(request1);
+
+        PostClientsRequest request2 = ClientHelper.defaultClientCreationRequest();
+        clientHelper.createClient(request2);
+
+        PostClientsRequest request3 = ClientHelper.defaultClientCreationRequest();
+        clientHelper.createClient(request3);
+        // when
+        PageClientSearchData result = clientHelper.searchClients(request2.getExternalId().toUpperCase());
+        // then
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().get(0).getExternalId().getValue()).isEqualTo(request2.getExternalId());
+    }
+
+    @Test
     public void testClientSearchWorks_ByAccountNumber() {
         // given
         PostClientsRequest request1 = ClientHelper.defaultClientCreationRequest();
@@ -212,6 +230,29 @@ public class ClientSearchTest extends IntegrationTest {
         clientHelper.createClient(request3);
         // when
         PageClientSearchData result = clientHelper.searchClients(client2DisplayName);
+        // then
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().get(0).getDisplayName()).isEqualTo(client2DisplayName);
+    }
+
+    @Test
+    public void testClientSearchWorks_ByDisplayName_CaseInsensitive() {
+        // given
+        PostClientsRequest request1 = ClientHelper.defaultClientCreationRequest();
+        clientHelper.createClient(request1);
+
+        PostClientsRequest request2 = ClientHelper.defaultClientCreationRequest();
+        String uniqueFirstName = Utils.randomStringGenerator("FN_", 10);
+        String uniqueLastName = Utils.randomStringGenerator("LN_", 10);
+        request2.setFirstname(uniqueFirstName);
+        request2.setLastname(uniqueLastName);
+        clientHelper.createClient(request2);
+        String client2DisplayName = "%s %s".formatted(uniqueFirstName, uniqueLastName);
+
+        PostClientsRequest request3 = ClientHelper.defaultClientCreationRequest();
+        clientHelper.createClient(request3);
+        // when
+        PageClientSearchData result = clientHelper.searchClients(client2DisplayName.toLowerCase());
         // then
         assertThat(result.getTotalElements()).isEqualTo(1);
         assertThat(result.getContent().get(0).getDisplayName()).isEqualTo(client2DisplayName);
@@ -275,6 +316,29 @@ public class ClientSearchTest extends IntegrationTest {
         clientHelper.createClient(request3);
         // when
         PageClientSearchData result = clientHelper.searchClients(documentKey);
+        // then
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().get(0).getMobileNo()).isEqualTo(request1.getMobileNo());
+    }
+
+    @Test
+    public void testClientSearchWorks_ByClientIdentifier_CaseInsensitive() {
+        // given
+        PostClientsRequest request1 = ClientHelper.defaultClientCreationRequest();
+        request1.setMobileNo(Utils.randomStringGenerator("", 8, Utils.SOURCE_SET_NUMBERS));
+        PostClientsResponse clientResponse = clientHelper.createClient(request1);
+        final Long documentType = 1L;
+        PostClientsClientIdIdentifiersRequest identifierRequest = ClientHelper.createClientIdentifer(documentType);
+        final String documentKey = identifierRequest.getDocumentKey();
+        clientHelper.createClientIdentifer(clientResponse.getClientId(), identifierRequest);
+
+        PostClientsRequest request2 = ClientHelper.defaultClientCreationRequest();
+        clientHelper.createClient(request2);
+
+        PostClientsRequest request3 = ClientHelper.defaultClientCreationRequest();
+        clientHelper.createClient(request3);
+        // when
+        PageClientSearchData result = clientHelper.searchClients(documentKey.toLowerCase());
         // then
         assertThat(result.getTotalElements()).isEqualTo(1);
         assertThat(result.getContent().get(0).getMobileNo()).isEqualTo(request1.getMobileNo());


### PR DESCRIPTION
## Summary
- `GET /v2/clients/search` matched `accountNumber`, `displayName`, `externalId`, `mobileNo`, and identifier `documentKey` using case-sensitive `LIKE` predicates, so a search term differing only in letter case from the stored value would not match.
- `SearchingClientRepositoryImpl.searchByText` now lower-cases the incoming search text and wraps each compared field with `CriteriaBuilder.lower(...)` (via `cb.function("LOWER", ...)` for the `externalId` path), making the match case-insensitive.

## Test plan
- [x] `./gradlew :fineract-core:compileJava` — builds clean
- [x] `./gradlew :fineract-core:compileTestJava :fineract-provider:compileTestJava` — builds clean
- [ ] Manual verification: create a client with a mixed-case `displayName`/`accountNumber`, call `GET /v2/clients/search?searchText=<lowercase-substring>` and confirm the client is now returned

https://issues.apache.org/jira/browse/FINERACT-2702