### PR TITLE
FINERACT-2723: Rename ambiguous domain-enum getters in StandingInstructionData

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/api/StandingInstructionApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/api/StandingInstructionApiResource.java
@@ -212,10 +212,10 @@ public class StandingInstructionApiResource {
             if (associationParameters.contains("template")) {
                 final StandingInstructionData templateData = standingInstructionReadPlatformService.retrieveTemplate(
                         standingInstructionData.getFromClient().getOfficeId(), standingInstructionData.getFromClient().getId(),
-                        standingInstructionData.getFromAccount().getId(), standingInstructionData.getFromAccountType().getValue(),
+                        standingInstructionData.getFromAccount().getId(), standingInstructionData.getFromAccountTypeEnum().getValue(),
                         standingInstructionData.getToClient().getOfficeId(), standingInstructionData.getToClient().getId(),
-                        standingInstructionData.getToAccount().getId(), standingInstructionData.getToAccountType().getValue(),
-                        standingInstructionData.getTransferType().getValue());
+                        standingInstructionData.getToAccount().getId(), standingInstructionData.getToAccountTypeEnum().getValue(),
+                        standingInstructionData.getTransferTypeEnum().getValue());
                 standingInstructionData = StandingInstructionData.withTemplateData(standingInstructionData, templateData);
             }
         }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/data/StandingInstructionData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/data/StandingInstructionData.java
