### PR TITLE
FINERACT-2717: Check all currency usages before allowing currency removal

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/organisation/monetary/exception/CurrencyInUseException.java
+++ b/fineract-core/src/main/java/org/apache/fineract/organisation/monetary/exception/CurrencyInUseException.java
@@ -27,7 +27,7 @@ public class CurrencyInUseException extends AbstractPlatformDomainRuleException 
 
     public CurrencyInUseException(final String currencyCode) {
         super("error.msg.currency.currencyCode.inUse",
-                "Currency cannot be removed because it is already used in existing transactions or accounts.", currencyCode);
+                "Cannot remove currency with identifier " + currencyCode + " while it is still in use", currencyCode);
     }
 
 }

--- a/fineract-core/src/main/java/org/apache/fineract/organisation/monetary/exception/CurrencyInUseException.java
+++ b/fineract-core/src/main/java/org/apache/fineract/organisation/monetary/exception/CurrencyInUseException.java
@@ -27,7 +27,7 @@ public class CurrencyInUseException extends AbstractPlatformDomainRuleException 
 
     public CurrencyInUseException(final String currencyCode) {
         super("error.msg.currency.currencyCode.inUse",
-                "Cannot remove currency with identifier " + currencyCode + " while it is still in use", currencyCode);
+                "Currency cannot be removed because it is already used in existing transactions or accounts.", currencyCode);
     }
 
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/monetary/service/CurrencyWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/monetary/service/CurrencyWritePlatformServiceJpaRepositoryImpl.java
@@ -75,9 +75,9 @@ public class CurrencyWritePlatformServiceJpaRepositoryImpl implements CurrencyWr
     private boolean isCurrencyUsedInExistingData(final String currencyCode) {
         return hasCurrencyUsage("m_product_loan", currencyCode) || hasCurrencyUsage("m_savings_product", currencyCode)
                 || hasCurrencyUsage("m_share_product", currencyCode) || hasCurrencyUsage("m_charge", currencyCode)
-                || hasCurrencyUsage("m_loan", currencyCode)
-                || hasCurrencyUsage("m_savings_account", currencyCode) || hasCurrencyUsage("m_share_account", currencyCode)
-                || hasCurrencyUsage("m_client_transaction", currencyCode) || hasCurrencyUsage("m_account_transfer_transaction", currencyCode)
+                || hasCurrencyUsage("m_loan", currencyCode) || hasCurrencyUsage("m_savings_account", currencyCode)
+                || hasCurrencyUsage("m_share_account", currencyCode) || hasCurrencyUsage("m_client_transaction", currencyCode)
+                || hasCurrencyUsage("m_account_transfer_transaction", currencyCode)
                 || hasCurrencyUsage("m_cashier_transactions", currencyCode) || hasCurrencyUsage("acc_gl_journal_entry", currencyCode);
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/monetary/service/CurrencyWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/monetary/service/CurrencyWritePlatformServiceJpaRepositoryImpl.java
@@ -30,9 +30,7 @@ import org.apache.fineract.organisation.monetary.domain.ApplicationCurrencyRepos
 import org.apache.fineract.organisation.monetary.domain.OrganisationCurrency;
 import org.apache.fineract.organisation.monetary.domain.OrganisationCurrencyRepository;
 import org.apache.fineract.organisation.monetary.exception.CurrencyInUseException;
-import org.apache.fineract.portfolio.charge.service.ChargeReadPlatformService;
-import org.apache.fineract.portfolio.loanproduct.service.LoanProductReadPlatformService;
-import org.apache.fineract.portfolio.savings.service.SavingsProductReadPlatformService;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
@@ -40,9 +38,7 @@ public class CurrencyWritePlatformServiceJpaRepositoryImpl implements CurrencyWr
 
     private final ApplicationCurrencyRepositoryWrapper applicationCurrencyRepository;
     private final OrganisationCurrencyRepository organisationCurrencyRepository;
-    private final LoanProductReadPlatformService loanProductService;
-    private final SavingsProductReadPlatformService savingsProductService;
-    private final ChargeReadPlatformService chargeService;
+    private final JdbcTemplate jdbcTemplate;
 
     @Transactional
     @Override
@@ -64,9 +60,7 @@ public class CurrencyWritePlatformServiceJpaRepositoryImpl implements CurrencyWr
         for (OrganisationCurrency priorCurrency : organisationCurrencyRepository.findAll()) {
             if (!allowedCurrencyCodes.contains(priorCurrency.getCode())) {
                 // check if it's safe to remove this currency.
-                if (!loanProductService.retrieveAllLoanProductsForCurrency(priorCurrency.getCode()).isEmpty()
-                        || !savingsProductService.retrieveAllForCurrency(priorCurrency.getCode()).isEmpty()
-                        || !chargeService.retrieveAllChargesForCurrency(priorCurrency.getCode()).isEmpty()) {
+                if (isCurrencyUsedInExistingData(priorCurrency.getCode())) {
                     throw new CurrencyInUseException(priorCurrency.getCode());
                 }
             }
@@ -76,5 +70,20 @@ public class CurrencyWritePlatformServiceJpaRepositoryImpl implements CurrencyWr
         organisationCurrencyRepository.saveAll(allowedCurrencies);
 
         return CurrencyUpdateResponse.builder().currencies(allowedCurrencyCodes).build();
+    }
+
+    private boolean isCurrencyUsedInExistingData(final String currencyCode) {
+        return hasCurrencyUsage("m_product_loan", currencyCode) || hasCurrencyUsage("m_savings_product", currencyCode)
+                || hasCurrencyUsage("m_share_product", currencyCode) || hasCurrencyUsage("m_charge", currencyCode)
+                || hasCurrencyUsage("m_loan", currencyCode)
+                || hasCurrencyUsage("m_savings_account", currencyCode) || hasCurrencyUsage("m_share_account", currencyCode)
+                || hasCurrencyUsage("m_client_transaction", currencyCode) || hasCurrencyUsage("m_account_transfer_transaction", currencyCode)
+                || hasCurrencyUsage("m_cashier_transactions", currencyCode) || hasCurrencyUsage("acc_gl_journal_entry", currencyCode);
+    }
+
+    private boolean hasCurrencyUsage(final String tableName, final String currencyCode) {
+        final Integer usageCount = jdbcTemplate.queryForObject("select count(1) from " + tableName + " where currency_code = ?",
+                Integer.class, currencyCode);
+        return usageCount != null && usageCount > 0;
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/monetary/starter/OrganisationMonetaryConfiguration.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/monetary/starter/OrganisationMonetaryConfiguration.java
@@ -26,9 +26,6 @@ import org.apache.fineract.organisation.monetary.service.CurrencyWritePlatformSe
 import org.apache.fineract.organisation.monetary.service.CurrencyWritePlatformServiceJpaRepositoryImpl;
 import org.apache.fineract.organisation.monetary.service.OrganisationCurrencyReadPlatformService;
 import org.apache.fineract.organisation.monetary.service.OrganisationCurrencyReadPlatformServiceImpl;
-import org.apache.fineract.portfolio.charge.service.ChargeReadPlatformService;
-import org.apache.fineract.portfolio.loanproduct.service.LoanProductReadPlatformService;
-import org.apache.fineract.portfolio.savings.service.SavingsProductReadPlatformService;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -46,10 +43,9 @@ public class OrganisationMonetaryConfiguration {
     @Bean
     @ConditionalOnMissingBean(CurrencyWritePlatformService.class)
     public CurrencyWritePlatformService currencyWritePlatformService(ApplicationCurrencyRepositoryWrapper applicationCurrencyRepository,
-            OrganisationCurrencyRepository organisationCurrencyRepository, LoanProductReadPlatformService loanProductService,
-            SavingsProductReadPlatformService savingsProductService, ChargeReadPlatformService chargeService) {
+            OrganisationCurrencyRepository organisationCurrencyRepository, JdbcTemplate jdbcTemplate) {
         return new CurrencyWritePlatformServiceJpaRepositoryImpl(applicationCurrencyRepository, organisationCurrencyRepository,
-                loanProductService, savingsProductService, chargeService);
+                jdbcTemplate);
     }
 
     @Bean

--- a/fineract-provider/src/test/java/org/apache/fineract/organisation/monetary/service/CurrencyWritePlatformServiceJpaRepositoryImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/organisation/monetary/service/CurrencyWritePlatformServiceJpaRepositoryImplTest.java
@@ -92,8 +92,8 @@ public class CurrencyWritePlatformServiceJpaRepositoryImplTest {
         // simulates the removed currency still being referenced by one of the checked tables (e.g. m_loan)
         given(jdbcTemplate.queryForObject(anyString(), eq(Integer.class), any(Object[].class))).willReturn(1);
 
-        assertThrows(CurrencyInUseException.class, () -> underTest
-                .updateAllowedCurrencies(CurrencyUpdateRequest.builder().currencies(List.of(KEPT_CODE)).build()));
+        assertThrows(CurrencyInUseException.class,
+                () -> underTest.updateAllowedCurrencies(CurrencyUpdateRequest.builder().currencies(List.of(KEPT_CODE)).build()));
 
         verify(organisationCurrencyRepository, never()).deleteAll();
         verify(organisationCurrencyRepository, never()).saveAll(any());

--- a/fineract-provider/src/test/java/org/apache/fineract/organisation/monetary/service/CurrencyWritePlatformServiceJpaRepositoryImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/organisation/monetary/service/CurrencyWritePlatformServiceJpaRepositoryImplTest.java
@@ -1,0 +1,113 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.organisation.monetary.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import org.apache.fineract.organisation.monetary.data.CurrencyUpdateRequest;
+import org.apache.fineract.organisation.monetary.data.CurrencyUpdateResponse;
+import org.apache.fineract.organisation.monetary.domain.ApplicationCurrency;
+import org.apache.fineract.organisation.monetary.domain.ApplicationCurrencyRepositoryWrapper;
+import org.apache.fineract.organisation.monetary.domain.OrganisationCurrency;
+import org.apache.fineract.organisation.monetary.domain.OrganisationCurrencyRepository;
+import org.apache.fineract.organisation.monetary.exception.CurrencyInUseException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class CurrencyWritePlatformServiceJpaRepositoryImplTest {
+
+    @InjectMocks
+    private CurrencyWritePlatformServiceJpaRepositoryImpl underTest;
+
+    @Mock
+    private ApplicationCurrencyRepositoryWrapper applicationCurrencyRepository;
+
+    @Mock
+    private OrganisationCurrencyRepository organisationCurrencyRepository;
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    private static final String KEPT_CODE = "USD";
+    private static final String REMOVED_CODE = "EUR";
+
+    private OrganisationCurrency organisationCurrency(final String code) {
+        return new OrganisationCurrency(code, code, 2, 100, code, code);
+    }
+
+    @Test
+    public void shouldRemoveCurrencyWhenNotUsedInAnyExistingData() {
+        given(applicationCurrencyRepository.findOneWithNotFoundDetection(KEPT_CODE))
+                .willReturn(new ApplicationCurrency(KEPT_CODE, KEPT_CODE, 2, 100, KEPT_CODE, KEPT_CODE));
+        given(organisationCurrencyRepository.findAll())
+                .willReturn(List.of(organisationCurrency(KEPT_CODE), organisationCurrency(REMOVED_CODE)));
+        given(jdbcTemplate.queryForObject(anyString(), eq(Integer.class), any(Object[].class))).willReturn(0);
+
+        final CurrencyUpdateResponse result = underTest
+                .updateAllowedCurrencies(CurrencyUpdateRequest.builder().currencies(List.of(KEPT_CODE)).build());
+
+        assertEquals(List.of(KEPT_CODE), result.getCurrencies());
+        verify(organisationCurrencyRepository).deleteAll();
+        verify(organisationCurrencyRepository).saveAll(any());
+    }
+
+    @Test
+    public void shouldThrowCurrencyInUseExceptionWhenRemovedCurrencyIsStillReferenced() {
+        given(applicationCurrencyRepository.findOneWithNotFoundDetection(KEPT_CODE))
+                .willReturn(new ApplicationCurrency(KEPT_CODE, KEPT_CODE, 2, 100, KEPT_CODE, KEPT_CODE));
+        given(organisationCurrencyRepository.findAll())
+                .willReturn(List.of(organisationCurrency(KEPT_CODE), organisationCurrency(REMOVED_CODE)));
+        // simulates the removed currency still being referenced by one of the checked tables (e.g. m_loan)
+        given(jdbcTemplate.queryForObject(anyString(), eq(Integer.class), any(Object[].class))).willReturn(1);
+
+        assertThrows(CurrencyInUseException.class, () -> underTest
+                .updateAllowedCurrencies(CurrencyUpdateRequest.builder().currencies(List.of(KEPT_CODE)).build()));
+
+        verify(organisationCurrencyRepository, never()).deleteAll();
+        verify(organisationCurrencyRepository, never()).saveAll(any());
+    }
+
+    @Test
+    public void shouldNotCheckUsageForCurrenciesThatRemainAllowed() {
+        given(applicationCurrencyRepository.findOneWithNotFoundDetection(KEPT_CODE))
+                .willReturn(new ApplicationCurrency(KEPT_CODE, KEPT_CODE, 2, 100, KEPT_CODE, KEPT_CODE));
+        given(organisationCurrencyRepository.findAll()).willReturn(List.of(organisationCurrency(KEPT_CODE)));
+
+        underTest.updateAllowedCurrencies(CurrencyUpdateRequest.builder().currencies(List.of(KEPT_CODE)).build());
+
+        verify(jdbcTemplate, never()).queryForObject(anyString(), eq(Integer.class), any(Object[].class));
+        verify(organisationCurrencyRepository).deleteAll();
+    }
+}


### PR DESCRIPTION
## Description

`CurrencyWritePlatformServiceJpaRepositoryImpl#updateAllowedCurrencies` allows removing a currency from the organisation's allowed-currency list. The existing in-use check only looked at loan products, savings products, and charges, so a currency still referenced by actual loans, savings/share accounts, client transactions, account transfers, cashier transactions, or GL journal entries could be silently removed.

This broadens the check to a `JdbcTemplate`-based scan across all relevant tables (`m_product_loan`, `m_savings_product`, `m_share_product`, `m_charge`, `m_loan`, `m_savings_account`, `m_share_account`, `m_client_transaction`, `m_account_transfer_transaction`, `m_cashier_transactions`, `acc_gl_journal_entry`) and improves `CurrencyInUseException`'s message to be clearer to end users.

## JIRA

https://issues.apache.org/jira/browse/FINERACT-2717

## Test plan

- [x] `./gradlew :fineract-core:compileJava :fineract-provider:compileJava` passes
- [x] Added `CurrencyWritePlatformServiceJpaRepositoryImplTest` (no prior test existed for this class), covering:
  - currency removed successfully when unused
  - `CurrencyInUseException` thrown when the removed currency is still referenced
  - the usage check is skipped entirely for currencies that remain allowed
- [x] `./gradlew :fineract-provider:test --tests "...CurrencyWritePlatformServiceJpaRepositoryImplTest"` — all 3 tests pass