### PR TITLE
FINERACT-2713: Bind untyped report parameters numerically so Postgres cascades work

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/ReadReportingServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/ReadReportingServiceImpl.java
@@ -88,6 +88,9 @@ public class ReadReportingServiceImpl implements ReadReportingService {
     /** Matches any {@code ${placeholderName}} token in a report SQL template. */
     private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("\\$\\{([^}]+)\\}");
 
+    /** A plain integer with no leading zeros, so identifiers like {@code 000123} stay strings. */
+    private static final Pattern UNTYPED_INTEGER = Pattern.compile("-?(0|[1-9]\\d*)");
+
     private final JdbcTemplate jdbcTemplate;
     private final PlatformSecurityContext context;
     private final GenericDataService genericDataService;
@@ -162,6 +165,18 @@ public class ReadReportingServiceImpl implements ReadReportingService {
         }
         if ("DATE".equalsIgnoreCase(formatType)) {
             return java.sql.Date.valueOf(value);
+        }
+        // No declared format type — typically an office/product-cascaded lookup parameter
+        // substituted into another report's SQL (e.g. ${officeId} inside loanOfficerIdSelectAll).
+        // Bind a plain integer as a number so strict engines compare correctly; Postgres, unlike
+        // MySQL, rejects "bigint = varchar". Everything else (currency codes, ids with leading
+        // zeros, free text) stays a string.
+        if ((formatType == null || formatType.isBlank()) && UNTYPED_INTEGER.matcher(value).matches()) {
+            try {
+                return Long.parseLong(value);
+            } catch (NumberFormatException e) {
+                return value;
+            }
         }
         return value;
     }

--- a/fineract-provider/src/test/java/org/apache/fineract/infrastructure/dataqueries/service/ReadReportingServiceImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/infrastructure/dataqueries/service/ReadReportingServiceImplTest.java
@@ -22,7 +22,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
@@ -30,6 +32,7 @@ import java.util.Map;
 import org.apache.fineract.infrastructure.core.config.FineractProperties;
 import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
 import org.apache.fineract.infrastructure.core.service.database.DatabaseSpecificSQLGenerator;
+import org.apache.fineract.infrastructure.dataqueries.data.GenericResultsetData;
 import org.apache.fineract.infrastructure.report.service.ReportParameterTypeResolver;
 import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
 import org.apache.fineract.infrastructure.security.service.SqlInjectionPreventerService;
