### PR TITLE
FINERACT-2710: Fix NPE downloading the recurring-deposit template without a term type

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/populator/RecurringDepositProductSheetPopulator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/populator/RecurringDepositProductSheetPopulator.java
@@ -81,7 +81,11 @@ public class RecurringDepositProductSheetPopulator extends AbstractWorkbookPopul
             writeString(INTEREST_CALCULATION_COL, row, product.getInterestCalculationType().getValue());
             writeString(INTEREST_CALCULATION_DAYS_IN_YEAR_COL, row, product.getInterestCalculationDaysInYearType().getValue());
             writeBoolean(PRECLOSURE_PENAL_APPLICABLE_COL, row, product.isPreClosurePenalApplicable());
-            writeString(MIN_DEPOSIT_TERM_TYPE_COL, row, product.getMinDepositTermType().getValue());
+            // Null-guarded like the sibling optional fields below — a product without a min-deposit-term type would
+            // otherwise NPE here and 500 the whole recurring-deposit download template.
+            if (product.getMinDepositTermType() != null) {
+                writeString(MIN_DEPOSIT_TERM_TYPE_COL, row, product.getMinDepositTermType().getValue());
+            }
 
             if (product.getMinDepositAmount() != null) {
                 writeBigDecimal(MIN_DEPOSIT_COL, row, product.getMinDepositAmount());

--- a/fineract-provider/src/test/java/org/apache/fineract/infrastructure/bulkimport/populator/RecurringDepositProductSheetPopulatorTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/infrastructure/bulkimport/populator/RecurringDepositProductSheetPopulatorTest.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.bulkimport.populator;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.apache.fineract.infrastructure.bulkimport.constants.TemplatePopulateImportConstants;
+import org.apache.fineract.portfolio.savings.data.RecurringDepositProductData;
+import org.apache.poi.hssf.usermodel.HSSFWorkbook;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.junit.jupiter.api.Test;
+
+class RecurringDepositProductSheetPopulatorTest {
+
+    private static final String DATE_FORMAT = "dd MMMM yyyy";
+    private static final int NAME_COL = 1;
+
+    // Deep stubs cover the enum-valued lookups (interest compounding/posting/calculation, …) that the populator
+    // always dereferences; the test only pins the field under test.
+    private RecurringDepositProductData product(String name) {
+        RecurringDepositProductData product = mock(RecurringDepositProductData.class, RETURNS_DEEP_STUBS);
+        when(product.getId()).thenReturn(1L);
+        when(product.getName()).thenReturn(name);
+        when(product.getShortName()).thenReturn("RD01");
+        return product;
+    }
+
+    // Regression: a recurring-deposit product with no minimum-deposit-term type made the download template 500 —
+    // populate() wrote MIN_DEPOSIT_TERM_TYPE_COL through an unguarded getMinDepositTermType().getValue() while every
+    // sibling optional field was null-guarded (the fixed-deposit populator already guards the equivalent field).
+    // The column is optional on the product, so the sheet must simply leave that cell empty.
+    @Test
+    void productWithoutMinDepositTermTypeStillPopulates() throws Exception {
+        RecurringDepositProductData product = product("Regular Recurring Deposit");
+        when(product.getMinDepositTermType()).thenReturn(null);
+
+        try (Workbook workbook = new HSSFWorkbook()) {
+            RecurringDepositProductSheetPopulator populator = new RecurringDepositProductSheetPopulator(List.of(product));
+
+            assertDoesNotThrow(() -> populator.populate(workbook, DATE_FORMAT));
+
+            Sheet productSheet = workbook.getSheet(TemplatePopulateImportConstants.PRODUCT_SHEET_NAME);
+            assertEquals("Regular_Recurring_Deposit", productSheet.getRow(1).getCell(NAME_COL).getStringCellValue());
+        }
+    }
+}


### PR DESCRIPTION
     - GET /v1/recurringdepositaccounts/downloadtemplate returned HTTP 500 on any tenant
        holding a recurring-deposit product with no minimum-deposit-term type:
        RecurringDepositProductSheetPopulator.populate writes the min-deposit-term-type cell
        through an unguarded product.getMinDepositTermType().getValue(), so a null term type
        throws and the whole template download fails. The template is unusable for the entire
        tenant and there is no API-side workaround.
      - The field is optional on the product, and every sibling optional field in the same loop
        (min/max deposit amount, min/max deposit term, lock-in period, pre-closure penal
        interest) is already null-guarded. The fixed-deposit product sheet populator guards the
        equivalent field too, so this is an inconsistency between two sibling populators rather
        than a deliberate requirement.
      - Guard the write like its siblings: a product without a minimum-deposit-term type leaves
        that lookup cell blank instead of failing the download. Nothing changes for products
        that do carry one.
      - Add a unit test (RecurringDepositProductSheetPopulatorTest) covering a product whose
        term type is null: it fails on the unfixed code with the exact production NPE and
        asserts the product sheet is still written.

## Description

Describe the changes made and why they were made. (Ignore if these details are present on the associated Apache Fineract JIRA ticket.)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [ ] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).
- [ ] If merging this PR resolves a JIRA issue, I will mark that issue as resolved and set "Fix Version/s" appropriately.

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
