### PR TITLE
FINERACT-2707: Email campaign JSON parsing failures are silently swallowed instead of logged

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/campaigns/email/service/EmailCampaignWritePlatformCommandHandlerImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/campaigns/email/service/EmailCampaignWritePlatformCommandHandlerImpl.java
@@ -214,7 +214,8 @@ public class EmailCampaignWritePlatformCommandHandlerImpl implements EmailCampai
                 }
             }
         } catch (final IOException e) {
-            // TODO throw something here
+            log.error("Failed to parse campaign params while inserting direct campaign into email outbound table for campaign {} ({})",
+                    emailCampaign.getId(), emailCampaign.getCampaignName(), e);
         }
 
     }
@@ -247,7 +248,8 @@ public class EmailCampaignWritePlatformCommandHandlerImpl implements EmailCampai
                 }
             }
         } catch (final IOException e) {
-            // TODO throw something here
+            log.error("Failed to parse campaign params while inserting direct campaign into email outbound table for campaign {} ({})",
+                    campaignId, campaignName, e);
         }
 
     }
@@ -410,7 +412,7 @@ public class EmailCampaignWritePlatformCommandHandlerImpl implements EmailCampai
                 }
             }
         } catch (final IOException e) {
-            // TODO throw something here
+            log.error("Failed to parse campaign params while generating email campaign preview message", e);
         }
 
         return campaignMessage;


### PR DESCRIPTION
## JIRA
- https://issues.apache.org/jira/browse/FINERACT-2707

## Problem

Three catch blocks in `EmailCampaignWritePlatformCommandHandlerImpl` caught `IOException` from JSON parsing and did nothing with it. No log, no rethrow. Failures during email campaign processing disappeared silently.

Affected methods:
- `insertDirectCampaignIntoEmailOutboundTable(Loan, EmailCampaign, HashMap)`
- `insertDirectCampaignIntoEmailOutboundTable(String, String, String, String, Long)` (private overload)
- `previewMessage(JsonQuery)`

## Fix

Replaced each `// TODO throw something here` with a `log.error` call, including campaign id and name where available.

Both public callers of `insertDirectCampaignIntoEmailOutboundTable` loop over multiple campaigns in a single pass: `EmailCampaignDomainServiceImpl` and the scheduled `UpdateEmailOutboundWithCampaignMessageTasklet`. Throwing from inside either loop would abort processing for every other campaign in that run. Logging and continuing avoids that regression while still surfacing the failure.

This matches the existing convention for the same scenario in the SMS campaign equivalents (`SmsCampaignDomainServiceImpl`, `SmsCampaignWritePlatformServiceJpaImpl`), which already log and continue on the same `IOException`.

No functional change otherwise.

## Note

`SmsCampaignWritePlatformServiceJpaImpl` has the same unresolved `// TODO throw something here` in its own preview-message method, the only one in that class not already following the log-and-continue pattern. Planning to file a separate ticket and PR for that as a follow-up, keeping this PR scoped to the email campaign class.