### PR TITLE
FINERACT-2443: Test client listing report output

### DIFF
--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/ReportsTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/ReportsTest.java
@@ -27,8 +27,10 @@ import java.util.Map;
 import okhttp3.MediaType;
 import okhttp3.Request;
 import okhttp3.ResponseBody;
+import org.apache.fineract.client.models.PostClientsRequest;
 import org.apache.fineract.client.models.PostReportsResponse;
 import org.apache.fineract.client.models.PostRepostRequest;
+import org.apache.fineract.client.models.ResultsetRowData;
 import org.apache.fineract.client.models.RunReportsResponse;
 import org.apache.fineract.client.services.RunReportsApi;
 import org.apache.fineract.client.util.CallFailedRuntimeException;
@@ -100,6 +102,32 @@ public class ReportsTest extends IntegrationTest {
                 fineractClient().reportsRun.runReportGetFile("Client Listing", Map.of("R_officeId", "1", "exportCSV", "true")));
         assertThat(result.body().contentType()).isEqualTo(MediaType.parse("text/csv"));
         assertThat(result.body().string()).contains("Office/Branch");
+    }
+
+    @Test
+    void runClientListingReportIncludesCreatedClientInTableAndCSV() throws IOException {
+        String clientName = Utils.randomStringGenerator("ReportTestClient", 8);
+        createClient(clientName);
+
+        RunReportsResponse tableResult = ok(fineractClient().reportsRun.runReportGetData("Client Listing", Map.of("R_officeId", "1")));
+        List<ResultsetRowData> tableRows = tableResult.getData();
+        assertThat(tableRows).isNotNull();
+        boolean tableContainsClient = tableRows.stream().map(ResultsetRowData::getRow)
+                .anyMatch(row -> row != null && row.contains(clientName));
+        assertThat(tableContainsClient).as("Client Listing table output should contain client %s in rows %s", clientName, tableRows)
+                .isTrue();
+
+        Response<ResponseBody> csvResult = okR(
+                fineractClient().reportsRun.runReportGetFile("Client Listing", Map.of("R_officeId", "1", "exportCSV", "true")));
+        ResponseBody csvBody = csvResult.body();
+        assertThat(csvBody).isNotNull();
+        assertThat(csvBody.contentType()).isEqualTo(MediaType.parse("text/csv"));
+        assertThat(csvBody.string()).as("Client Listing CSV output should contain client %s", clientName).contains(clientName);
+    }
+
+    private Long createClient(String fullName) {
+        return ok(fineractClient().clients.createClient(new PostClientsRequest().legalFormId(1L).officeId(1L).fullname(fullName)
+                .dateFormat(Utils.DATE_FORMAT).locale("en_US").active(true).activationDate("01 January 2023"))).getClientId();
     }
 
     @Test // see FINERACT-1306


### PR DESCRIPTION
## Description

Adds a focused integration test for the `Client Listing` report output scenario in FINERACT-2443. The test creates a uniquely named active client, verifies that one table response row includes that client, and verifies the CSV export includes the same client.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes. No API changes.
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).
- [x] If merging this PR resolves a JIRA issue, I will mark that issue as resolved and set "Fix Version/s" appropriately.
