### PR TITLE
FINERACT-2711: Fix shared-account template named-range bounds built by string concat

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/populator/shareaccount/SharedAccountWorkBookPopulator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/populator/shareaccount/SharedAccountWorkBookPopulator.java
@@ -133,11 +133,11 @@ public class SharedAccountWorkBookPopulator extends AbstractWorkbookPopulator {
 
         Name clientsGroup = sharedAccountWorkbook.createName();
         clientsGroup.setNameName("Clients");
-        clientsGroup.setRefersToFormula(TemplatePopulateImportConstants.CLIENT_SHEET_NAME + "!$B$2:$B$" + clients.size() + 1);
+        clientsGroup.setRefersToFormula(TemplatePopulateImportConstants.CLIENT_SHEET_NAME + "!$B$2:$B$" + (clients.size() + 1));
 
         Name productGroup = sharedAccountWorkbook.createName();
         productGroup.setNameName("Products");
-        productGroup.setRefersToFormula(TemplatePopulateImportConstants.SHARED_PRODUCTS_SHEET_NAME + "!$B$2:$B$" + products.size() + 1);
+        productGroup.setRefersToFormula(TemplatePopulateImportConstants.SHARED_PRODUCTS_SHEET_NAME + "!$B$2:$B$" + (products.size() + 1));
 
         for (Integer i = 0; i < products.size(); i++) {
             Name currecyName = sharedAccountWorkbook.createName();

--- a/fineract-provider/src/test/java/org/apache/fineract/infrastructure/bulkimport/populator/shareaccount/SharedAccountWorkBookPopulatorTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/infrastructure/bulkimport/populator/shareaccount/SharedAccountWorkBookPopulatorTest.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.bulkimport.populator.shareaccount;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.apache.fineract.infrastructure.bulkimport.populator.ClientSheetPopulator;
+import org.apache.fineract.infrastructure.bulkimport.populator.SavingsAccountSheetPopulator;
+import org.apache.fineract.infrastructure.bulkimport.populator.SharedProductsSheetPopulator;
+import org.apache.fineract.portfolio.client.data.ClientData;
+import org.apache.fineract.portfolio.shareproducts.data.ShareProductData;
+import org.apache.poi.hssf.usermodel.HSSFWorkbook;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.junit.jupiter.api.Test;
+
+class SharedAccountWorkBookPopulatorTest {
+
+    private static final String DATE_FORMAT = "dd MMMM yyyy";
+
+    // The Clients and Products named-range upper bounds must be (size + 1) as a NUMBER — row 3 for two entries. The
+    // former code wrote `... "!$B$2:$B$" + list.size() + 1`, where the whole expression is left-to-right STRING
+    // concatenation, so the "1" was appended rather than added: two entries produced "$B$21" instead of "$B$3" and
+    // the dropdown spanned dozens of blank rows. The sibling populators already parenthesise both bounds.
+    //
+    // The spies let setNames see controlled client/product counts while the real (empty) populate() still builds the
+    // sheets safely — the sheet writers iterate their own fields, not these accessors.
+    @Test
+    void namedRangeBoundsAreSizePlusOneNotStringConcat() throws Exception {
+        ShareProductData firstProduct = mock(ShareProductData.class);
+        ShareProductData secondProduct = mock(ShareProductData.class);
+        when(firstProduct.getName()).thenReturn("Alpha");
+        when(secondProduct.getName()).thenReturn("Beta");
+        SharedProductsSheetPopulator products = spy(new SharedProductsSheetPopulator(List.of(), List.of()));
+        doReturn(List.of(firstProduct, secondProduct)).when(products).getSharedProductDataList();
+
+        ClientSheetPopulator clients = spy(new ClientSheetPopulator(List.of(), List.of()));
+        doReturn(List.of(mock(ClientData.class), mock(ClientData.class))).when(clients).getClients();
+
+        try (Workbook workbook = new HSSFWorkbook()) {
+            new SharedAccountWorkBookPopulator(products, clients, new SavingsAccountSheetPopulator(List.of())).populate(workbook,
+                    DATE_FORMAT);
+
+            String productsFormula = workbook.getName("Products").getRefersToFormula();
+            String clientsFormula = workbook.getName("Clients").getRefersToFormula();
+            assertTrue(productsFormula.endsWith("$B$2:$B$3"), "expected a (size + 1) row bound, got: " + productsFormula);
+            assertTrue(clientsFormula.endsWith("$B$2:$B$3"), "expected a (size + 1) row bound, got: " + clientsFormula);
+        }
+    }
+}


### PR DESCRIPTION
     - SharedAccountWorkBookPopulator.setNames built the Clients and Products named ranges as
        SHEET + "!$B$2:$B$" + list.size() + 1. The whole expression is left-to-right string
        concatenation, so size() + 1 does not add: the "1" is appended as text. With two
        products the range became SharedProducts!$B$2:$B$21 instead of $B$2:$B$3, and likewise
        for the client range.
      - The template still downloads, so this is not a 500; the effect is that both dropdowns
        reference far more rows than exist and the picker is padded with blank entries. On a
        tenant with ten products the bound reads $B$101.
      - Parenthesise both bounds so the arithmetic happens before the concatenation, matching
        every sibling populator (LoanWorkbookPopulator, SavingsWorkbookPopulator and others
        already write (size() + 1)).
      - Add a unit test asserting both named ranges end at $B$2:$B$3 for two clients and two
        products. It fails on the unfixed code with the concatenated bound
        (SharedProducts!$B$2:$B$21). Spies feed setNames controlled client and product counts
        while the real populators write their own (empty) sheets, so the assertion isolates the
        range arithmetic.

## Description

Describe the changes made and why they were made. (Ignore if these details are present on the associated Apache Fineract JIRA ticket.)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [ ] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).
- [ ] If merging this PR resolves a JIRA issue, I will mark that issue as resolved and set "Fix Version/s" appropriately.

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
