### PR TITLE
FINERACT-2621: Add CI-only diagnostics for missing external events in e2e

### DIFF
--- a/.github/workflows/build-e2e-tests.yml
+++ b/.github/workflows/build-e2e-tests.yml
@@ -34,6 +34,7 @@ jobs:
       TEST_TENANT_ID: default
       INITIALIZATION_ENABLED: true
       EVENT_VERIFICATION_ENABLED: true
+      EVENT_FAILURE_DIAGNOSTICS_ENABLED: true
       ACTIVEMQ_BROKER_URL: tcp://localhost:61616
       ACTIVEMQ_TOPIC_NAME: events
 

--- a/fineract-client-feign/src/main/java/org/apache/fineract/client/feign/FineractFeignClient.java
+++ b/fineract-client-feign/src/main/java/org/apache/fineract/client/feign/FineractFeignClient.java
@@ -81,6 +81,7 @@ import org.apache.fineract.client.feign.services.InterOperationApi;
 import org.apache.fineract.client.feign.services.InterestRateChartApi;
 import org.apache.fineract.client.feign.services.InterestRateSlabAKAInterestBandsApi;
 import org.apache.fineract.client.feign.services.InternalCobApi;
+import org.apache.fineract.client.feign.services.InternalExternalEventsApi;
 import org.apache.fineract.client.feign.services.InternalWorkingCapitalLoansApi;
 import org.apache.fineract.client.feign.services.JournalEntriesApi;
 import org.apache.fineract.client.feign.services.LikelihoodApi;
