### PR TITLE
FINERACT-2709: Fix chart-of-accounts template guarding the wrong variable

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/populator/chartofaccounts/ChartOfAccountsWorkbook.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/populator/chartofaccounts/ChartOfAccountsWorkbook.java
@@ -158,7 +158,7 @@ public class ChartOfAccountsWorkbook extends AbstractWorkbookPopulator {
         for (Integer i = 0; i < accountTypesNoDuplicatesList.size(); i++) {
             Name tags = chartOfAccountsWorkbook.createName();
             Integer[] tagValueBeginEndIndexes = accountTypeToBeginEndIndexesofAccountNames.get(i);
-            if (accountTypeToBeginEndIndexesofAccountNames != null) {
+            if (tagValueBeginEndIndexes != null) {
                 setSanitized(tags, "Tags_" + accountTypesNoDuplicatesList.get(i));
                 tags.setRefersToFormula(TemplatePopulateImportConstants.CHART_OF_ACCOUNTS_SHEET_NAME + "!$V$" + tagValueBeginEndIndexes[0]
                         + ":$V$" + tagValueBeginEndIndexes[1]);

--- a/fineract-provider/src/test/java/org/apache/fineract/infrastructure/bulkimport/populator/chartofaccounts/ChartOfAccountsWorkbookTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/infrastructure/bulkimport/populator/chartofaccounts/ChartOfAccountsWorkbookTest.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.bulkimport.populator.chartofaccounts;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+import org.apache.fineract.accounting.glaccount.data.GLAccountData;
+import org.apache.fineract.infrastructure.codes.data.CodeValueData;
+import org.apache.fineract.infrastructure.core.data.EnumOptionData;
+import org.apache.fineract.organisation.monetary.data.CurrencyData;
+import org.apache.fineract.organisation.office.data.OfficeData;
+import org.apache.poi.hssf.usermodel.HSSFWorkbook;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.junit.jupiter.api.Test;
+
+class ChartOfAccountsWorkbookTest {
+
+    private static final String DATE_FORMAT = "dd MMMM yyyy";
+
+    private GLAccountData glAccount(Long id, String name, String type, String tag) {
+        return GLAccountData.importInstance(name, null, "GL" + id, Boolean.TRUE, new EnumOptionData(1L, type, type),
+                new EnumOptionData(1L, "DETAIL", "DETAIL"), null, CodeValueData.instance(id, tag), null).setId(id);
+    }
+
+    private ChartOfAccountsWorkbook workbook(List<GLAccountData> glAccounts) {
+        return new ChartOfAccountsWorkbook(glAccounts, List.of(OfficeData.testInstance(1L, "Head Office")),
+                List.of(new CurrencyData("USD")));
+    }
+
+    // The Tags named range is built per account type from the lookup-index entry, and the guard in front of it must
+    // test the per-iteration array it dereferences (tagValueBeginEndIndexes) rather than the map it was read from.
+    // Guarding the map instead makes the check always true — dead code that protects nothing and would let a null
+    // index entry through to tagValueBeginEndIndexes[0]. This pins the working path: one Tags_<type> defined name
+    // per account type, alongside the AccountName_<type> range its correctly-guarded sibling block emits.
+    @Test
+    void tagsNamedRangeIsBuiltForEachAccountType() throws Exception {
+        List<GLAccountData> glAccounts = List.of(glAccount(1L, "Cash", "ASSET", "Current Assets"),
+                glAccount(2L, "Share Capital", "EQUITY", "Capital"));
+
+        try (Workbook workbook = new HSSFWorkbook()) {
+            assertDoesNotThrow(() -> workbook(glAccounts).populate(workbook, DATE_FORMAT));
+
+            assertNotNull(workbook.getName("Tags_ASSET"), "expected a Tags named range for the ASSET account type");
+            assertNotNull(workbook.getName("Tags_EQUITY"), "expected a Tags named range for the EQUITY account type");
+            // the sibling AccountName block guards correctly and must keep working unchanged
+            assertNotNull(workbook.getName("AccountName_ASSET"));
+            assertNotNull(workbook.getName("AccountName_EQUITY"));
+
+            long tagRanges = workbook.getAllNames().stream().filter(name -> name.getNameName().startsWith("Tags_")).count();
+            assertEquals(2, tagRanges, "one Tags named range per account type");
+        }
+    }
+}


### PR DESCRIPTION
     - ChartOfAccountsWorkbook.setNames builds a Tags named range per account type from the
        lookup-index entry, but null-checks the map it read the entry from rather than the
        entry itself: it reads Integer[] tagValueBeginEndIndexes from
        accountTypeToBeginEndIndexesofAccountNames, then tests the map for null and
        dereferences tagValueBeginEndIndexes[0] and [1] inside the block.
      - The map is an instance field that was already dereferenced on the line above (.get(i)),
        so it is never null at that point: the guard is always true and protects nothing, while
        reading as though it protects the array access. The value that can be null is the
        per-iteration array, from a Map.get miss.
      - The sibling block immediately below, which builds the AccountName named range, shows the
        intended pattern and guards the array it dereferences. The Tags block appears to be a
        copy of it with the guarded variable left unchanged.
      - Guard tagValueBeginEndIndexes instead, so a missing lookup-index entry skips the Tags
        named range rather than dereferencing null, matching the sibling block.
      - Note on reachability and on the test: with well-formed GL-account data the null branch
        cannot be reached. accountTypesNoDuplicatesList and the index map are both derived from
        the same glAccounts list, and setLookupTable only skips a put -- leaving a gap -- for an
        account type whose account-name list is empty, which cannot happen for a type that came
        from an actual account. This is therefore a dead guard and a latent NPE rather than a
        reproducible failure, and the added ChartOfAccountsWorkbookTest is a characterisation
        test: it pins the working path (one Tags_<type> range per account type, alongside the
        AccountName_<type> range) and would catch an incorrect fix, but it passes both with and
        without this change, since no input reachable through the public API can produce the
        null entry. Reaching the null branch would require reflecting into the populator's
        internal map, which would test an implementation detail rather than behaviour.

## Description

Describe the changes made and why they were made. (Ignore if these details are present on the associated Apache Fineract JIRA ticket.)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [ ] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).
- [ ] If merging this PR resolves a JIRA issue, I will mark that issue as resolved and set "Fix Version/s" appropriately.

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
