### PR TITLE
FINERACT-2714: Add ability to exclude closed clients from client search results

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/client/domain/search/SearchingClientRepository.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/client/domain/search/SearchingClientRepository.java
@@ -23,5 +23,5 @@ import org.springframework.data.domain.Pageable;
 
 public interface SearchingClientRepository {
 
-    Page<SearchedClient> searchByText(String searchText, Pageable pageable, String officeHierarchy);
+    Page<SearchedClient> searchByText(String searchText, Pageable pageable, String officeHierarchy, boolean excludeClosed);
 }

--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/client/domain/search/SearchingClientRepositoryImpl.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/client/domain/search/SearchingClientRepositoryImpl.java
@@ -36,6 +36,7 @@ import org.apache.fineract.infrastructure.core.jpa.CriteriaQueryFactory;
 import org.apache.fineract.organisation.office.domain.Office;
 import org.apache.fineract.portfolio.client.domain.Client;
 import org.apache.fineract.portfolio.client.domain.ClientIdentifier;
+import org.apache.fineract.portfolio.client.domain.ClientStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
@@ -51,7 +52,7 @@ public class SearchingClientRepositoryImpl implements SearchingClientRepository 
     private final CriteriaQueryFactory criteriaQueryFactory;
 
     @Override
-    public Page<SearchedClient> searchByText(String searchText, Pageable pageable, String officeHierarchy) {
+    public Page<SearchedClient> searchByText(String searchText, Pageable pageable, String officeHierarchy, boolean excludeClosed) {
         /*
          * this whole thing can be replaced with Spring Data JPA 3+ with a findBy(Specification, Pageable) call but at
          * this point the upgrade is too costly
@@ -80,6 +81,11 @@ public class SearchingClientRepositoryImpl implements SearchingClientRepository 
                     cb.like(cb.function("LOWER", String.class, r.get("externalId")), searchLikeValue),
                     cb.like(cb.lower(r.get("mobileNo")), searchLikeValue),
                     cb.like(cb.lower(identity.get("documentKey")), searchLikeValue)));
+
+            // Add status filter to exclude closed clients only if excludeClosed is true
+            if (excludeClosed) {
+                predicates.add(cb.notEqual(r.get("status"), ClientStatus.CLOSED.getValue()));
+            }
 
             return cb.and(predicates.toArray(new Predicate[0]));
         };

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/service/search/ClientSearchService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/service/search/ClientSearchService.java
@@ -58,9 +58,10 @@ public class ClientSearchService {
         Optional<ClientTextSearch> request = searchRequest.getRequest();
         String requestSearchText = request.map(ClientTextSearch::getText).orElse(null);
         String searchText = Objects.toString(requestSearchText, "");
+        boolean excludeClosed = Boolean.TRUE.equals(request.map(ClientTextSearch::getExcludeClosed).orElse(null));
 
         Pageable pageable = searchRequest.toPageable();
 
-        return clientRepository.searchByText(searchText, pageable, hierarchy).map(clientSearchDataMapper::map);
+        return clientRepository.searchByText(searchText, pageable, hierarchy, excludeClosed).map(clientSearchDataMapper::map);
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/service/search/domain/ClientTextSearch.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/service/search/domain/ClientTextSearch.java
@@ -24,4 +24,5 @@ import lombok.Data;
 public class ClientTextSearch {
 
     private String text;
+    private Boolean excludeClosed;
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/ClientSearchTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/ClientSearchTest.java
@@ -24,6 +24,7 @@ import io.restassured.http.ContentType;
 import io.restassured.specification.RequestSpecification;
 import io.restassured.specification.ResponseSpecification;
 import java.time.LocalDate;
+import java.util.HashMap;
 import org.apache.fineract.client.models.GetClientsClientIdResponse;
 import org.apache.fineract.client.models.GetClientsResponse;
 import org.apache.fineract.client.models.PageClientSearchData;
@@ -372,6 +373,59 @@ public class ClientSearchTest extends IntegrationTest {
         assertThat(result.getTotalElements()).isEqualTo(1);
         assertThat(result.getContent().size()).isEqualTo(1);
         assertThat(result.getContent().get(0).getExternalId().getValue()).isEqualTo(request.getExternalId());
+    }
+
+    @Test
+    public void testClientSearchExcludesClosedClients_WhenExcludeClosedIsTrue() {
+        // given
+        String lastname = Utils.randomStringGenerator("Client_LastName_", 5);
+        PostClientsRequest openClientRequest = ClientHelper.defaultClientCreationRequest();
+        openClientRequest.setLastname(lastname);
+        clientHelper.createClient(openClientRequest);
+
+        PostClientsRequest closedClientRequest = ClientHelper.defaultClientCreationRequest();
+        closedClientRequest.setLastname(lastname);
+        clientHelper.createClient(closedClientRequest);
+
+        HashMap<String, Object> code = CodeHelper.getCodeByName(requestSpec, responseSpec, "ClientClosureReason");
+        Integer codeId = (Integer) code.get("id");
+        HashMap<String, Object> codeValue = CodeHelper.retrieveOrCreateCodeValue(codeId, requestSpec, responseSpec);
+        Integer closureReasonId = (Integer) codeValue.get("id");
+        ClientHelper.closeClient(closedClientRequest.getExternalId(), closureReasonId);
+
+        // when
+        PageClientSearchData resultIncludingClosed = clientHelper.searchClients(lastname);
+        PageClientSearchData resultExcludingClosed = clientHelper.searchClients(lastname, true);
+
+        // then
+        assertThat(resultIncludingClosed.getTotalElements()).isEqualTo(2);
+        assertThat(resultExcludingClosed.getTotalElements()).isEqualTo(1);
+        assertThat(resultExcludingClosed.getContent().get(0).getExternalId().getValue()).isEqualTo(openClientRequest.getExternalId());
+    }
+
+    @Test
+    public void testClientSearchIncludesClosedClients_WhenExcludeClosedIsFalse() {
+        // given
+        String lastname = Utils.randomStringGenerator("Client_LastName_", 5);
+        PostClientsRequest openClientRequest = ClientHelper.defaultClientCreationRequest();
+        openClientRequest.setLastname(lastname);
+        clientHelper.createClient(openClientRequest);
+
+        PostClientsRequest closedClientRequest = ClientHelper.defaultClientCreationRequest();
+        closedClientRequest.setLastname(lastname);
+        clientHelper.createClient(closedClientRequest);
+
+        HashMap<String, Object> code = CodeHelper.getCodeByName(requestSpec, responseSpec, "ClientClosureReason");
+        Integer codeId = (Integer) code.get("id");
+        HashMap<String, Object> codeValue = CodeHelper.retrieveOrCreateCodeValue(codeId, requestSpec, responseSpec);
+        Integer closureReasonId = (Integer) codeValue.get("id");
+        ClientHelper.closeClient(closedClientRequest.getExternalId(), closureReasonId);
+
+        // when
+        PageClientSearchData result = clientHelper.searchClients(lastname, false);
+
+        // then
+        assertThat(result.getTotalElements()).isEqualTo(2);
     }
 
     @Test

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/ClientHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/ClientHelper.java
@@ -213,6 +213,15 @@ public class ClientHelper {
         return searchClients(request);
     }
 
+    public PageClientSearchData searchClients(String text, boolean excludeClosed) {
+        ClientTextSearch clientTextSearch = new ClientTextSearch();
+        clientTextSearch.setText(text);
+        clientTextSearch.setExcludeClosed(excludeClosed);
+        PagedRequestClientTextSearch request = new PagedRequestClientTextSearch();
+        request.setRequest(clientTextSearch);
+        return searchClients(request);
+    }
+
     public PageClientSearchData searchClients(PagedRequestClientTextSearch request) {
         return Calls.ok(FineractClientHelper.getFineractClient().clientSearchV2.searchClientsByText(request));
     }


### PR DESCRIPTION
## Description

The `POST /v2/clients/search` endpoint returns matching clients regardless of status, including closed ones, with no way for the caller to filter them out.

This adds an optional `excludeClosed` boolean field to the `ClientTextSearch` search request. When `excludeClosed=true`, the search excludes clients whose status is `CLOSED` (via a `status != CLOSED` predicate in `SearchingClientRepositoryImpl`). When omitted or `false`, behavior is unchanged — fully backward compatible for existing callers.

https://issues.apache.org/jira/browse/FINERACT-2714

## Checklist

- [x] Write the commit message as per our guidelines
- [x] Acknowledge that we will not review PRs that are not passing the build ("green") - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update unit or integration tests for verifying the changes made.
- [x] Follow our coding conventions.
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes (not applicable — no new endpoint, just an optional field on an existing request DTO, already reflected via existing annotations)
- [x] This PR must not be a "code dump".
- [ ] If merging this PR resolves a JIRA issue, I will mark that issue as resolved and set "Fix Version/s" appropriately.