### PR TITLE
FINERACT-2515: Remove stale auto-generated TODO stub comments

### DIFF
--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanInstallmentCharge.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanInstallmentCharge.java
@@ -73,9 +73,7 @@ public class LoanInstallmentCharge extends AbstractPersistableCustom<Long> imple
     @Column(name = "waived", nullable = false)
     private boolean waived = false;
 
-    public LoanInstallmentCharge() {
-        // TODO Auto-generated constructor stub
-    }
+    public LoanInstallmentCharge() {}
 
     @Override
     public int compareTo(LoanInstallmentCharge o) {

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanTransaction.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanTransaction.java
@@ -870,7 +870,6 @@ public class LoanTransaction extends AbstractAuditableWithUTCDateTimeCustom<Long
     }
 
     public boolean isNotRefundForActiveLoan() {
-        // TODO Auto-generated method stub
         return !isRefundForActiveLoan();
     }
 

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/guarantor/exception/DuplicateGuarantorException.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/guarantor/exception/DuplicateGuarantorException.java
@@ -25,6 +25,5 @@ public class DuplicateGuarantorException extends AbstractPlatformDomainRuleExcep
     public DuplicateGuarantorException(final String action, final String postFix, final String defaultUserMessage,
             final Object... defaultUserMessageArgs) {
         super("error.msg." + action + "." + postFix, defaultUserMessage, defaultUserMessageArgs);
-        // TODO Auto-generated constructor stub
     }
 }

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/domain/LoanProductTrancheDetails.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/domain/LoanProductTrancheDetails.java
@@ -41,9 +41,7 @@ public class LoanProductTrancheDetails {
     @Column(name = "allow_full_term_for_tranche")
     private boolean allowFullTermForTranche;
 
-    protected LoanProductTrancheDetails() {
-        // TODO Auto-generated constructor stub
-    }
+    protected LoanProductTrancheDetails() {}
 
     public LoanProductTrancheDetails(final boolean multiDisburseLoan, final Integer maxTrancheCount,
             final BigDecimal outstandingLoanBalance, final boolean allowFullTermForTranche) {

--- a/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/AccrualBasedAccountingProcessorForLoan.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/AccrualBasedAccountingProcessorForLoan.java
@@ -2169,7 +2169,6 @@ public class AccrualBasedAccountingProcessorForLoan implements AccountingProcess
     }
 
     private void createJournalEntriesForRefundForActiveLoan(LoanDTO loanDTO, LoanTransactionDTO loanTransactionDTO, Office office) {
-        // TODO Auto-generated method stub
         // loan properties
         final Long loanProductId = loanDTO.getLoanProductId();
         final Long loanId = loanDTO.getLoanId();

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/populator/journalentry/JournalEntriesWorkbookPopulator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/populator/journalentry/JournalEntriesWorkbookPopulator.java
@@ -96,8 +96,6 @@ public class JournalEntriesWorkbookPopulator extends AbstractWorkbookPopulator {
         writeString(JournalEntryConstants.BANK_NO_COL, rowHeader, "Bank#");
         writeString(JournalEntryConstants.COMMENTS_COL, rowHeader, "Comments");
 
-        // TODO Auto-generated method stub
-
     }
 
     private void setRules(Sheet worksheet) {

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/service/ExternalServiceWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/service/ExternalServiceWritePlatformServiceJpaRepositoryImpl.java
@@ -53,7 +53,6 @@ public class ExternalServiceWritePlatformServiceJpaRepositoryImpl implements Ext
     @Transactional
     @Override
     public CommandProcessingResult updateExternalServicesProperties(String externalServiceName, JsonCommand command) {
-        // TODO Auto-generated method stub
         this.context.authenticatedUser();
         this.fromApiJsonDeserializer.validateForUpdate(command.json(), externalServiceName);
         Set<String> keyName = this.fromApiJsonDeserializer.getNameKeys(command.json());

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/service/ExternalServicesReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/service/ExternalServicesReadPlatformServiceImpl.java
@@ -36,7 +36,6 @@ public class ExternalServicesReadPlatformServiceImpl implements ExternalServices
 
     @Override
     public ExternalServicesData getExternalServiceDetailsByServiceName(String serviceName) {
-        // TODO Auto-generated method stub
         final ResultSetExtractor<ExternalServicesData> resultSetExtractor = new ExternalServicesDetailsDataExtractor();
         String serviceNameToUse = null;
         switch (serviceName) {
@@ -68,7 +67,6 @@ public class ExternalServicesReadPlatformServiceImpl implements ExternalServices
 
         @Override
         public ExternalServicesData extractData(ResultSet rs) throws SQLException, DataAccessException {
-            // TODO Auto-generated method stub
             Long id = (long) 0;
             String name = null;
             while (rs.next()) {

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/teller/service/TellerWritePlatformServiceJpaImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/teller/service/TellerWritePlatformServiceJpaImpl.java
@@ -161,7 +161,6 @@ public class TellerWritePlatformServiceJpaImpl implements TellerWritePlatformSer
     @Override
     @Transactional
     public CommandProcessingResult deleteTeller(Long tellerId) {
-        // TODO Auto-generated method stub
 
         Teller teller = tellerRepositoryWrapper.findOneWithNotFoundDetection(tellerId);
         Set<Cashier> isTellerIdPresentInCashier = teller.getCashiers();

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/service/AccountTransfersReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/service/AccountTransfersReadPlatformServiceImpl.java
@@ -303,7 +303,6 @@ public class AccountTransfersReadPlatformServiceImpl implements AccountTransfers
     public AccountTransferData retrieveRefundByTransferTemplate(final Long fromOfficeId, final Long fromClientId, final Long fromAccountId,
             final Integer fromAccountType, final Long toOfficeId, final Long toClientId, final Long toAccountId,
             final Integer toAccountType) {
-        // TODO Auto-generated method stub
         final EnumOptionData loanAccountType = AccountTransferEnumerations.accountType(PortfolioAccountType.LOAN);
         final EnumOptionData savingsAccountType = AccountTransferEnumerations.accountType(PortfolioAccountType.SAVINGS);
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/service/AccountTransfersWritePlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/service/AccountTransfersWritePlatformServiceImpl.java
@@ -567,7 +567,6 @@ public class AccountTransfersWritePlatformServiceImpl implements AccountTransfer
     @Override
     @Transactional
     public CommandProcessingResult refundByTransfer(JsonCommand command) {
-        // TODO Auto-generated method stub
         this.accountTransfersDataValidator.validate(command);
 
         final LocalDate transactionDate = command.localDateValueOfParameterNamed(transferDateParamName);

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/service/PortfolioAccountReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/service/PortfolioAccountReadPlatformServiceImpl.java
@@ -370,7 +370,6 @@ public class PortfolioAccountReadPlatformServiceImpl implements PortfolioAccount
 
     @Override
     public PortfolioAccountData retrieveOneByPaidInAdvance(Long accountId, Integer accountTypeId) {
-        // TODO Auto-generated method stub
         Object[] sqlParams = new Object[] { accountId, accountId };
         PortfolioAccountData accountData = null;
         // String currencyCode = null;

--- a/fineract-rates/src/main/java/org/apache/fineract/portfolio/floatingrates/data/FloatingRateData.java
+++ b/fineract-rates/src/main/java/org/apache/fineract/portfolio/floatingrates/data/FloatingRateData.java
@@ -100,7 +100,6 @@ public class FloatingRateData implements Comparable<FloatingRateData>, Serializa
     }
 
     public static FloatingRateData toTemplate(List<EnumOptionData> interestRateFrequencyTypeOptions) {
-        // TODO Auto-generated method stub
         return new FloatingRateData(null, null, false, true, null, null, null, null, null, interestRateFrequencyTypeOptions);
     }
 }

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/DepositAccountInterestIncentive.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/DepositAccountInterestIncentive.java
@@ -37,9 +37,7 @@ public class DepositAccountInterestIncentive extends AbstractPersistableCustom<L
     @Embedded
     private InterestIncentivesFields interestIncentivesFields;
 
-    protected DepositAccountInterestIncentive() {
-        // TODO Auto-generated constructor stub
-    }
+    protected DepositAccountInterestIncentive() {}
 
     public DepositAccountInterestIncentive(final DepositAccountInterestRateChartSlabs depositAccountInterestRateChartSlabs,
             final InterestIncentivesFields interestIncentivesFields) {


### PR DESCRIPTION
## JIRA
- https://issues.apache.org/jira/browse/FINERACT-2515

## Problem

Three files (`LoanInstallmentCharge.java`, `LoanTransaction.java`, `DuplicateGuarantorException.java`) contained stale `// TODO Auto-generated...` stub comments left over from IDE code generation, despite the implementations being complete. Two prior PRs attempted to address this but each covered only these same 3 files:

- #5672 (FINERACT-2515, KRYSTALM7)
- #5844 (FINERACT-2346, Harshdhall01)

Both were converted to draft after a maintainer requested the scope be widened to cover all instances of this pattern across the codebase, and both stalled without further updates.

## Fix

Removes the same stub comments from the original 3 files plus 11 additional files across `fineract-loan`, `fineract-provider`, `fineract-rates`, and `fineract-savings`, covering the full scope requested on #5672 and #5844.

Files touched:
- `LoanInstallmentCharge.java`
- `LoanTransaction.java`
- `DuplicateGuarantorException.java`
- `LoanProductTrancheDetails.java`
- `AccrualBasedAccountingProcessorForLoan.java`
- `JournalEntriesWorkbookPopulator.java`
- `ExternalServiceWritePlatformServiceJpaRepositoryImpl.java`
- `ExternalServicesReadPlatformServiceImpl.java`
- `TellerWritePlatformServiceJpaImpl.java`
- `AccountTransfersReadPlatformServiceImpl.java`
- `AccountTransfersWritePlatformServiceImpl.java`
- `PortfolioAccountReadPlatformServiceImpl.java`
- `FloatingRateData.java`
- `DepositAccountInterestIncentive.java`

No functional changes. Comment removal only.

## Overlap with prior PRs

This PR's diff is a superset of both #5672 and #5844. Recommend closing both as superseded once this is merged, to avoid duplicate review of the same 3 files.