### PR TITLE
FINERACT-754: Preserve transfer links during overdraft recalculation

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/AccountingProcessorHelper.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/AccountingProcessorHelper.java
@@ -21,10 +21,12 @@ package org.apache.fineract.accounting.journalentry.service;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.fineract.accounting.closure.domain.GLClosure;
@@ -214,7 +216,10 @@ public class AccountingProcessorHelper {
         final Long officeId = (Long) accountingBridgeData.get("officeId");
         final String currencyCode = (String) accountingBridgeData.get("currencyCode");
         final List<SavingsTransactionDTO> newSavingsTransactions = new ArrayList<>();
-        boolean isAccountTransfer = (Boolean) accountingBridgeData.get("isAccountTransfer");
+        final boolean isAccountTransfer = (Boolean) accountingBridgeData.get("isAccountTransfer");
+        @SuppressWarnings("unchecked")
+        final Set<Long> accountTransferTransactionIds = (Set<Long>) accountingBridgeData.getOrDefault("accountTransferTransactionIds",
+                Collections.emptySet());
 
         @SuppressWarnings("unchecked")
         final List<Map<String, Object>> newTransactionsMap = (List<Map<String, Object>>) accountingBridgeData.get("newSavingsTransactions");
@@ -261,13 +266,14 @@ public class AccountingProcessorHelper {
                 }
             }
 
-            if (!isAccountTransfer) {
-                isAccountTransfer = this.accountTransfersReadPlatformService.isAccountTransfer(Long.parseLong(transactionId),
+            boolean localIsAccountTransfer = isAccountTransfer || accountTransferTransactionIds.contains(Long.parseLong(transactionId));
+            if (!localIsAccountTransfer) {
+                localIsAccountTransfer = this.accountTransfersReadPlatformService.isAccountTransfer(Long.parseLong(transactionId),
                         PortfolioAccountType.SAVINGS);
             }
             final SavingsTransactionDTO transaction = new SavingsTransactionDTO(transactionOfficeId, paymentTypeId, transactionId,
-                    transactionDate, transactionType, amount, reversed, feePayments, penaltyPayments, overdraftAmount, isAccountTransfer,
-                    taxPayments);
+                    transactionDate, transactionType, amount, reversed, feePayments, penaltyPayments, overdraftAmount,
+                    localIsAccountTransfer, taxPayments);
 
             newSavingsTransactions.add(transaction);
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/domain/AccountTransferRepository.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/domain/AccountTransferRepository.java
@@ -39,4 +39,7 @@ public interface AccountTransferRepository
 
     @Query("select att from AccountTransferTransaction att where att.fromLoanTransaction.id IN :loanTransactions and att.reversed=false")
     List<AccountTransferTransaction> findByFromLoanTransactions(@Param("loanTransactions") Collection<Long> loanTransactions);
+
+    @Query("select att from AccountTransferTransaction att where att.reversed=false and (att.fromSavingsTransaction.id IN :savingsTransactionIds or att.toSavingsTransaction.id IN :savingsTransactionIds)")
+    List<AccountTransferTransaction> findBySavingsTransactionIds(@Param("savingsTransactionIds") Collection<Long> savingsTransactionIds);
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/domain/AccountTransferTransaction.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/domain/AccountTransferTransaction.java
@@ -138,6 +138,14 @@ public class AccountTransferTransaction extends AbstractPersistableCustom<Long> 
         this.toLoanTransaction = toLoanTransaction;
     }
 
+    public void updateFromSavingsTransaction(SavingsAccountTransaction fromSavingsTransaction) {
+        this.fromSavingsTransaction = fromSavingsTransaction;
+    }
+
+    public void updateToSavingsTransaction(SavingsAccountTransaction toSavingsTransaction) {
+        this.toSavingsTransaction = toSavingsTransaction;
+    }
+
     public AccountTransferDetails accountTransferDetails() {
         return this.accountTransferDetails;
     }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/service/SavingsAccountTransfersServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/service/SavingsAccountTransfersServiceImpl.java
