### PR TITLE
FINERACT-2721: Fix loan collateral quantity adjustment and modify-loan change detection

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/collateralmanagement/service/LoanCollateralAssembler.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/collateralmanagement/service/LoanCollateralAssembler.java
@@ -43,7 +43,7 @@ public class LoanCollateralAssembler {
     private final LoanCollateralManagementRepository loanCollateralRepository;
     private final ClientCollateralManagementRepositoryWrapper clientCollateralManagementRepositoryWrapper;
 
-    public Set<LoanCollateralManagement> fromParsedJson(final JsonElement element) {
+    public Set<LoanCollateralManagement> fromParsedJson(final JsonElement element, final boolean adjustClientCollateralQuantity) {
 
         final Set<LoanCollateralManagement> collateralItems = new HashSet<>();
 
@@ -63,27 +63,33 @@ public class LoanCollateralAssembler {
                 BigDecimal updatedClientQuantity = null;
 
                 if (id == null) {
-                    updatedClientQuantity = clientCollateral.getQuantity().subtract(quantity);
-                    if (BigDecimal.ZERO.compareTo(updatedClientQuantity) > 0) {
-                        throw new InvalidAmountOfCollateralQuantity(quantity);
+                    if (adjustClientCollateralQuantity) {
+                        updatedClientQuantity = clientCollateral.getQuantity().subtract(quantity);
+                        if (BigDecimal.ZERO.compareTo(updatedClientQuantity) > 0) {
+                            throw new InvalidAmountOfCollateralQuantity(quantity);
+                        }
+                        clientCollateral.updateQuantity(updatedClientQuantity);
                     }
-                    clientCollateral.updateQuantity(updatedClientQuantity);
                     collateralItems.add(LoanCollateralManagement.from(clientCollateral, quantity));
                 } else {
                     LoanCollateralManagement loanCollateralManagement = this.loanCollateralRepository.findById(id)
                             .orElseThrow(() -> new LoanCollateralManagementNotFoundException(id));
 
-                    if (loanCollateralManagement.getQuantity().compareTo(quantity) != 0) {
-                        updatedClientQuantity = clientCollateral.getQuantity().add(loanCollateralManagement.getQuantity())
-                                .subtract(quantity);
-                        if (BigDecimal.ZERO.compareTo(updatedClientQuantity) > 0) {
-                            throw new InvalidAmountOfCollateralQuantity(quantity);
+                    if (adjustClientCollateralQuantity) {
+                        if (loanCollateralManagement.getQuantity().compareTo(quantity) != 0) {
+                            updatedClientQuantity = clientCollateral.getQuantity().add(loanCollateralManagement.getQuantity())
+                                    .subtract(quantity);
+                            if (BigDecimal.ZERO.compareTo(updatedClientQuantity) > 0) {
+                                throw new InvalidAmountOfCollateralQuantity(quantity);
+                            }
+                        } else {
+                            // when quantity is unchanged, restore the original client collateral quantity rather than
+                            // setting it to the requested quantity value which may be less than available
+                            updatedClientQuantity = clientCollateral.getQuantity().add(loanCollateralManagement.getQuantity());
                         }
-                    } else {
-                        updatedClientQuantity = quantity;
-                    }
 
-                    clientCollateral.updateQuantity(updatedClientQuantity);
+                        clientCollateral.updateQuantity(updatedClientQuantity);
+                    }
                     collateralItems
                             .add(LoanCollateralManagement.fromExisting(clientCollateral, quantity, loanCollateralManagement.getLoanData(),
                                     loanCollateralManagement.getLoanTransaction(), loanCollateralManagement.getId()));
@@ -91,5 +97,11 @@ public class LoanCollateralAssembler {
             }
         }
         return collateralItems;
+    }
+
+    public Set<LoanCollateralManagement> fromParsedJson(final JsonElement element) {
+        // Default behavior should not adjust client collateral quantities to avoid side effects
+        // during read-only operations such as repayment schedule calculation or validation.
+        return fromParsedJson(element, false);
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanAssemblerImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanAssemblerImpl.java
@@ -207,7 +207,8 @@ public class LoanAssemblerImpl implements LoanAssembler {
 
         final AccountType loanAccountType = AccountType.fromName(loanTypeStr);
         if (loanAccountType.isIndividualAccount()) {
-            collateral = this.collateralAssembler.fromParsedJson(element);
+            // When assembling a real loan application we need to adjust the client's collateral quantities
+            collateral = this.collateralAssembler.fromParsedJson(element, true);
         }
 
         final Set<LoanCharge> loanCharges = this.loanChargeAssembler.fromParsedJson(element, disbursementDetails);
@@ -511,7 +512,9 @@ public class LoanAssemblerImpl implements LoanAssembler {
             final AccountType loanType = AccountType.fromName(loanTypeStr);
 
             if (!StringUtils.isBlank(loanTypeStr) && loanType.isIndividualAccount()) {
-                possiblyModifedLoanCollateralItems = this.loanCollateralAssembler.fromParsedJson(command.parsedJson());
+                // When updating an existing loan, adjust client collateral quantities based on the
+                // difference between the requested collateral amount and the existing loan collateral
+                possiblyModifedLoanCollateralItems = this.loanCollateralAssembler.fromParsedJson(command.parsedJson(), true);
             }
         }
         this.loanScheduleAssembler.updateLoanApplicationAttributes(command, loan, changes);
@@ -707,8 +710,9 @@ public class LoanAssemblerImpl implements LoanAssembler {
             changes.put(Loan.RECALCULATE_LOAN_SCHEDULE, true);
         }
 
+        // Update collateral only when it actually changed compared to existing items
         if (command.parameterExists(LoanApiConstants.collateralParameterName) && possiblyModifedLoanCollateralItems != null
-                && possiblyModifedLoanCollateralItems.equals(loan.getLoanCollateralManagements())) {
+                && !possiblyModifedLoanCollateralItems.equals(loan.getLoanCollateralManagements())) {
             changes.put(LoanApiConstants.collateralParameterName, loanCollateralManagementMapper.map(possiblyModifedLoanCollateralItems));
         }
 

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/ClientLoanIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/ClientLoanIntegrationTest.java
@@ -203,6 +203,118 @@ public class ClientLoanIntegrationTest extends BaseLoanIntegrationTest {
         verifyLoanRepaymentSchedule(loanSchedule);
     }
 
+    // FINERACT-2721: submitting a loan application used to decrement the linked client collateral quantity twice
+    // (once during submission validation, once during the actual assembly of the loan), because both call sites
+    // shared the same LoanCollateralAssembler#fromParsedJson overload. Verify the client collateral quantity is now
+    // only reduced by the requested amount, exactly once.
+    @Test
+    public void checkClientCollateralQuantityIsDecrementedExactlyOnceOnLoanSubmission() {
+        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
+        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+
+        // CollateralManagementHelper always seeds a client collateral with quantity 100
+        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
+                String.valueOf(clientID), collateralId);
+        final BigDecimal initialClientCollateralQuantity = getClientCollateralQuantity(clientID, clientCollateralId);
+        assertEquals(0, BigDecimal.valueOf(100).compareTo(initialClientCollateralQuantity));
+
+        List<HashMap> collaterals = new ArrayList<>();
+        final BigDecimal loanCollateralQuantity = BigDecimal.valueOf(10);
+        addCollaterals(collaterals, clientCollateralId, loanCollateralQuantity);
+
+        final Integer loanProductID = createLoanProduct(false, NONE);
+        final Integer loanID = applyForLoanApplication(clientID, loanProductID, null, null, "12,000.00", collaterals);
+        assertNotNull(loanID);
+
+        final BigDecimal remainingClientCollateralQuantity = getClientCollateralQuantity(clientID, clientCollateralId);
+        assertEquals(0, initialClientCollateralQuantity.subtract(loanCollateralQuantity).compareTo(remainingClientCollateralQuantity),
+                "Client collateral quantity should be reduced by the requested amount exactly once, not twice: expected "
+                        + initialClientCollateralQuantity.subtract(loanCollateralQuantity) + " but was "
+                        + remainingClientCollateralQuantity);
+    }
+
+    // FINERACT-2721: modifying a pending loan's collateral used to check
+    // `possiblyModifedLoanCollateralItems.equals(loan.getLoanCollateralManagements())` (inverted) to decide whether
+    // to persist the change, so a genuine collateral quantity change on modify-loan was silently dropped. Verify the
+    // change is now both reported in the "changes" response and actually persisted against the loan.
+    @Test
+    public void checkModifyLoanApplicationPersistsGenuineCollateralQuantityChange() {
+        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
+        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+
+        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
+                String.valueOf(clientID), collateralId);
+
+        List<HashMap> collaterals = new ArrayList<>();
+        addCollaterals(collaterals, clientCollateralId, BigDecimal.valueOf(10));
+        final Integer loanProductID = createLoanProduct(false, NONE);
+        final Integer loanID = applyForLoanApplication(clientID, loanProductID, null, null, "12,000.00", collaterals);
+
+        final String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        final Object loanCollateralManagementId = JsonPath.from(loanDetails).get("collateral[0].id");
+
+        List<HashMap> updatedCollaterals = new ArrayList<>();
+        HashMap<String, String> updatedCollateral = collaterals(clientCollateralId, BigDecimal.valueOf(20));
+        updatedCollateral.put("id", loanCollateralManagementId.toString());
+        updatedCollaterals.add(updatedCollateral);
+
+        final String updateJson = updateLoanJson(clientID, loanProductID, null, null, updatedCollaterals);
+        final String changesJson = Utils.performServerPut(REQUEST_SPEC, RESPONSE_SPEC,
+                "/fineract-provider/api/v1/loans/" + loanID + "?" + Utils.TENANT_IDENTIFIER, updateJson, null);
+        final Object collateralChange = JsonPath.from(changesJson).get("changes.collateral");
+        assertNotNull(collateralChange, "A genuine collateral quantity change must be reported in the update response");
+
+        final String updatedLoanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        final Object persistedQuantity = JsonPath.from(updatedLoanDetails).get("collateral[0].quantity");
+        assertEquals(0, BigDecimal.valueOf(20).compareTo(new BigDecimal(String.valueOf(persistedQuantity))),
+                "The new collateral quantity must actually be persisted against the loan");
+    }
+
+    // FINERACT-2721: resubmitting the same collateral quantity on modify-loan takes the "unchanged" branch in
+    // LoanCollateralAssembler#fromParsedJson. Verify this is idempotent: the loan's persisted collateral quantity
+    // must still read back as the original value, not be corrupted by the restore-quantity bookkeeping.
+    @Test
+    public void checkModifyLoanApplicationWithUnchangedCollateralQuantityStaysConsistent() {
+        final Integer collateralId = CollateralManagementHelper.createCollateralProduct(REQUEST_SPEC, RESPONSE_SPEC);
+        final Integer clientID = ClientHelper.createClient(REQUEST_SPEC, RESPONSE_SPEC);
+        ClientHelper.verifyClientCreatedOnServer(REQUEST_SPEC, RESPONSE_SPEC, clientID);
+
+        final Integer clientCollateralId = CollateralManagementHelper.createClientCollateral(REQUEST_SPEC, RESPONSE_SPEC,
+                String.valueOf(clientID), collateralId);
+
+        List<HashMap> collaterals = new ArrayList<>();
+        final BigDecimal loanCollateralQuantity = BigDecimal.valueOf(10);
+        addCollaterals(collaterals, clientCollateralId, loanCollateralQuantity);
+        final Integer loanProductID = createLoanProduct(false, NONE);
+        final Integer loanID = applyForLoanApplication(clientID, loanProductID, null, null, "12,000.00", collaterals);
+
+        final String loanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        final Object loanCollateralManagementId = JsonPath.from(loanDetails).get("collateral[0].id");
+
+        List<HashMap> unchangedCollaterals = new ArrayList<>();
+        HashMap<String, String> unchangedCollateral = collaterals(clientCollateralId, loanCollateralQuantity);
+        unchangedCollateral.put("id", loanCollateralManagementId.toString());
+        unchangedCollaterals.add(unchangedCollateral);
+
+        final String updateJson = updateLoanJson(clientID, loanProductID, null, null, unchangedCollaterals);
+        Utils.performServerPut(REQUEST_SPEC, RESPONSE_SPEC, "/fineract-provider/api/v1/loans/" + loanID + "?" + Utils.TENANT_IDENTIFIER,
+                updateJson, null);
+
+        final String updatedLoanDetails = LOAN_TRANSACTION_HELPER.getLoanDetails(REQUEST_SPEC, RESPONSE_SPEC, loanID);
+        final Object persistedQuantity = JsonPath.from(updatedLoanDetails).get("collateral[0].quantity");
+        assertEquals(0, loanCollateralQuantity.compareTo(new BigDecimal(String.valueOf(persistedQuantity))),
+                "Resubmitting an unchanged collateral quantity must not alter the loan's persisted collateral quantity");
+    }
+
+    private BigDecimal getClientCollateralQuantity(final Integer clientId, final Integer clientCollateralId) {
+        final String url = "/fineract-provider/api/v1/clients/" + clientId + "/collaterals/" + clientCollateralId + "?"
+                + Utils.TENANT_IDENTIFIER;
+        final Object quantity = Utils.performServerGet(REQUEST_SPEC, RESPONSE_SPEC, url, "quantity");
+        return new BigDecimal(String.valueOf(quantity));
+    }
+
     @Test
     public void validateClientLoanWithUniqueExternalId() {
         // Given


### PR DESCRIPTION
## Description

Two related defects in loan collateral handling (`LoanCollateralAssembler` / `LoanAssemblerImpl`):

1. **Repeated quantity deduction.** `LoanCollateralAssembler.fromParsedJson(...)` deducted client collateral quantity on every call, including from read-only paths (loan application validation, schedule preview), not just actual loan submission/update. Since the same parsing method is reused across both, a client's available collateral quantity could be decremented more than once for the same loan, and submitting a loan with linked collateral could fail with an "invalid amount of collateral quantity" error even with sufficient collateral available.

2. **Inverted change detection on loan modification.** In `LoanAssemblerImpl`, the check that decides whether collateral changed on a Modify Loan Application request was inverted:
   ```java
   possiblyModifedLoanCollateralItems.equals(loan.getLoanCollateralManagements())
   ```
   This recorded a "collateral changed" entry (and triggered `loan.updateLoanCollateral(...)`) only when the new and existing collateral sets were **equal** — i.e. when nothing changed — and skipped it when they genuinely differed. Real collateral changes on loan modification were silently dropped.

**Fix:** `LoanCollateralAssembler.fromParsedJson` now takes an explicit `adjustClientCollateralQuantity` flag, defaulting to `false` for read-only/validation callers (existing single-arg overload preserved) and `true` only for actual loan submission/update. The modify-loan condition is flipped to `!equals(...)` so genuine changes are detected and persisted.

JIRA: https://issues.apache.org/jira/browse/FINERACT-2721

## Checklist

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] This PR must not be a "code dump". Large changes can be made in a branch, with assistance.
- [ ] If merging this PR resolves a JIRA issue, I will mark that issue as resolved and set "Fix Version/s" appropriately.

Note: no existing unit/integration test covers `LoanCollateralAssembler`/`LoanAssemblerImpl`'s collateral-handling logic, so none were added — happy to add coverage if a reviewer points to the right harness (loan submission with collateral is normally exercised via integration tests).