@@ -38,6 +41,7 @@ import org.apache.fineract.useradministration.domain.AppUser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -45,6 +49,11 @@ import org.springframework.jdbc.support.rowset.SqlRowSet;
 
 @ExtendWith(MockitoExtension.class)
 public class ReadReportingServiceImplTest {
+
+    /** A cascaded lookup: {@code ${officeId}} comes from the PARENT parameter, so this report does not declare it. */
+    private static final String CASCADED_REPORT_NAME = "loanOfficerIdSelectAll";
+    private static final String CASCADED_REPORT_SQL = "select lo.id, lo.display_name as name from m_staff lo "
+            + "join m_office o on o.id = lo.office_id where lo.is_loan_officer = true and o.id = ${officeId}";
 
     @Mock
     private JdbcTemplate jdbcTemplate;
@@ -108,4 +117,73 @@ public class ReadReportingServiceImplTest {
         assertEquals("loanOfficerId", exception.getErrors().get(0).getParameterName());
     }
 
+    // FINERACT-2713: a cascaded parameter is absent from the running report's own format-type map, so it used to bind
+    // as a String. PostgreSQL rejects "bigint = character varying" (MySQL silently coerces it), leaving the dependent
+    // dropdown empty. A plain integer with no declared type must bind numerically.
+    @Test
+    public void untypedIntegerParameterBindsAsNumber() {
+        stubCascadedReport(Map.of()); // officeId not declared
+
+        Object[] bound = boundParamsFor(Map.of("officeId", "1"));
+
+        assertEquals(1, bound.length);
+        assertEquals(Long.valueOf(1L), bound[0], "an untyped plain integer must bind as a number, not a String");
+    }
+
+    // The inference must stay narrow: anything that is not a plain integer keeps its String binding, so currency codes
+    // and identifiers carrying leading zeros are not silently mangled into numbers.
+    @Test
+    public void untypedNonIntegerParameterStaysAString() {
+        stubCascadedReport(Map.of());
+
+        assertEquals("USD", boundParamsFor(Map.of("officeId", "USD"))[0]);
+    }
+
+    @Test
+    public void untypedIntegerWithLeadingZerosStaysAString() {
+        stubCascadedReport(Map.of());
+
+        assertEquals("000123", boundParamsFor(Map.of("officeId", "000123"))[0], "leading zeros are significant in identifiers");
+    }
+
+    // A declared type still wins - this path is untouched by the fix.
+    @Test
+    public void declaredNumberParameterStillBindsAsNumber() {
+        stubCascadedReport(Map.of("officeId", "number"));
+
+        assertEquals(Long.valueOf(7L), boundParamsFor(Map.of("officeId", "7"))[0]);
+    }
+
+    /** Serves {@link #CASCADED_REPORT_SQL} for {@link #CASCADED_REPORT_NAME} with the given declared format types. */
+    private void stubCascadedReport(Map<String, String> paramFormatTypes) {
+        SqlRowSet rowSet = mock(SqlRowSet.class);
+        when(rowSet.next()).thenReturn(true);
+        when(rowSet.getString("the_sql")).thenReturn(CASCADED_REPORT_SQL);
+        when(jdbcTemplate.queryForRowSet(anyString(), eq(CASCADED_REPORT_NAME))).thenReturn(rowSet);
+        when(sqlInjectionPreventerService.quoteIdentifier(anyString())).thenAnswer(call -> call.getArgument(0));
+        when(reportParameterTypeResolver.loadParamFormatTypes(CASCADED_REPORT_NAME)).thenReturn(paramFormatTypes);
+
+        AppUser appUser = mock(AppUser.class);
+        Office office = mock(Office.class);
+        when(context.authenticatedUser()).thenReturn(appUser);
+        when(appUser.getOffice()).thenReturn(office);
+        when(appUser.getId()).thenReturn(1L);
+        when(office.getHierarchy()).thenReturn(".");
+
+        when(sqlGenerator.currentBusinessDate()).thenReturn("'2024-01-01'");
+        when(sqlGenerator.currentTenantDateTime()).thenReturn("'2024-01-01 00:00:00'");
+
+        // pass the SQL through untouched so the assertions are about the bound values, not the rewriting
+        when(genericDataService.wrapSQL(anyString())).thenAnswer(call -> call.getArgument(0));
+        when(genericDataService.replace(anyString(), anyString(), anyString())).thenAnswer(call -> call.getArgument(0));
+        when(genericDataService.fillGenericResultSet(anyString(), any())).thenReturn(mock(GenericResultsetData.class));
+    }
+
+    /** Runs the cascaded report and returns the values actually bound to the prepared statement. */
+    private Object[] boundParamsFor(Map<String, String> queryParams) {
+        readReportingService.retrieveGenericResultset(CASCADED_REPORT_NAME, "report", queryParams);
+        ArgumentCaptor<Object[]> captor = ArgumentCaptor.forClass(Object[].class);
+        verify(genericDataService).fillGenericResultSet(anyString(), captor.capture());
+        return captor.getValue();
+    }
 }


### PR DESCRIPTION
     - Since FINERACT-2624 switched report-parameter substitution from string interpolation to
        JDBC bind variables, a placeholder that appears in a report's SQL but is not one of that
        report's own declared parameters binds as a String. On PostgreSQL, comparing a bigint
        column to a bound character varying raises "operator does not exist: bigint = character
        varying" and the query fails with HTTP 403; MySQL and MariaDB coerce the types silently,
        which is why CI does not see it.
      - The stock loanOfficerIdSelectAll option lookup is the clearest case. Its SQL filters
        "... and o.id = ${officeId}", where officeId is supplied by the parent parameter, so
        ReadReportingServiceImpl.getSQLtoRun loads the format types of loanOfficerIdSelectAll,
        finds no entry for officeId, and castParamValue falls through to returning the raw
        String. Every report whose Loan Officer dropdown cascades off office is therefore empty
        on a PostgreSQL deployment.
      - When no format type is declared, infer a numeric bind for a plain integer value so
        strict engines compare correctly. The inference is deliberately narrow: the value must
        match -?(0|[1-9]\d*), so currency codes, free text and identifiers carrying leading
        zeros such as 000123 keep their String binding and are not mangled into numbers.
        Declared NUMBER, INTEGER and DATE types are untouched.
      - Add ReadReportingServiceImplTest, which captures the values bound for a report whose SQL
        cascades on ${officeId}: an untyped "1" must arrive as a Long, while "USD" and "000123"
        must stay Strings and a declared number type must keep working. The first case fails on
        the unfixed code with "expected: java.lang.Long<1> but was: java.lang.String<1>"; the
        other three assert the narrowness of the inference and hold either way by design.
      

## Description

Describe the changes made and why they were made. (Ignore if these details are present on the associated Apache Fineract JIRA ticket.)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [ ] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).
- [ ] If merging this PR resolves a JIRA issue, I will mark that issue as resolved and set "Fix Version/s" appropriately.

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