@@ -1,0 +1,133 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.account.service;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.portfolio.account.domain.AccountTransferRepository;
+import org.apache.fineract.portfolio.savings.domain.SavingsAccountTransaction;
+import org.apache.fineract.portfolio.savings.domain.SavingsAccountTransactionReplacement;
+import org.apache.fineract.portfolio.savings.service.SavingsAccountTransfersService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SavingsAccountTransfersServiceImpl implements SavingsAccountTransfersService {
+
+    private final AccountTransferRepository accountTransferRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public Set<Long> findTransferTransactionIds(final Collection<SavingsAccountTransactionReplacement> transactionReplacements) {
+        if (transactionReplacements.isEmpty()) {
+            return Set.of();
+        }
+
+        final var replacementsByTransactionId = mapReplacementsByTransactionId(transactionReplacements);
+        final var transferTransactions = this.accountTransferRepository.findBySavingsTransactionIds(replacementsByTransactionId.keySet());
+        final Set<Long> transferTransactionIds = new HashSet<>();
+        transferTransactions.forEach(transferTransaction -> {
+            final var fromSavingsTransaction = transferTransaction.getFromTransaction();
+            if (fromSavingsTransaction != null) {
+                addTransactionIds(fromSavingsTransaction, replacementsByTransactionId, transferTransactionIds);
+            }
+
+            final var toSavingsTransaction = transferTransaction.getToSavingsTransaction();
+            if (toSavingsTransaction != null) {
+                addTransactionIds(toSavingsTransaction, replacementsByTransactionId, transferTransactionIds);
+            }
+        });
+        return transferTransactionIds;
+    }
+
+    @Override
+    @Transactional
+    public void updateSavingsTransactionReferences(final Collection<SavingsAccountTransactionReplacement> transactionReplacements) {
+        if (transactionReplacements.isEmpty()) {
+            return;
+        }
+
+        final var replacementsByTransactionId = mapReplacementsByTransactionId(transactionReplacements);
+        final var transferTransactions = this.accountTransferRepository.findBySavingsTransactionIds(replacementsByTransactionId.keySet());
+        transferTransactions.forEach(transferTransaction -> {
+            final var fromSavingsTransaction = transferTransaction.getFromTransaction();
+            if (fromSavingsTransaction != null) {
+                final var replacementChain = resolveReplacementChain(fromSavingsTransaction, replacementsByTransactionId);
+                if (!replacementChain.isEmpty()) {
+                    transferTransaction.updateFromSavingsTransaction(replacementChain.getLast());
+                }
+            }
+
+            final var toSavingsTransaction = transferTransaction.getToSavingsTransaction();
+            if (toSavingsTransaction != null) {
+                final var replacementChain = resolveReplacementChain(toSavingsTransaction, replacementsByTransactionId);
+                if (!replacementChain.isEmpty()) {
+                    transferTransaction.updateToSavingsTransaction(replacementChain.getLast());
+                }
+            }
+        });
+        this.accountTransferRepository.saveAll(transferTransactions);
+    }
+
+    private Map<Long, SavingsAccountTransactionReplacement> mapReplacementsByTransactionId(
+            final Collection<SavingsAccountTransactionReplacement> transactionReplacements) {
+        final Map<Long, SavingsAccountTransactionReplacement> replacementsByTransactionId = new HashMap<>();
+        transactionReplacements
+                .forEach(replacement -> replacementsByTransactionId.put(replacement.replacedTransaction().getId(), replacement));
+        return replacementsByTransactionId;
+    }
+
+    private void addTransactionIds(final SavingsAccountTransaction replacedTransaction,
+            final Map<Long, SavingsAccountTransactionReplacement> replacementsByTransactionId, final Set<Long> transferTransactionIds) {
+        resolveReplacementChain(replacedTransaction, replacementsByTransactionId).stream().map(SavingsAccountTransaction::getId)
+                .forEach(transferTransactionIds::add);
+    }
+
+    private List<SavingsAccountTransaction> resolveReplacementChain(final SavingsAccountTransaction replacedTransaction,
+            final Map<Long, SavingsAccountTransactionReplacement> replacementsByTransactionId) {
+        if (!replacementsByTransactionId.containsKey(replacedTransaction.getId())) {
+            return List.of();
+        }
+
+        final List<SavingsAccountTransaction> replacementChain = new ArrayList<>();
+        final Set<Long> visitedTransactionIds = new HashSet<>();
+        var currentTransaction = replacedTransaction;
+        while (currentTransaction != null) {
+            final var currentTransactionId = currentTransaction.getId();
+            if (!visitedTransactionIds.add(currentTransactionId)) {
+                throw new IllegalStateException("Circular savings transaction replacement chain for transaction " + currentTransactionId);
+            }
+
+            replacementChain.add(currentTransaction);
+            final var replacement = replacementsByTransactionId.get(currentTransactionId);
+            if (replacement == null) {
+                break;
+            }
+            currentTransaction = replacement.replacementTransaction();
+        }
+        return replacementChain;
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountDomainServiceJpa.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountDomainServiceJpa.java
@@ -46,6 +46,7 @@ import org.apache.fineract.portfolio.savings.data.SavingsAccountTransactionDTO;
 import org.apache.fineract.portfolio.savings.exception.DepositAccountTransactionNotAllowedException;
 import org.apache.fineract.portfolio.savings.service.SavingsAccountDomainService;
 import org.apache.fineract.portfolio.savings.service.SavingsAccountPostInterestService;
+import org.apache.fineract.portfolio.savings.service.SavingsAccountTransfersService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -62,6 +63,7 @@ public class SavingsAccountDomainServiceJpa implements SavingsAccountDomainServi
     private final DepositAccountOnHoldTransactionRepository depositAccountOnHoldTransactionRepository;
     private final BusinessEventNotifierService businessEventNotifierService;
     private final SavingsAccountPostInterestService savingsAccountPostInterestService;
+    private final SavingsAccountTransfersService savingsAccountTransfersService;
 
     @Autowired
     public SavingsAccountDomainServiceJpa(final SavingsAccountRepositoryWrapper savingsAccountRepository,
@@ -71,7 +73,8 @@ public class SavingsAccountDomainServiceJpa implements SavingsAccountDomainServi
             final ConfigurationDomainService configurationDomainService, final PlatformSecurityContext context,
             final DepositAccountOnHoldTransactionRepository depositAccountOnHoldTransactionRepository,
             final BusinessEventNotifierService businessEventNotifierService,
-            final SavingsAccountPostInterestService savingsAccountPostInterestService) {
+            final SavingsAccountPostInterestService savingsAccountPostInterestService,
+            final SavingsAccountTransfersService savingsAccountTransfersService) {
         this.savingsAccountRepository = savingsAccountRepository;
         this.savingsAccountTransactionRepository = savingsAccountTransactionRepository;
         this.applicationCurrencyRepositoryWrapper = applicationCurrencyRepositoryWrapper;
@@ -81,6 +84,7 @@ public class SavingsAccountDomainServiceJpa implements SavingsAccountDomainServi
         this.depositAccountOnHoldTransactionRepository = depositAccountOnHoldTransactionRepository;
         this.businessEventNotifierService = businessEventNotifierService;
         this.savingsAccountPostInterestService = savingsAccountPostInterestService;
+        this.savingsAccountTransfersService = savingsAccountTransfersService;
     }
 
     @Transactional
@@ -270,9 +274,13 @@ public class SavingsAccountDomainServiceJpa implements SavingsAccountDomainServi
     private void postJournalEntries(final SavingsAccount savingsAccount, final Set<Long> existingTransactionIds,
             final Set<Long> existingReversedTransactionIds, boolean isAccountTransfer, final boolean backdatedTxnsAllowedTill) {
 
+        final var transactionReplacements = savingsAccount.getTransactionReplacements();
+        final var accountTransferTransactionIds = this.savingsAccountTransfersService.findTransferTransactionIds(transactionReplacements);
         final Map<String, Object> accountingBridgeData = savingsAccount.deriveAccountingBridgeData(savingsAccount.getCurrency().getCode(),
-                existingTransactionIds, existingReversedTransactionIds, isAccountTransfer, backdatedTxnsAllowedTill);
+                existingTransactionIds, existingReversedTransactionIds, isAccountTransfer, backdatedTxnsAllowedTill,
+                accountTransferTransactionIds);
         this.journalEntryWritePlatformService.createJournalEntriesForSavings(accountingBridgeData);
+        this.savingsAccountTransfersService.updateSavingsTransactionReferences(transactionReplacements);
     }
 
     @Transactional

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformServiceJpaRepositoryImpl.java
@@ -49,7 +49,6 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.fineract.accounting.journalentry.service.JournalEntryWritePlatformService;
 import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
 import org.apache.fineract.infrastructure.core.data.ApiParameterError;
@@ -149,7 +148,6 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
     private final SavingsAccountTransactionDataValidator savingsAccountTransactionDataValidator;
     private final SavingsAccountChargeDataValidator savingsAccountChargeDataValidator;
     private final PaymentDetailWritePlatformService paymentDetailWritePlatformService;
-    private final JournalEntryWritePlatformService journalEntryWritePlatformService;
     private final SavingsAccountDomainService savingsAccountDomainService;
     private final NoteRepository noteRepository;
     private final AccountTransfersReadPlatformService accountTransfersReadPlatformService;
@@ -516,6 +514,13 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
         final boolean backdatedTxnsAllowedTill = this.savingAccountAssembler.getPivotConfigStatus();
         final SavingsAccount account = this.savingAccountAssembler.assembleFrom(savingsId, backdatedTxnsAllowedTill);
         checkClientOrGroupActive(account);
+        final Set<Long> existingTransactionIds = new HashSet<>();
+        final Set<Long> existingReversedTransactionIds = new HashSet<>();
+        if (backdatedTxnsAllowedTill) {
+            updateSavingsTransactionsDetails(account, existingTransactionIds, existingReversedTransactionIds);
+        } else {
+            updateExistingTransactionsDetails(account, existingTransactionIds, existingReversedTransactionIds);
+        }
 
         final LocalDate today = DateUtils.getBusinessLocalDate();
         final MathContext mc = new MathContext(15, MoneyHelper.getRoundingMode());
@@ -529,7 +534,8 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
             this.savingsAccountTransactionRepository.saveAll(account.getSavingsAccountTransactionsWithPivotConfig());
         }
 