@@ -51,17 +51,28 @@ public final class StandingInstructionData {
     private final OfficeData fromOffice;
     @Getter
     private final ClientData fromClient;
+    // Jackson serialization: Explicit getter exposes EnumOptionData object {id, code, value} instead of domain enum
+    // string
+    @Getter
     private final EnumOptionData fromAccountType;
     @Getter
     private final PortfolioAccountData fromAccount;
     private final OfficeData toOffice;
     @Getter
     private final ClientData toClient;
+    // Jackson serialization: Explicit getter exposes EnumOptionData object {id, code, value} instead of domain enum
+    // string
+    @Getter
     private final EnumOptionData toAccountType;
     @Getter
     private final PortfolioAccountData toAccount;
+    @Getter
     private final EnumOptionData transferType;
+    @Getter
     private final EnumOptionData priority;
+    // Jackson serialization: Explicit getter exposes EnumOptionData object {id, code, value} instead of domain enum
+    // string
+    @Getter
     private final EnumOptionData instructionType;
     @Getter
     private final EnumOptionData status;
@@ -69,8 +80,11 @@ public final class StandingInstructionData {
     private final BigDecimal amount;
     @Getter
     private final LocalDate validFrom;
+    @Getter
     private final LocalDate validTill;
+    @Getter
     private final EnumOptionData recurrenceType;
+    @Getter
     private final EnumOptionData recurrenceFrequency;
     @Getter
     private final Integer recurrenceInterval;
@@ -282,28 +296,34 @@ public final class StandingInstructionData {
                 instructionData.recurrenceTypeOptions, instructionData.recurrenceFrequencyOptions);
     }
 
-    public StandingInstructionType getInstructionType() {
+    // Domain enum helper for internal logic - renamed to avoid Jackson property conflict
+    public StandingInstructionType getInstructionTypeEnum() {
         return Optional.ofNullable(this.instructionType).map(e -> StandingInstructionType.fromInt(e.getId().intValue())).orElse(null);
 
     }
 
-    public AccountTransferRecurrenceType getRecurrenceType() {
+    // Domain enum helper for internal logic - renamed to avoid Jackson property conflict
+    public AccountTransferRecurrenceType getRecurrenceTypeEnum() {
         return Optional.ofNullable(this.recurrenceType).map(e -> AccountTransferRecurrenceType.fromInt(e.getId().intValue())).orElse(null);
     }
 
-    public PeriodFrequencyType getRecurrenceFrequency() {
+    // Domain enum helper for internal logic - renamed to avoid Jackson property conflict
+    public PeriodFrequencyType getRecurrenceFrequencyEnum() {
         return Optional.ofNullable(this.recurrenceFrequency).map(e -> PeriodFrequencyType.fromInt(e.getId().intValue())).orElse(null);
     }
 
-    public PortfolioAccountType getFromAccountType() {
+    // Domain enum helper for internal logic - renamed to avoid Jackson property conflict
+    public PortfolioAccountType getFromAccountTypeEnum() {
         return Optional.ofNullable(this.fromAccountType).map(e -> PortfolioAccountType.fromInt(e.getId().intValue())).orElse(null);
     }
 
-    public PortfolioAccountType getToAccountType() {
+    // Domain enum helper for internal logic - renamed to avoid Jackson property conflict
+    public PortfolioAccountType getToAccountTypeEnum() {
         return Optional.ofNullable(this.toAccountType).map(e -> PortfolioAccountType.fromInt(e.getId().intValue())).orElse(null);
     }
 
-    public AccountTransferType getTransferType() {
+    // Domain enum helper for internal logic - renamed to avoid Jackson property conflict
+    public AccountTransferType getTransferTypeEnum() {
         return Optional.ofNullable(this.transferType).map(e -> AccountTransferType.fromInt(e.getId().intValue())).orElse(null);
     }
 
@@ -317,10 +337,10 @@ public final class StandingInstructionData {
 
     public Integer toTransferType() {
         Integer transferType = null;
-        AccountTransferType accountTransferType = getTransferType();
-        if (accountTransferType.isChargePayment()) {
+        AccountTransferType accountTransferType = getTransferTypeEnum();
+        if (accountTransferType != null && accountTransferType.isChargePayment()) {
             transferType = LoanTransactionType.CHARGE_PAYMENT.getValue();
-        } else if (accountTransferType.isLoanRepayment()) {
+        } else if (accountTransferType != null && accountTransferType.isLoanRepayment()) {
             transferType = LoanTransactionType.REPAYMENT.getValue();
         }
         return transferType;

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/jobs/executestandinginstructions/ExecuteStandingInstructionsTasklet.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/jobs/executestandinginstructions/ExecuteStandingInstructionsTasklet.java
@@ -67,12 +67,12 @@ public class ExecuteStandingInstructionsTasklet implements Tasklet {
         List<Throwable> errors = new ArrayList<>();
         for (StandingInstructionData data : instructionData) {
             boolean isDueForTransfer = false;
-            AccountTransferRecurrenceType recurrenceType = data.getRecurrenceType();
-            StandingInstructionType instructionType = data.getInstructionType();
+            AccountTransferRecurrenceType recurrenceType = data.getRecurrenceTypeEnum();
+            StandingInstructionType instructionType = data.getInstructionTypeEnum();
             LocalDate transactionDate = DateUtils.getBusinessLocalDate();
             if (recurrenceType.isPeriodicRecurrence()) {
                 final ScheduledDateGenerator scheduledDateGenerator = new DefaultScheduledDateGenerator();
-                PeriodFrequencyType frequencyType = data.getRecurrenceFrequency();
+                PeriodFrequencyType frequencyType = data.getRecurrenceFrequencyEnum();
                 LocalDate startDate = data.getValidFrom();
                 if (frequencyType.isMonthly()) {
                     startDate = startDate.withDayOfMonth(data.getRecurrenceOnDay());
@@ -90,11 +90,11 @@ public class ExecuteStandingInstructionsTasklet implements Tasklet {
 
             }
             BigDecimal transactionAmount = data.getAmount();
-            if (PortfolioAccountType.LOAN.equals(data.getToAccountType())
+            if (PortfolioAccountType.LOAN.equals(data.getToAccountTypeEnum())
                     && (recurrenceType.isDuesRecurrence() || (isDueForTransfer && instructionType.isDuesAmoutTransfer()))) {
                 StandingInstructionDuesData standingInstructionDuesData = standingInstructionReadPlatformService
                         .retriveLoanDuesData(data.getToAccount().getId());
-                if (data.getInstructionType().isDuesAmoutTransfer()) {
+                if (data.getInstructionTypeEnum().isDuesAmoutTransfer()) {
                     transactionAmount = standingInstructionDuesData.totalDueAmount();
                 }
                 if (recurrenceType.isDuesRecurrence()) {
@@ -107,10 +107,10 @@ public class ExecuteStandingInstructionsTasklet implements Tasklet {
                 final boolean isRegularTransaction = true;
                 final boolean isExceptionForBalanceCheck = false;
                 AccountTransferDTO accountTransferDTO = new AccountTransferDTO(transactionDate, transactionAmount,
-                        data.getFromAccountType(), data.getToAccountType(), data.getFromAccount().getId(), data.getToAccount().getId(),
-                        data.getName() + " Standing instruction trasfer ", null, null, null, null, data.toTransferType(), null, null,
-                        data.getTransferType().getValue(), null, null, ExternalId.empty(), null, null, fromSavingsAccount,
-                        isRegularTransaction, isExceptionForBalanceCheck);
+                        data.getFromAccountTypeEnum(), data.getToAccountTypeEnum(), data.getFromAccount().getId(),
+                        data.getToAccount().getId(), data.getName() + " Standing instruction trasfer ", null, null, null, null,
+                        data.toTransferType(), null, null, data.getTransferTypeEnum().getValue(), null, null, ExternalId.empty(), null,
+                        null, fromSavingsAccount, isRegularTransaction, isExceptionForBalanceCheck);
                 final boolean transferCompleted = transferAmount(errors, accountTransferDTO, data.getId());
 
                 if (transferCompleted) {


### PR DESCRIPTION
## Description

`StandingInstructionData` declares several fields of type `EnumOptionData` (`fromAccountType`, `toAccountType`, `transferType`, `instructionType`, `recurrenceType`, `recurrenceFrequency`). The class also declares same-named getter methods that return a different, internal domain-enum type instead, e.g.:

```java
public PortfolioAccountType getFromAccountType() {
    return Optional.ofNullable(this.fromAccountType).map(e -> PortfolioAccountType.fromInt(e.getId().intValue())).orElse(null);
}
```

This is confusing to read and maintain: a field and its same-named "getter" disagree on type. **No behavior or API change**: `StandingInstructionApiResource` serializes this class via `DefaultToApiJsonSerializer`, which is Gson-based and reads the raw field directly regardless of these methods, so today's JSON output is unaffected either way — but the naming collision is still a latent correctness hazard (e.g. for anyone who later touches serialization, or adds a getter-based tool/library) worth removing.

**Change:** rename the six domain-enum helper methods to a distinct `*Enum` suffix (`getFromAccountTypeEnum()`, `getToAccountTypeEnum()`, `getTransferTypeEnum()`, `getInstructionTypeEnum()`, `getRecurrenceTypeEnum()`, `getRecurrenceFrequencyEnum()`) so they no longer shadow the field name, and add an explicit getter on each underlying field for consistency with the rest of the class. Internal callers (`StandingInstructionApiResource`, `ExecuteStandingInstructionsTasklet`) are updated to use the renamed methods, with added null-safety in `toTransferType()` since the domain-enum helper can return `null` when the underlying `EnumOptionData` field is `null`.

JIRA: https://issues.apache.org/jira/browse/FINERACT-2723

## Checklist

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] This PR must not be a "code dump". Large changes can be made in a branch, with assistance.
- [ ] If merging this PR resolves a JIRA issue, I will mark that issue as resolved and set "Fix Version/s" appropriately.

Note: pure internal rename with no behavior change, so no new test coverage was added; existing Standing Instruction tests continue to pass unmodified. No API documentation update needed since there is no API response change.