@@ -463,6 +464,10 @@ public final class FineractFeignClient {
 
     public InternalCobApi internalCob() {
         return create(InternalCobApi.class);
+    }
+
+    public InternalExternalEventsApi internalExternalEvents() {
+        return create(InternalExternalEventsApi.class);
     }
 
     public JournalEntriesApi journalEntries() {

--- a/fineract-client-feign/src/main/java/org/apache/fineract/client/feign/FineractFeignClient.java
+++ b/fineract-client-feign/src/main/java/org/apache/fineract/client/feign/FineractFeignClient.java
@@ -83,6 +83,7 @@ import org.apache.fineract.client.feign.services.InterOperationApi;
 import org.apache.fineract.client.feign.services.InterestRateChartApi;
 import org.apache.fineract.client.feign.services.InterestRateSlabAKAInterestBandsApi;
 import org.apache.fineract.client.feign.services.InternalCobApi;
+import org.apache.fineract.client.feign.services.InternalExternalEventsApi;
 import org.apache.fineract.client.feign.services.InternalWorkingCapitalLoansApi;
 import org.apache.fineract.client.feign.services.JournalEntriesApi;
 import org.apache.fineract.client.feign.services.LikelihoodApi;
@@ -476,6 +477,10 @@ public final class FineractFeignClient {
 
     public InternalCobApi internalCob() {
         return create(InternalCobApi.class);
+    }
+
+    public InternalExternalEventsApi internalExternalEvents() {
+        return create(InternalExternalEventsApi.class);
     }
 
     public JournalEntriesApi journalEntries() {

--- a/fineract-client-feign/src/main/java/org/apache/fineract/client/feign/services/InternalExternalEventsApi.java
+++ b/fineract-client-feign/src/main/java/org/apache/fineract/client/feign/services/InternalExternalEventsApi.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.client.feign.services;
+
+import feign.Headers;
+import feign.Param;
+import feign.RequestLine;
+
+/**
+ * Internal testing API for external events. These endpoints are only available when the TEST profile is active.
+ */
+public interface InternalExternalEventsApi {
+
+    /**
+     * Returns the raw JSON array of external events persisted in {@code m_external_event}, so callers can tell whether
+     * an event was ever recorded independently of whether it was delivered to the message broker.
+     */
+    @RequestLine("GET v1/internal/externalevents?type={type}&aggregateRootId={aggregateRootId}")
+    @Headers("Content-Type: application/json")
+    String getExternalEvents(@Param("type") String type, @Param("aggregateRootId") Long aggregateRootId);
+}

--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/messaging/EventFailureDiagnostics.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/messaging/EventFailureDiagnostics.java
@@ -1,0 +1,132 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.test.messaging;
+
+import static org.apache.fineract.client.feign.util.FeignCalls.ok;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.client.feign.FineractFeignClient;
+import org.apache.fineract.test.messaging.config.EventProperties;
+import org.apache.fineract.test.messaging.store.EventStore;
+import org.springframework.stereotype.Component;
+
+/**
+ * Explains why an event assertion timed out.
+ *
+ * <p>
+ * An event only reaches the test through two independent stages: it must be persisted into {@code m_external_event} by
+ * the business transaction, and it must then be published to the broker by the "Send Asynchronous Events" job. A
+ * timeout alone cannot tell those apart, which makes intermittent CI failures hard to attribute. This queries the
+ * server for what it actually persisted so the log states which stage lost the event.
+ *
+ * <p>
+ * Only runs when {@code EVENT_FAILURE_DIAGNOSTICS_ENABLED} is set, and only after an assertion has already failed, so
+ * it never affects passing runs. Any error raised while gathering diagnostics is swallowed - it must never replace the
+ * original assertion failure.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EventFailureDiagnostics {
+
+    private static final Gson GSON = new Gson();
+    private static final Type EVENT_LIST_TYPE = new TypeToken<List<Map<String, Object>>>() {}.getType();
+
+    private final FineractFeignClient fineractClient;
+    private final EventProperties eventProperties;
+    private final EventStore eventStore;
+
+    /**
+     * Reports whether the missing event was persisted server-side.
+     *
+     * @param eventName
+     *            external event type, e.g. {@code LoanBuyDownFeeAmortizationTransactionCreatedBusinessEvent}
+     * @param aggregateRootId
+     *            aggregate root the event belongs to (the loan id for loan events); may be null
+     * @param expectedPayloadId
+     *            id the assertion waited for, matched against {@code payLoad.id} - for loan transaction events this is
+     *            the loan transaction id
+     */
+    public void reportMissingEvent(final String eventName, final Long aggregateRootId, final Long expectedPayloadId) {
+        if (!eventProperties.isFailureDiagnosticsEnabled()) {
+            return;
+        }
+        try {
+            final String rawJson = ok(() -> fineractClient.internalExternalEvents().getExternalEvents(eventName, aggregateRootId));
+            final List<Map<String, Object>> persisted = GSON.fromJson(rawJson, EVENT_LIST_TYPE);
+
+            log.error("=== EVENT DIAGNOSTICS: {} (aggregateRootId={}, expected payLoad.id={}) ===", eventName, aggregateRootId,
+                    expectedPayloadId);
+
+            if (persisted == null || persisted.isEmpty()) {
+                log.error("""
+                        VERDICT: NOT PERSISTED - server has no '{}' event for aggregateRootId={}.
+                        The event was never written to m_external_event, so the loss is upstream of the sender job \
+                        (event not raised, or discarded before/at transaction commit).
+                        """, eventName, aggregateRootId);
+            } else if (containsPayloadId(persisted, expectedPayloadId)) {
+                log.error("""
+                        VERDICT: PERSISTED BUT NOT DELIVERED - server persisted a '{}' event with payLoad.id={}, \
+                        but it never reached the test's JMS listener within {}ms.
+                        The loss is in delivery (sender job selection, broker publish, or test-side consumption).
+                        """, eventName, expectedPayloadId, eventProperties.getWaitTimeoutInMillis());
+            } else {
+                log.error("""
+                        VERDICT: PERSISTED UNDER A DIFFERENT ID - server has {} '{}' event(s) for aggregateRootId={}, \
+                        but none with payLoad.id={}.
+                        The assertion may be waiting on the wrong transaction id.
+                        """, persisted.size(), eventName, aggregateRootId, expectedPayloadId);
+            }
+
+            log.error("Server-persisted events (raw): {}", rawJson);
+            log.error("Events of this type received by the test: {}", describeReceived(eventName));
+            log.error("=== END EVENT DIAGNOSTICS ===");
+        } catch (Exception e) {
+            // Never let diagnostics mask the real assertion failure.
+            log.error("Failed to collect event diagnostics for {} (aggregateRootId={})", eventName, aggregateRootId, e);
+        }
+    }
+
+    private boolean containsPayloadId(final List<Map<String, Object>> persisted, final Long expectedPayloadId) {
+        if (expectedPayloadId == null) {
+            return false;
+        }
+        return persisted.stream().anyMatch(event -> {
+            final Object payload = event.get("payLoad");
+            if (!(payload instanceof Map<?, ?> payloadMap)) {
+                return false;
+            }
+            final Object id = payloadMap.get("id");
+            // Gson decodes untyped JSON numbers as Double.
+            return id instanceof Number number && expectedPayloadId.longValue() == number.longValue();
+        });
+    }
+
+    private String describeReceived(final String eventName) {
+        return eventStore.getReceivedEvents().stream().filter(message -> eventName.equals(message.getType()))
+                .map(message -> "idempotencyKey=" + message.getIdempotencyKey() + ", businessDate=" + message.getBusinessDate()).toList()
+                .toString();
+    }
+}

--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/messaging/config/EventProperties.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/messaging/config/EventProperties.java
@@ -38,6 +38,13 @@ public class EventProperties {
     @Value("${fineract-test.event.verification-enabled}")
     private boolean eventVerificationEnabled;
 
+    /**
+     * When enabled, a failed event assertion queries the server for the events it actually persisted, so CI logs show
+     * whether the event was never recorded or merely never delivered. Off by default; switched on in CI only.
+     */
+    @Value("${fineract-test.event.failure-diagnostics-enabled}")
+    private boolean failureDiagnosticsEnabled;
+
     public boolean isEventVerificationDisabled() {
         return !isEventVerificationEnabled();
     }

--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/messaging/event/EventCheckHelper.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/messaging/event/EventCheckHelper.java
@@ -175,6 +175,7 @@ public class EventCheckHelper {
     private static final long TRANSACTION_COMMIT_DELAY_MS = 100L;
     private static final String JOURNAL_ENTRY_TYPE_DEBIT = "DEBIT";
     private static final String JOURNAL_ENTRY_TYPE_CREDIT = "CREDIT";
+    private static final int EVENT_VERIFICATION_MAX_ATTEMPTS = 3;
 
     @Autowired
     private FineractFeignClient fineractClient;
@@ -260,6 +261,27 @@ public class EventCheckHelper {
         GetLoansLoanIdResponse body = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", false, "associations", "all", "exclude", "", "fields", "")));
 
+        // Earlier steps may have raised events of the same type for this loan; assertEvent consumes the
+        // latest one received, which is a stale predecessor when the newest event is still in transit.
+        // Each attempt consumes one event, so retrying waits for the next one to arrive.
+        retryOnAssertionError(EVENT_VERIFICATION_MAX_ATTEMPTS, () -> verifyLoanAccountDataV1(eventClazz, loanId, body));
+    }
+
+    private void retryOnAssertionError(int maxAttempts, Runnable verification) {
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                verification.run();
+                return;
+            } catch (AssertionError e) {
+                if (attempt == maxAttempts) {
+                    throw e;
+                }
+                log.debug("Event verification attempt {} of {} failed, retrying with the next received event", attempt, maxAttempts);
+            }
+        }
+    }
+
+    private void verifyLoanAccountDataV1(Class<? extends AbstractLoanEvent> eventClazz, Long loanId, GetLoansLoanIdResponse body) {
         eventAssertion.assertEvent(eventClazz, loanId)//
                 .extractingData(loanAccountDataV1 -> {
                     assertThat(loanAccountDataV1.getId()).as("id").isEqualTo(body.getId());

--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/messaging/event/EventCheckHelper.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/messaging/event/EventCheckHelper.java
@@ -99,6 +99,7 @@ public class EventCheckHelper {
     private static final DateTimeFormatter FORMATTER_EVENTS = DateTimeFormatter.ofPattern("yyyy-MM-dd");
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern(DATE_FORMAT);
     private static final long TRANSACTION_COMMIT_DELAY_MS = 100L;
+    private static final int EVENT_VERIFICATION_MAX_ATTEMPTS = 3;
 
     @Autowired
     private FineractFeignClient fineractClient;
@@ -184,6 +185,27 @@ public class EventCheckHelper {
         GetLoansLoanIdResponse body = ok(() -> fineractClient.loans().retrieveOneLoan(loanId,
                 Map.of("staffInSelectedOfficeOnly", false, "associations", "all", "exclude", "", "fields", "")));
 
+        // Earlier steps may have raised events of the same type for this loan; assertEvent consumes the
+        // latest one received, which is a stale predecessor when the newest event is still in transit.
+        // Each attempt consumes one event, so retrying waits for the next one to arrive.
+        retryOnAssertionError(EVENT_VERIFICATION_MAX_ATTEMPTS, () -> verifyLoanAccountDataV1(eventClazz, loanId, body));
+    }
+
+    private void retryOnAssertionError(int maxAttempts, Runnable verification) {
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                verification.run();
+                return;
+            } catch (AssertionError e) {
+                if (attempt == maxAttempts) {
+                    throw e;
+                }
+                log.debug("Event verification attempt {} of {} failed, retrying with the next received event", attempt, maxAttempts);
+            }
+        }
+    }
+
+    private void verifyLoanAccountDataV1(Class<? extends AbstractLoanEvent> eventClazz, Long loanId, GetLoansLoanIdResponse body) {
         eventAssertion.assertEvent(eventClazz, loanId)//
                 .extractingData(loanAccountDataV1 -> {
                     Long idActual = loanAccountDataV1.getId();

--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanStepDef.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanStepDef.java
@@ -149,6 +149,7 @@ import org.apache.fineract.test.helper.CodeHelper;
 import org.apache.fineract.test.helper.ErrorMessageHelper;
 import org.apache.fineract.test.helper.Utils;
 import org.apache.fineract.test.messaging.EventAssertion;
+import org.apache.fineract.test.messaging.EventFailureDiagnostics;
 import org.apache.fineract.test.messaging.config.EventProperties;
 import org.apache.fineract.test.messaging.config.JobPollingProperties;
 import org.apache.fineract.test.messaging.event.EventCheckHelper;
@@ -197,6 +198,7 @@ public class LoanStepDef extends AbstractStepDef {
     private final BusinessDateHelper businessDateHelper;
     private final FineractFeignClient fineractClient;
     private final EventAssertion eventAssertion;
+    private final EventFailureDiagnostics eventFailureDiagnostics;
     private final PaymentTypeResolver paymentTypeResolver;
     private final LoanProductResolver loanProductResolver;
     private final LoanRequestFactory loanRequestFactory;
@@ -5932,8 +5934,16 @@ public class LoanStepDef extends AbstractStepDef {
                 .orElseThrow(() -> new IllegalStateException(String.format("No Buy Down Fee Amortization transaction found on %s", date)));
         Long buyDownFeeAmortizationTransactionId = buyDownFeeAmortizationTransaction.getId();
 
-        eventAssertion.assertEventRaised(LoanBuyDownFeeAmortizationTransactionCreatedBusinessEvent.class,
-                buyDownFeeAmortizationTransactionId);
+        try {
+            eventAssertion.assertEventRaised(LoanBuyDownFeeAmortizationTransactionCreatedBusinessEvent.class,
+                    buyDownFeeAmortizationTransactionId);
+        } catch (AssertionError e) {
+            // This assertion fails intermittently in CI only; the diagnostics say whether the event was never
+            // persisted or merely never delivered.
+            eventFailureDiagnostics.reportMissingEvent("LoanBuyDownFeeAmortizationTransactionCreatedBusinessEvent", loanId,
+                    buyDownFeeAmortizationTransactionId);
+            throw e;
+        }
     }
 
     @Then("LoanBuyDownFeeAdjustmentTransactionCreatedBusinessEvent is created on {string}")

--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanStepDef.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/loan/LoanStepDef.java
@@ -147,6 +147,7 @@ import org.apache.fineract.test.helper.CodeHelper;
 import org.apache.fineract.test.helper.ErrorMessageHelper;
 import org.apache.fineract.test.helper.Utils;
 import org.apache.fineract.test.messaging.EventAssertion;
+import org.apache.fineract.test.messaging.EventFailureDiagnostics;
 import org.apache.fineract.test.messaging.config.EventProperties;
 import org.apache.fineract.test.messaging.config.JobPollingProperties;
 import org.apache.fineract.test.messaging.event.EventCheckHelper;
@@ -195,6 +196,7 @@ public class LoanStepDef extends AbstractStepDef {
     private final BusinessDateHelper businessDateHelper;
     private final FineractFeignClient fineractClient;
     private final EventAssertion eventAssertion;
+    private final EventFailureDiagnostics eventFailureDiagnostics;
     private final PaymentTypeResolver paymentTypeResolver;
     private final LoanProductResolver loanProductResolver;
     private final LoanRequestFactory loanRequestFactory;
@@ -5848,8 +5850,16 @@ public class LoanStepDef extends AbstractStepDef {
                 .orElseThrow(() -> new IllegalStateException(String.format("No Buy Down Fee Amortization transaction found on %s", date)));
         Long buyDownFeeAmortizationTransactionId = buyDownFeeAmortizationTransaction.getId();
 
-        eventAssertion.assertEventRaised(LoanBuyDownFeeAmortizationTransactionCreatedBusinessEvent.class,
-                buyDownFeeAmortizationTransactionId);
+        try {
+            eventAssertion.assertEventRaised(LoanBuyDownFeeAmortizationTransactionCreatedBusinessEvent.class,
+                    buyDownFeeAmortizationTransactionId);
+        } catch (AssertionError e) {
+            // This assertion fails intermittently in CI only; the diagnostics say whether the event was never
+            // persisted or merely never delivered.
+            eventFailureDiagnostics.reportMissingEvent("LoanBuyDownFeeAmortizationTransactionCreatedBusinessEvent", loanId,
+                    buyDownFeeAmortizationTransactionId);
+            throw e;
+        }
     }
 
     @Then("LoanBuyDownFeeAdjustmentTransactionCreatedBusinessEvent is created on {string}")

--- a/fineract-e2e-tests-core/src/test/resources/fineract-test-application.properties
+++ b/fineract-e2e-tests-core/src/test/resources/fineract-test-application.properties
@@ -40,6 +40,7 @@ fineract-test.event.verification-enabled=${EVENT_VERIFICATION_ENABLED:false}
 fineract-test.event.wait-timeout-in-ms=${POLLING_EVENT_WAIT_TIMEOUT_IN_MS:15000}
 fineract-test.event.delay-in-ms=${POLLING_EVENT_WAIT_TIMEOUT_IN_MS:100}
 fineract-test.event.interval-in-ms=${POLLING_EVENT_WAIT_TIMEOUT_IN_MS:100}
+fineract-test.event.failure-diagnostics-enabled=${EVENT_FAILURE_DIAGNOSTICS_ENABLED:false}
 
 fineract-test.job.interval-in-ms=${POLLING_JOB_INTERVAL_IN_MS:100}
 fineract-test.job.delay-in-ms=${POLLING_JOB_DELAY_IN_MS:3000}


### PR DESCRIPTION
## Description

Extracted from #6069, where review asked for these e2e changes to be raised in a separate PR since they are not part of the Spring Boot upgrade itself.

- When an event assertion times out, the step now queries the internal external events endpoint and logs whether the event was never persisted to `m_external_event` or was persisted but never delivered to the broker. A timeout alone cannot tell these two stages apart, which makes intermittent CI failures hard to attribute. Controlled by `EVENT_FAILURE_DIAGNOSTICS_ENABLED`, off by default and set only in the e2e workflow, and it only runs after an assertion has already failed, so passing runs are unaffected.
- `loanAccountDataV1Check` consumes the latest received event of the asserted type, which can be a stale predecessor when earlier steps raised events of the same type for the same loan. The verification is now retried so each attempt consumes the next event as it arrives.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