-        this.savingAccountRepositoryWrapper.save(account);
+        this.savingAccountRepositoryWrapper.saveAndFlush(account);
+        postJournalEntries(account, existingTransactionIds, existingReversedTransactionIds, backdatedTxnsAllowedTill);
 
         return new CommandProcessingResultBuilder() //
                 .withEntityId(savingsId) //
@@ -1573,10 +1579,8 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
     private void postJournalEntries(final SavingsAccount savingsAccount, final Set<Long> existingTransactionIds,
             final Set<Long> existingReversedTransactionIds, final boolean backdatedTxnsAllowedTill) {
 
-        boolean isAccountTransfer = false;
-        final Map<String, Object> accountingBridgeData = savingsAccount.deriveAccountingBridgeData(savingsAccount.getCurrency().getCode(),
-                existingTransactionIds, existingReversedTransactionIds, isAccountTransfer, backdatedTxnsAllowedTill);
-        this.journalEntryWritePlatformService.createJournalEntriesForSavings(accountingBridgeData);
+        this.savingsAccountDomainService.postJournalEntries(savingsAccount, existingTransactionIds, existingReversedTransactionIds,
+                backdatedTxnsAllowedTill);
     }
 
     @Override

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/starter/SavingsConfiguration.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/starter/SavingsConfiguration.java
@@ -386,8 +386,7 @@ public class SavingsConfiguration {
             StaffRepositoryWrapper staffRepository, SavingsAccountTransactionRepository savingsAccountTransactionRepository,
             SavingsAccountAssembler savingAccountAssembler, SavingsAccountTransactionDataValidator savingsAccountTransactionDataValidator,
             SavingsAccountChargeDataValidator savingsAccountChargeDataValidator,
-            PaymentDetailWritePlatformService paymentDetailWritePlatformService,
-            JournalEntryWritePlatformService journalEntryWritePlatformService, SavingsAccountDomainService savingsAccountDomainService,
+            PaymentDetailWritePlatformService paymentDetailWritePlatformService, SavingsAccountDomainService savingsAccountDomainService,
             NoteRepository noteRepository, AccountTransfersReadPlatformService accountTransfersReadPlatformService,
             AccountAssociationsReadPlatformService accountAssociationsReadPlatformService, ChargeRepositoryWrapper chargeRepository,
             SavingsAccountChargeRepositoryWrapper savingsAccountChargeRepository, HolidayRepositoryWrapper holidayRepository,
@@ -401,9 +400,9 @@ public class SavingsConfiguration {
             ErrorHandler errorHandler) {
         return new SavingsAccountWritePlatformServiceJpaRepositoryImpl(context, fromApiJsonDeserializer, savingAccountRepositoryWrapper,
                 staffRepository, savingsAccountTransactionRepository, savingAccountAssembler, savingsAccountTransactionDataValidator,
-                savingsAccountChargeDataValidator, paymentDetailWritePlatformService, journalEntryWritePlatformService,
-                savingsAccountDomainService, noteRepository, accountTransfersReadPlatformService, accountAssociationsReadPlatformService,
-                chargeRepository, savingsAccountChargeRepository, holidayRepository, workingDaysRepository, configurationDomainService,
+                savingsAccountChargeDataValidator, paymentDetailWritePlatformService, savingsAccountDomainService, noteRepository,
+                accountTransfersReadPlatformService, accountAssociationsReadPlatformService, chargeRepository,
+                savingsAccountChargeRepository, holidayRepository, workingDaysRepository, configurationDomainService,
                 depositAccountOnHoldTransactionRepository, entityDatatableChecksWritePlatformService, appuserRepository,
                 standingInstructionRepository, businessEventNotifierService, gsimRepository, savingsAccountInterestPostingService,
                 savingsAccountPostInterestService, savingsAccountActivationService, externalIdFactory, errorHandler);

--- a/fineract-provider/src/test/java/org/apache/fineract/accounting/journalentry/service/AccountingProcessorHelperTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/accounting/journalentry/service/AccountingProcessorHelperTest.java
@@ -1,0 +1,125 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.accounting.journalentry.service;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.fineract.accounting.closure.domain.GLClosureRepository;
+import org.apache.fineract.accounting.financialactivityaccount.domain.FinancialActivityAccountRepositoryWrapper;
+import org.apache.fineract.accounting.glaccount.domain.GLAccountRepository;
+import org.apache.fineract.accounting.journalentry.domain.JournalEntryRepository;
+import org.apache.fineract.accounting.producttoaccountmapping.domain.ProductToGLAccountMappingRepository;
+import org.apache.fineract.infrastructure.event.business.service.BusinessEventNotifierService;
+import org.apache.fineract.organisation.office.domain.OfficeRepository;
+import org.apache.fineract.portfolio.account.PortfolioAccountType;
+import org.apache.fineract.portfolio.account.service.AccountTransfersReadPlatformService;
+import org.apache.fineract.portfolio.charge.domain.ChargeRepositoryWrapper;
+import org.apache.fineract.portfolio.savings.data.SavingsAccountTransactionEnumData;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AccountingProcessorHelperTest {
+
+    @Mock
+    private JournalEntryRepository glJournalEntryRepository;
+    @Mock
+    private ProductToGLAccountMappingRepository accountMappingRepository;
+    @Mock
+    private FinancialActivityAccountRepositoryWrapper financialActivityAccountRepository;
+    @Mock
+    private GLClosureRepository closureRepository;
+    @Mock
+    private GLAccountRepository glAccountRepository;
+    @Mock
+    private OfficeRepository officeRepository;
+    @Mock
+    private AccountTransfersReadPlatformService accountTransfersReadPlatformService;
+    @Mock
+    private ChargeRepositoryWrapper chargeRepositoryWrapper;
+    @Mock
+    private BusinessEventNotifierService businessEventNotifierService;
+
+    @InjectMocks
+    private AccountingProcessorHelper helper;
+
+    @Test
+    void classifyReplacedTransferTransactionsWithoutLeakingToRegularTransactions() {
+        final var accountingBridgeData = accountingBridgeData(List.of(transaction(10L), transaction(11L), transaction(12L)),
+                Set.of(10L, 12L));
+        when(accountTransfersReadPlatformService.isAccountTransfer(11L, PortfolioAccountType.SAVINGS)).thenReturn(false);
+
+        final var transactions = helper.populateSavingsDtoFromMap(accountingBridgeData, true, false).getNewSavingsTransactions();
+
+        assertTrue(transactions.get(0).isAccountTransfer());
+        assertFalse(transactions.get(1).isAccountTransfer());
+        assertTrue(transactions.get(2).isAccountTransfer());
+        verify(accountTransfersReadPlatformService).isAccountTransfer(11L, PortfolioAccountType.SAVINGS);
+    }
+
+    @Test
+    void determineTransferStatusIndependentlyForEachTransaction() {
+        final var accountingBridgeData = accountingBridgeData(List.of(transaction(20L), transaction(21L)), Set.of());
+        when(accountTransfersReadPlatformService.isAccountTransfer(20L, PortfolioAccountType.SAVINGS)).thenReturn(true);
+        when(accountTransfersReadPlatformService.isAccountTransfer(21L, PortfolioAccountType.SAVINGS)).thenReturn(false);
+
+        final var transactions = helper.populateSavingsDtoFromMap(accountingBridgeData, true, false).getNewSavingsTransactions();
+
+        assertTrue(transactions.get(0).isAccountTransfer());
+        assertFalse(transactions.get(1).isAccountTransfer());
+    }
+
+    private Map<String, Object> accountingBridgeData(final List<Map<String, Object>> transactions,
+            final Set<Long> accountTransferTransactionIds) {
+        final Map<String, Object> accountingBridgeData = new LinkedHashMap<>();
+        accountingBridgeData.put("savingsId", 1L);
+        accountingBridgeData.put("savingsProductId", 2L);
+        accountingBridgeData.put("officeId", 1L);
+        accountingBridgeData.put("currencyCode", "USD");
+        accountingBridgeData.put("isAccountTransfer", false);
+        accountingBridgeData.put("accountTransferTransactionIds", accountTransferTransactionIds);
+        accountingBridgeData.put("newSavingsTransactions", transactions);
+        return accountingBridgeData;
+    }
+
+    private Map<String, Object> transaction(final Long id) {
+        final Map<String, Object> transaction = new LinkedHashMap<>();
+        transaction.put("officeId", 1L);
+        transaction.put("id", id);
+        transaction.put("date", LocalDate.of(2013, 2, 28));
+        transaction.put("type", new SavingsAccountTransactionEnumData(2L, "withdrawal", "Withdrawal"));
+        transaction.put("amount", BigDecimal.TEN);
+        transaction.put("reversed", false);
+        transaction.put("paymentTypeId", null);
+        transaction.put("overdraftAmount", BigDecimal.ZERO);
+        return transaction;
+    }
+}

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/account/service/SavingsAccountTransfersServiceImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/account/service/SavingsAccountTransfersServiceImplTest.java
@@ -1,0 +1,144 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.account.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+import org.apache.fineract.portfolio.account.domain.AccountTransferRepository;
+import org.apache.fineract.portfolio.account.domain.AccountTransferTransaction;
+import org.apache.fineract.portfolio.savings.domain.SavingsAccountTransaction;
+import org.apache.fineract.portfolio.savings.domain.SavingsAccountTransactionReplacement;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SavingsAccountTransfersServiceImplTest {
+
+    @Mock
+    private AccountTransferRepository accountTransferRepository;
+
+    @InjectMocks
+    private SavingsAccountTransfersServiceImpl service;
+
+    @Test
+    void updateSourceTransactionReference() {
+        final var replacedTransaction = transaction(1L);
+        final var replacementTransaction = mock(SavingsAccountTransaction.class);
+        final var transferTransaction = mock(AccountTransferTransaction.class);
+        when(transferTransaction.getFromTransaction()).thenReturn(replacedTransaction);
+        when(accountTransferRepository.findBySavingsTransactionIds(Set.of(1L))).thenReturn(List.of(transferTransaction));
+
+        service.updateSavingsTransactionReferences(
+                List.of(new SavingsAccountTransactionReplacement(replacedTransaction, replacementTransaction)));
+
+        verify(transferTransaction).updateFromSavingsTransaction(replacementTransaction);
+        verify(transferTransaction, never()).updateToSavingsTransaction(replacementTransaction);
+        verify(accountTransferRepository).saveAll(List.of(transferTransaction));
+    }
+
+    @Test
+    void updateDestinationTransactionReference() {
+        final var replacedTransaction = transaction(3L);
+        final var replacementTransaction = mock(SavingsAccountTransaction.class);
+        final var transferTransaction = mock(AccountTransferTransaction.class);
+        when(transferTransaction.getToSavingsTransaction()).thenReturn(replacedTransaction);
+        when(accountTransferRepository.findBySavingsTransactionIds(Set.of(3L))).thenReturn(List.of(transferTransaction));
+
+        service.updateSavingsTransactionReferences(
+                List.of(new SavingsAccountTransactionReplacement(replacedTransaction, replacementTransaction)));
+
+        verify(transferTransaction).updateToSavingsTransaction(replacementTransaction);
+        verify(transferTransaction, never()).updateFromSavingsTransaction(replacementTransaction);
+        verify(accountTransferRepository).saveAll(List.of(transferTransaction));
+    }
+
+    @Test
+    void updateTransactionReferenceToFinalReplacement() {
+        final var replacedTransaction = transaction(9L);
+        final var firstReplacement = transaction(10L);
+        final var finalReplacement = transaction(11L);
+        final var transferTransaction = mock(AccountTransferTransaction.class);
+        when(transferTransaction.getFromTransaction()).thenReturn(replacedTransaction);
+        when(accountTransferRepository.findBySavingsTransactionIds(Set.of(9L, 10L))).thenReturn(List.of(transferTransaction));
+
+        service.updateSavingsTransactionReferences(List.of(new SavingsAccountTransactionReplacement(replacedTransaction, firstReplacement),
+                new SavingsAccountTransactionReplacement(firstReplacement, finalReplacement)));
+
+        verify(transferTransaction).updateFromSavingsTransaction(finalReplacement);
+        verify(accountTransferRepository).saveAll(List.of(transferTransaction));
+    }
+
+    @Test
+    void identifyBothSidesOfTransferReplacementForAccounting() {
+        final var replacedSource = transaction(5L);
+        final var replacementSource = transaction(6L);
+        final var replacedDestination = transaction(7L);
+        final var replacementDestination = transaction(8L);
+        final var transferTransaction = mock(AccountTransferTransaction.class);
+        when(transferTransaction.getFromTransaction()).thenReturn(replacedSource);
+        when(transferTransaction.getToSavingsTransaction()).thenReturn(replacedDestination);
+        when(accountTransferRepository.findBySavingsTransactionIds(Set.of(5L, 7L))).thenReturn(List.of(transferTransaction));
+
+        final var transactionIds = service
+                .findTransferTransactionIds(List.of(new SavingsAccountTransactionReplacement(replacedSource, replacementSource),
+                        new SavingsAccountTransactionReplacement(replacedDestination, replacementDestination)));
+
+        assertEquals(Set.of(5L, 6L, 7L, 8L), transactionIds);
+    }
+
+    @Test
+    void identifyEveryTransactionInReplacementChainForAccounting() {
+        final var replacedTransaction = transaction(12L);
+        final var firstReplacement = transaction(13L);
+        final var finalReplacement = transaction(14L);
+        final var transferTransaction = mock(AccountTransferTransaction.class);
+        when(transferTransaction.getFromTransaction()).thenReturn(replacedTransaction);
+        when(accountTransferRepository.findBySavingsTransactionIds(Set.of(12L, 13L))).thenReturn(List.of(transferTransaction));
+
+        final var transactionIds = service
+                .findTransferTransactionIds(List.of(new SavingsAccountTransactionReplacement(replacedTransaction, firstReplacement),
+                        new SavingsAccountTransactionReplacement(firstReplacement, finalReplacement)));
+
+        assertEquals(Set.of(12L, 13L, 14L), transactionIds);
+    }
+
+    @Test
+    void ignoreEmptyReplacementCollection() {
+        assertEquals(Set.of(), service.findTransferTransactionIds(List.of()));
+        service.updateSavingsTransactionReferences(List.of());
+
+        verifyNoInteractions(accountTransferRepository);
+    }
+
+    private SavingsAccountTransaction transaction(final Long id) {
+        final var transaction = mock(SavingsAccountTransaction.class);
+        when(transaction.getId()).thenReturn(id);
+        return transaction;
+    }
+}

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformServiceJpaRepositoryImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformServiceJpaRepositoryImplTest.java
@@ -38,7 +38,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import org.apache.fineract.accounting.journalentry.service.JournalEntryWritePlatformService;
+import java.util.Set;
 import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
 import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
@@ -111,8 +111,6 @@ class SavingsAccountWritePlatformServiceJpaRepositoryImplTest {
     private SavingsAccountChargeDataValidator savingsAccountChargeDataValidator;
     @Mock
     private PaymentDetailWritePlatformService paymentDetailWritePlatformService;
-    @Mock
-    private JournalEntryWritePlatformService journalEntryWritePlatformService;
     @Mock
     private SavingsAccountDomainService savingsAccountDomainService;
     @Mock
@@ -397,6 +395,30 @@ class SavingsAccountWritePlatformServiceJpaRepositoryImplTest {
         verify(savingsAccountTransactionDataValidator).validatePostInterest(command);
         verify(postingTransaction).updateExternalId(externalId);
         verify(savingsAccountTransactionRepository).save(postingTransaction);
+    }
+
+    @Test
+    void calculateInterest_shouldPersistBeforePostingReplacementAwareJournalEntries() {
+        final Long savingsId = 1L;
+        final LocalDate businessDate = LocalDate.of(2024, 4, 5);
+        final SavingsAccount account = mock(SavingsAccount.class);
+
+        setupTenantContext(businessDate);
+        when(savingAccountAssembler.getPivotConfigStatus()).thenReturn(false);
+        when(savingAccountAssembler.assembleFrom(savingsId, false)).thenReturn(account);
+        when(account.findExistingTransactionIds()).thenReturn(Set.of(10L));
+        when(account.findExistingReversedTransactionIds()).thenReturn(Set.of(11L));
+        when(account.officeId()).thenReturn(1L);
+        when(account.clientId()).thenReturn(2L);
+        when(account.groupId()).thenReturn(3L);
+        when(configurationDomainService.isSavingsInterestPostingAtCurrentPeriodEnd()).thenReturn(false);
+        when(configurationDomainService.retrieveFinancialYearBeginningMonth()).thenReturn(1);
+
+        service.calculateInterest(savingsId);
+
+        final var inOrder = Mockito.inOrder(savingAccountRepositoryWrapper, savingsAccountDomainService);
+        inOrder.verify(savingAccountRepositoryWrapper).saveAndFlush(account);
+        inOrder.verify(savingsAccountDomainService).postJournalEntries(account, Set.of(10L), Set.of(11L), false);
     }
 
     private void setupTenantContext(final LocalDate businessDate) {

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccount.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccount.java
@@ -324,6 +324,8 @@ public class SavingsAccount extends AbstractAuditableWithUTCDateTimeCustom<Long>
     protected SavingsHelper savingsHelper;
     @Transient
     protected List<SavingsAccountTransaction> savingsAccountTransactions = new ArrayList<>();
+    @Transient
+    private List<SavingsAccountTransactionReplacement> transactionReplacements = new ArrayList<>();
 
     @Column(name = "deposit_type_enum", insertable = false, updatable = false)
     private Integer depositType;
@@ -937,6 +939,7 @@ public class SavingsAccount extends AbstractAuditableWithUTCDateTimeCustom<Long>
                     if (postReversals) {
                         reversal = SavingsAccountTransaction.reversal(transaction);
                     }
+                    this.transactionReplacements.add(new SavingsAccountTransactionReplacement(transaction, accountTransaction));
                     if (MathUtil.isGreaterThanZero(overdraftAmount)) {
                         accountTransaction.setOverdraftAmount(overdraftAmount);
                     }
@@ -1781,7 +1784,13 @@ public class SavingsAccount extends AbstractAuditableWithUTCDateTimeCustom<Long>
 
     public Map<String, Object> deriveAccountingBridgeData(final String currencyCode, final Set<Long> existingTransactionIds,
             final Set<Long> existingReversedTransactionIds, boolean isAccountTransfer, final boolean backdatedTxnsAllowedTill) {
+        return deriveAccountingBridgeData(currencyCode, existingTransactionIds, existingReversedTransactionIds, isAccountTransfer,
+                backdatedTxnsAllowedTill, Set.of());
+    }
 
+    public Map<String, Object> deriveAccountingBridgeData(final String currencyCode, final Set<Long> existingTransactionIds,
+            final Set<Long> existingReversedTransactionIds, boolean isAccountTransfer, final boolean backdatedTxnsAllowedTill,
+            final Set<Long> accountTransferTransactionIds) {
         final Map<String, Object> accountingBridgeData = new LinkedHashMap<>();
         accountingBridgeData.put("savingsId", getId());
         accountingBridgeData.put("savingsProductId", productId());
@@ -1790,6 +1799,7 @@ public class SavingsAccount extends AbstractAuditableWithUTCDateTimeCustom<Long>
         accountingBridgeData.put("cashBasedAccountingEnabled", isCashBasedAccountingEnabledOnSavingsProduct());
         accountingBridgeData.put("accrualBasedAccountingEnabled", isAccrualBasedAccountingEnabledOnSavingsProduct());
         accountingBridgeData.put("isAccountTransfer", isAccountTransfer);
+        accountingBridgeData.put("accountTransferTransactionIds", accountTransferTransactionIds);
 
         final List<Map<String, Object>> newSavingsTransactions = new ArrayList<>();
 
@@ -1803,6 +1813,9 @@ public class SavingsAccount extends AbstractAuditableWithUTCDateTimeCustom<Long>
 
         // Adding new transactions to the array
         for (final SavingsAccountTransaction transaction : trans) {
+            if (transaction.isReversalTransaction()) {
+                continue;
+            }
             if (transaction.isReversed() && !existingReversedTransactionIds.contains(transaction.getId())) {
                 newSavingsTransactions.add(transaction.toMapData(currencyCode));
             } else if (!existingTransactionIds.contains(transaction.getId())) {
@@ -1821,6 +1834,10 @@ public class SavingsAccount extends AbstractAuditableWithUTCDateTimeCustom<Long>
             ids.add(transaction.getId());
         }
         return ids;
+    }
+
+    public List<SavingsAccountTransactionReplacement> getTransactionReplacements() {
+        return List.copyOf(this.transactionReplacements);
     }
 
     public Collection<Long> findCurrentTransactionIdsWithPivotDateConfig() {

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountTransactionReplacement.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountTransactionReplacement.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.savings.domain;
+
+import java.util.List;
+import java.util.Objects;
+
+public record SavingsAccountTransactionReplacement(SavingsAccountTransaction replacedTransaction,
+        SavingsAccountTransaction replacementTransaction) {
+
+    public SavingsAccountTransactionReplacement {
+        Objects.requireNonNull(replacedTransaction);
+        Objects.requireNonNull(replacementTransaction);
+    }
+
+    public List<SavingsAccountTransaction> transactionsForAccounting() {
+        return List.of(replacedTransaction, replacementTransaction);
+    }
+}

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountTransfersService.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountTransfersService.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.savings.service;
+
+import java.util.Collection;
+import java.util.Set;
+import org.apache.fineract.portfolio.savings.domain.SavingsAccountTransactionReplacement;
+
+public interface SavingsAccountTransfersService {
+
+    Set<Long> findTransferTransactionIds(Collection<SavingsAccountTransactionReplacement> transactionReplacements);
+
+    void updateSavingsTransactionReferences(Collection<SavingsAccountTransactionReplacement> transactionReplacements);
+}

--- a/fineract-savings/src/test/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountAccountingBridgeTest.java
+++ b/fineract-savings/src/test/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountAccountingBridgeTest.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.savings.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class SavingsAccountAccountingBridgeTest {
+
+    @Test
+    void excludeAuditOnlyReversalTransactionsFromAccounting() {
+        final var account = new SavingsAccount() {};
+        final var product = mock(SavingsProduct.class);
+        when(product.getId()).thenReturn(1L);
+        when(product.isCashBasedAccountingEnabled()).thenReturn(true);
+        when(product.isAccrualBasedAccountingEnabled()).thenReturn(false);
+        account.product = product;
+
+        final var reversedTransaction = mock(SavingsAccountTransaction.class);
+        final var auditReversalTransaction = mock(SavingsAccountTransaction.class);
+        final var replacementTransaction = mock(SavingsAccountTransaction.class);
+        final Map<String, Object> reversedTransactionData = Map.of("id", 10L);
+        final Map<String, Object> replacementTransactionData = Map.of("id", 12L);
+
+        when(reversedTransaction.getId()).thenReturn(10L);
+        when(reversedTransaction.isReversed()).thenReturn(true);
+        when(reversedTransaction.toMapData("USD")).thenReturn(reversedTransactionData);
+        when(auditReversalTransaction.getId()).thenReturn(11L);
+        when(auditReversalTransaction.isReversalTransaction()).thenReturn(true);
+        when(replacementTransaction.getId()).thenReturn(12L);
+        when(replacementTransaction.toMapData("USD")).thenReturn(replacementTransactionData);
+        account.transactions = List.of(reversedTransaction, auditReversalTransaction, replacementTransaction);
+
+        final var accountingBridgeData = account.deriveAccountingBridgeData("USD", Set.of(10L), Set.of(), false, false);
+
+        assertEquals(List.of(reversedTransactionData, replacementTransactionData), accountingBridgeData.get("newSavingsTransactions"));
+        verify(auditReversalTransaction, never()).toMapData(anyString());
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/savings/AccountTransferOverdraftTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/savings/AccountTransferOverdraftTest.java
@@ -1,0 +1,266 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests.savings;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.fineract.accounting.common.AccountingConstants;
+import org.apache.fineract.client.models.AccountTransferRequest;
+import org.apache.fineract.client.models.JournalEntryTransactionItem;
+import org.apache.fineract.client.models.PostFinancialActivityAccountsRequest;
+import org.apache.fineract.client.models.PutGlobalConfigurationsRequest;
+import org.apache.fineract.client.models.SavingsAccountTransactionData;
+import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
+import org.apache.fineract.integrationtests.common.ClientHelper;
+import org.apache.fineract.integrationtests.common.accounting.Account;
+import org.apache.fineract.integrationtests.common.accounting.AccountHelper;
+import org.apache.fineract.integrationtests.common.accounting.FinancialActivityAccountHelper;
+import org.apache.fineract.integrationtests.common.savings.SavingsProductHelper;
+import org.apache.fineract.integrationtests.savings.base.BaseSavingsIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class AccountTransferOverdraftTest extends BaseSavingsIntegrationTest {
+
+    private static final String ACTIVATION_DATE = "01 January 2013";
+    private static final String BACKDATED_DEPOSIT_DATE = "27 February 2013";
+    private static final String TRANSFER_DATE = "28 February 2013";
+    private static final BigDecimal OPENING_BALANCE = BigDecimal.valueOf(100);
+    private static final BigDecimal TRANSFER_AMOUNT = BigDecimal.valueOf(110);
+    private static final BigDecimal BACKDATED_DEPOSIT_AMOUNT = BigDecimal.valueOf(5);
+    private static final BigDecimal ORIGINAL_OVERDRAFT_AMOUNT = BigDecimal.TEN;
+    private static final BigDecimal RECALCULATED_OVERDRAFT_AMOUNT = BigDecimal.valueOf(5);
+    private static final String DEBIT = "DEBIT";
+    private static final String CREDIT = "CREDIT";
+
+    @Test
+    void preserveTransferLinkWhenBackdatedDepositRecalculatesOverdraft() {
+        runAt("01 March 2013", () -> runWithPostReversalTransactions(() -> {
+            final var accounting = createAccountingFixture();
+            try {
+                final var savingsProductId = createOverdraftSavingsProduct(accounting);
+                final var sourceClientId = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+                final var destinationClientId = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+                final var sourceSavingsId = createActiveSavingsAccount(sourceClientId, savingsProductId);
+                final var destinationSavingsId = createActiveSavingsAccount(destinationClientId, savingsProductId);
+
+                deposit(sourceSavingsId, ACTIVATION_DATE, OPENING_BALANCE);
+                final var accountTransferId = transfer(sourceClientId, sourceSavingsId, destinationClientId, destinationSavingsId);
+
+                final var originalWithdrawal = findActiveWithdrawal(sourceSavingsId);
+                assertNotNull(originalWithdrawal.getTransfer());
+                final var transferId = originalWithdrawal.getTransfer().getId();
+
+                final var backdatedDepositId = deposit(sourceSavingsId, BACKDATED_DEPOSIT_DATE, BACKDATED_DEPOSIT_AMOUNT).getResourceId();
+
+                assertRecalculationHistory(sourceSavingsId);
+                final var recalculatedWithdrawal = findActiveWithdrawal(sourceSavingsId);
+                assertNotNull(recalculatedWithdrawal.getTransfer());
+                assertEquals(transferId, recalculatedWithdrawal.getTransfer().getId());
+                final var auditOnlyReversal = findAuditOnlyReversal(sourceSavingsId, originalWithdrawal.getId());
+
+                assertReversedWithdrawalJournalEntries(originalWithdrawal.getId(), accounting);
+                assertReplacementWithdrawalJournalEntries(recalculatedWithdrawal.getId(), accounting);
+                assertBackdatedDepositJournalEntries(backdatedDepositId, accounting);
+                assertNoJournalEntries(auditOnlyReversal.getId());
+
+                ok(fineractClient().accountTransfers.accountTransferOperation(accountTransferId, "undo"));
+                assertBalance(sourceSavingsId, BigDecimal.valueOf(105));
+                assertBalance(destinationSavingsId, BigDecimal.ZERO);
+            } finally {
+                accounting.deleteCreatedFinancialActivityMapping();
+            }
+        }));
+    }
+
+    private Long createOverdraftSavingsProduct(final AccountingFixture accounting) {
+        final var product = new SavingsProductHelper().withCurrencyCode("USD").withInterestCompoundingPeriodTypeAsDaily()
+                .withInterestPostingPeriodTypeAsMonthly().withInterestCalculationPeriodTypeAsDailyBalance().withMinimumOpenningBalance("0")
+                .withOverDraft("1000.0").withAccountingRuleAsCashBased(new Account[] { accounting.savingsReferenceAccount(),
+                        accounting.incomeAccount(), accounting.expenseAccount(), accounting.savingsControlAccount() })
+                .build();
+        return SavingsProductHelper.createSavingsProduct(product, requestSpec, responseSpec).longValue();
+    }
+
+    private Long createActiveSavingsAccount(final Long clientId, final Long productId) {
+        final var savingsId = applySavingsAccount(applySavingsRequest(clientId, productId, ACTIVATION_DATE)).getSavingsId();
+        approveSavingsAccount(savingsId, ACTIVATION_DATE);
+        activateSavingsAccount(savingsId, ACTIVATION_DATE);
+        return savingsId;
+    }
+
+    private Long transfer(final Long sourceClientId, final Long sourceSavingsId, final Long destinationClientId,
+            final Long destinationSavingsId) {
+        return ok(fineractClient().accountTransfers.createAccountTransfer(new AccountTransferRequest()
+                .fromClientId(sourceClientId.toString()).fromAccountId(sourceSavingsId.toString()).fromAccountType("2").fromOfficeId("1")
+                .toClientId(destinationClientId.toString()).toAccountId(destinationSavingsId.toString()).toAccountType("2").toOfficeId("1")
+                .transferDate(TRANSFER_DATE).transferAmount(TRANSFER_AMOUNT.toPlainString()).transferDescription("Transfer")
+                .dateFormat(DATETIME_PATTERN).locale("en_GB"))).getResourceId();
+    }
+
+    private void assertBalance(final Long savingsId, final BigDecimal expectedBalance) {
+        final var account = ok(fineractClient().savingsAccounts.retrieveSavingsAccount(savingsId, false, null, "summary"));
+        assertEquals(0, expectedBalance.compareTo(account.getSummary().getAccountBalance()));
+    }
+
+    private SavingsAccountTransactionData findActiveWithdrawal(final Long savingsId) {
+        return transferWithdrawals(savingsId).stream().filter(transaction -> !Boolean.TRUE.equals(transaction.getReversed())).findFirst()
+                .orElseThrow();
+    }
+
+    private SavingsAccountTransactionData findAuditOnlyReversal(final Long savingsId, final Long originalTransactionId) {
+        final var auditOnlyReversals = getTransactions(savingsId).stream()
+                .filter(transaction -> Boolean.TRUE.equals(transaction.getIsReversal()))
+                .filter(transaction -> originalTransactionId.equals(transaction.getOriginalTransactionId())).toList();
+        assertEquals(1, auditOnlyReversals.size());
+        return auditOnlyReversals.get(0);
+    }
+
+    private void assertRecalculationHistory(final Long savingsId) {
+        final var withdrawals = transferWithdrawals(savingsId);
+        assertEquals(2, withdrawals.size());
+        assertEquals(1, withdrawals.stream().filter(transaction -> Boolean.TRUE.equals(transaction.getReversed())).count());
+        assertEquals(1, withdrawals.stream().filter(transaction -> !Boolean.TRUE.equals(transaction.getReversed())).count());
+    }
+
+    private List<SavingsAccountTransactionData> transferWithdrawals(final Long savingsId) {
+        return getTransactions(savingsId).stream().filter(transaction -> !Boolean.TRUE.equals(transaction.getIsReversal()))
+                .filter(transaction -> Boolean.TRUE.equals(transaction.getTransactionType().getWithdrawal()))
+                .filter(transaction -> TRANSFER_AMOUNT.compareTo(transaction.getAmount()) == 0)
+                .filter(transaction -> LocalDate.of(2013, 2, 28).equals(transaction.getDate())).toList();
+    }
+
+    private AccountingFixture createAccountingFixture() {
+        final var accountHelper = new AccountHelper(requestSpec, responseSpec);
+        final var savingsReferenceAccount = accountHelper.createAssetAccount();
+        final var savingsControlAccount = accountHelper.createLiabilityAccount();
+        final var incomeAccount = accountHelper.createIncomeAccount();
+        final var expenseAccount = accountHelper.createExpenseAccount();
+        final var financialActivityAccountHelper = new FinancialActivityAccountHelper(requestSpec);
+        final var financialActivityId = AccountingConstants.FinancialActivity.LIABILITY_TRANSFER.getValue();
+        final var existingMapping = financialActivityAccountHelper.getAllFinancialActivityAccounts().stream()
+                .filter(mapping -> mapping.getFinancialActivityData() != null
+                        && financialActivityId.equals(mapping.getFinancialActivityData().getId()))
+                .findFirst();
+
+        if (existingMapping.isPresent()) {
+            final var glAccountId = existingMapping.orElseThrow().getGlAccountData().getId();
+            return new AccountingFixture(savingsReferenceAccount, savingsControlAccount, incomeAccount, expenseAccount,
+                    new Account(Math.toIntExact(glAccountId), Account.AccountType.LIABILITY), financialActivityAccountHelper, null);
+        }
+
+        final var liabilityTransferAccount = accountHelper.createLiabilityAccount();
+        final var mapping = financialActivityAccountHelper.createFinancialActivityAccount(new PostFinancialActivityAccountsRequest()
+                .financialActivityId(financialActivityId.longValue()).glAccountId(liabilityTransferAccount.getAccountID().longValue()));
+        assertNotNull(mapping.getResourceId());
+        return new AccountingFixture(savingsReferenceAccount, savingsControlAccount, incomeAccount, expenseAccount,
+                liabilityTransferAccount, financialActivityAccountHelper, mapping.getResourceId());
+    }
+
+    private void runWithPostReversalTransactions(final Runnable action) {
+        final var configurationName = GlobalConfigurationConstants.ENABLE_POST_REVERSAL_TXNS_FOR_REVERSE_TRANSACTIONS;
+        final var configuration = globalConfigurationHelper.getGlobalConfigurationByName(configurationName);
+        final var originallyEnabled = Boolean.TRUE.equals(configuration.getEnabled());
+        try {
+            globalConfigurationHelper.updateGlobalConfiguration(configurationName, new PutGlobalConfigurationsRequest().enabled(true));
+            action.run();
+        } finally {
+            globalConfigurationHelper.updateGlobalConfiguration(configurationName,
+                    new PutGlobalConfigurationsRequest().enabled(originallyEnabled));
+        }
+    }
+
+    private void assertReversedWithdrawalJournalEntries(final Long transactionId, final AccountingFixture accounting) {
+        assertJournalEntries(transactionId, new ExpectedJournalEntry(accounting.savingsControlAccount(), DEBIT, OPENING_BALANCE),
+                new ExpectedJournalEntry(accounting.liabilityTransferAccount(), CREDIT, OPENING_BALANCE),
+                new ExpectedJournalEntry(accounting.savingsReferenceAccount(), DEBIT, ORIGINAL_OVERDRAFT_AMOUNT),
+                new ExpectedJournalEntry(accounting.liabilityTransferAccount(), CREDIT, ORIGINAL_OVERDRAFT_AMOUNT),
+                new ExpectedJournalEntry(accounting.savingsControlAccount(), CREDIT, OPENING_BALANCE),
+                new ExpectedJournalEntry(accounting.liabilityTransferAccount(), DEBIT, OPENING_BALANCE),
+                new ExpectedJournalEntry(accounting.savingsReferenceAccount(), CREDIT, ORIGINAL_OVERDRAFT_AMOUNT),
+                new ExpectedJournalEntry(accounting.liabilityTransferAccount(), DEBIT, ORIGINAL_OVERDRAFT_AMOUNT));
+    }
+
+    private void assertReplacementWithdrawalJournalEntries(final Long transactionId, final AccountingFixture accounting) {
+        assertJournalEntries(transactionId,
+                new ExpectedJournalEntry(accounting.savingsControlAccount(), DEBIT,
+                        TRANSFER_AMOUNT.subtract(RECALCULATED_OVERDRAFT_AMOUNT)),
+                new ExpectedJournalEntry(accounting.liabilityTransferAccount(), CREDIT,
+                        TRANSFER_AMOUNT.subtract(RECALCULATED_OVERDRAFT_AMOUNT)),
+                new ExpectedJournalEntry(accounting.savingsReferenceAccount(), DEBIT, RECALCULATED_OVERDRAFT_AMOUNT),
+                new ExpectedJournalEntry(accounting.liabilityTransferAccount(), CREDIT, RECALCULATED_OVERDRAFT_AMOUNT));
+    }
+
+    private void assertBackdatedDepositJournalEntries(final Long transactionId, final AccountingFixture accounting) {
+        assertJournalEntries(transactionId, new ExpectedJournalEntry(accounting.savingsReferenceAccount(), DEBIT, BACKDATED_DEPOSIT_AMOUNT),
+                new ExpectedJournalEntry(accounting.savingsControlAccount(), CREDIT, BACKDATED_DEPOSIT_AMOUNT));
+    }
+
+    private void assertNoJournalEntries(final Long transactionId) {
+        final var journalEntries = journalEntries(transactionId);
+        assertTrue(journalEntries.isEmpty(), () -> "Audit-only reversal must not create journal entries: " + journalEntries);
+    }
+
+    private void assertJournalEntries(final Long transactionId, final ExpectedJournalEntry... expectedEntries) {
+        final var remainingEntries = new ArrayList<>(journalEntries(transactionId));
+        assertEquals(expectedEntries.length, remainingEntries.size(),
+                () -> "Unexpected journal entry count for savings transaction " + transactionId + ": " + remainingEntries);
+
+        for (final var expected : expectedEntries) {
+            final var matchingEntry = remainingEntries.stream().filter(expected::matches).findFirst();
+            assertTrue(matchingEntry.isPresent(),
+                    () -> "Missing journal entry " + expected + " for savings transaction " + transactionId + ": " + remainingEntries);
+            remainingEntries.remove(matchingEntry.orElseThrow());
+        }
+        assertFalse(remainingEntries.iterator().hasNext());
+    }
+
+    private List<JournalEntryTransactionItem> journalEntries(final Long transactionId) {
+        final var journalEntries = journalEntryHelper.getJournalEntries("S" + transactionId);
+        assertNotNull(journalEntries);
+        assertNotNull(journalEntries.getPageItems());
+        return journalEntries.getPageItems();
+    }
+
+    private record ExpectedJournalEntry(Account account, String entryType, BigDecimal amount) {
+
+        private boolean matches(final JournalEntryTransactionItem actual) {
+            return account.getAccountID().longValue() == actual.getGlAccountId() && entryType.equals(actual.getEntryType().getValue())
+                    && amount.compareTo(BigDecimal.valueOf(actual.getAmount())) == 0;
+        }
+    }
+
+    private record AccountingFixture(Account savingsReferenceAccount, Account savingsControlAccount, Account incomeAccount,
+            Account expenseAccount, Account liabilityTransferAccount, FinancialActivityAccountHelper financialActivityAccountHelper,
+            Long createdFinancialActivityMappingId) {
+
+        private void deleteCreatedFinancialActivityMapping() {
+            if (createdFinancialActivityMappingId != null) {
+                final var response = financialActivityAccountHelper.deleteFinancialActivityAccount(createdFinancialActivityMappingId);
+                assertEquals(createdFinancialActivityMappingId, response.getResourceId());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

Fixes [FINERACT-754](https://issues.apache.org/jira/browse/FINERACT-754).

When backdated savings activity changes overdraft allocation, Fineract reverses and replaces affected transactions. The account transfer row remained linked to the reversed transaction, so the active replacement appeared as a regular withdrawal and transfer undo could no longer find it.

This change:

- records exact old-to-new replacement chains during savings recalculation;
- classifies every replacement-chain member as an account transfer for corrected journal posting;
- posts reversal and replacement journals before retargeting the transfer reference to the final active replacement in the same JPA transaction;
- excludes audit-only reversal rows from accounting;
- routes regular savings posting and manual interest calculation through the canonical replacement-aware service.

## Scope

This patch fixes the entity-backed transaction flow used by FINERACT-754, including manual interest posting and backdated transaction recalculation. The scheduled post-interest job uses an independent DTO/JDBC batch pipeline and is unchanged.

## Verification

- 20 focused unit tests passed across fineract-savings and fineract-provider.
- AccountTransferOverdraftTest passed against a rebuilt local image with PostgreSQL. It verifies transfer-link continuity, exact original reversal and replacement GL entries, no journal for the audit-only reversal row, successful transfer undo, and final balances.
- Spotless, Checkstyle, license checks, full RAT, SpotBugs, and git diff --check passed.

## Checklist

- [x] Write the commit message as per the contribution guidelines.
- [x] Acknowledge that the pull request must pass the build before review.
- [x] Add unit and integration tests for the change.
- [x] Follow the project coding conventions.
- [x] No API contract changed, so Swagger and legacy API documentation updates are not required.
- [x] Keep the change reviewable and focused.
- [x] If this PR resolves the Jira issue, update its resolution and Fix Version after merge.