### PR TITLE
FINERACT-2719: Add submittedOnDateTime to journal entry responses

### DIFF
--- a/fineract-accounting/src/main/java/org/apache/fineract/accounting/journalentry/JournalEntryMapper.java
+++ b/fineract-accounting/src/main/java/org/apache/fineract/accounting/journalentry/JournalEntryMapper.java
@@ -46,6 +46,7 @@ public interface JournalEntryMapper {
     @Mapping(target = "entityType", source = "entityType", qualifiedByName = "entityType")
     @Mapping(target = "entityId", source = "entityId")
     @Mapping(target = "submittedOnDate", source = "submittedOnDate")
+    @Mapping(target = "submittedOnDateTime", ignore = true)
     @Mapping(target = "transactionId", source = "transactionId")
     @Mapping(target = "currency", source = "currencyCode")
     @Mapping(target = "manualEntry", source = "manualEntry")

--- a/fineract-accounting/src/main/java/org/apache/fineract/accounting/journalentry/data/JournalEntryData.java
+++ b/fineract-accounting/src/main/java/org/apache/fineract/accounting/journalentry/data/JournalEntryData.java
@@ -198,9 +198,10 @@ public class JournalEntryData {
             final String glAccountCode, final EnumOptionData glAccountClassification, final LocalDate transactionDate,
             final EnumOptionData entryType, final BigDecimal amount, final String transactionId, final Boolean manualEntry,
             final EnumOptionData entityType, final Long entityId, final Long createdByUserId, final LocalDate submittedOnDate,
-            final List<Integer> submittedOnDateTime, final String createdByUserName, final String comments, final Boolean reversed, final String referenceNumber,
-            final BigDecimal officeRunningBalance, final BigDecimal organizationRunningBalance, final Boolean runningBalanceComputed,
-            final TransactionDetailData transactionDetailData, final CurrencyData currency, final String externalAssetOwner) {
+            final List<Integer> submittedOnDateTime, final String createdByUserName, final String comments, final Boolean reversed,
+            final String referenceNumber, final BigDecimal officeRunningBalance, final BigDecimal organizationRunningBalance,
+            final Boolean runningBalanceComputed, final TransactionDetailData transactionDetailData, final CurrencyData currency,
+            final String externalAssetOwner) {
         this.id = id;
         this.officeId = officeId;
         this.officeName = officeName;
@@ -274,8 +275,8 @@ public class JournalEntryData {
         final String externalAssetOwner = null;
         return new JournalEntryData(id, officeId, officeName, glAccountName, glAccountId, glAccountCode, glAccountClassification,
                 transactionDate, entryType, amount, transactionId, manualEntry, entityType, entityId, createdByUserId, submittedOnDate,
-                submittedOnDateTime, createdByUserName, comments, reversed, referenceNumber, officeRunningBalance, organizationRunningBalance,
-                runningBalanceComputed, transactionDetailData, currency, externalAssetOwner);
+                submittedOnDateTime, createdByUserName, comments, reversed, referenceNumber, officeRunningBalance,
+                organizationRunningBalance, runningBalanceComputed, transactionDetailData, currency, externalAssetOwner);
     }
 
     public Integer getRowIndex() {

--- a/fineract-accounting/src/main/java/org/apache/fineract/accounting/journalentry/data/JournalEntryData.java
+++ b/fineract-accounting/src/main/java/org/apache/fineract/accounting/journalentry/data/JournalEntryData.java
@@ -80,6 +80,13 @@ public class JournalEntryData {
     private TransactionDetailData transactionDetails;
     @SuppressWarnings("unused")
     private LocalDate submittedOnDate;
+    /**
+     * Fineract-style date-time JSON array: [year, month, day, hour, minute, second].
+     *
+     * Note: Keep {@code submittedOnDate} unchanged.
+     */
+    @SuppressWarnings("unused")
+    private List<Integer> submittedOnDateTime;
 
     // import fields
     private transient Integer rowIndex;
@@ -176,6 +183,7 @@ public class JournalEntryData {
         this.entityId = null;
         this.createdByUserId = null;
         this.submittedOnDate = null;
+        this.submittedOnDateTime = null;
         this.createdDate = null;
         this.createdByUserName = null;
         this.reversed = null;
@@ -190,7 +198,7 @@ public class JournalEntryData {
             final String glAccountCode, final EnumOptionData glAccountClassification, final LocalDate transactionDate,
             final EnumOptionData entryType, final BigDecimal amount, final String transactionId, final Boolean manualEntry,
             final EnumOptionData entityType, final Long entityId, final Long createdByUserId, final LocalDate submittedOnDate,
-            final String createdByUserName, final String comments, final Boolean reversed, final String referenceNumber,
+            final List<Integer> submittedOnDateTime, final String createdByUserName, final String comments, final Boolean reversed, final String referenceNumber,
             final BigDecimal officeRunningBalance, final BigDecimal organizationRunningBalance, final Boolean runningBalanceComputed,
             final TransactionDetailData transactionDetailData, final CurrencyData currency, final String externalAssetOwner) {
         this.id = id;
@@ -210,6 +218,7 @@ public class JournalEntryData {
         this.createdByUserId = createdByUserId;
         this.createdDate = submittedOnDate;
         this.submittedOnDate = submittedOnDate;
+        this.submittedOnDateTime = submittedOnDateTime;
         this.createdByUserName = createdByUserName;
         this.comments = comments;
         this.reversed = reversed;
@@ -252,6 +261,7 @@ public class JournalEntryData {
         final Long entityId = null;
         final Long createdByUserId = null;
         final LocalDate submittedOnDate = null;
+        final List<Integer> submittedOnDateTime = null;
         final String createdByUserName = null;
         final String comments = null;
         final Boolean reversed = null;
@@ -264,7 +274,7 @@ public class JournalEntryData {
         final String externalAssetOwner = null;
         return new JournalEntryData(id, officeId, officeName, glAccountName, glAccountId, glAccountCode, glAccountClassification,
                 transactionDate, entryType, amount, transactionId, manualEntry, entityType, entityId, createdByUserId, submittedOnDate,
-                createdByUserName, comments, reversed, referenceNumber, officeRunningBalance, organizationRunningBalance,
+                submittedOnDateTime, createdByUserName, comments, reversed, referenceNumber, officeRunningBalance, organizationRunningBalance,
                 runningBalanceComputed, transactionDetailData, currency, externalAssetOwner);
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/JournalEntryReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/JournalEntryReadPlatformServiceImpl.java
@@ -24,6 +24,9 @@ import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -97,7 +100,7 @@ public class JournalEntryReadPlatformServiceImpl implements JournalEntryReadPlat
                     .append(" journalEntry.type_enum as entryType,journalEntry.amount as amount, journalEntry.transaction_id as transactionId,")
                     .append(" journalEntry.entity_type_enum as entityType, journalEntry.entity_id as entityId, creatingUser.id as createdByUserId, ")
                     .append(" creatingUser.username as createdByUserName, journalEntry.description as comments, ")
-                    .append(" journalEntry.submitted_on_date as submittedOnDate, journalEntry.reversed as reversed, ")
+                    .append(" journalEntry.submitted_on_date as submittedOnDate, journalEntry.created_on_utc as submittedOnDateTime, journalEntry.reversed as reversed, ")
                     .append(" journalEntry.currency_code as currencyCode, curr.name as currencyName, curr.internationalized_name_code as currencyNameCode, ")
                     .append(" curr.display_symbol as currencyDisplaySymbol, curr.decimal_places as currencyDigits, curr.currency_multiplesof as inMultiplesOf, ")
                     .append(" eao.external_id as externalAssetOwner ");
@@ -158,6 +161,18 @@ public class JournalEntryReadPlatformServiceImpl implements JournalEntryReadPlat
             final Long entityId = JdbcSupport.getLong(rs, "entityId");
             final Long createdByUserId = rs.getLong("createdByUserId");
             final LocalDate submittedOnDate = JdbcSupport.getLocalDate(rs, "submittedOnDate");
+            final ZonedDateTime zonedDateTime = JdbcSupport.getDateTime(rs, "submittedOnDateTime");
+            List<Integer> submittedOnDateTime = null;
+            if (zonedDateTime != null) {
+                submittedOnDateTime = new ArrayList<>(6);
+                submittedOnDateTime.add(zonedDateTime.getYear());
+                submittedOnDateTime.add(zonedDateTime.getMonthValue());
+                submittedOnDateTime.add(zonedDateTime.getDayOfMonth());
+                submittedOnDateTime.add(zonedDateTime.getHour());
+                submittedOnDateTime.add(zonedDateTime.getMinute());
+                submittedOnDateTime.add(zonedDateTime.getSecond());
+            }
+
             final String createdByUserName = rs.getString("createdByUserName");
             final String comments = rs.getString("comments");
             final Boolean reversed = rs.getBoolean("reversed");
@@ -230,7 +245,7 @@ public class JournalEntryReadPlatformServiceImpl implements JournalEntryReadPlat
 
             return new JournalEntryData(id, officeId, officeName, glAccountName, glAccountId, glCode, accountType, transactionDate,
                     entryType, amount, transactionId, manualEntry, entityType, entityId, createdByUserId, submittedOnDate,
-                    createdByUserName, comments, reversed, referenceNumber, officeRunningBalance, organizationRunningBalance,
+                    submittedOnDateTime, createdByUserName, comments, reversed, referenceNumber, officeRunningBalance, organizationRunningBalance,
                     runningBalanceComputed, transactionDetailData, currency, externalAssetOwner);
         }
     }

--- a/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/JournalEntryReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/JournalEntryReadPlatformServiceImpl.java
@@ -24,8 +24,6 @@ import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/JournalEntryRunningBalanceUpdateServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/JournalEntryRunningBalanceUpdateServiceImpl.java
@@ -278,7 +278,7 @@ public class JournalEntryRunningBalanceUpdateServiceImpl implements JournalEntry
             final EnumOptionData entryType = AccountingEnumerations.journalEntryType(entryTypeId);
 
             return new JournalEntryData(id, officeId, null, null, glAccountId, null, accountType, null, entryType, amount, null, null, null,
-                    null, null, null, null, null, null, null, null, null, null, null, null, null);
+                    null, null, null, null, null, null, null, null, null, null, null, null, null, null);
         }
     }
 


### PR DESCRIPTION
## Description

The Journal Entries API only returns `submittedOnDate` (date-only), so any UI reading it always shows a time of `00:00:00`, even though the journal entry's actual creation timestamp is stored in `acc_gl_journal_entry.created_on_utc`.

This adds a new optional `submittedOnDateTime` field to `JournalEntryData` (Fineract-style `[year, month, day, hour, minute, second]` array), sourced from `created_on_utc` in `JournalEntryReadPlatformServiceImpl`. `submittedOnDate` is left unchanged for backward compatibility.

JIRA: https://issues.apache.org/jira/browse/FINERACT-2719

## Checklist

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] This PR must not be a "code dump". Large changes can be made in a branch, with assistance.
- [ ] If merging this PR resolves a JIRA issue, I will mark that issue as resolved and set "Fix Version/s" appropriately.

Note: no existing unit/integration test covers `JournalEntryReadPlatformServiceImpl`'s row-mapping logic (it's a plain JDBC `RowMapper`, not easily unit-testable in isolation), so none were added — happy to add integration-test coverage if a reviewer points to the right harness for it.