### PR TITLE
FINERACT-2715: Mark Activation Date as required in Client Entity import template

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/populator/client/ClientEntityWorkbookPopulator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/populator/client/ClientEntityWorkbookPopulator.java
@@ -228,7 +228,7 @@ public class ClientEntityWorkbookPopulator extends AbstractWorkbookPopulator {
         writeString(ClientEntityConstants.EXTERNAL_ID_COL, rowHeader, "External ID ");
         writeString(ClientEntityConstants.SUBMITTED_ON_COL, rowHeader, "Submitted On Date");
         writeString(ClientEntityConstants.ACTIVE_COL, rowHeader, "Active*");
-        writeString(ClientEntityConstants.ACTIVATION_DATE_COL, rowHeader, "Activation Date ");
+        writeString(ClientEntityConstants.ACTIVATION_DATE_COL, rowHeader, "Activation Date* ");
         writeString(ClientEntityConstants.ADDRESS_ENABLED, rowHeader, "Address Enabled ");
         writeString(ClientEntityConstants.ADDRESS_TYPE_COL, rowHeader, "Address Type ");
         writeString(ClientEntityConstants.STREET_COL, rowHeader, "Street  ");


### PR DESCRIPTION
## Description

The Client Entity bulk import template did not visually indicate that "Activation Date" is a required column. `ClientEntityImportHandler` requires a valid Activation Date whenever the "Active" column is set to `true`, so imports failed on rows left blank without any indication from the template that the field was mandatory.

This changes the column header in `ClientEntityWorkbookPopulator` from `"Activation Date "` to `"Activation Date* "`, consistent with how other conditionally-required columns (e.g. `"Active*"`) are marked on the same sheet.

## JIRA

https://issues.apache.org/jira/browse/FINERACT-2715

## Test plan

- [x] `./gradlew :fineract-provider:compileJava` passes
- [x] Verified no existing test asserts the previous header string (integration test `ClientEntityWorkbookPopulatorTest` does not hardcode it)