### PR TITLE
FINERACT-2621: Fix SchedulerJobsTest business date job race

### DIFF
--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/SchedulerJobsTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/SchedulerJobsTest.java
@@ -20,6 +20,7 @@ package org.apache.fineract.integrationtests;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.http.ContentType;
@@ -139,7 +140,17 @@ public class SchedulerJobsTest {
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
 
-            ParallelExecutionHelper.runInParallel(SchedulerJobHelper.getAllSchedulerJobNames(), SchedulerJobHelper::executeAndAwaitJob);
+            // Both date jobs write m_business_date: they race to insert the initial row while none exists yet, and
+            // the business date job also writes the COB date row when COB date adjustment is enabled. Running them
+            // next to each other makes one of them fail, so keep them out of the parallel batch.
+            List<String> dateJobs = List.of(JobName.INCREASE_BUSINESS_DATE_BY_1_DAY.toString(),
+                    JobName.INCREASE_COB_DATE_BY_1_DAY.toString());
+            List<String> allJobs = SchedulerJobHelper.getAllSchedulerJobNames();
+            assertTrue(allJobs.containsAll(dateJobs), "Date jobs are no longer named as expected, they would run in parallel: " + allJobs);
+
+            ParallelExecutionHelper.runInParallel(allJobs.stream().filter(jobName -> !dateJobs.contains(jobName)).toList(),
+                    SchedulerJobHelper::executeAndAwaitJob);
+            dateJobs.forEach(SchedulerJobHelper::executeAndAwaitJob);
         } finally {
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(false));

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/SchedulerJobsTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/SchedulerJobsTest.java
@@ -20,6 +20,7 @@ package org.apache.fineract.integrationtests;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.http.ContentType;
@@ -141,7 +142,17 @@ public class SchedulerJobsTest {
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(true));
 
-            ParallelExecutionHelper.runInParallel(schedulerJobHelper.getAllSchedulerJobNames(), schedulerJobHelper::executeAndAwaitJob);
+            // Both date jobs write m_business_date: they race to insert the initial row while none exists yet, and
+            // the business date job also writes the COB date row when COB date adjustment is enabled. Running them
+            // next to each other makes one of them fail, so keep them out of the parallel batch.
+            List<String> dateJobs = List.of(JobName.INCREASE_BUSINESS_DATE_BY_1_DAY.toString(),
+                    JobName.INCREASE_COB_DATE_BY_1_DAY.toString());
+            List<String> allJobs = schedulerJobHelper.getAllSchedulerJobNames();
+            assertTrue(allJobs.containsAll(dateJobs), "Date jobs are no longer named as expected, they would run in parallel: " + allJobs);
+
+            ParallelExecutionHelper.runInParallel(allJobs.stream().filter(jobName -> !dateJobs.contains(jobName)).toList(),
+                    schedulerJobHelper::executeAndAwaitJob);
+            dateJobs.forEach(schedulerJobHelper::executeAndAwaitJob);
         } finally {
             globalConfigurationHelper.updateGlobalConfiguration(GlobalConfigurationConstants.ENABLE_BUSINESS_DATE,
                     new PutGlobalConfigurationsRequest().enabled(false));


### PR DESCRIPTION
## Description

Replaces the original approach in this PR (retrying the business date increase in a `REQUIRES_NEW` transaction), which @adamsaghy pushed back on. He was right: a new transaction decouples the date write from the job status, and a rerun after a false FAILED would increase the date twice — worse than the duplicate key it avoided.

The problem was in the test, not in production code. `SchedulerJobsTest.testTriggeringManualExecutionOfAllSchedulerJobs` enables business date and then runs every scheduled job in parallel. `INCREASE_BUSINESS_DATE_BY_1_DAY` and `INCREASE_COB_DATE_BY_1_DAY` both write `m_business_date`, so they race to insert the initial row while none exists yet, and the business date job also writes the COB date row when COB date adjustment is enabled. One of them then fails on `uq_business_date_type`, which surfaced as an intermittent failure on a MySQL CI shard of #6069.

Both date jobs now run on their own, after the parallel batch. They are excluded rather than the rows being pre-seeded, because seeding only closes the insert race — `BusinessDate` carries an `@Version` field, so two jobs writing the COB date row could still collide on optimistic locking.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
