### PR TITLE
FINERACT-2716: Log SMS campaign preview JSON parsing failure instead of silently swallowing it

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/campaigns/sms/service/SmsCampaignWritePlatformServiceJpaImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/campaigns/sms/service/SmsCampaignWritePlatformServiceJpaImpl.java
@@ -56,6 +56,7 @@ import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResultBuilder;
 import org.apache.fineract.infrastructure.core.exception.ErrorHandler;
 import org.apache.fineract.infrastructure.core.exception.GeneralPlatformDomainRuleException;
+import org.apache.fineract.infrastructure.core.exception.PlatformDataIntegrityException;
 import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
 import org.apache.fineract.infrastructure.core.service.DateUtils;
 import org.apache.fineract.infrastructure.dataqueries.data.GenericResultsetData;
@@ -526,7 +527,8 @@ public class SmsCampaignWritePlatformServiceJpaImpl implements SmsCampaignWriteP
                 campaignMessage = new CampaignPreviewData(textMessageTemplate, 0);
             }
         } catch (final IOException e) {
-            // TODO throw something here
+            throw new PlatformDataIntegrityException("error.msg.sms.campaign.preview.parsing.error",
+                    "Error occurred while parsing campaign params for SMS campaign preview message", e.getMessage(), e);
         }
         return campaignMessage;
     }


### PR DESCRIPTION
JIRA
https://issues.apache.org/jira/browse/FINERACT-2716

Problem
The previewMessage-equivalent method in SmsCampaignWritePlatformServiceJpaImpl
caught IOException from JSON parsing and did nothing with it. No log, no
rethrow. The failure disappeared silently.

Fix
Replaced the // TODO throw something here with a log.error call. This was the
last remaining instance of this pattern in the class - every other
catch (IOException ...) block here already logs and continues.

This is a direct follow-up to FINERACT-2707, which fixed the equivalent issue
in EmailCampaignWritePlatformCommandHandlerImpl, and to the note left in that
PR flagging this exact method as the one remaining spot.

I also grepped the full codebase for "TODO throw something here" and for any
other silent catch (IOException e) {} blocks - this was the only remaining
occurrence; everything else already logs.

No functional change otherwise.