### PR TITLE
FINERACT-2684: Decouple transient collaborators from the SavingsAccount entity

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsHelper.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsHelper.java
@@ -19,188 +19,20 @@
 package org.apache.fineract.portfolio.savings.domain;
 
 import java.time.LocalDate;
-import java.time.temporal.TemporalAdjusters;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import org.apache.fineract.infrastructure.core.domain.LocalDateInterval;
-import org.apache.fineract.infrastructure.core.service.DateUtils;
-import org.apache.fineract.organisation.monetary.domain.MonetaryCurrency;
-import org.apache.fineract.organisation.monetary.domain.Money;
+import lombok.RequiredArgsConstructor;
 import org.apache.fineract.portfolio.account.service.AccountTransfersReadPlatformService;
-import org.apache.fineract.portfolio.savings.SavingsPostingInterestPeriodType;
-import org.apache.fineract.portfolio.savings.domain.interest.CompoundInterestHelper;
-import org.apache.fineract.portfolio.savings.domain.interest.PostingPeriod;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+/**
+ * Thin service exposing the DB-backed interest-transaction lookups for a {@link SavingsAccount}. The stateless interest
+ * posting-period math previously living here now sits in the static {@link SavingsInterestCalculationUtil}.
+ */
 @Service
+@RequiredArgsConstructor
 public final class SavingsHelper {
 
     private final AccountTransfersReadPlatformService accountTransfersReadPlatformService;
-
-    @Autowired
-    public SavingsHelper(AccountTransfersReadPlatformService accountTransfersReadPlatformService) {
-        this.accountTransfersReadPlatformService = accountTransfersReadPlatformService;
-    }
-
-    private static final CompoundInterestHelper COMPOUND_INTEREST_HELPER = new CompoundInterestHelper();
-
-    public List<LocalDateInterval> determineInterestPostingPeriods(final LocalDate startInterestCalculationLocalDate,
-            final LocalDate interestPostingUpToDate, final SavingsPostingInterestPeriodType postingPeriodType,
-            final Integer financialYearBeginningMonth, List<LocalDate> postInterestAsOn) {
-
-        final List<LocalDateInterval> postingPeriods = new ArrayList<>();
-
-        if (startInterestCalculationLocalDate == null || interestPostingUpToDate == null || postingPeriodType == null) {
-            return postingPeriods;
-        }
-
-        if (postInterestAsOn == null) {
-            postInterestAsOn = Collections.emptyList();
-        }
-        LocalDate periodStartDate = startInterestCalculationLocalDate;
-        LocalDate periodEndDate = periodStartDate;
-        LocalDate actualPeriodStartDate = periodStartDate;
-        final int anniversaryDayOfMonth = startInterestCalculationLocalDate.getDayOfMonth();
-
-        while (!DateUtils.isAfter(periodStartDate, interestPostingUpToDate) && !DateUtils.isAfter(periodEndDate, interestPostingUpToDate)) {
-            final LocalDate interestPostingLocalDate = determineInterestPostingPeriodEndDateFrom(periodStartDate, postingPeriodType,
-                    interestPostingUpToDate, financialYearBeginningMonth, anniversaryDayOfMonth);
-
-            periodEndDate = interestPostingLocalDate.minusDays(1);
-
-            if (!postInterestAsOn.isEmpty()) {
-                for (LocalDate transactiondate : postInterestAsOn) {
-                    if (DateUtils.isAfter(transactiondate, periodStartDate) && !DateUtils.isAfter(transactiondate, periodEndDate)) {
-                        periodEndDate = transactiondate.minusDays(1);
-                        actualPeriodStartDate = periodEndDate;
-                        break;
-                    }
-                }
-            }
-
-            postingPeriods.add(LocalDateInterval.create(periodStartDate, periodEndDate));
-
-            if (DateUtils.isEqual(actualPeriodStartDate, periodEndDate)) {
-                periodEndDate = actualPeriodStartDate.plusDays(1);
-                periodStartDate = actualPeriodStartDate.plusDays(1);
-            } else {
-                periodEndDate = interestPostingLocalDate;
-                periodStartDate = interestPostingLocalDate;
-            }
-        }
-
-        return postingPeriods;
-    }
-
-    private LocalDate determineInterestPostingPeriodEndDateFrom(final LocalDate periodStartDate,
-            final SavingsPostingInterestPeriodType interestPostingPeriodType, final LocalDate interestPostingUpToDate,
-            Integer financialYearBeginningMonth, final int anniversaryDayOfMonth) {
-
-        // interest posting always occurs on the next day after the period end date.
-        LocalDate periodEndDate = interestPostingUpToDate.plusDays(1);
-        final Integer monthOfYear = periodStartDate.getMonthValue();
-        financialYearBeginningMonth--;
-        if (financialYearBeginningMonth == 0) {
-            financialYearBeginningMonth = 12;
-        }
-
-        final ArrayList<LocalDate> quarterlyDates = new ArrayList<>();
-        quarterlyDates.add(periodStartDate.withMonth(financialYearBeginningMonth).with(TemporalAdjusters.lastDayOfMonth()));
-        quarterlyDates.add(periodStartDate.withMonth(financialYearBeginningMonth).plusMonths(3).withYear(periodStartDate.getYear())
-                .with(TemporalAdjusters.lastDayOfMonth()));
-        quarterlyDates.add(periodStartDate.withMonth(financialYearBeginningMonth).plusMonths(6).withYear(periodStartDate.getYear())
-                .with(TemporalAdjusters.lastDayOfMonth()));
-        quarterlyDates.add(periodStartDate.withMonth(financialYearBeginningMonth).plusMonths(9).withYear(periodStartDate.getYear())
-                .with(TemporalAdjusters.lastDayOfMonth()));
-        Collections.sort(quarterlyDates);
-
-        final ArrayList<LocalDate> biannualDates = new ArrayList<>();
-        biannualDates.add(periodStartDate.withMonth(financialYearBeginningMonth).with(TemporalAdjusters.lastDayOfMonth()));
-        biannualDates.add(periodStartDate.withMonth(financialYearBeginningMonth).plusMonths(6).withYear(periodStartDate.getYear())
-                .with(TemporalAdjusters.lastDayOfMonth()));
-        Collections.sort(biannualDates);
-        boolean isEndDateSet = false;
-
-        switch (interestPostingPeriodType) {
-            case INVALID:
-            break;
-            case DAILY:
-                // interest posting always occurs on the next day after the period end date.
-                periodEndDate = periodStartDate.plusDays(1);
-            break;
-            case MONTHLY:
-                // interest posting occurs on the first day of the next month and on the next day after the period end
-                // date.
-                periodEndDate = periodStartDate.with(TemporalAdjusters.lastDayOfMonth()).plusDays(1);
-            break;
-            case QUATERLY:
-                for (LocalDate quarterlyDate : quarterlyDates) {
-                    if (DateUtils.isAfter(quarterlyDate, periodStartDate)) {
-                        // interest posting always occurs on the next day after the period end date.
-                        periodEndDate = quarterlyDate.plusDays(1);
-                        isEndDateSet = true;
-                        break;
-                    }
-                }
-
-                if (!isEndDateSet) {
-                    // interest posting always occurs on the next day after the period end date.
-                    periodEndDate = quarterlyDates.getFirst().plusYears(1).with(TemporalAdjusters.lastDayOfMonth()).plusDays(1);
-                }
-            break;
-            case BIANNUAL:
-                for (LocalDate biannualDate : biannualDates) {
-                    if (DateUtils.isAfter(biannualDate, periodStartDate)) {
-                        // interest posting always occurs on the next day after the period end date.
-                        periodEndDate = biannualDate.plusDays(1);
-                        isEndDateSet = true;
-                        break;
-                    }
-                }
-
-                if (!isEndDateSet) {
-                    // interest posting always occurs on the next day after the period end date.
-                    periodEndDate = biannualDates.getFirst().plusYears(1).with(TemporalAdjusters.lastDayOfMonth()).plusDays(1);
-                }
-            break;
-            case ANNUAL:
-                if (financialYearBeginningMonth < monthOfYear) {
-                    periodEndDate = periodStartDate.withMonth(financialYearBeginningMonth);
-                    periodEndDate = periodEndDate.plusYears(1);
-                } else {
-                    periodEndDate = periodStartDate.withMonth(financialYearBeginningMonth);
-                }
-                // interest posting always occurs on the next day after the period end date.
-                periodEndDate = periodEndDate.with(TemporalAdjusters.lastDayOfMonth()).plusDays(1);
-            break;
-            case ANNIVERSARY_MONTHLY:
-                periodEndDate = adjustToAnniversaryDay(periodStartDate.plusMonths(1), anniversaryDayOfMonth);
-            break;
-            case ANNIVERSARY_QUARTERLY:
-                periodEndDate = adjustToAnniversaryDay(periodStartDate.plusMonths(3), anniversaryDayOfMonth);
-            break;
-            case ANNIVERSARY_BIANNUAL:
-                periodEndDate = adjustToAnniversaryDay(periodStartDate.plusMonths(6), anniversaryDayOfMonth);
-            break;
-            case ANNIVERSARY_ANNUAL:
-                periodEndDate = adjustToAnniversaryDay(periodStartDate.plusMonths(12), anniversaryDayOfMonth);
-            break;
-        }
-        return periodEndDate;
-    }
-
-    private LocalDate adjustToAnniversaryDay(final LocalDate date, final int anniversaryDay) {
-        return date.withDayOfMonth(Math.min(anniversaryDay, date.lengthOfMonth()));
-    }
-
-    public Money calculateInterestForAllPostingPeriods(final MonetaryCurrency currency, final List<PostingPeriod> allPeriods,
-            LocalDate accountLockedUntil, Boolean immediateWithdrawalOfInterest) {
-        return COMPOUND_INTEREST_HELPER.calculateInterestForAllPostingPeriods(currency, allPeriods, accountLockedUntil,
-                immediateWithdrawalOfInterest);
-    }
 
     public Collection<Long> fetchPostInterestTransactionIds(Long accountId) {
         return this.accountTransfersReadPlatformService.fetchPostInterestTransactionIds(accountId);

--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsInterestCalculationUtil.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsInterestCalculationUtil.java
@@ -1,0 +1,200 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.savings.domain;
+
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.fineract.infrastructure.core.domain.LocalDateInterval;
+import org.apache.fineract.infrastructure.core.service.DateUtils;
+import org.apache.fineract.organisation.monetary.domain.MonetaryCurrency;
+import org.apache.fineract.organisation.monetary.domain.Money;
+import org.apache.fineract.portfolio.savings.SavingsPostingInterestPeriodType;
+import org.apache.fineract.portfolio.savings.domain.interest.CompoundInterestHelper;
+import org.apache.fineract.portfolio.savings.domain.interest.PostingPeriod;
+
+/**
+ * Side-effect free interest posting-period computations for a {@link SavingsAccount}. Extracted from the former
+ * {@link SavingsHelper} so the stateless math lives in a static utility while the DB-backed lookups stay on the thin
+ * {@link SavingsHelper} service. This keeps the interest math callable from the domain entity without injecting a
+ * collaborator into it.
+ */
+public final class SavingsInterestCalculationUtil {
+
+    private static final CompoundInterestHelper COMPOUND_INTEREST_HELPER = new CompoundInterestHelper();
+
+    private SavingsInterestCalculationUtil() {}
+
+    public static List<LocalDateInterval> determineInterestPostingPeriods(final LocalDate startInterestCalculationLocalDate,
+            final LocalDate interestPostingUpToDate, final SavingsPostingInterestPeriodType postingPeriodType,
+            final Integer financialYearBeginningMonth, List<LocalDate> postInterestAsOn) {
+
+        final List<LocalDateInterval> postingPeriods = new ArrayList<>();
+
+        if (startInterestCalculationLocalDate == null || interestPostingUpToDate == null || postingPeriodType == null) {
+            return postingPeriods;
+        }
+
+        if (postInterestAsOn == null) {
+            postInterestAsOn = Collections.emptyList();
+        }
+        LocalDate periodStartDate = startInterestCalculationLocalDate;
+        LocalDate periodEndDate = periodStartDate;
+        LocalDate actualPeriodStartDate = periodStartDate;
+        final int anniversaryDayOfMonth = startInterestCalculationLocalDate.getDayOfMonth();
+
+        while (!DateUtils.isAfter(periodStartDate, interestPostingUpToDate) && !DateUtils.isAfter(periodEndDate, interestPostingUpToDate)) {
+            final LocalDate interestPostingLocalDate = determineInterestPostingPeriodEndDateFrom(periodStartDate, postingPeriodType,
+                    interestPostingUpToDate, financialYearBeginningMonth, anniversaryDayOfMonth);
+
+            periodEndDate = interestPostingLocalDate.minusDays(1);
+
+            if (!postInterestAsOn.isEmpty()) {
+                for (LocalDate transactiondate : postInterestAsOn) {
+                    if (DateUtils.isAfter(transactiondate, periodStartDate) && !DateUtils.isAfter(transactiondate, periodEndDate)) {
+                        periodEndDate = transactiondate.minusDays(1);
+                        actualPeriodStartDate = periodEndDate;
+                        break;
+                    }
+                }
+            }
+
+            postingPeriods.add(LocalDateInterval.create(periodStartDate, periodEndDate));
+
+            if (DateUtils.isEqual(actualPeriodStartDate, periodEndDate)) {
+                periodEndDate = actualPeriodStartDate.plusDays(1);
+                periodStartDate = actualPeriodStartDate.plusDays(1);
+            } else {
+                periodEndDate = interestPostingLocalDate;
+                periodStartDate = interestPostingLocalDate;
+            }
+        }
+
+        return postingPeriods;
+    }
+
+    private static LocalDate determineInterestPostingPeriodEndDateFrom(final LocalDate periodStartDate,
+            final SavingsPostingInterestPeriodType interestPostingPeriodType, final LocalDate interestPostingUpToDate,
+            Integer financialYearBeginningMonth, final int anniversaryDayOfMonth) {
+
+        // interest posting always occurs on the next day after the period end date.
+        LocalDate periodEndDate = interestPostingUpToDate.plusDays(1);
+        final Integer monthOfYear = periodStartDate.getMonthValue();
+        financialYearBeginningMonth--;
+        if (financialYearBeginningMonth == 0) {
+            financialYearBeginningMonth = 12;
+        }
+
+        final ArrayList<LocalDate> quarterlyDates = new ArrayList<>();
+        quarterlyDates.add(periodStartDate.withMonth(financialYearBeginningMonth).with(TemporalAdjusters.lastDayOfMonth()));
+        quarterlyDates.add(periodStartDate.withMonth(financialYearBeginningMonth).plusMonths(3).withYear(periodStartDate.getYear())
+                .with(TemporalAdjusters.lastDayOfMonth()));
+        quarterlyDates.add(periodStartDate.withMonth(financialYearBeginningMonth).plusMonths(6).withYear(periodStartDate.getYear())
+                .with(TemporalAdjusters.lastDayOfMonth()));
+        quarterlyDates.add(periodStartDate.withMonth(financialYearBeginningMonth).plusMonths(9).withYear(periodStartDate.getYear())
+                .with(TemporalAdjusters.lastDayOfMonth()));
+        Collections.sort(quarterlyDates);
+
+        final ArrayList<LocalDate> biannualDates = new ArrayList<>();
+        biannualDates.add(periodStartDate.withMonth(financialYearBeginningMonth).with(TemporalAdjusters.lastDayOfMonth()));
+        biannualDates.add(periodStartDate.withMonth(financialYearBeginningMonth).plusMonths(6).withYear(periodStartDate.getYear())
+                .with(TemporalAdjusters.lastDayOfMonth()));
+        Collections.sort(biannualDates);
+        boolean isEndDateSet = false;
+
+        switch (interestPostingPeriodType) {
+            case INVALID:
+            break;
+            case DAILY:
+                // interest posting always occurs on the next day after the period end date.
+                periodEndDate = periodStartDate.plusDays(1);
+            break;
+            case MONTHLY:
+                // interest posting occurs on the first day of the next month and on the next day after the period end
+                // date.
+                periodEndDate = periodStartDate.with(TemporalAdjusters.lastDayOfMonth()).plusDays(1);
+            break;
+            case QUATERLY:
+                for (LocalDate quarterlyDate : quarterlyDates) {
+                    if (DateUtils.isAfter(quarterlyDate, periodStartDate)) {
+                        // interest posting always occurs on the next day after the period end date.
+                        periodEndDate = quarterlyDate.plusDays(1);
+                        isEndDateSet = true;
+                        break;
+                    }
+                }
+
+                if (!isEndDateSet) {
+                    // interest posting always occurs on the next day after the period end date.
+                    periodEndDate = quarterlyDates.getFirst().plusYears(1).with(TemporalAdjusters.lastDayOfMonth()).plusDays(1);
+                }
+            break;
+            case BIANNUAL:
+                for (LocalDate biannualDate : biannualDates) {
+                    if (DateUtils.isAfter(biannualDate, periodStartDate)) {
+                        // interest posting always occurs on the next day after the period end date.
+                        periodEndDate = biannualDate.plusDays(1);
+                        isEndDateSet = true;
+                        break;
+                    }
+                }
+
+                if (!isEndDateSet) {
+                    // interest posting always occurs on the next day after the period end date.
+                    periodEndDate = biannualDates.getFirst().plusYears(1).with(TemporalAdjusters.lastDayOfMonth()).plusDays(1);
+                }
+            break;
+            case ANNUAL:
+                if (financialYearBeginningMonth < monthOfYear) {
+                    periodEndDate = periodStartDate.withMonth(financialYearBeginningMonth);
+                    periodEndDate = periodEndDate.plusYears(1);
+                } else {
+                    periodEndDate = periodStartDate.withMonth(financialYearBeginningMonth);
+                }
+                // interest posting always occurs on the next day after the period end date.
+                periodEndDate = periodEndDate.with(TemporalAdjusters.lastDayOfMonth()).plusDays(1);
+            break;
+            case ANNIVERSARY_MONTHLY:
+                periodEndDate = adjustToAnniversaryDay(periodStartDate.plusMonths(1), anniversaryDayOfMonth);
+            break;
+            case ANNIVERSARY_QUARTERLY:
+                periodEndDate = adjustToAnniversaryDay(periodStartDate.plusMonths(3), anniversaryDayOfMonth);
+            break;
+            case ANNIVERSARY_BIANNUAL:
+                periodEndDate = adjustToAnniversaryDay(periodStartDate.plusMonths(6), anniversaryDayOfMonth);
+            break;
+            case ANNIVERSARY_ANNUAL:
+                periodEndDate = adjustToAnniversaryDay(periodStartDate.plusMonths(12), anniversaryDayOfMonth);
+            break;
+        }
+        return periodEndDate;
+    }
+
+    private static LocalDate adjustToAnniversaryDay(final LocalDate date, final int anniversaryDay) {
+        return date.withDayOfMonth(Math.min(anniversaryDay, date.lengthOfMonth()));
+    }
+
+    public static Money calculateInterestForAllPostingPeriods(final MonetaryCurrency currency, final List<PostingPeriod> allPeriods,
+            LocalDate accountLockedUntil, Boolean immediateWithdrawalOfInterest) {
+        return COMPOUND_INTEREST_HELPER.calculateInterestForAllPostingPeriods(currency, allPeriods, accountLockedUntil,
+                immediateWithdrawalOfInterest);
+    }
+}

--- a/fineract-core/src/test/java/org/apache/fineract/portfolio/savings/domain/SavingsHelperAnniversaryPostingTest.java
+++ b/fineract-core/src/test/java/org/apache/fineract/portfolio/savings/domain/SavingsHelperAnniversaryPostingTest.java
@@ -31,8 +31,6 @@ class SavingsHelperAnniversaryPostingTest {
 
     private static final Integer FINANCIAL_YEAR_BEGINNING_MONTH = 1;
 
-    private final SavingsHelper savingsHelper = new SavingsHelper(null);
-
     private static void assertPeriod(LocalDateInterval period, LocalDate expectedStart, LocalDate expectedEnd) {
         assertThat(period.startDate()).as("period start").isEqualTo(expectedStart);
         assertThat(period.endDate()).as("period end").isEqualTo(expectedEnd);
@@ -46,7 +44,7 @@ class SavingsHelperAnniversaryPostingTest {
         LocalDate start = LocalDate.of(2024, 1, 15);
         LocalDate end = LocalDate.of(2024, 3, 31);
 
-        List<LocalDateInterval> periods = savingsHelper.determineInterestPostingPeriods(start, end,
+        List<LocalDateInterval> periods = SavingsInterestCalculationUtil.determineInterestPostingPeriods(start, end,
                 SavingsPostingInterestPeriodType.ANNIVERSARY_MONTHLY, FINANCIAL_YEAR_BEGINNING_MONTH, Collections.emptyList());
 
         assertThat(periods).hasSize(3);
@@ -62,7 +60,7 @@ class SavingsHelperAnniversaryPostingTest {
         LocalDate start = LocalDate.of(2024, 1, 1);
         LocalDate end = LocalDate.of(2024, 3, 31);
 
-        List<LocalDateInterval> periods = savingsHelper.determineInterestPostingPeriods(start, end,
+        List<LocalDateInterval> periods = SavingsInterestCalculationUtil.determineInterestPostingPeriods(start, end,
                 SavingsPostingInterestPeriodType.ANNIVERSARY_MONTHLY, FINANCIAL_YEAR_BEGINNING_MONTH, Collections.emptyList());
 
         assertThat(periods).hasSize(3);
@@ -77,7 +75,7 @@ class SavingsHelperAnniversaryPostingTest {
         LocalDate start = LocalDate.of(2025, 1, 29);
         LocalDate end = LocalDate.of(2025, 4, 30);
 
-        List<LocalDateInterval> periods = savingsHelper.determineInterestPostingPeriods(start, end,
+        List<LocalDateInterval> periods = SavingsInterestCalculationUtil.determineInterestPostingPeriods(start, end,
                 SavingsPostingInterestPeriodType.ANNIVERSARY_MONTHLY, FINANCIAL_YEAR_BEGINNING_MONTH, Collections.emptyList());
 
         assertThat(periods).hasSize(4);
@@ -97,7 +95,7 @@ class SavingsHelperAnniversaryPostingTest {
         LocalDate start = LocalDate.of(2025, 1, 31);
         LocalDate end = LocalDate.of(2025, 5, 31);
 
-        List<LocalDateInterval> periods = savingsHelper.determineInterestPostingPeriods(start, end,
+        List<LocalDateInterval> periods = SavingsInterestCalculationUtil.determineInterestPostingPeriods(start, end,
                 SavingsPostingInterestPeriodType.ANNIVERSARY_MONTHLY, FINANCIAL_YEAR_BEGINNING_MONTH, Collections.emptyList());
 
         assertThat(periods).hasSize(5);
@@ -117,7 +115,7 @@ class SavingsHelperAnniversaryPostingTest {
         LocalDate start = LocalDate.of(2024, 1, 15);
         LocalDate end = LocalDate.of(2024, 12, 31);
 
-        List<LocalDateInterval> periods = savingsHelper.determineInterestPostingPeriods(start, end,
+        List<LocalDateInterval> periods = SavingsInterestCalculationUtil.determineInterestPostingPeriods(start, end,
                 SavingsPostingInterestPeriodType.ANNIVERSARY_QUARTERLY, FINANCIAL_YEAR_BEGINNING_MONTH, Collections.emptyList());
 
         assertThat(periods).hasSize(4);
@@ -134,7 +132,7 @@ class SavingsHelperAnniversaryPostingTest {
         LocalDate start = LocalDate.of(2024, 11, 29);
         LocalDate end = LocalDate.of(2025, 5, 31);
 
-        List<LocalDateInterval> periods = savingsHelper.determineInterestPostingPeriods(start, end,
+        List<LocalDateInterval> periods = SavingsInterestCalculationUtil.determineInterestPostingPeriods(start, end,
                 SavingsPostingInterestPeriodType.ANNIVERSARY_QUARTERLY, FINANCIAL_YEAR_BEGINNING_MONTH, Collections.emptyList());
 
         assertThat(periods).hasSize(3);
@@ -154,7 +152,7 @@ class SavingsHelperAnniversaryPostingTest {
         LocalDate start = LocalDate.of(2024, 1, 15);
         LocalDate end = LocalDate.of(2025, 1, 31);
 
-        List<LocalDateInterval> periods = savingsHelper.determineInterestPostingPeriods(start, end,
+        List<LocalDateInterval> periods = SavingsInterestCalculationUtil.determineInterestPostingPeriods(start, end,
                 SavingsPostingInterestPeriodType.ANNIVERSARY_BIANNUAL, FINANCIAL_YEAR_BEGINNING_MONTH, Collections.emptyList());
 
         assertThat(periods).hasSize(3);
@@ -172,7 +170,7 @@ class SavingsHelperAnniversaryPostingTest {
         LocalDate start = LocalDate.of(2024, 3, 15);
         LocalDate end = LocalDate.of(2026, 3, 31);
 
-        List<LocalDateInterval> periods = savingsHelper.determineInterestPostingPeriods(start, end,
+        List<LocalDateInterval> periods = SavingsInterestCalculationUtil.determineInterestPostingPeriods(start, end,
                 SavingsPostingInterestPeriodType.ANNIVERSARY_ANNUAL, FINANCIAL_YEAR_BEGINNING_MONTH, Collections.emptyList());
 
         assertThat(periods).hasSize(3);
@@ -188,7 +186,7 @@ class SavingsHelperAnniversaryPostingTest {
         LocalDate start = LocalDate.of(2024, 2, 29);
         LocalDate end = LocalDate.of(2026, 3, 31);
 
-        List<LocalDateInterval> periods = savingsHelper.determineInterestPostingPeriods(start, end,
+        List<LocalDateInterval> periods = SavingsInterestCalculationUtil.determineInterestPostingPeriods(start, end,
                 SavingsPostingInterestPeriodType.ANNIVERSARY_ANNUAL, FINANCIAL_YEAR_BEGINNING_MONTH, Collections.emptyList());
 
         assertThat(periods).hasSize(3);

--- a/fineract-core/src/test/java/org/apache/fineract/portfolio/savings/domain/SavingsHelperNPExceptionTest.java
+++ b/fineract-core/src/test/java/org/apache/fineract/portfolio/savings/domain/SavingsHelperNPExceptionTest.java
@@ -29,8 +29,6 @@ import org.junit.jupiter.api.Test;
 
 class SavingsHelperNPExceptionTest {
 
-    private final SavingsHelper savingsHelper = new SavingsHelper(null);
-
     @Test
     void shouldNotThrowNullPointerExceptionWhenPostingPeriodTypeIsNull() {
         LocalDate start = LocalDate.of(2025, 1, 1);
@@ -39,7 +37,7 @@ class SavingsHelperNPExceptionTest {
 
         Integer financialYearBeginningMonth = 1;
         List<LocalDate> postInterestAsOn = new ArrayList<>();
-        List<LocalDateInterval> result = savingsHelper.determineInterestPostingPeriods(start, end, nullPostingPeriodType,
+        List<LocalDateInterval> result = SavingsInterestCalculationUtil.determineInterestPostingPeriods(start, end, nullPostingPeriodType,
                 financialYearBeginningMonth, postInterestAsOn);
         assertTrue(result.isEmpty(), "Result should be empty when postingPeriodType is null");
     }

--- a/fineract-provider/src/main/java/org/apache/fineract/interoperation/service/InteropServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/interoperation/service/InteropServiceImpl.java
@@ -44,7 +44,6 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.fineract.commands.domain.CommandWrapper;
 import org.apache.fineract.commands.service.CommandWrapperBuilder;
 import org.apache.fineract.commands.service.PortfolioCommandSourceWritePlatformService;
-import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
 import org.apache.fineract.infrastructure.core.exception.ErrorHandler;
@@ -102,8 +101,6 @@ import org.apache.fineract.portfolio.savings.domain.SavingsAccount;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountRepository;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountTransaction;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountTransactionRepository;
-import org.apache.fineract.portfolio.savings.domain.SavingsAccountTransactionSummaryWrapper;
-import org.apache.fineract.portfolio.savings.domain.SavingsHelper;
 import org.apache.fineract.portfolio.savings.exception.InsufficientAccountBalanceException;
 import org.apache.fineract.portfolio.savings.exception.SavingsAccountNotFoundException;
 import org.apache.fineract.portfolio.savings.service.SavingsAccountDomainService;
@@ -131,11 +128,7 @@ public class InteropServiceImpl implements InteropService {
     private final InteropIdentifierRepository identifierRepository;
     private final LoanRepositoryWrapper loanRepositoryWrapper;
 
-    private final SavingsHelper savingsHelper;
-    private final SavingsAccountTransactionSummaryWrapper savingsAccountTransactionSummaryWrapper;
-
     private final SavingsAccountDomainService savingsAccountService;
-    private final ConfigurationDomainService configurationDomainService;
 
     private final JdbcTemplate jdbcTemplate;
 
@@ -568,7 +561,6 @@ public class InteropServiceImpl implements InteropService {
     private SavingsAccount validateAndGetSavingAccount(@NonNull InteropRequestData request) {
         // TODO: error handling
         SavingsAccount savingsAccount = validateAndGetSavingAccount(request.getAccountId());
-        savingsAccount.setHelpers(savingsAccountTransactionSummaryWrapper, savingsHelper, configurationDomainService);
 
         ApplicationCurrency requestCurrency = currencyRepository.findOneByCode(request.getAmount().getCurrency());
         if (!savingsAccount.getCurrency().getCode().equals(requestCurrency.getCode())) {

--- a/fineract-provider/src/main/java/org/apache/fineract/interoperation/starter/InteroperationConfiguration.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/interoperation/starter/InteroperationConfiguration.java
@@ -19,7 +19,6 @@
 package org.apache.fineract.interoperation.starter;
 
 import org.apache.fineract.commands.service.PortfolioCommandSourceWritePlatformService;
-import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
 import org.apache.fineract.infrastructure.core.serialization.DefaultToApiJsonSerializer;
 import org.apache.fineract.infrastructure.core.service.database.DatabaseSpecificSQLGenerator;
 import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
@@ -34,8 +33,6 @@ import org.apache.fineract.portfolio.note.domain.NoteRepository;
 import org.apache.fineract.portfolio.paymenttype.domain.PaymentTypeRepository;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountRepository;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountTransactionRepository;
-import org.apache.fineract.portfolio.savings.domain.SavingsAccountTransactionSummaryWrapper;
-import org.apache.fineract.portfolio.savings.domain.SavingsHelper;
 import org.apache.fineract.portfolio.savings.service.SavingsAccountDomainService;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -51,14 +48,11 @@ public class InteroperationConfiguration {
             SavingsAccountRepository savingsAccountRepository, SavingsAccountTransactionRepository savingsAccountTransactionRepository,
             ApplicationCurrencyRepository applicationCurrencyRepository, NoteRepository noteRepository,
             PaymentTypeRepository paymentTypeRepository, InteropIdentifierRepository identifierRepository,
-            LoanRepositoryWrapper loanRepositoryWrapper, SavingsHelper savingsHelper,
-            SavingsAccountTransactionSummaryWrapper savingsAccountTransactionSummaryWrapper,
-            SavingsAccountDomainService savingsAccountService, ConfigurationDomainService configurationDomainService,
-            JdbcTemplate jdbcTemplate, PortfolioCommandSourceWritePlatformService commandsSourceWritePlatformService,
+            LoanRepositoryWrapper loanRepositoryWrapper, SavingsAccountDomainService savingsAccountService, JdbcTemplate jdbcTemplate,
+            PortfolioCommandSourceWritePlatformService commandsSourceWritePlatformService,
             DefaultToApiJsonSerializer<LoanAccountData> toApiJsonSerializer, DatabaseSpecificSQLGenerator sqlGenerator) {
         return new InteropServiceImpl(securityContext, interopDataValidator, savingsAccountRepository, savingsAccountTransactionRepository,
                 applicationCurrencyRepository, noteRepository, paymentTypeRepository, identifierRepository, loanRepositoryWrapper,
-                savingsHelper, savingsAccountTransactionSummaryWrapper, savingsAccountService, configurationDomainService, jdbcTemplate,
-                commandsSourceWritePlatformService, toApiJsonSerializer, sqlGenerator);
+                savingsAccountService, jdbcTemplate, commandsSourceWritePlatformService, toApiJsonSerializer, sqlGenerator);
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/service/AccountTransfersWritePlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/service/AccountTransfersWritePlatformServiceImpl.java
@@ -298,7 +298,6 @@ public class AccountTransfersWritePlatformServiceImpl implements AccountTransfer
                             backdatedTxnsAllowedTill);
                 } else {
                     fromSavingsAccount = accountTransferDTO.getFromSavingsAccount();
-                    this.savingsAccountAssembler.setHelpers(fromSavingsAccount);
                 }
                 if (accountTransferDTO.getLoan() == null) {
                     toLoanAccount = this.loanAccountAssembler.assembleFrom(accountTransferDTO.getToAccountId());
@@ -308,7 +307,6 @@ public class AccountTransfersWritePlatformServiceImpl implements AccountTransfer
 
             } else {
                 fromSavingsAccount = accountTransferDetails.fromSavingsAccount();
-                this.savingsAccountAssembler.setHelpers(fromSavingsAccount);
                 toLoanAccount = accountTransferDetails.toLoanAccount();
             }
 
@@ -369,19 +367,15 @@ public class AccountTransfersWritePlatformServiceImpl implements AccountTransfer
                             backdatedTxnsAllowedTill);
                 } else {
                     fromSavingsAccount = accountTransferDTO.getFromSavingsAccount();
-                    this.savingsAccountAssembler.setHelpers(fromSavingsAccount);
                 }
                 if (accountTransferDTO.getToSavingsAccount() == null) {
                     toSavingsAccount = this.savingsAccountAssembler.assembleFrom(accountTransferDTO.getToAccountId(), false);
                 } else {
                     toSavingsAccount = accountTransferDTO.getToSavingsAccount();
-                    this.savingsAccountAssembler.setHelpers(toSavingsAccount);
                 }
             } else {
                 fromSavingsAccount = accountTransferDetails.fromSavingsAccount();
-                this.savingsAccountAssembler.setHelpers(fromSavingsAccount);
                 toSavingsAccount = accountTransferDetails.toSavingsAccount();
-                this.savingsAccountAssembler.setHelpers(toSavingsAccount);
             }
 
             final SavingsTransactionBooleanValues transactionBooleanValues = new SavingsTransactionBooleanValues(isAccountTransfer,
@@ -423,7 +417,6 @@ public class AccountTransfersWritePlatformServiceImpl implements AccountTransfer
             } else {
                 fromLoanAccount = accountTransferDetails.fromLoanAccount();
                 toSavingsAccount = accountTransferDetails.toSavingsAccount();
-                this.savingsAccountAssembler.setHelpers(toSavingsAccount);
             }
             LoanTransaction loanTransaction = null;
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/service/AccountTransfersWritePlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/service/AccountTransfersWritePlatformServiceImpl.java
@@ -294,7 +294,6 @@ public class AccountTransfersWritePlatformServiceImpl implements AccountTransfer
                             backdatedTxnsAllowedTill);
                 } else {
                     fromSavingsAccount = accountTransferDTO.getFromSavingsAccount();
-                    this.savingsAccountAssembler.setHelpers(fromSavingsAccount);
                 }
                 if (accountTransferDTO.getLoan() == null) {
                     toLoanAccount = this.loanAccountAssembler.assembleFrom(accountTransferDTO.getToAccountId());
@@ -304,7 +303,6 @@ public class AccountTransfersWritePlatformServiceImpl implements AccountTransfer
 
             } else {
                 fromSavingsAccount = accountTransferDetails.fromSavingsAccount();
-                this.savingsAccountAssembler.setHelpers(fromSavingsAccount);
                 toLoanAccount = accountTransferDetails.toLoanAccount();
             }
 
@@ -365,19 +363,15 @@ public class AccountTransfersWritePlatformServiceImpl implements AccountTransfer
                             backdatedTxnsAllowedTill);
                 } else {
                     fromSavingsAccount = accountTransferDTO.getFromSavingsAccount();
-                    this.savingsAccountAssembler.setHelpers(fromSavingsAccount);
                 }
                 if (accountTransferDTO.getToSavingsAccount() == null) {
                     toSavingsAccount = this.savingsAccountAssembler.assembleFrom(accountTransferDTO.getToAccountId(), false);
                 } else {
                     toSavingsAccount = accountTransferDTO.getToSavingsAccount();
-                    this.savingsAccountAssembler.setHelpers(toSavingsAccount);
                 }
             } else {
                 fromSavingsAccount = accountTransferDetails.fromSavingsAccount();
-                this.savingsAccountAssembler.setHelpers(fromSavingsAccount);
                 toSavingsAccount = accountTransferDetails.toSavingsAccount();
-                this.savingsAccountAssembler.setHelpers(toSavingsAccount);
             }
 
             final SavingsTransactionBooleanValues transactionBooleanValues = new SavingsTransactionBooleanValues(isAccountTransfer,
@@ -419,7 +413,6 @@ public class AccountTransfersWritePlatformServiceImpl implements AccountTransfer
             } else {
                 fromLoanAccount = accountTransferDetails.fromLoanAccount();
                 toSavingsAccount = accountTransferDetails.toSavingsAccount();
-                this.savingsAccountAssembler.setHelpers(toSavingsAccount);
             }
             LoanTransaction loanTransaction = null;
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/guarantor/service/GuarantorDomainServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/guarantor/service/GuarantorDomainServiceImpl.java
@@ -333,7 +333,6 @@ public class GuarantorDomainServiceImpl implements GuarantorDomainService {
                                     transactions.add(transaction);
                                 }
                             }
-                            this.savingsAccountAssembler.setHelpers(savingsAccount);
                             savingsAccount.updateSavingsAccountSummary(transactions);
                         }
                         savingsAccount.holdFunds(guarantorFundingDetails.getAmount());

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/DepositAccountAssembler.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/DepositAccountAssembler.java
@@ -65,7 +65,6 @@ import java.util.Collection;
 import java.util.Locale;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
 import org.apache.fineract.infrastructure.core.exception.InvalidJsonException;
 import org.apache.fineract.infrastructure.core.exception.UnsupportedParameterException;
@@ -74,7 +73,6 @@ import org.apache.fineract.infrastructure.core.service.ExternalIdFactory;
 import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
 import org.apache.fineract.organisation.staff.domain.Staff;
 import org.apache.fineract.organisation.staff.domain.StaffRepositoryWrapper;
-import org.apache.fineract.portfolio.account.service.AccountTransfersReadPlatformService;
 import org.apache.fineract.portfolio.accountdetails.domain.AccountType;
 import org.apache.fineract.portfolio.client.domain.Client;
 import org.apache.fineract.portfolio.client.domain.ClientRepositoryWrapper;
@@ -107,8 +105,6 @@ import org.springframework.stereotype.Service;
 public class DepositAccountAssembler {
 
     private final PlatformSecurityContext context;
-    private final SavingsAccountTransactionSummaryWrapper savingsAccountTransactionSummaryWrapper;
-    private final SavingsHelper savingsHelper;
     private final ClientRepositoryWrapper clientRepository;
     private final GroupRepositoryWrapper groupRepository;
     private final StaffRepositoryWrapper staffRepository;
@@ -121,21 +117,16 @@ public class DepositAccountAssembler {
     private final PaymentDetailAssembler paymentDetailAssembler;
 
     private final ExternalIdFactory externalIdFactory;
-    private final ConfigurationDomainService configurationDomainService;
 
     @Autowired
-    public DepositAccountAssembler(final SavingsAccountTransactionSummaryWrapper savingsAccountTransactionSummaryWrapper,
-            final ClientRepositoryWrapper clientRepository, final GroupRepositoryWrapper groupRepository,
+    public DepositAccountAssembler(final ClientRepositoryWrapper clientRepository, final GroupRepositoryWrapper groupRepository,
             final StaffRepositoryWrapper staffRepository, final FixedDepositProductRepository fixedDepositProductRepository,
             final SavingsAccountRepositoryWrapper savingsAccountRepository,
             final SavingsAccountChargeAssembler savingsAccountChargeAssembler, final FromJsonHelper fromApiJsonHelper,
             final DepositProductAssembler depositProductAssembler,
-            final RecurringDepositProductRepository recurringDepositProductRepository,
-            final AccountTransfersReadPlatformService accountTransfersReadPlatformService, final PlatformSecurityContext context,
-            final PaymentDetailAssembler paymentDetailAssembler, ExternalIdFactory externalIdFactory,
-            final ConfigurationDomainService configurationDomainService) {
+            final RecurringDepositProductRepository recurringDepositProductRepository, final PlatformSecurityContext context,
+            final PaymentDetailAssembler paymentDetailAssembler, ExternalIdFactory externalIdFactory) {
 
-        this.savingsAccountTransactionSummaryWrapper = savingsAccountTransactionSummaryWrapper;
         this.clientRepository = clientRepository;
         this.groupRepository = groupRepository;
         this.staffRepository = staffRepository;
@@ -145,11 +136,9 @@ public class DepositAccountAssembler {
         this.fromApiJsonHelper = fromApiJsonHelper;
         this.depositProductAssembler = depositProductAssembler;
         this.recurringDepositProductRepository = recurringDepositProductRepository;
-        this.savingsHelper = new SavingsHelper(accountTransfersReadPlatformService);
         this.context = context;
         this.paymentDetailAssembler = paymentDetailAssembler;
         this.externalIdFactory = externalIdFactory;
-        this.configurationDomainService = configurationDomainService;
     }
 
     /**
@@ -360,7 +349,6 @@ public class DepositAccountAssembler {
         }
 
         if (account != null) {
-            account.setHelpers(this.savingsAccountTransactionSummaryWrapper, this.savingsHelper, this.configurationDomainService);
             account.validateNewApplicationState(depositAccountType.resourceName());
         }
 
@@ -368,13 +356,7 @@ public class DepositAccountAssembler {
     }
 
     public SavingsAccount assembleFrom(final Long savingsId, DepositAccountType depositAccountType) {
-        final SavingsAccount account = this.savingsAccountRepository.findOneWithNotFoundDetection(savingsId, depositAccountType);
-        account.setHelpers(this.savingsAccountTransactionSummaryWrapper, this.savingsHelper, this.configurationDomainService);
-        return account;
-    }
-
-    public void assignSavingAccountHelpers(final SavingsAccount savingsAccount) {
-        savingsAccount.setHelpers(this.savingsAccountTransactionSummaryWrapper, this.savingsHelper, this.configurationDomainService);
+        return this.savingsAccountRepository.findOneWithNotFoundDetection(savingsId, depositAccountType);
     }
 
     public DepositAccountTermAndPreClosure assembleAccountTermAndPreClosure(final JsonCommand command,

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/DepositAccountDomainServiceJpa.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/DepositAccountDomainServiceJpa.java
@@ -77,6 +77,7 @@ public class DepositAccountDomainServiceJpa implements DepositAccountDomainServi
     private final AccountNumberGenerator accountNumberGenerator;
     private final DepositAccountAssembler depositAccountAssembler;
     private final SavingsAccountDomainService savingsAccountDomainService;
+    private final SavingsHelper savingsHelper;
     private final AccountTransfersWritePlatformService accountTransfersWritePlatformService;
     private final ConfigurationDomainService configurationDomainService;
     private final AccountNumberFormatRepositoryWrapper accountNumberFormatRepository;
@@ -134,8 +135,8 @@ public class DepositAccountDomainServiceJpa implements DepositAccountDomainServi
             this.savingsAccountRepository.saveAndFlush(account);
         }
         account.handleScheduleInstallments(deposit);
-        account.updateMaturityDateAndAmount(mc, isPreMatureClosure, isSavingsInterestPostingAtCurrentPeriodEnd,
-                financialYearBeginningMonth);
+        account.updateMaturityDateAndAmount(mc, isPreMatureClosure, isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth,
+                this.savingsHelper);
         account.updateOverduePayments(DateUtils.getBusinessLocalDate());
         if (isAnyActivationChargesDue) {
             postJournalEntries(account, existingTransactionIds, existingReversedTransactionIds, isAccountTransfer);
@@ -198,7 +199,7 @@ public class DepositAccountDomainServiceJpa implements DepositAccountDomainServi
         final DateTimeFormatter fmt = DateTimeFormatter.ofPattern(command.dateFormat()).withLocale(locale);
         final LocalDate closedDate = command.localDateValueOfParameterNamed(SavingsApiConstants.closedOnDateParamName);
         Long savingsTransactionId = null;
-        account.postMaturityInterest(isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth);
+        account.postMaturityInterest(isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth, this.savingsHelper);
         account.setClosedOnDate(closedDate);
         final Integer onAccountClosureId = command.integerValueOfParameterNamed(onAccountClosureIdParamName);
         final DepositAccountOnClosureType onClosureType = DepositAccountOnClosureType.fromInt(onAccountClosureId);
@@ -206,9 +207,8 @@ public class DepositAccountDomainServiceJpa implements DepositAccountDomainServi
                 || onClosureType == DepositAccountOnClosureType.REINVEST_PRINCIPAL_ONLY) {
             ExternalId externalId = this.externalIdFactory.create();
             FixedDepositAccount reinvestedDeposit = account.reInvest(account.getAccountBalance(), externalId);
-            this.depositAccountAssembler.assignSavingAccountHelpers(reinvestedDeposit);
             reinvestedDeposit.updateMaturityDateAndAmountBeforeAccountActivation(mc, isPreMatureClosure,
-                    isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth);
+                    isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth, this.savingsHelper);
             this.savingsAccountRepository.saveAndFlush(reinvestedDeposit);
             autoGenerateAccountNumber(reinvestedDeposit);
             final SavingsAccountTransaction withdrawal = this.handleWithdrawal(account, fmt, closedDate, account.getAccountBalance(),
@@ -261,7 +261,7 @@ public class DepositAccountDomainServiceJpa implements DepositAccountDomainServi
 
         final MathContext mc = MathContext.DECIMAL64;
         Long savingsTransactionId = null;
-        account.postMaturityInterest(isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth);
+        account.postMaturityInterest(isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth, this.savingsHelper);
         account.setClosedOnDate(closedDate);
         final DepositAccountOnClosureType onClosureType = DepositAccountOnClosureType.fromInt(onAccountClosureId);
         if (onClosureType == DepositAccountOnClosureType.REINVEST_PRINCIPAL_AND_INTEREST
@@ -275,9 +275,8 @@ public class DepositAccountDomainServiceJpa implements DepositAccountDomainServi
             ExternalId externalId = this.externalIdFactory.create();
 
             FixedDepositAccount reinvestedDeposit = account.reInvest(reInvestAmount, externalId);
-            this.depositAccountAssembler.assignSavingAccountHelpers(reinvestedDeposit);
             reinvestedDeposit.updateMaturityDateAndAmountBeforeAccountActivation(mc, isPreMatureClosure,
-                    isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth);
+                    isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth, this.savingsHelper);
 
             this.savingsAccountRepository.saveAndFlush(reinvestedDeposit);
             autoGenerateAccountNumber(reinvestedDeposit);
@@ -343,7 +342,8 @@ public class DepositAccountDomainServiceJpa implements DepositAccountDomainServi
         final DateTimeFormatter fmt = DateTimeFormatter.ofPattern(command.dateFormat()).withLocale(locale);
         final LocalDate closedDate = command.localDateValueOfParameterNamed(SavingsApiConstants.closedOnDateParamName);
         Long savingsTransactionId = null;
-        account.postMaturityInterest(isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth, closedDate, postReversals);
+        account.postMaturityInterest(isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth, closedDate, postReversals,
+                this.savingsHelper);
         final BigDecimal transactionAmount = account.getAccountBalance();
         final Integer onAccountClosureId = command.integerValueOfParameterNamed(onAccountClosureIdParamName);
         final DepositAccountOnClosureType onClosureType = DepositAccountOnClosureType.fromInt(onAccountClosureId);
@@ -356,7 +356,6 @@ public class DepositAccountDomainServiceJpa implements DepositAccountDomainServi
                 reInvestAmount = account.getAccountBalance();
             }
             RecurringDepositAccount reinvestedDeposit = account.reInvest(reInvestAmount);
-            depositAccountAssembler.assignSavingAccountHelpers(reinvestedDeposit);
             this.savingsAccountRepository.save(reinvestedDeposit);
             final CalendarInstance calendarInstance = getCalendarInstance(account, reinvestedDeposit);
             this.calendarInstanceRepository.save(calendarInstance);
@@ -368,7 +367,7 @@ public class DepositAccountDomainServiceJpa implements DepositAccountDomainServi
             reinvestedDeposit.generateSchedule(frequencyType, frequency, calendar);
             reinvestedDeposit.processAccountUponActivation(fmt, postReversals, relaxingDaysConfigForPivotDate);
             reinvestedDeposit.updateMaturityDateAndAmount(mc, isPreMatureClosure, isSavingsInterestPostingAtCurrentPeriodEnd,
-                    financialYearBeginningMonth);
+                    financialYearBeginningMonth, this.savingsHelper);
             this.savingsAccountRepository.save(reinvestedDeposit);
             autoGenerateAccountNumber(reinvestedDeposit);
 
@@ -459,7 +458,7 @@ public class DepositAccountDomainServiceJpa implements DepositAccountDomainServi
 
         // post interest
         account.postPreMaturityInterest(closedDate, isPreMatureClosure, isSavingsInterestPostingAtCurrentPeriodEnd,
-                financialYearBeginningMonth);
+                financialYearBeginningMonth, this.savingsHelper);
 
         final Integer closureTypeValue = command.integerValueOfParameterNamed(DepositsApiConstants.onAccountClosureIdParamName);
         DepositAccountOnClosureType closureType = DepositAccountOnClosureType.fromInt(closureTypeValue);
@@ -515,7 +514,7 @@ public class DepositAccountDomainServiceJpa implements DepositAccountDomainServi
         Long savingsTransactionId = null;
         // post interest
         account.postPreMaturityInterest(closedDate, isPreMatureClosure, isSavingsInterestPostingAtCurrentPeriodEnd,
-                financialYearBeginningMonth, postReversals);
+                financialYearBeginningMonth, postReversals, this.savingsHelper);
 
         final Integer closureTypeValue = command.integerValueOfParameterNamed(DepositsApiConstants.onAccountClosureIdParamName);
         DepositAccountOnClosureType closureType = DepositAccountOnClosureType.fromInt(closureTypeValue);

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/DepositAccountRecurringDetail.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/DepositAccountRecurringDetail.java
@@ -113,7 +113,8 @@ public class DepositAccountRecurringDetail extends AbstractPersistableCustom<Lon
     }
 
     public Map<String, Object> updateMandatoryRecommendedDepositAmount(BigDecimal newMandatoryRecommendedDepositAmount,
-            LocalDate effectiveDate, Boolean isSavingsInterestPostingAtCurrentPeriodEnd, Integer financialYearBeginningMonth) {
+            LocalDate effectiveDate, Boolean isSavingsInterestPostingAtCurrentPeriodEnd, Integer financialYearBeginningMonth,
+            final SavingsHelper savingsHelper) {
         final Map<String, Object> actualChanges = new LinkedHashMap<>(10);
         actualChanges.put(mandatoryRecommendedDepositAmountParamName, newMandatoryRecommendedDepositAmount);
         this.mandatoryRecommendedDepositAmount = newMandatoryRecommendedDepositAmount;
@@ -131,7 +132,7 @@ public class DepositAccountRecurringDetail extends AbstractPersistableCustom<Lon
         MathContext mc = MathContext.DECIMAL64;
         Boolean isPreMatureClosure = false;
         depositAccount.updateMaturityDateAndAmount(mc, isPreMatureClosure, isSavingsInterestPostingAtCurrentPeriodEnd,
-                financialYearBeginningMonth);
+                financialYearBeginningMonth, savingsHelper);
         return actualChanges;
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/FixedDepositAccount.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/FixedDepositAccount.java
@@ -193,7 +193,8 @@ public class FixedDepositAccount extends SavingsAccount {
     }
 
     public void updateMaturityDateAndAmountBeforeAccountActivation(final MathContext mc, final boolean isPreMatureClosure,
-            final boolean isSavingsInterestPostingAtCurrentPeriodEnd, final Integer financialYearBeginningMonth) {
+            final boolean isSavingsInterestPostingAtCurrentPeriodEnd, final Integer financialYearBeginningMonth,
+            final SavingsHelper savingsHelper) {
         List<SavingsAccountTransaction> allTransactions = new ArrayList<>();
         String refNo = null;
         final Money transactionAmountMoney = Money.of(getCurrency(), this.accountTermAndPreClosure.depositAmount());
@@ -203,18 +204,19 @@ public class FixedDepositAccount extends SavingsAccount {
         transaction.updateCumulativeBalanceAndDates(this.getCurrency(), interestCalculatedUpto());
         allTransactions.add(transaction);
         updateMaturityDateAndAmount(mc, allTransactions, isPreMatureClosure, isSavingsInterestPostingAtCurrentPeriodEnd,
-                financialYearBeginningMonth);
+                financialYearBeginningMonth, savingsHelper);
     }
 
     public void updateMaturityDateAndAmount(final MathContext mc, final boolean isPreMatureClosure,
-            final boolean isSavingsInterestPostingAtCurrentPeriodEnd, final Integer financialYearBeginningMonth) {
+            final boolean isSavingsInterestPostingAtCurrentPeriodEnd, final Integer financialYearBeginningMonth,
+            final SavingsHelper savingsHelper) {
         updateMaturityDateAndAmount(mc, retreiveOrderedNonInterestPostingTransactions(), isPreMatureClosure,
-                isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth);
+                isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth, savingsHelper);
     }
 
     public void updateMaturityDateAndAmount(final MathContext mc, final List<SavingsAccountTransaction> transactions,
             final boolean isPreMatureClosure, final boolean isSavingsInterestPostingAtCurrentPeriodEnd,
-            final Integer financialYearBeginningMonth) {
+            final Integer financialYearBeginningMonth, final SavingsHelper savingsHelper) {
         final LocalDate maturityDate = calculateMaturityDate();
         final LocalDate interestCalculationUpto = maturityDate.minusDays(1);
 
@@ -223,7 +225,7 @@ public class FixedDepositAccount extends SavingsAccount {
         this.resetAccountTransactionsEndOfDayBalances(transactions, maturityDate);
 
         final List<PostingPeriod> postingPeriods = calculateInterestPayable(mc, interestCalculationUpto, transactions, isPreMatureClosure,
-                isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth);
+                isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth, savingsHelper);
 
         // reset end of day balance back to today's date
         this.resetAccountTransactionsEndOfDayBalances(transactions, DateUtils.getBusinessLocalDate());
@@ -238,7 +240,8 @@ public class FixedDepositAccount extends SavingsAccount {
         this.accountTermAndPreClosure.updateMaturityDetails(maturityAmount.getAmount(), maturityDate);
     }
 
-    public void updateMaturityStatus(final boolean isSavingsInterestPostingAtCurrentPeriodEnd, final Integer financialYearBeginningMonth) {
+    public void updateMaturityStatus(final boolean isSavingsInterestPostingAtCurrentPeriodEnd, final Integer financialYearBeginningMonth,
+            final SavingsHelper savingsHelper) {
         final List<ApiParameterError> dataValidationErrors = new ArrayList<>();
         final DataValidatorBuilder baseDataValidator = new DataValidatorBuilder(dataValidationErrors)
                 .resource(FIXED_DEPOSIT_ACCOUNT_RESOURCE_NAME + SavingsApiConstants.updateMaturityDetailsAction);
@@ -254,7 +257,7 @@ public class FixedDepositAccount extends SavingsAccount {
         if (!DateUtils.isDateInTheFuture(maturityDate())) {
             // update account status
             this.status = SavingsAccountStatusType.MATURED.getValue();
-            postMaturityInterest(isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth);
+            postMaturityInterest(isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth, savingsHelper);
         }
     }
 
@@ -285,7 +288,8 @@ public class FixedDepositAccount extends SavingsAccount {
 
     private List<PostingPeriod> calculateInterestPayable(final MathContext mc, final LocalDate maturityDate,
             final List<SavingsAccountTransaction> transactions, final boolean isPreMatureClosure,
-            final boolean isSavingsInterestPostingAtCurrentPeriodEnd, final Integer financialYearBeginningMonth) {
+            final boolean isSavingsInterestPostingAtCurrentPeriodEnd, final Integer financialYearBeginningMonth,
+            final SavingsHelper savingsHelper) {
 
         final SavingsPostingInterestPeriodType postingPeriodType = SavingsPostingInterestPeriodType.fromInt(this.interestPostingPeriodType);
 
@@ -296,7 +300,7 @@ public class FixedDepositAccount extends SavingsAccount {
                 .fromInt(this.interestCalculationDaysInYearType);
         List<LocalDate> postedAsOnTransactionDates = getManualPostingDates();
 
-        final List<LocalDateInterval> postingPeriodIntervals = this.savingsHelper.determineInterestPostingPeriods(
+        final List<LocalDateInterval> postingPeriodIntervals = SavingsInterestCalculationUtil.determineInterestPostingPeriods(
                 accountSubmittedOrActivationDate(), maturityDate, postingPeriodType, financialYearBeginningMonth,
                 postedAsOnTransactionDates);
 
@@ -306,7 +310,7 @@ public class FixedDepositAccount extends SavingsAccount {
 
         final SavingsInterestCalculationType interestCalculationType = SavingsInterestCalculationType.fromInt(this.interestCalculationType);
         final BigDecimal interestRateAsFraction = getEffectiveInterestRateAsFraction(mc, maturityDate, isPreMatureClosure);
-        final Collection<Long> interestPostTransactions = this.savingsHelper.fetchPostInterestTransactionIds(getId());
+        final Collection<Long> interestPostTransactions = savingsHelper.fetchPostInterestTransactionIds(getId());
         boolean isInterestTransfer = false;
         final Money minBalanceForInterestCalculation = Money.of(getCurrency(), minBalanceForInterestCalculation());
         List<SavingsAccountTransactionDetailsForPostingPeriod> savingsAccountTransactionDetailsForPostingPeriodList = toSavingsAccountTransactionDetailsForPostingPeriodList(
@@ -325,7 +329,7 @@ public class FixedDepositAccount extends SavingsAccount {
         }
 
         this.summary.updateFromInterestPeriodSummaries(this.currency, allPostingPeriods);
-        this.savingsHelper.calculateInterestForAllPostingPeriods(this.currency, allPostingPeriods, getLockedInUntilDate(),
+        SavingsInterestCalculationUtil.calculateInterestForAllPostingPeriods(this.currency, allPostingPeriods, getLockedInUntilDate(),
                 isTransferInterestToOtherAccount());
         return allPostingPeriods;
     }
@@ -411,7 +415,7 @@ public class FixedDepositAccount extends SavingsAccount {
         this.withdrawnBy = null;
         this.closedOnDate = closedDate;
         this.closedBy = currentUser;
-        this.summary.updateSummary(this.currency, this.savingsAccountTransactionSummaryWrapper, this.transactions);
+        this.summary.updateSummary(this.currency, this.transactions);
     }
 
     @Override
@@ -497,8 +501,6 @@ public class FixedDepositAccount extends SavingsAccount {
         this.withdrawnBy = null;
         this.closedOnDate = closedDate;
         this.closedBy = currentUser;
-        // this.summary.updateSummary(this.currency,
-        // this.savingsAccountTransactionSummaryWrapper, this.transactions);
     }
 
     public void updateClosedStatus() {
@@ -509,7 +511,8 @@ public class FixedDepositAccount extends SavingsAccount {
         this.accountTermAndPreClosure.updateOnAccountClosureStatus(onClosureType);
     }
 
-    public void postMaturityInterest(final boolean isSavingsInterestPostingAtCurrentPeriodEnd, final Integer financialYearBeginningMonth) {
+    public void postMaturityInterest(final boolean isSavingsInterestPostingAtCurrentPeriodEnd, final Integer financialYearBeginningMonth,
+            final SavingsHelper savingsHelper) {
         final LocalDate interestPostingUpToDate = maturityDate();
         final MathContext mc = MathContext.DECIMAL64;
         final boolean isInterestTransfer = false;
@@ -518,7 +521,7 @@ public class FixedDepositAccount extends SavingsAccount {
         boolean postReversals = false;
         final List<PostingPeriod> postingPeriods = calculateInterestUsing(mc, interestPostingUpToDate, isInterestTransfer,
                 isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth, postInterestOnDate, backdatedTxnsAllowedTill,
-                postReversals);
+                postReversals, savingsHelper);
 
         Money interestPostedToDate = Money.zero(this.currency);
 
@@ -561,18 +564,19 @@ public class FixedDepositAccount extends SavingsAccount {
             recalculateDailyBalances(Money.zero(this.currency), interestPostingUpToDate, backdatedTxnsAllowedTill, postReversals);
         }
 
-        this.summary.updateSummary(this.currency, this.savingsAccountTransactionSummaryWrapper, this.transactions);
+        this.summary.updateSummary(this.currency, this.transactions);
     }
 
     public void postPreMaturityInterest(final LocalDate accountCloseDate, final boolean isPreMatureClosure,
-            final boolean isSavingsInterestPostingAtCurrentPeriodEnd, final Integer financialYearBeginningMonth) {
+            final boolean isSavingsInterestPostingAtCurrentPeriodEnd, final Integer financialYearBeginningMonth,
+            final SavingsHelper savingsHelper) {
 
         Money interestPostedToDate = totalInterestPosted();
         // calculate interest before one day of closure date
         final LocalDate interestCalculatedToDate = accountCloseDate.minusDays(1);
         final Money interestOnMaturity = calculatePreMatureInterest(interestCalculatedToDate,
                 retreiveOrderedNonInterestPostingTransactions(), isPreMatureClosure, isSavingsInterestPostingAtCurrentPeriodEnd,
-                financialYearBeginningMonth);
+                financialYearBeginningMonth, savingsHelper);
         boolean recalucateDailyBalance = false;
 
         // post remaining interest
@@ -593,18 +597,19 @@ public class FixedDepositAccount extends SavingsAccount {
             // correct.
             recalculateDailyBalances(Money.zero(this.currency), accountCloseDate, backdatedTxnsAllowedTill, postReversals);
         }
-        this.summary.updateSummary(this.currency, this.savingsAccountTransactionSummaryWrapper, this.transactions);
+        this.summary.updateSummary(this.currency, this.transactions);
         this.accountTermAndPreClosure.updateMaturityDetails(this.getAccountBalance(), accountCloseDate);
 
     }
 
     public BigDecimal calculatePreMatureAmount(final LocalDate preMatureDate, final boolean isPreMatureClosure,
-            final boolean isSavingsInterestPostingAtCurrentPeriodEnd, final Integer financialYearBeginningMonth) {
+            final boolean isSavingsInterestPostingAtCurrentPeriodEnd, final Integer financialYearBeginningMonth,
+            final SavingsHelper savingsHelper) {
 
         final Money interestPostedToDate = totalInterestPosted().copy();
 
         final Money interestEarnedTillDate = calculatePreMatureInterest(preMatureDate, retreiveOrderedNonInterestPostingTransactions(),
-                isPreMatureClosure, isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth);
+                isPreMatureClosure, isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth, savingsHelper);
 
         final Money accountBalance = Money.of(getCurrency(), getAccountBalance());
         final Money maturityAmount = accountBalance.minus(interestPostedToDate).plus(interestEarnedTillDate);
@@ -614,10 +619,10 @@ public class FixedDepositAccount extends SavingsAccount {
 
     private Money calculatePreMatureInterest(final LocalDate preMatureDate, final List<SavingsAccountTransaction> transactions,
             final boolean isPreMatureClosure, final boolean isSavingsInterestPostingAtCurrentPeriodEnd,
-            final Integer financialYearBeginningMonth) {
+            final Integer financialYearBeginningMonth, final SavingsHelper savingsHelper) {
         final MathContext mc = MathContext.DECIMAL64;
         final List<PostingPeriod> postingPeriods = calculateInterestPayable(mc, preMatureDate, transactions, isPreMatureClosure,
-                isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth);
+                isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth, savingsHelper);
 
         Money interestOnMaturity = Money.zero(this.currency);
 
@@ -632,10 +637,11 @@ public class FixedDepositAccount extends SavingsAccount {
     @Override
     public List<PostingPeriod> calculateInterestUsing(final MathContext mc, final LocalDate postingDate, boolean isInterestTransfer,
             final boolean isSavingsInterestPostingAtCurrentPeriodEnd, final Integer financialYearBeginningMonth,
-            final LocalDate postAsInterestOn, final boolean backdatedTxnsAllowedTill, final boolean postReversals) {
+            final LocalDate postAsInterestOn, final boolean backdatedTxnsAllowedTill, final boolean postReversals,
+            final SavingsHelper savingsHelper) {
         final LocalDate interestPostingUpToDate = maturityAdjustedPostingDate(postingDate);
         return super.calculateInterestUsing(mc, interestPostingUpToDate, isInterestTransfer, isSavingsInterestPostingAtCurrentPeriodEnd,
-                financialYearBeginningMonth, postAsInterestOn, backdatedTxnsAllowedTill, postReversals);
+                financialYearBeginningMonth, postAsInterestOn, backdatedTxnsAllowedTill, postReversals, savingsHelper);
     }
 
     /**

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/RecurringDepositAccount.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/RecurringDepositAccount.java
@@ -244,7 +244,8 @@ public class RecurringDepositAccount extends SavingsAccount {
     }
 
     public void updateMaturityDateAndAmount(final MathContext mc, final boolean isPreMatureClosure,
-            final boolean isSavingsInterestPostingAtCurrentPeriodEnd, final Integer financialYearBeginningMonth) {
+            final boolean isSavingsInterestPostingAtCurrentPeriodEnd, final Integer financialYearBeginningMonth,
+            final SavingsHelper savingsHelper) {
         final LocalDate maturityDate = calculateMaturityDate();
         LocalDate interestCalculationUpto = null;
         List<SavingsAccountTransaction> allTransactions = null;
@@ -258,7 +259,7 @@ public class RecurringDepositAccount extends SavingsAccount {
         }
 
         final List<PostingPeriod> postingPeriods = calculateInterestPayable(mc, interestCalculationUpto, allTransactions,
-                isPreMatureClosure, isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth);
+                isPreMatureClosure, isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth, savingsHelper);
         Money totalInterestPayable = Money.zero(getCurrency());
         Money totalDepositAmount = Money.zero(getCurrency());
         for (PostingPeriod postingPeriod : postingPeriods) {
@@ -274,7 +275,7 @@ public class RecurringDepositAccount extends SavingsAccount {
     }
 
     public void updateMaturityStatus(final boolean isSavingsInterestPostingAtCurrentPeriodEnd, final Integer financialYearBeginningMonth,
-            final boolean postReversals) {
+            final boolean postReversals, final SavingsHelper savingsHelper) {
         final List<ApiParameterError> dataValidationErrors = new ArrayList<>();
         final DataValidatorBuilder baseDataValidator = new DataValidatorBuilder(dataValidationErrors)
                 .resource(RECURRING_DEPOSIT_ACCOUNT_RESOURCE_NAME + SavingsApiConstants.updateMaturityDetailsAction);
@@ -290,7 +291,8 @@ public class RecurringDepositAccount extends SavingsAccount {
         if (!DateUtils.isAfter(this.maturityDate(), todayDate)) {
             // update account status
             this.status = SavingsAccountStatusType.MATURED.getValue();
-            postMaturityInterest(isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth, todayDate, postReversals);
+            postMaturityInterest(isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth, todayDate, postReversals,
+                    savingsHelper);
         }
     }
 
@@ -324,7 +326,8 @@ public class RecurringDepositAccount extends SavingsAccount {
 
     private List<PostingPeriod> calculateInterestPayable(final MathContext mc, final LocalDate maturityDate,
             final List<SavingsAccountTransaction> transactions, final boolean isPreMatureClosure,
-            final boolean isSavingsInterestPostingAtCurrentPeriodEnd, final Integer financialYearBeginningMonth) {
+            final boolean isSavingsInterestPostingAtCurrentPeriodEnd, final Integer financialYearBeginningMonth,
+            final SavingsHelper savingsHelper) {
 
         // 1. default to calculate interest based on entire history OR
         // 2. determine latest 'posting period' and find interest credited to
@@ -339,8 +342,8 @@ public class RecurringDepositAccount extends SavingsAccount {
         final SavingsInterestCalculationDaysInYearType daysInYearType = SavingsInterestCalculationDaysInYearType
                 .fromInt(this.interestCalculationDaysInYearType);
         List<LocalDate> PostedAsOnDates = getManualPostingDates();
-        final List<LocalDateInterval> postingPeriodIntervals = this.savingsHelper.determineInterestPostingPeriods(depositStartDate(),
-                maturityDate, postingPeriodType, financialYearBeginningMonth, PostedAsOnDates);
+        final List<LocalDateInterval> postingPeriodIntervals = SavingsInterestCalculationUtil.determineInterestPostingPeriods(
+                depositStartDate(), maturityDate, postingPeriodType, financialYearBeginningMonth, PostedAsOnDates);
 
         final List<PostingPeriod> allPostingPeriods = new ArrayList<>();
 
@@ -348,7 +351,7 @@ public class RecurringDepositAccount extends SavingsAccount {
 
         final SavingsInterestCalculationType interestCalculationType = SavingsInterestCalculationType.fromInt(this.interestCalculationType);
         final BigDecimal interestRateAsFraction = getEffectiveInterestRateAsFraction(mc, maturityDate, isPreMatureClosure);
-        final Collection<Long> interestPostTransactions = this.savingsHelper.fetchPostInterestTransactionIds(getId());
+        final Collection<Long> interestPostTransactions = savingsHelper.fetchPostInterestTransactionIds(getId());
         boolean isInterestTransfer = false;
         final Money minBalanceForInterestCalculation = Money.of(getCurrency(), minBalanceForInterestCalculation());
         List<SavingsAccountTransactionDetailsForPostingPeriod> savingsAccountTransactionDetailsForPostingPeriodList = toSavingsAccountTransactionDetailsForPostingPeriodList(
@@ -369,7 +372,7 @@ public class RecurringDepositAccount extends SavingsAccount {
             allPostingPeriods.add(postingPeriod);
         }
 
-        this.savingsHelper.calculateInterestForAllPostingPeriods(this.currency, allPostingPeriods, this.getLockedInUntilDate(),
+        SavingsInterestCalculationUtil.calculateInterestForAllPostingPeriods(this.currency, allPostingPeriods, this.getLockedInUntilDate(),
                 isTransferInterestToOtherAccount());
         // this.summary.updateFromInterestPeriodSummaries(this.currency,
         // allPostingPeriods);
@@ -528,7 +531,7 @@ public class RecurringDepositAccount extends SavingsAccount {
         this.withdrawnBy = null;
         this.closedOnDate = closedDate;
         this.closedBy = currentUser;
-        this.summary.updateSummary(this.currency, this.savingsAccountTransactionSummaryWrapper, this.transactions);
+        this.summary.updateSummary(this.currency, this.transactions);
 
     }
 
@@ -628,11 +631,11 @@ public class RecurringDepositAccount extends SavingsAccount {
         this.withdrawnBy = null;
         this.closedOnDate = closedDate;
         this.closedBy = currentUser;
-        this.summary.updateSummary(this.currency, this.savingsAccountTransactionSummaryWrapper, this.transactions);
+        this.summary.updateSummary(this.currency, this.transactions);
     }
 
     public void postMaturityInterest(final boolean isSavingsInterestPostingAtCurrentPeriodEnd, final Integer financialYearBeginningMonth,
-            final LocalDate closeDate, final boolean postReversals) {
+            final LocalDate closeDate, final boolean postReversals, final SavingsHelper savingsHelper) {
         LocalDate interestPostingUpToDate = maturityDate();
         if (interestPostingUpToDate == null) {
             interestPostingUpToDate = closeDate;
@@ -644,7 +647,7 @@ public class RecurringDepositAccount extends SavingsAccount {
         final boolean backdatedTxnsAllowedTill = false;
         final List<PostingPeriod> postingPeriods = calculateInterestUsing(mc, interestPostingUpToDate.minusDays(1), isInterestTransfer,
                 isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth, postInterestOnDate, backdatedTxnsAllowedTill,
-                postReversals);
+                postReversals, savingsHelper);
 
         Money interestPostedToDate = Money.zero(this.currency);
 
@@ -683,18 +686,19 @@ public class RecurringDepositAccount extends SavingsAccount {
             // correct.
             recalculateDailyBalances(Money.zero(this.currency), interestPostingUpToDate, backdatedTxnsAllowedTill, postReversals);
         }
-        this.summary.updateSummary(this.currency, this.savingsAccountTransactionSummaryWrapper, this.transactions);
+        this.summary.updateSummary(this.currency, this.transactions);
     }
 
     public void postPreMaturityInterest(final LocalDate accountCloseDate, final boolean isPreMatureClosure,
-            final boolean isSavingsInterestPostingAtCurrentPeriodEnd, final Integer financialYearBeginningMonth, boolean postReversals) {
+            final boolean isSavingsInterestPostingAtCurrentPeriodEnd, final Integer financialYearBeginningMonth, boolean postReversals,
+            final SavingsHelper savingsHelper) {
 
         final Money interestPostedToDate = totalInterestPosted();
         // calculate interest before one day of closure date
         final LocalDate interestCalculatedToDate = accountCloseDate.minusDays(1);
         final Money interestOnMaturity = calculatePreMatureInterest(interestCalculatedToDate,
                 retreiveOrderedNonInterestPostingTransactions(), isPreMatureClosure, isSavingsInterestPostingAtCurrentPeriodEnd,
-                financialYearBeginningMonth);
+                financialYearBeginningMonth, savingsHelper);
 
         boolean recalucateDailyBalance = false;
         final boolean backdatedTxnsAllowedTill = false;
@@ -716,17 +720,18 @@ public class RecurringDepositAccount extends SavingsAccount {
             recalculateDailyBalances(Money.zero(this.currency), accountCloseDate, backdatedTxnsAllowedTill, postReversals);
         }
 
-        this.summary.updateSummary(this.currency, this.savingsAccountTransactionSummaryWrapper, this.transactions);
+        this.summary.updateSummary(this.currency, this.transactions);
         this.accountTermAndPreClosure.updateMaturityDetails(this.getAccountBalance(), accountCloseDate);
     }
 
     public BigDecimal calculatePreMatureAmount(final LocalDate preMatureDate, final boolean isPreMatureClosure,
-            final boolean isSavingsInterestPostingAtCurrentPeriodEnd, final Integer financialYearBeginningMonth) {
+            final boolean isSavingsInterestPostingAtCurrentPeriodEnd, final Integer financialYearBeginningMonth,
+            final SavingsHelper savingsHelper) {
 
         final Money interestPostedToDate = totalInterestPosted().copy();
 
         final Money interestEarnedTillDate = calculatePreMatureInterest(preMatureDate, retreiveOrderedNonInterestPostingTransactions(),
-                isPreMatureClosure, isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth);
+                isPreMatureClosure, isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth, savingsHelper);
 
         final Money accountBalance = Money.of(getCurrency(), getAccountBalance());
         final Money maturityAmount = accountBalance.minus(interestPostedToDate).plus(interestEarnedTillDate);
@@ -736,10 +741,10 @@ public class RecurringDepositAccount extends SavingsAccount {
 
     private Money calculatePreMatureInterest(final LocalDate preMatureDate, final List<SavingsAccountTransaction> transactions,
             final boolean isPreMatureClosure, final boolean isSavingsInterestPostingAtCurrentPeriodEnd,
-            final Integer financialYearBeginningMonth) {
+            final Integer financialYearBeginningMonth, final SavingsHelper savingsHelper) {
         final MathContext mc = MathContext.DECIMAL64;
         final List<PostingPeriod> postingPeriods = calculateInterestPayable(mc, preMatureDate, transactions, isPreMatureClosure,
-                isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth);
+                isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth, savingsHelper);
 
         Money interestOnMaturity = Money.zero(this.currency);
 
@@ -754,10 +759,11 @@ public class RecurringDepositAccount extends SavingsAccount {
     @Override
     public List<PostingPeriod> calculateInterestUsing(final MathContext mc, final LocalDate postingDate, boolean isInterestTransfer,
             final boolean isSavingsInterestPostingAtCurrentPeriodEnd, final Integer financialYearBeginningMonth,
-            final LocalDate postAsInterestOn, final boolean backdatedTxnsAllowedTill, final boolean postReversals) {
+            final LocalDate postAsInterestOn, final boolean backdatedTxnsAllowedTill, final boolean postReversals,
+            final SavingsHelper savingsHelper) {
         final LocalDate interestPostingUpToDate = interestPostingUpToDate(postingDate);
         return super.calculateInterestUsing(mc, interestPostingUpToDate, isInterestTransfer, isSavingsInterestPostingAtCurrentPeriodEnd,
-                financialYearBeginningMonth, postAsInterestOn, backdatedTxnsAllowedTill, postReversals);
+                financialYearBeginningMonth, postAsInterestOn, backdatedTxnsAllowedTill, postReversals, savingsHelper);
     }
 
     @Override

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountAssembler.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountAssembler.java
@@ -88,7 +88,6 @@ import org.springframework.stereotype.Service;
 public class SavingsAccountAssembler {
 
     private static final Logger LOG = LoggerFactory.getLogger(SavingsAccountAssembler.class);
-    private final SavingsAccountTransactionSummaryWrapper savingsAccountTransactionSummaryWrapper;
     private final SavingsAccountTransactionDataSummaryWrapper savingsAccountTransactionDataSummaryWrapper;
     private final SavingsHelper savingsHelper;
     private final ClientRepositoryWrapper clientRepository;
@@ -103,15 +102,13 @@ public class SavingsAccountAssembler {
     private final ExternalIdFactory externalIdFactory;
 
     @Autowired
-    public SavingsAccountAssembler(final SavingsAccountTransactionSummaryWrapper savingsAccountTransactionSummaryWrapper,
-            final SavingsAccountTransactionDataSummaryWrapper savingsAccountTransactionDataSummaryWrapper,
+    public SavingsAccountAssembler(final SavingsAccountTransactionDataSummaryWrapper savingsAccountTransactionDataSummaryWrapper,
             final ClientRepositoryWrapper clientRepository, final GroupRepositoryWrapper groupRepository,
             final StaffRepositoryWrapper staffRepository, final SavingsProductRepository savingProductRepository,
             final SavingsAccountRepositoryWrapper savingsAccountRepository,
             final SavingsAccountChargeAssembler savingsAccountChargeAssembler, final FromJsonHelper fromApiJsonHelper,
             final AccountTransfersReadPlatformService accountTransfersReadPlatformService, final JdbcTemplate jdbcTemplate,
             final ConfigurationDomainService configurationDomainService, ExternalIdFactory externalIdFactory) {
-        this.savingsAccountTransactionSummaryWrapper = savingsAccountTransactionSummaryWrapper;
         this.savingsAccountTransactionDataSummaryWrapper = savingsAccountTransactionDataSummaryWrapper;
         this.clientRepository = clientRepository;
         this.groupRepository = groupRepository;
@@ -330,7 +327,6 @@ public class SavingsAccountAssembler {
                 minRequiredOpeningBalance, lockinPeriodFrequency, lockinPeriodFrequencyType, iswithdrawalFeeApplicableForTransfer, charges,
                 allowOverdraft, overdraftLimit, enforceMinRequiredBalance, minRequiredBalance, maxAllowedLienLimit, lienAllowed,
                 nominalAnnualInterestRateOverdraft, minOverdraftForInterestCalculation, withHoldTax);
-        account.setHelpers(this.savingsAccountTransactionSummaryWrapper, this.savingsHelper, this.configurationDomainService);
 
         account.validateNewApplicationState(SAVINGS_ACCOUNT_RESOURCE_NAME);
 
@@ -381,7 +377,6 @@ public class SavingsAccountAssembler {
             }
         }
 
-        account.setHelpers(this.savingsAccountTransactionSummaryWrapper, this.savingsHelper, this.configurationDomainService);
         return account;
     }
 
@@ -418,10 +413,6 @@ public class SavingsAccountAssembler {
 
     public boolean isRelaxingDaysConfigForPivotDateEnabled() {
         return this.configurationDomainService.isRelaxingDaysConfigForPivotDateEnabled();
-    }
-
-    public void setHelpers(final SavingsAccount account) {
-        account.setHelpers(this.savingsAccountTransactionSummaryWrapper, this.savingsHelper, this.configurationDomainService);
     }
 
     /**
@@ -465,17 +456,12 @@ public class SavingsAccountAssembler {
                 product.isMinRequiredBalanceEnforced(), product.minRequiredBalance(), product.maxAllowedLienLimit(),
                 product.isLienAllowed(), product.nominalAnnualInterestRateOverdraft(), product.minOverdraftForInterestCalculation(),
                 product.withHoldTax());
-        account.setHelpers(this.savingsAccountTransactionSummaryWrapper, this.savingsHelper, this.configurationDomainService);
 
         account.validateNewApplicationState(SAVINGS_ACCOUNT_RESOURCE_NAME);
 
         account.validateAccountValuesWithProduct();
 
         return account;
-    }
-
-    public void assignSavingAccountHelpers(final SavingsAccount savingsAccount) {
-        savingsAccount.setHelpers(this.savingsAccountTransactionSummaryWrapper, this.savingsHelper, this.configurationDomainService);
     }
 
     public void assignSavingAccountHelpers(final SavingsAccountData savingsAccountData) {

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountDomainServiceJpa.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountDomainServiceJpa.java
@@ -36,7 +36,6 @@ import org.apache.fineract.infrastructure.event.business.domain.savings.transact
 import org.apache.fineract.infrastructure.event.business.domain.savings.transaction.SavingsWithdrawalBusinessEvent;
 import org.apache.fineract.infrastructure.event.business.service.BusinessEventNotifierService;
 import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
-import org.apache.fineract.organisation.monetary.domain.ApplicationCurrencyRepositoryWrapper;
 import org.apache.fineract.organisation.monetary.domain.Money;
 import org.apache.fineract.organisation.monetary.domain.MoneyHelper;
 import org.apache.fineract.portfolio.paymentdetail.domain.PaymentDetail;
@@ -57,34 +56,33 @@ public class SavingsAccountDomainServiceJpa implements SavingsAccountDomainServi
     private final PlatformSecurityContext context;
     private final SavingsAccountRepositoryWrapper savingsAccountRepository;
     private final SavingsAccountTransactionRepository savingsAccountTransactionRepository;
-    private final ApplicationCurrencyRepositoryWrapper applicationCurrencyRepositoryWrapper;
     private final JournalEntryWritePlatformService journalEntryWritePlatformService;
     private final ConfigurationDomainService configurationDomainService;
     private final DepositAccountOnHoldTransactionRepository depositAccountOnHoldTransactionRepository;
     private final BusinessEventNotifierService businessEventNotifierService;
     private final SavingsAccountPostInterestService savingsAccountPostInterestService;
     private final SavingsAccountTransfersService savingsAccountTransfersService;
+    private final SavingsHelper savingsHelper;
 
     @Autowired
     public SavingsAccountDomainServiceJpa(final SavingsAccountRepositoryWrapper savingsAccountRepository,
             final SavingsAccountTransactionRepository savingsAccountTransactionRepository,
-            final ApplicationCurrencyRepositoryWrapper applicationCurrencyRepositoryWrapper,
             final JournalEntryWritePlatformService journalEntryWritePlatformService,
             final ConfigurationDomainService configurationDomainService, final PlatformSecurityContext context,
             final DepositAccountOnHoldTransactionRepository depositAccountOnHoldTransactionRepository,
             final BusinessEventNotifierService businessEventNotifierService,
-            final SavingsAccountPostInterestService savingsAccountPostInterestService,
-            final SavingsAccountTransfersService savingsAccountTransfersService) {
+            final SavingsAccountTransfersService savingsAccountTransfersService,
+            final SavingsAccountPostInterestService savingsAccountPostInterestService, final SavingsHelper savingsHelper) {
         this.savingsAccountRepository = savingsAccountRepository;
         this.savingsAccountTransactionRepository = savingsAccountTransactionRepository;
-        this.applicationCurrencyRepositoryWrapper = applicationCurrencyRepositoryWrapper;
         this.journalEntryWritePlatformService = journalEntryWritePlatformService;
         this.configurationDomainService = configurationDomainService;
         this.context = context;
         this.depositAccountOnHoldTransactionRepository = depositAccountOnHoldTransactionRepository;
         this.businessEventNotifierService = businessEventNotifierService;
-        this.savingsAccountPostInterestService = savingsAccountPostInterestService;
         this.savingsAccountTransfersService = savingsAccountTransfersService;
+        this.savingsAccountPostInterestService = savingsAccountPostInterestService;
+        this.savingsHelper = savingsHelper;
     }
 
     @Transactional
@@ -130,7 +128,7 @@ public class SavingsAccountDomainServiceJpa implements SavingsAccountDomainServi
         } else {
             account.calculateInterestUsing(mc, today, transactionBooleanValues.isInterestTransfer(),
                     isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth, postInterestOnDate, backdatedTxnsAllowedTill,
-                    postReversals);
+                    postReversals, this.savingsHelper);
         }
 
         List<DepositAccountOnHoldTransaction> depositAccountOnHoldTransactions = null;
@@ -140,7 +138,9 @@ public class SavingsAccountDomainServiceJpa implements SavingsAccountDomainServi
         }
 
         account.validateAccountBalanceConstraints(transactionAmount, transactionBooleanValues.isExceptionForBalanceCheck(),
-                depositAccountOnHoldTransactions, backdatedTxnsAllowedTill, transactionBooleanValues.isForceWithdrawal());
+                depositAccountOnHoldTransactions, backdatedTxnsAllowedTill, transactionBooleanValues.isForceWithdrawal(),
+                this.configurationDomainService.isForceWithdrawalOnSavingsAccountEnabled(),
+                this.configurationDomainService.retrieveForceWithdrawalOnSavingsAccountLimit());
 
         saveTransactionToGenerateTransactionId(withdrawal);
         if (backdatedTxnsAllowedTill) {
@@ -213,7 +213,7 @@ public class SavingsAccountDomainServiceJpa implements SavingsAccountDomainServi
                     postReversals);
         } else {
             account.calculateInterestUsing(mc, today, isInterestTransfer, isSavingsInterestPostingAtCurrentPeriodEnd,
-                    financialYearBeginningMonth, postInterestOnDate, backdatedTxnsAllowedTill, postReversals);
+                    financialYearBeginningMonth, postInterestOnDate, backdatedTxnsAllowedTill, postReversals, this.savingsHelper);
         }
 
         saveTransactionToGenerateTransactionId(deposit);
@@ -336,7 +336,7 @@ public class SavingsAccountDomainServiceJpa implements SavingsAccountDomainServi
                         backdatedTxnsAllowedTill, postReversals);
             } else {
                 account.calculateInterestUsing(mc, today, isInterestTransfer, isSavingsInterestPostingAtCurrentPeriodEnd,
-                        financialYearBeginningMonth, postInterestOnDate, backdatedTxnsAllowedTill, postReversals);
+                        financialYearBeginningMonth, postInterestOnDate, backdatedTxnsAllowedTill, postReversals, this.savingsHelper);
             }
             account.validatePivotDateTransaction(savingsAccountTransaction.getTransactionDate(), backdatedTxnsAllowedTill,
                     relaxingDaysConfigForPivotDate, "savingsaccount");

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/DepositAccountPreMatureCalculationPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/DepositAccountPreMatureCalculationPlatformServiceImpl.java
@@ -41,12 +41,14 @@ import org.apache.fineract.portfolio.savings.domain.DepositAccountAssembler;
 import org.apache.fineract.portfolio.savings.domain.FixedDepositAccount;
 import org.apache.fineract.portfolio.savings.domain.RecurringDepositAccount;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccount;
+import org.apache.fineract.portfolio.savings.domain.SavingsHelper;
 import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 public class DepositAccountPreMatureCalculationPlatformServiceImpl implements DepositAccountPreMatureCalculationPlatformService {
 
     private final FromJsonHelper fromJsonHelper;
+    private final SavingsHelper savingsHelper;
     private final DepositAccountTransactionDataValidator depositAccountTransactionDataValidator;
     private final DepositAccountAssembler depositAccountAssembler;
     private final SavingsAccountReadPlatformService savingsAccountReadPlatformService;
@@ -80,15 +82,15 @@ public class DepositAccountPreMatureCalculationPlatformServiceImpl implements De
 
         if (depositAccountType == DepositAccountType.FIXED_DEPOSIT) {
             final FixedDepositAccount fd = (FixedDepositAccount) account;
-            accountData = FixedDepositAccountData.preClosureDetails(
-                    account.getId(), fd.calculatePreMatureAmount(interestCalculatedToDate, isPreMatureClosure,
-                            isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth),
+            accountData = FixedDepositAccountData.preClosureDetails(account.getId(),
+                    fd.calculatePreMatureAmount(interestCalculatedToDate, isPreMatureClosure, isSavingsInterestPostingAtCurrentPeriodEnd,
+                            financialYearBeginningMonth, this.savingsHelper),
                     onAccountClosureOptions, paymentTypeOptions, savingsAccountDatas);
         } else if (depositAccountType == DepositAccountType.RECURRING_DEPOSIT) {
             final RecurringDepositAccount rd = (RecurringDepositAccount) account;
-            accountData = RecurringDepositAccountData.preClosureDetails(
-                    account.getId(), rd.calculatePreMatureAmount(interestCalculatedToDate, isPreMatureClosure,
-                            isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth),
+            accountData = RecurringDepositAccountData.preClosureDetails(account.getId(),
+                    rd.calculatePreMatureAmount(interestCalculatedToDate, isPreMatureClosure, isSavingsInterestPostingAtCurrentPeriodEnd,
+                            financialYearBeginningMonth, this.savingsHelper),
                     onAccountClosureOptions, paymentTypeOptions, savingsAccountDatas);
         }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/DepositAccountWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/DepositAccountWritePlatformServiceJpaRepositoryImpl.java
@@ -100,6 +100,7 @@ import org.apache.fineract.portfolio.savings.domain.SavingsAccountChargeReposito
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountRepositoryWrapper;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountTransaction;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountTransactionRepository;
+import org.apache.fineract.portfolio.savings.domain.SavingsHelper;
 import org.apache.fineract.portfolio.savings.exception.SavingsAccountTransactionNotFoundException;
 import org.apache.fineract.portfolio.savings.exception.TransactionUpdateNotAllowedException;
 import org.apache.fineract.useradministration.domain.AppUser;
@@ -113,6 +114,7 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
     private final SavingsAccountRepositoryWrapper savingAccountRepositoryWrapper;
     private final SavingsAccountTransactionRepository savingsAccountTransactionRepository;
     private final DepositAccountAssembler depositAccountAssembler;
+    private final SavingsHelper savingsHelper;
     private final SavingsAccountPostInterestService savingsAccountPostInterestService;
     private final DepositAccountTransactionDataValidator depositAccountTransactionDataValidator;
     private final SavingsAccountChargeDataValidator savingsAccountChargeDataValidator;
@@ -189,7 +191,7 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
                 } else {
                     final LocalDate today = DateUtils.getBusinessLocalDate();
                     account.calculateInterestUsing(mc, today, isInterestTransfer, isSavingsInterestPostingAtCurrentPeriodEnd,
-                            financialYearBeginningMonth, postInterestOnDate, false, postReversals);
+                            financialYearBeginningMonth, postInterestOnDate, false, postReversals, this.savingsHelper);
                 }
 
                 updateExistingTransactionsDetails(account, existingTransactionIds, existingReversedTransactionIds);
@@ -197,7 +199,7 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
 
             final boolean isPreMatureClosure = false;
             account.updateMaturityDateAndAmount(mc, isPreMatureClosure, isSavingsInterestPostingAtCurrentPeriodEnd,
-                    financialYearBeginningMonth);
+                    financialYearBeginningMonth, this.savingsHelper);
             List<DepositAccountOnHoldTransaction> depositAccountOnHoldTransactions = null;
             if (account.getOnHoldFunds().compareTo(BigDecimal.ZERO) > 0) {
                 depositAccountOnHoldTransactions = this.depositAccountOnHoldTransactionRepository
@@ -298,7 +300,7 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
                 frequency = frequency == -1 ? 1 : frequency;
                 account.generateSchedule(frequencyType, frequency, calendar);
                 account.updateMaturityDateAndAmount(mc, isPreMatureClosure, isSavingsInterestPostingAtCurrentPeriodEnd,
-                        financialYearBeginningMonth);
+                        financialYearBeginningMonth, this.savingsHelper);
             }
 
             final LocalDate overdueUptoDate = DateUtils.getBusinessLocalDate();
@@ -312,7 +314,7 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
             } else {
                 final LocalDate today = DateUtils.getBusinessLocalDate();
                 account.calculateInterestUsing(mc, today, isInterestTransfer, isSavingsInterestPostingAtCurrentPeriodEnd,
-                        financialYearBeginningMonth, postInterestOnDate, false, postReversals);
+                        financialYearBeginningMonth, postInterestOnDate, false, postReversals, this.savingsHelper);
             }
             List<DepositAccountOnHoldTransaction> depositAccountOnHoldTransactions = null;
             if (account.getOnHoldFunds().compareTo(BigDecimal.ZERO) > 0) {
@@ -388,7 +390,8 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
                 .assembleFrom(savingsId, DepositAccountType.RECURRING_DEPOSIT);
         DepositAccountRecurringDetail recurringDetail = recurringDepositAccount.getRecurringDetail();
         Map<String, Object> changes = recurringDetail.updateMandatoryRecommendedDepositAmount(mandatoryRecommendedDepositAmount,
-                depositAmountUpdateEffectiveFromDate, isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth);
+                depositAmountUpdateEffectiveFromDate, isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth,
+                this.savingsHelper);
 
         return new CommandProcessingResultBuilder() //
                 .withEntityId(savingsId) //
@@ -489,7 +492,7 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
         boolean isInterestTransfer = false;
         LocalDate postInterestOnDate = null;
         account.calculateInterestUsing(mc, today, isInterestTransfer, isSavingsInterestPostingAtCurrentPeriodEnd,
-                financialYearBeginningMonth, postInterestOnDate, false, postReversals);
+                financialYearBeginningMonth, postInterestOnDate, false, postReversals, this.savingsHelper);
 
         this.savingAccountRepositoryWrapper.save(account);
 
@@ -585,7 +588,7 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
                     false);
         } else {
             account.calculateInterestUsing(mc, today, isInterestTransfer, isSavingsInterestPostingAtCurrentPeriodEnd,
-                    financialYearBeginningMonth, postInterestOnDate, backdatedTxnsAllowedTill, postReversals);
+                    financialYearBeginningMonth, postInterestOnDate, backdatedTxnsAllowedTill, postReversals, this.savingsHelper);
         }
         List<DepositAccountOnHoldTransaction> depositAccountOnHoldTransactions = null;
         if (account.getOnHoldFunds().compareTo(BigDecimal.ZERO) > 0) {
@@ -595,8 +598,8 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
 
         account.validateAccountBalanceConstraints(SavingsApiConstants.undoTransactionAction, depositAccountOnHoldTransactions, false);
         final boolean isPreMatureClosure = false;
-        account.updateMaturityDateAndAmount(mc, isPreMatureClosure, isSavingsInterestPostingAtCurrentPeriodEnd,
-                financialYearBeginningMonth);
+        account.updateMaturityDateAndAmount(mc, isPreMatureClosure, isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth,
+                this.savingsHelper);
 
         this.savingAccountRepositoryWrapper.saveAndFlush(account);
         postJournalEntries(account, existingTransactionIds, existingReversedTransactionIds);
@@ -649,7 +652,7 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
                     isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth, postInterestOnDate, false, postReversals);
         } else {
             account.calculateInterestUsing(mc, today, isInterestTransfer, isSavingsInterestPostingAtCurrentPeriodEnd,
-                    financialYearBeginningMonth, postInterestOnDate, false, postReversals);
+                    financialYearBeginningMonth, postInterestOnDate, false, postReversals, this.savingsHelper);
         }
         List<DepositAccountOnHoldTransaction> depositAccountOnHoldTransactions = null;
         if (account.getOnHoldFunds().compareTo(BigDecimal.ZERO) > 0) {
@@ -660,8 +663,8 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
         account.validateAccountBalanceConstraints(SavingsApiConstants.undoTransactionAction, depositAccountOnHoldTransactions, false);
         // account.activateAccountBasedOnBalance();
         final boolean isPreMatureClosure = false;
-        account.updateMaturityDateAndAmount(mc, isPreMatureClosure, isSavingsInterestPostingAtCurrentPeriodEnd,
-                financialYearBeginningMonth);
+        account.updateMaturityDateAndAmount(mc, isPreMatureClosure, isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth,
+                this.savingsHelper);
 
         final LocalDate overdueUptoDate = DateUtils.getBusinessLocalDate();
 
@@ -756,7 +759,7 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
                     false);
         } else {
             account.calculateInterestUsing(mc, today, isInterestTransfer, isSavingsInterestPostingAtCurrentPeriodEnd,
-                    financialYearBeginningMonth, postInterestOnDate, backdatedTxnsAllowedTill, postReversals);
+                    financialYearBeginningMonth, postInterestOnDate, backdatedTxnsAllowedTill, postReversals, this.savingsHelper);
         }
         List<DepositAccountOnHoldTransaction> depositAccountOnHoldTransactions = null;
         if (account.getOnHoldFunds().compareTo(BigDecimal.ZERO) > 0) {
@@ -765,8 +768,8 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
         }
         account.validateAccountBalanceConstraints(SavingsApiConstants.adjustTransactionAction, depositAccountOnHoldTransactions, false);
         final boolean isPreMatureClosure = false;
-        account.updateMaturityDateAndAmount(mc, isPreMatureClosure, isSavingsInterestPostingAtCurrentPeriodEnd,
-                financialYearBeginningMonth);
+        account.updateMaturityDateAndAmount(mc, isPreMatureClosure, isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth,
+                this.savingsHelper);
 
         this.savingAccountRepositoryWrapper.saveAndFlush(account);
         postJournalEntries(account, existingTransactionIds, existingReversedTransactionIds);
@@ -850,7 +853,7 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
                     isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth, postInterestOnDate, false, postReversals);
         } else {
             account.calculateInterestUsing(mc, today, isInterestTransfer, isSavingsInterestPostingAtCurrentPeriodEnd,
-                    financialYearBeginningMonth, postInterestOnDate, false, postReversals);
+                    financialYearBeginningMonth, postInterestOnDate, false, postReversals, this.savingsHelper);
         }
         List<DepositAccountOnHoldTransaction> depositAccountOnHoldTransactions = null;
         if (account.getOnHoldFunds().compareTo(BigDecimal.ZERO) > 0) {
@@ -1057,7 +1060,6 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
 
         // Get Savings account from savings charge
         final SavingsAccount account = savingsAccountCharge.savingsAccount();
-        this.depositAccountAssembler.assignSavingAccountHelpers(account);
 
         final Set<Long> existingTransactionIds = new HashSet<>();
         final Set<Long> existingReversedTransactionIds = new HashSet<>();
@@ -1075,7 +1077,7 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
         } else {
             final LocalDate today = DateUtils.getBusinessLocalDate();
             account.calculateInterestUsing(mc, today, isInterestTransfer, isSavingsInterestPostingAtCurrentPeriodEnd,
-                    financialYearBeginningMonth, postInterestOnDate, false, postReversals);
+                    financialYearBeginningMonth, postInterestOnDate, false, postReversals, this.savingsHelper);
         }
         List<DepositAccountOnHoldTransaction> depositAccountOnHoldTransactions = null;
         if (account.getOnHoldFunds().compareTo(BigDecimal.ZERO) > 0) {
@@ -1158,7 +1160,6 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
 
         // Get Savings account from savings charge
         final SavingsAccount account = savingsAccountCharge.savingsAccount();
-        this.depositAccountAssembler.assignSavingAccountHelpers(account);
         final Set<Long> existingTransactionIds = new HashSet<>();
         final Set<Long> existingReversedTransactionIds = new HashSet<>();
         updateExistingTransactionsDetails(account, existingTransactionIds, existingReversedTransactionIds);
@@ -1174,7 +1175,7 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
         } else {
             final LocalDate today = DateUtils.getBusinessLocalDate();
             account.calculateInterestUsing(mc, today, isInterestTransfer, isSavingsInterestPostingAtCurrentPeriodEnd,
-                    financialYearBeginningMonth, postInterestOnDate, false, postReversals);
+                    financialYearBeginningMonth, postInterestOnDate, false, postReversals, this.savingsHelper);
         }
         List<DepositAccountOnHoldTransaction> depositAccountOnHoldTransactions = null;
         if (account.getOnHoldFunds().compareTo(BigDecimal.ZERO) > 0) {
@@ -1202,7 +1203,8 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
         updateExistingTransactionsDetails(account, existingTransactionIds, existingReversedTransactionIds);
 
         if (depositAccountType == DepositAccountType.FIXED_DEPOSIT) {
-            ((FixedDepositAccount) account).updateMaturityStatus(isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth);
+            ((FixedDepositAccount) account).updateMaturityStatus(isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth,
+                    this.savingsHelper);
             FixedDepositAccount fdAccount = ((FixedDepositAccount) account);
             // handle maturity instructions
 
@@ -1230,7 +1232,7 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
             }
         } else if (depositAccountType == DepositAccountType.RECURRING_DEPOSIT) {
             ((RecurringDepositAccount) account).updateMaturityStatus(isSavingsInterestPostingAtCurrentPeriodEnd,
-                    financialYearBeginningMonth, postReversals);
+                    financialYearBeginningMonth, postReversals, this.savingsHelper);
         }
         this.savingAccountRepositoryWrapper.saveAndFlush(account);
         postJournalEntries(account, existingTransactionIds, existingReversedTransactionIds);

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/DepositAccountWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/DepositAccountWritePlatformServiceJpaRepositoryImpl.java
@@ -105,6 +105,7 @@ import org.apache.fineract.portfolio.savings.domain.SavingsAccountRepositoryWrap
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountStatusType;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountTransaction;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountTransactionRepository;
+import org.apache.fineract.portfolio.savings.domain.SavingsHelper;
 import org.apache.fineract.portfolio.savings.exception.SavingsAccountTransactionNotFoundException;
 import org.apache.fineract.portfolio.savings.exception.TransactionUpdateNotAllowedException;
 import org.apache.fineract.useradministration.domain.AppUser;
@@ -119,6 +120,7 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
     private final SavingsAccountRepositoryWrapper savingAccountRepositoryWrapper;
     private final SavingsAccountTransactionRepository savingsAccountTransactionRepository;
     private final DepositAccountAssembler depositAccountAssembler;
+    private final SavingsHelper savingsHelper;
     private final SavingsAccountPostInterestService savingsAccountPostInterestService;
     private final DepositAccountTransactionDataValidator depositAccountTransactionDataValidator;
     private final SavingsAccountChargeDataValidator savingsAccountChargeDataValidator;
@@ -196,7 +198,7 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
                 } else {
                     final LocalDate today = DateUtils.getBusinessLocalDate();
                     account.calculateInterestUsing(mc, today, isInterestTransfer, isSavingsInterestPostingAtCurrentPeriodEnd,
-                            financialYearBeginningMonth, postInterestOnDate, false, postReversals);
+                            financialYearBeginningMonth, postInterestOnDate, false, postReversals, this.savingsHelper);
                 }
 
                 updateExistingTransactionsDetails(account, existingTransactionIds, existingReversedTransactionIds);
@@ -204,7 +206,7 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
 
             final boolean isPreMatureClosure = false;
             account.updateMaturityDateAndAmount(mc, isPreMatureClosure, isSavingsInterestPostingAtCurrentPeriodEnd,
-                    financialYearBeginningMonth);
+                    financialYearBeginningMonth, this.savingsHelper);
             List<DepositAccountOnHoldTransaction> depositAccountOnHoldTransactions = null;
             if (account.getOnHoldFunds().compareTo(BigDecimal.ZERO) > 0) {
                 depositAccountOnHoldTransactions = this.depositAccountOnHoldTransactionRepository
@@ -306,7 +308,7 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
                 frequency = frequency == -1 ? 1 : frequency;
                 account.generateSchedule(frequencyType, frequency, calendar);
                 account.updateMaturityDateAndAmount(mc, isPreMatureClosure, isSavingsInterestPostingAtCurrentPeriodEnd,
-                        financialYearBeginningMonth);
+                        financialYearBeginningMonth, this.savingsHelper);
             }
 
             final LocalDate overdueUptoDate = DateUtils.getBusinessLocalDate();
@@ -320,7 +322,7 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
             } else {
                 final LocalDate today = DateUtils.getBusinessLocalDate();
                 account.calculateInterestUsing(mc, today, isInterestTransfer, isSavingsInterestPostingAtCurrentPeriodEnd,
-                        financialYearBeginningMonth, postInterestOnDate, false, postReversals);
+                        financialYearBeginningMonth, postInterestOnDate, false, postReversals, this.savingsHelper);
             }
             List<DepositAccountOnHoldTransaction> depositAccountOnHoldTransactions = null;
             if (account.getOnHoldFunds().compareTo(BigDecimal.ZERO) > 0) {
@@ -396,7 +398,8 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
                 .assembleFrom(savingsId, DepositAccountType.RECURRING_DEPOSIT);
         DepositAccountRecurringDetail recurringDetail = recurringDepositAccount.getRecurringDetail();
         Map<String, Object> changes = recurringDetail.updateMandatoryRecommendedDepositAmount(mandatoryRecommendedDepositAmount,
-                depositAmountUpdateEffectiveFromDate, isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth);
+                depositAmountUpdateEffectiveFromDate, isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth,
+                this.savingsHelper);
 
         return new CommandProcessingResultBuilder() //
                 .withEntityId(savingsId) //
@@ -497,7 +500,7 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
         boolean isInterestTransfer = false;
         LocalDate postInterestOnDate = null;
         account.calculateInterestUsing(mc, today, isInterestTransfer, isSavingsInterestPostingAtCurrentPeriodEnd,
-                financialYearBeginningMonth, postInterestOnDate, false, postReversals);
+                financialYearBeginningMonth, postInterestOnDate, false, postReversals, this.savingsHelper);
 
         this.savingAccountRepositoryWrapper.save(account);
 
@@ -594,7 +597,7 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
                     false);
         } else {
             account.calculateInterestUsing(mc, today, isInterestTransfer, isSavingsInterestPostingAtCurrentPeriodEnd,
-                    financialYearBeginningMonth, postInterestOnDate, backdatedTxnsAllowedTill, postReversals);
+                    financialYearBeginningMonth, postInterestOnDate, backdatedTxnsAllowedTill, postReversals, this.savingsHelper);
         }
         List<DepositAccountOnHoldTransaction> depositAccountOnHoldTransactions = null;
         if (account.getOnHoldFunds().compareTo(BigDecimal.ZERO) > 0) {
@@ -604,8 +607,8 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
 
         account.validateAccountBalanceConstraints(SavingsApiConstants.undoTransactionAction, depositAccountOnHoldTransactions, false);
         final boolean isPreMatureClosure = false;
-        account.updateMaturityDateAndAmount(mc, isPreMatureClosure, isSavingsInterestPostingAtCurrentPeriodEnd,
-                financialYearBeginningMonth);
+        account.updateMaturityDateAndAmount(mc, isPreMatureClosure, isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth,
+                this.savingsHelper);
 
         this.savingAccountRepositoryWrapper.saveAndFlush(account);
         postJournalEntries(account, existingTransactionIds, existingReversedTransactionIds);
@@ -658,7 +661,7 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
                     isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth, postInterestOnDate, false, postReversals);
         } else {
             account.calculateInterestUsing(mc, today, isInterestTransfer, isSavingsInterestPostingAtCurrentPeriodEnd,
-                    financialYearBeginningMonth, postInterestOnDate, false, postReversals);
+                    financialYearBeginningMonth, postInterestOnDate, false, postReversals, this.savingsHelper);
         }
         List<DepositAccountOnHoldTransaction> depositAccountOnHoldTransactions = null;
         if (account.getOnHoldFunds().compareTo(BigDecimal.ZERO) > 0) {
@@ -669,8 +672,8 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
         account.validateAccountBalanceConstraints(SavingsApiConstants.undoTransactionAction, depositAccountOnHoldTransactions, false);
         // account.activateAccountBasedOnBalance();
         final boolean isPreMatureClosure = false;
-        account.updateMaturityDateAndAmount(mc, isPreMatureClosure, isSavingsInterestPostingAtCurrentPeriodEnd,
-                financialYearBeginningMonth);
+        account.updateMaturityDateAndAmount(mc, isPreMatureClosure, isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth,
+                this.savingsHelper);
 
         final LocalDate overdueUptoDate = DateUtils.getBusinessLocalDate();
 
@@ -765,7 +768,7 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
                     false);
         } else {
             account.calculateInterestUsing(mc, today, isInterestTransfer, isSavingsInterestPostingAtCurrentPeriodEnd,
-                    financialYearBeginningMonth, postInterestOnDate, backdatedTxnsAllowedTill, postReversals);
+                    financialYearBeginningMonth, postInterestOnDate, backdatedTxnsAllowedTill, postReversals, this.savingsHelper);
         }
         List<DepositAccountOnHoldTransaction> depositAccountOnHoldTransactions = null;
         if (account.getOnHoldFunds().compareTo(BigDecimal.ZERO) > 0) {
@@ -774,8 +777,8 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
         }
         account.validateAccountBalanceConstraints(SavingsApiConstants.adjustTransactionAction, depositAccountOnHoldTransactions, false);
         final boolean isPreMatureClosure = false;
-        account.updateMaturityDateAndAmount(mc, isPreMatureClosure, isSavingsInterestPostingAtCurrentPeriodEnd,
-                financialYearBeginningMonth);
+        account.updateMaturityDateAndAmount(mc, isPreMatureClosure, isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth,
+                this.savingsHelper);
 
         this.savingAccountRepositoryWrapper.saveAndFlush(account);
         postJournalEntries(account, existingTransactionIds, existingReversedTransactionIds);
@@ -859,7 +862,7 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
                     isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth, postInterestOnDate, false, postReversals);
         } else {
             account.calculateInterestUsing(mc, today, isInterestTransfer, isSavingsInterestPostingAtCurrentPeriodEnd,
-                    financialYearBeginningMonth, postInterestOnDate, false, postReversals);
+                    financialYearBeginningMonth, postInterestOnDate, false, postReversals, this.savingsHelper);
         }
         List<DepositAccountOnHoldTransaction> depositAccountOnHoldTransactions = null;
         if (account.getOnHoldFunds().compareTo(BigDecimal.ZERO) > 0) {
@@ -1073,7 +1076,7 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
         boolean isInterestTransfer = false;
         final boolean postReversals = false;
         savingsAccount.calculateInterestUsing(mc, transferDate, isInterestTransfer, isSavingsInterestPostingAtCurrentPeriodEnd,
-                financialYearBeginningMonth, postInterestOnDate, false, postReversals);
+                financialYearBeginningMonth, postInterestOnDate, false, postReversals, this.savingsHelper);
 
         this.savingsAccountTransactionRepository.save(newTransferTransaction);
         this.savingAccountRepositoryWrapper.saveAndFlush(savingsAccount);
@@ -1107,7 +1110,7 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
         boolean isInterestTransfer = false;
         LocalDate postInterestOnDate = null;
         savingsAccount.calculateInterestUsing(mc, transferDate, isInterestTransfer, isSavingsInterestPostingAtCurrentPeriodEnd,
-                financialYearBeginningMonth, postInterestOnDate, false, postReversals);
+                financialYearBeginningMonth, postInterestOnDate, false, postReversals, this.savingsHelper);
 
         this.savingsAccountTransactionRepository.save(withdrawtransferTransaction);
         this.savingAccountRepositoryWrapper.saveAndFlush(savingsAccount);
@@ -1151,7 +1154,7 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
         LocalDate postInterestOnDate = null;
         final MathContext mc = MathContext.DECIMAL64;
         savingsAccount.calculateInterestUsing(mc, transferDate, isInterestTransfer, isSavingsInterestPostingAtCurrentPeriodEnd,
-                financialYearBeginningMonth, postInterestOnDate, false, postReversals);
+                financialYearBeginningMonth, postInterestOnDate, false, postReversals, this.savingsHelper);
 
         this.savingsAccountTransactionRepository.save(acceptTransferTransaction);
         this.savingAccountRepositoryWrapper.saveAndFlush(savingsAccount);
@@ -1293,7 +1296,6 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
 
         // Get Savings account from savings charge
         final SavingsAccount account = savingsAccountCharge.savingsAccount();
-        this.depositAccountAssembler.assignSavingAccountHelpers(account);
 
         final Set<Long> existingTransactionIds = new HashSet<>();
         final Set<Long> existingReversedTransactionIds = new HashSet<>();
@@ -1311,7 +1313,7 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
         } else {
             final LocalDate today = DateUtils.getBusinessLocalDate();
             account.calculateInterestUsing(mc, today, isInterestTransfer, isSavingsInterestPostingAtCurrentPeriodEnd,
-                    financialYearBeginningMonth, postInterestOnDate, false, postReversals);
+                    financialYearBeginningMonth, postInterestOnDate, false, postReversals, this.savingsHelper);
         }
         List<DepositAccountOnHoldTransaction> depositAccountOnHoldTransactions = null;
         if (account.getOnHoldFunds().compareTo(BigDecimal.ZERO) > 0) {
@@ -1433,7 +1435,6 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
 
         // Get Savings account from savings charge
         final SavingsAccount account = savingsAccountCharge.savingsAccount();
-        this.depositAccountAssembler.assignSavingAccountHelpers(account);
         final Set<Long> existingTransactionIds = new HashSet<>();
         final Set<Long> existingReversedTransactionIds = new HashSet<>();
         updateExistingTransactionsDetails(account, existingTransactionIds, existingReversedTransactionIds);
@@ -1449,7 +1450,7 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
         } else {
             final LocalDate today = DateUtils.getBusinessLocalDate();
             account.calculateInterestUsing(mc, today, isInterestTransfer, isSavingsInterestPostingAtCurrentPeriodEnd,
-                    financialYearBeginningMonth, postInterestOnDate, false, postReversals);
+                    financialYearBeginningMonth, postInterestOnDate, false, postReversals, this.savingsHelper);
         }
         List<DepositAccountOnHoldTransaction> depositAccountOnHoldTransactions = null;
         if (account.getOnHoldFunds().compareTo(BigDecimal.ZERO) > 0) {
@@ -1478,7 +1479,8 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
         updateExistingTransactionsDetails(account, existingTransactionIds, existingReversedTransactionIds);
 
         if (depositAccountType == DepositAccountType.FIXED_DEPOSIT) {
-            ((FixedDepositAccount) account).updateMaturityStatus(isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth);
+            ((FixedDepositAccount) account).updateMaturityStatus(isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth,
+                    this.savingsHelper);
             FixedDepositAccount fdAccount = ((FixedDepositAccount) account);
             // handle maturity instructions
 
@@ -1506,7 +1508,7 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
             }
         } else if (depositAccountType == DepositAccountType.RECURRING_DEPOSIT) {
             ((RecurringDepositAccount) account).updateMaturityStatus(isSavingsInterestPostingAtCurrentPeriodEnd,
-                    financialYearBeginningMonth, postReversals);
+                    financialYearBeginningMonth, postReversals, this.savingsHelper);
         }
         this.savingAccountRepositoryWrapper.saveAndFlush(account);
         postJournalEntries(account, existingTransactionIds, existingReversedTransactionIds);

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/DepositApplicationProcessWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/DepositApplicationProcessWritePlatformServiceJpaRepositoryImpl.java
@@ -90,6 +90,7 @@ import org.apache.fineract.portfolio.savings.domain.SavingsAccount;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountCharge;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountChargeAssembler;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountRepositoryWrapper;
+import org.apache.fineract.portfolio.savings.domain.SavingsHelper;
 import org.apache.fineract.portfolio.savings.domain.SavingsProduct;
 import org.apache.fineract.portfolio.savings.domain.SavingsProductRepository;
 import org.apache.fineract.portfolio.savings.exception.SavingsProductNotFoundException;
@@ -102,6 +103,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class DepositApplicationProcessWritePlatformServiceJpaRepositoryImpl implements DepositApplicationProcessWritePlatformService {
 
     private final PlatformSecurityContext context;
+    private final SavingsHelper savingsHelper;
     private final SavingsAccountRepositoryWrapper savingAccountRepository;
     private final FixedDepositAccountRepository fixedDepositAccountRepository;
     private final RecurringDepositAccountRepository recurringDepositAccountRepository;
@@ -169,7 +171,7 @@ public class DepositApplicationProcessWritePlatformServiceJpaRepositoryImpl impl
             final boolean isPreMatureClosure = false;
 
             account.updateMaturityDateAndAmountBeforeAccountActivation(mc, isPreMatureClosure, isSavingsInterestPostingAtCurrentPeriodEnd,
-                    financialYearBeginningMonth);
+                    financialYearBeginningMonth, this.savingsHelper);
             this.fixedDepositAccountRepository.saveAndFlush(account);
 
             if (account.isAccountNumberRequiresAutoGeneration()) {
@@ -248,7 +250,7 @@ public class DepositApplicationProcessWritePlatformServiceJpaRepositoryImpl impl
             account.generateSchedule(frequencyType, frequency, calendar);
             final boolean isPreMatureClosure = false;
             account.updateMaturityDateAndAmount(mc, isPreMatureClosure, isSavingsInterestPostingAtCurrentPeriodEnd,
-                    financialYearBeginningMonth);
+                    financialYearBeginningMonth, this.savingsHelper);
             account.validateApplicableInterestRate();
             savingAccountRepository.save(account);
             businessEventNotifierService.notifyPostBusinessEvent(new RecurringDepositAccountCreateBusinessEvent(account));
@@ -353,7 +355,7 @@ public class DepositApplicationProcessWritePlatformServiceJpaRepositoryImpl impl
                 final MathContext mc = MathContext.DECIMAL64;
                 final boolean isPreMatureClosure = false;
                 account.updateMaturityDateAndAmountBeforeAccountActivation(mc, isPreMatureClosure,
-                        isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth);
+                        isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth, this.savingsHelper);
                 this.savingAccountRepository.save(account);
             }
 
@@ -450,7 +452,7 @@ public class DepositApplicationProcessWritePlatformServiceJpaRepositoryImpl impl
                 account.generateSchedule(frequencyType, frequency, calendar);
                 final boolean isPreMatureClosure = false;
                 account.updateMaturityDateAndAmount(mc, isPreMatureClosure, isSavingsInterestPostingAtCurrentPeriodEnd,
-                        financialYearBeginningMonth);
+                        financialYearBeginningMonth, this.savingsHelper);
                 account.validateApplicableInterestRate();
                 this.savingAccountRepository.save(account);
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformServiceJpaRepositoryImpl.java
@@ -56,7 +56,6 @@ import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResultBuilder;
 import org.apache.fineract.infrastructure.core.data.DataValidatorBuilder;
 import org.apache.fineract.infrastructure.core.domain.ExternalId;
-import org.apache.fineract.infrastructure.core.exception.ErrorHandler;
 import org.apache.fineract.infrastructure.core.exception.GeneralPlatformDomainRuleException;
 import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
 import org.apache.fineract.infrastructure.core.exception.PlatformDataIntegrityException;
@@ -118,6 +117,7 @@ import org.apache.fineract.portfolio.savings.domain.SavingsAccountRepositoryWrap
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountStatusType;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountTransaction;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountTransactionRepository;
+import org.apache.fineract.portfolio.savings.domain.SavingsHelper;
 import org.apache.fineract.portfolio.savings.exception.PostInterestAsOnDateException;
 import org.apache.fineract.portfolio.savings.exception.PostInterestAsOnDateException.PostInterestAsOnExceptionType;
 import org.apache.fineract.portfolio.savings.exception.PostInterestClosingDateException;
@@ -145,6 +145,7 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
     private final StaffRepositoryWrapper staffRepository;
     private final SavingsAccountTransactionRepository savingsAccountTransactionRepository;
     private final SavingsAccountAssembler savingAccountAssembler;
+    private final SavingsHelper savingsHelper;
     private final SavingsAccountTransactionDataValidator savingsAccountTransactionDataValidator;
     private final SavingsAccountChargeDataValidator savingsAccountChargeDataValidator;
     private final PaymentDetailWritePlatformService paymentDetailWritePlatformService;
@@ -167,7 +168,6 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
     private final SavingsAccountPostInterestService savingsAccountPostInterestService;
     private final SavingsAccountActivationService savingsAccountActivationService;
     private final ExternalIdFactory externalIdFactory;
-    private final ErrorHandler errorHandler;
 
     @Transactional
     @Override
@@ -528,7 +528,7 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
         final LocalDate postInterestOnDate = null;
         boolean postReversals = false;
         account.calculateInterestUsing(mc, today, isInterestTransfer, isSavingsInterestPostingAtCurrentPeriodEnd,
-                financialYearBeginningMonth, postInterestOnDate, backdatedTxnsAllowedTill, postReversals);
+                financialYearBeginningMonth, postInterestOnDate, backdatedTxnsAllowedTill, postReversals, this.savingsHelper);
 
         if (backdatedTxnsAllowedTill) {
             this.savingsAccountTransactionRepository.saveAll(account.getSavingsAccountTransactionsWithPivotConfig());
@@ -845,7 +845,7 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
                     isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth, postInterestOnDate, false, postReversals);
         } else {
             account.calculateInterestUsing(mc, today, isInterestTransfer, isSavingsInterestPostingAtCurrentPeriodEnd,
-                    financialYearBeginningMonth, postInterestOnDate, false, postReversals);
+                    financialYearBeginningMonth, postInterestOnDate, false, postReversals, this.savingsHelper);
         }
         List<DepositAccountOnHoldTransaction> depositAccountOnHoldTransactions = null;
         if (account.getOnHoldFunds().compareTo(BigDecimal.ZERO) > 0) {
@@ -947,7 +947,7 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
                     isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth, postInterestOnDate, false, postReversals);
         } else {
             account.calculateInterestUsing(mc, today, isInterestTransfer, isSavingsInterestPostingAtCurrentPeriodEnd,
-                    financialYearBeginningMonth, postInterestOnDate, false, postReversals);
+                    financialYearBeginningMonth, postInterestOnDate, false, postReversals, this.savingsHelper);
         }
         List<DepositAccountOnHoldTransaction> depositAccountOnHoldTransactions = null;
         if (account.getOnHoldFunds().compareTo(BigDecimal.ZERO) > 0) {
@@ -1115,7 +1115,6 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
         validateTransactionsForTransfer(savingsAccount, transferDate);
 
         final Integer financialYearBeginningMonth = this.configurationDomainService.retrieveFinancialYearBeginningMonth();
-        this.savingAccountAssembler.setHelpers(savingsAccount);
         final Set<Long> existingTransactionIds = new HashSet<>();
         final Set<Long> existingReversedTransactionIds = new HashSet<>();
         updateExistingTransactionsDetails(savingsAccount, existingTransactionIds, existingReversedTransactionIds);
@@ -1129,7 +1128,7 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
         LocalDate postInterestOnDate = null;
         boolean postReversals = false;
         savingsAccount.calculateInterestUsing(mc, transferDate, isInterestTransfer, isSavingsInterestPostingAtCurrentPeriodEnd,
-                financialYearBeginningMonth, postInterestOnDate, false, postReversals);
+                financialYearBeginningMonth, postInterestOnDate, false, postReversals, this.savingsHelper);
 
         this.savingsAccountTransactionRepository.save(newTransferTransaction);
         this.savingAccountRepositoryWrapper.saveAndFlush(savingsAccount);
@@ -1146,7 +1145,6 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
         final boolean isSavingsInterestPostingAtCurrentPeriodEnd = this.configurationDomainService
                 .isSavingsInterestPostingAtCurrentPeriodEnd();
         final Integer financialYearBeginningMonth = this.configurationDomainService.retrieveFinancialYearBeginningMonth();
-        this.savingAccountAssembler.setHelpers(savingsAccount);
         final Set<Long> existingTransactionIds = new HashSet<>();
         final Set<Long> existingReversedTransactionIds = new HashSet<>();
         updateExistingTransactionsDetails(savingsAccount, existingTransactionIds, existingReversedTransactionIds);
@@ -1160,7 +1158,7 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
         LocalDate postInterestOnDate = null;
         boolean postReversals = false;
         savingsAccount.calculateInterestUsing(mc, transferDate, isInterestTransfer, isSavingsInterestPostingAtCurrentPeriodEnd,
-                financialYearBeginningMonth, postInterestOnDate, false, postReversals);
+                financialYearBeginningMonth, postInterestOnDate, false, postReversals, this.savingsHelper);
 
         this.savingsAccountTransactionRepository.save(withdrawtransferTransaction);
         this.savingAccountRepositoryWrapper.saveAndFlush(savingsAccount);
@@ -1172,7 +1170,6 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
 
     @Override
     public void rejectSavingsTransfer(final SavingsAccount savingsAccount) {
-        this.savingAccountAssembler.setHelpers(savingsAccount);
         savingsAccount.setStatus(SavingsAccountStatusType.TRANSFER_ON_HOLD.getValue());
         this.savingAccountRepositoryWrapper.save(savingsAccount);
     }
@@ -1185,7 +1182,6 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
         final boolean isSavingsInterestPostingAtCurrentPeriodEnd = this.configurationDomainService
                 .isSavingsInterestPostingAtCurrentPeriodEnd();
         final Integer financialYearBeginningMonth = this.configurationDomainService.retrieveFinancialYearBeginningMonth();
-        this.savingAccountAssembler.setHelpers(savingsAccount);
         final Set<Long> existingTransactionIds = new HashSet<>();
         final Set<Long> existingReversedTransactionIds = new HashSet<>();
         updateExistingTransactionsDetails(savingsAccount, existingTransactionIds, existingReversedTransactionIds);
@@ -1202,7 +1198,7 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
         LocalDate postInterestOnDate = null;
         boolean postReversals = false;
         savingsAccount.calculateInterestUsing(mc, transferDate, isInterestTransfer, isSavingsInterestPostingAtCurrentPeriodEnd,
-                financialYearBeginningMonth, postInterestOnDate, false, postReversals);
+                financialYearBeginningMonth, postInterestOnDate, false, postReversals, this.savingsHelper);
 
         this.savingsAccountTransactionRepository.save(acceptTransferTransaction);
         this.savingAccountRepositoryWrapper.saveAndFlush(savingsAccount);
@@ -1380,7 +1376,7 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
         } else {
             final LocalDate today = DateUtils.getBusinessLocalDate();
             account.calculateInterestUsing(mc, today, isInterestTransfer, isSavingsInterestPostingAtCurrentPeriodEnd,
-                    financialYearBeginningMonth, postInterestOnDate, backdatedTxnsAllowedTill, postReversals);
+                    financialYearBeginningMonth, postInterestOnDate, backdatedTxnsAllowedTill, postReversals, this.savingsHelper);
         }
 
         List<DepositAccountOnHoldTransaction> depositAccountOnHoldTransactions = null;
@@ -1512,7 +1508,6 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
 
         // Get Savings account from savings charge
         final SavingsAccount account = savingsAccountCharge.savingsAccount();
-        this.savingAccountAssembler.assignSavingAccountHelpers(account);
         final Set<Long> existingTransactionIds = new HashSet<>();
         final Set<Long> existingReversedTransactionIds = new HashSet<>();
         Pageable sortedByDateAndIdDesc = PageRequest.of(0, 1, Sort.by("dateOf", "id").descending());
@@ -1537,7 +1532,7 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
         } else {
             final LocalDate today = DateUtils.getBusinessLocalDate();
             account.calculateInterestUsing(mc, today, isInterestTransfer, isSavingsInterestPostingAtCurrentPeriodEnd,
-                    financialYearBeginningMonth, postInterestOnDate, backdatedTxnsAllowedTill, postReversals);
+                    financialYearBeginningMonth, postInterestOnDate, backdatedTxnsAllowedTill, postReversals, this.savingsHelper);
         }
         List<DepositAccountOnHoldTransaction> depositAccountOnHoldTransactions = null;
 
@@ -1592,7 +1587,6 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
                 .findOneWithNotFoundDetection(savingsAccountChargeId, savingsAccountId);
 
         final SavingsAccount account = savingsAccountCharge.savingsAccount();
-        this.savingAccountAssembler.assignSavingAccountHelpers(account);
 
         final LocalDate inactivationOnDate = DateUtils.getBusinessLocalDate();
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccrualWritePlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccrualWritePlatformServiceImpl.java
@@ -48,6 +48,7 @@ import org.apache.fineract.portfolio.savings.domain.SavingsAccountAssembler;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountRepositoryWrapper;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountTransaction;
 import org.apache.fineract.portfolio.savings.domain.SavingsHelper;
+import org.apache.fineract.portfolio.savings.domain.SavingsInterestCalculationUtil;
 import org.apache.fineract.portfolio.savings.domain.interest.CompoundInterestValues;
 import org.apache.fineract.portfolio.savings.domain.interest.PostingPeriod;
 import org.apache.fineract.portfolio.savings.domain.interest.SavingsAccountTransactionDetailsForPostingPeriod;
@@ -120,8 +121,8 @@ public class SavingsAccrualWritePlatformServiceImpl implements SavingsAccrualWri
         final SavingsInterestCalculationDaysInYearType daysInYearType = SavingsInterestCalculationDaysInYearType
                 .fromInt(savingsAccount.getInterestCalculationDaysInYearType());
 
-        final List<LocalDateInterval> postingPeriodIntervals = this.savingsHelper.determineInterestPostingPeriods(fromDate, tillDate,
-                postingPeriodType, financialYearBeginningMonth, postedAsOnTransactionDates);
+        final List<LocalDateInterval> postingPeriodIntervals = SavingsInterestCalculationUtil.determineInterestPostingPeriods(fromDate,
+                tillDate, postingPeriodType, financialYearBeginningMonth, postedAsOnTransactionDates);
 
         final List<PostingPeriod> allPostingPeriods = new ArrayList<>();
         final MonetaryCurrency currency = savingsAccount.getCurrency();

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/starter/SavingsConfiguration.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/starter/SavingsConfiguration.java
@@ -25,7 +25,6 @@ import org.apache.fineract.infrastructure.accountnumberformat.domain.AccountNumb
 import org.apache.fineract.infrastructure.codes.service.CodeValueReadPlatformService;
 import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
 import org.apache.fineract.infrastructure.core.data.PaginationParametersDataValidator;
-import org.apache.fineract.infrastructure.core.exception.ErrorHandler;
 import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
 import org.apache.fineract.infrastructure.core.service.ExternalIdFactory;
 import org.apache.fineract.infrastructure.core.service.PaginationHelper;
@@ -90,7 +89,6 @@ import org.apache.fineract.portfolio.savings.domain.SavingsAccountChargeAssemble
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountChargeRepositoryWrapper;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountRepositoryWrapper;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountTransactionRepository;
-import org.apache.fineract.portfolio.savings.domain.SavingsAccountTransactionSummaryWrapper;
 import org.apache.fineract.portfolio.savings.domain.SavingsHelper;
 import org.apache.fineract.portfolio.savings.domain.SavingsProductAssembler;
 import org.apache.fineract.portfolio.savings.domain.SavingsProductRepository;
@@ -194,11 +192,13 @@ public class SavingsConfiguration {
     @Bean
     @ConditionalOnMissingBean(DepositAccountPreMatureCalculationPlatformService.class)
     public DepositAccountPreMatureCalculationPlatformService depositAccountPreMatureCalculationPlatformService(
-            FromJsonHelper fromJsonHelper, DepositAccountTransactionDataValidator depositAccountTransactionDataValidator,
-            DepositAccountAssembler depositAccountAssembler, SavingsAccountReadPlatformService savingsAccountReadPlatformService,
-            ConfigurationDomainService configurationDomainService, PaymentTypeReadService paymentTypeReadPlatformService) {
-        return new DepositAccountPreMatureCalculationPlatformServiceImpl(fromJsonHelper, depositAccountTransactionDataValidator,
-                depositAccountAssembler, savingsAccountReadPlatformService, configurationDomainService, paymentTypeReadPlatformService);
+            FromJsonHelper fromJsonHelper, SavingsHelper savingsHelper,
+            DepositAccountTransactionDataValidator depositAccountTransactionDataValidator, DepositAccountAssembler depositAccountAssembler,
+            SavingsAccountReadPlatformService savingsAccountReadPlatformService, ConfigurationDomainService configurationDomainService,
+            PaymentTypeReadService paymentTypeReadPlatformService) {
+        return new DepositAccountPreMatureCalculationPlatformServiceImpl(fromJsonHelper, savingsHelper,
+                depositAccountTransactionDataValidator, depositAccountAssembler, savingsAccountReadPlatformService,
+                configurationDomainService, paymentTypeReadPlatformService);
 
     }
 
@@ -226,7 +226,7 @@ public class SavingsConfiguration {
     public DepositAccountWritePlatformService depositAccountWritePlatformService(PlatformSecurityContext context,
             SavingsAccountRepositoryWrapper savingAccountRepositoryWrapper,
             SavingsAccountTransactionRepository savingsAccountTransactionRepository, DepositAccountAssembler depositAccountAssembler,
-            SavingsAccountPostInterestService savingsAccountPostInterestService,
+            SavingsHelper savingsHelper, SavingsAccountPostInterestService savingsAccountPostInterestService,
             DepositAccountTransactionDataValidator depositAccountTransactionDataValidator,
             SavingsAccountChargeDataValidator savingsAccountChargeDataValidator,
             PaymentDetailWritePlatformService paymentDetailWritePlatformService,
@@ -243,7 +243,7 @@ public class SavingsConfiguration {
 
     ) {
         return new DepositAccountWritePlatformServiceJpaRepositoryImpl(context, savingAccountRepositoryWrapper,
-                savingsAccountTransactionRepository, depositAccountAssembler, savingsAccountPostInterestService,
+                savingsAccountTransactionRepository, depositAccountAssembler, savingsHelper, savingsAccountPostInterestService,
                 depositAccountTransactionDataValidator, savingsAccountChargeDataValidator, paymentDetailWritePlatformService,
                 applicationCurrencyRepositoryWrapper, journalEntryWritePlatformService, depositAccountDomainService, noteRepository,
                 accountTransfersReadPlatformService, chargeRepository, savingsAccountChargeRepository,
@@ -255,7 +255,8 @@ public class SavingsConfiguration {
     @Bean
     @ConditionalOnMissingBean(DepositApplicationProcessWritePlatformService.class)
     public DepositApplicationProcessWritePlatformService depositApplicationProcessWritePlatformService(PlatformSecurityContext context,
-            SavingsAccountRepositoryWrapper savingAccountRepository, FixedDepositAccountRepository fixedDepositAccountRepository,
+            SavingsHelper savingsHelper, SavingsAccountRepositoryWrapper savingAccountRepository,
+            FixedDepositAccountRepository fixedDepositAccountRepository,
             RecurringDepositAccountRepository recurringDepositAccountRepository, DepositAccountAssembler depositAccountAssembler,
             DepositAccountDataValidator depositAccountDataValidator, AccountNumberGenerator accountNumberGenerator,
             ClientRepositoryWrapper clientRepository, GroupRepository groupRepository, SavingsProductRepository savingsProductRepository,
@@ -265,7 +266,7 @@ public class SavingsConfiguration {
             FromJsonHelper fromJsonHelper, CalendarInstanceRepository calendarInstanceRepository,
             ConfigurationDomainService configurationDomainService, AccountNumberFormatRepositoryWrapper accountNumberFormatRepository,
             BusinessEventNotifierService businessEventNotifierService) {
-        return new DepositApplicationProcessWritePlatformServiceJpaRepositoryImpl(context, savingAccountRepository,
+        return new DepositApplicationProcessWritePlatformServiceJpaRepositoryImpl(context, savingsHelper, savingAccountRepository,
                 fixedDepositAccountRepository, recurringDepositAccountRepository, depositAccountAssembler, depositAccountDataValidator,
                 accountNumberGenerator, clientRepository, groupRepository, savingsProductRepository, noteRepository, staffRepository,
                 savingsAccountApplicationTransitionApiJsonValidator, savingsAccountChargeAssembler, accountAssociationsRepository,
@@ -344,16 +345,15 @@ public class SavingsConfiguration {
 
     @Bean
     @ConditionalOnMissingBean(SavingsAccountPostInterestService.class)
-    public SavingsAccountPostInterestService savingsAccountPostInterestService(
-            SavingsAccountTransactionSummaryWrapper savingsAccountTransactionSummaryWrapper) {
-        return new SavingsAccountPostInterestServiceImpl(savingsAccountTransactionSummaryWrapper);
+    public SavingsAccountPostInterestService savingsAccountPostInterestService(SavingsHelper savingsHelper) {
+        return new SavingsAccountPostInterestServiceImpl(savingsHelper);
     }
 
     @Bean
     @ConditionalOnMissingBean(SavingsAccountActivationService.class)
     public SavingsAccountActivationService savingsAccountActivationService(
-            SavingsAccountPostInterestService savingsAccountPostInterestService) {
-        return new SavingsAccountActivationServiceImpl(savingsAccountPostInterestService);
+            SavingsAccountPostInterestService savingsAccountPostInterestService, SavingsHelper savingsHelper) {
+        return new SavingsAccountActivationServiceImpl(savingsAccountPostInterestService, savingsHelper);
     }
 
     @Bean
@@ -384,7 +384,8 @@ public class SavingsConfiguration {
     public SavingsAccountWritePlatformService savingsAccountWritePlatformService(PlatformSecurityContext context,
             SavingsAccountDataValidator fromApiJsonDeserializer, SavingsAccountRepositoryWrapper savingAccountRepositoryWrapper,
             StaffRepositoryWrapper staffRepository, SavingsAccountTransactionRepository savingsAccountTransactionRepository,
-            SavingsAccountAssembler savingAccountAssembler, SavingsAccountTransactionDataValidator savingsAccountTransactionDataValidator,
+            SavingsAccountAssembler savingAccountAssembler, SavingsHelper savingsHelper,
+            SavingsAccountTransactionDataValidator savingsAccountTransactionDataValidator,
             SavingsAccountChargeDataValidator savingsAccountChargeDataValidator,
             PaymentDetailWritePlatformService paymentDetailWritePlatformService, SavingsAccountDomainService savingsAccountDomainService,
             NoteRepository noteRepository, AccountTransfersReadPlatformService accountTransfersReadPlatformService,
@@ -396,16 +397,15 @@ public class SavingsConfiguration {
             StandingInstructionRepository standingInstructionRepository, BusinessEventNotifierService businessEventNotifierService,
             GSIMRepositoy gsimRepository, SavingsAccountInterestPostingService savingsAccountInterestPostingService,
             SavingsAccountPostInterestService savingsAccountPostInterestService,
-            SavingsAccountActivationService savingsAccountActivationService, ExternalIdFactory externalIdFactory,
-            ErrorHandler errorHandler) {
+            SavingsAccountActivationService savingsAccountActivationService, ExternalIdFactory externalIdFactory) {
         return new SavingsAccountWritePlatformServiceJpaRepositoryImpl(context, fromApiJsonDeserializer, savingAccountRepositoryWrapper,
-                staffRepository, savingsAccountTransactionRepository, savingAccountAssembler, savingsAccountTransactionDataValidator,
-                savingsAccountChargeDataValidator, paymentDetailWritePlatformService, savingsAccountDomainService, noteRepository,
-                accountTransfersReadPlatformService, accountAssociationsReadPlatformService, chargeRepository,
-                savingsAccountChargeRepository, holidayRepository, workingDaysRepository, configurationDomainService,
+                staffRepository, savingsAccountTransactionRepository, savingAccountAssembler, savingsHelper,
+                savingsAccountTransactionDataValidator, savingsAccountChargeDataValidator, paymentDetailWritePlatformService,
+                savingsAccountDomainService, noteRepository, accountTransfersReadPlatformService, accountAssociationsReadPlatformService,
+                chargeRepository, savingsAccountChargeRepository, holidayRepository, workingDaysRepository, configurationDomainService,
                 depositAccountOnHoldTransactionRepository, entityDatatableChecksWritePlatformService, appuserRepository,
                 standingInstructionRepository, businessEventNotifierService, gsimRepository, savingsAccountInterestPostingService,
-                savingsAccountPostInterestService, savingsAccountActivationService, externalIdFactory, errorHandler);
+                savingsAccountPostInterestService, savingsAccountActivationService, externalIdFactory);
     }
 
     @Bean

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccount.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccount.java
@@ -73,7 +73,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
 import org.apache.fineract.infrastructure.configuration.service.TemporaryConfigurationServiceContainer;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
 import org.apache.fineract.infrastructure.core.data.ApiParameterError;
@@ -319,10 +318,6 @@ public class SavingsAccount extends AbstractAuditableWithUTCDateTimeCustom<Long>
     @Transient
     protected boolean accountNumberRequiresAutoGeneration = false;
     @Transient
-    protected SavingsAccountTransactionSummaryWrapper savingsAccountTransactionSummaryWrapper;
-    @Transient
-    protected SavingsHelper savingsHelper;
-    @Transient
     protected List<SavingsAccountTransaction> savingsAccountTransactions = new ArrayList<>();
     @Transient
     private List<SavingsAccountTransactionReplacement> transactionReplacements = new ArrayList<>();
@@ -350,8 +345,6 @@ public class SavingsAccount extends AbstractAuditableWithUTCDateTimeCustom<Long>
     private BigDecimal savingsOnHoldAmount;
     @OneToMany(cascade = CascadeType.ALL, mappedBy = "account", orphanRemoval = true, fetch = FetchType.LAZY)
     protected List<InteropIdentifier> identifiers = new ArrayList<>();
-
-    public transient ConfigurationDomainService configurationDomainService;
 
     protected SavingsAccount() {
         //
@@ -454,17 +447,6 @@ public class SavingsAccount extends AbstractAuditableWithUTCDateTimeCustom<Long>
         // this.savingsOfficerHistory = null;
         this.withHoldTax = withHoldTax;
         this.taxGroup = product.getTaxGroup();
-    }
-
-    /**
-     * Used after fetching/hydrating a {@link SavingsAccount} object to inject helper services/components used for
-     * update summary details after events/transactions on a {@link SavingsAccount}.
-     */
-    public void setHelpers(final SavingsAccountTransactionSummaryWrapper savingsAccountTransactionSummaryWrapper,
-            final SavingsHelper savingsHelper, final ConfigurationDomainService configurationDomainService) {
-        this.savingsAccountTransactionSummaryWrapper = savingsAccountTransactionSummaryWrapper;
-        this.savingsHelper = savingsHelper;
-        this.configurationDomainService = configurationDomainService;
     }
 
     public void setSavingsAccountTransactions(final List<SavingsAccountTransaction> savingsAccountTransactions) {
@@ -695,7 +677,8 @@ public class SavingsAccount extends AbstractAuditableWithUTCDateTimeCustom<Long>
 
     public List<PostingPeriod> calculateInterestUsing(final MathContext mc, final LocalDate upToInterestCalculationDate,
             boolean isInterestTransfer, final boolean isSavingsInterestPostingAtCurrentPeriodEnd, final Integer financialYearBeginningMonth,
-            final LocalDate postInterestOnDate, final boolean backdatedTxnsAllowedTill, final boolean postReversals) {
+            final LocalDate postInterestOnDate, final boolean backdatedTxnsAllowedTill, final boolean postReversals,
+            final SavingsHelper savingsHelper) {
 
         // no openingBalance concept supported yet but probably will to allow for
         // migrations.
@@ -730,7 +713,7 @@ public class SavingsAccount extends AbstractAuditableWithUTCDateTimeCustom<Long>
             if (postInterestOnDate != null) {
                 postedAsOnDates.add(postInterestOnDate);
             }
-            final List<LocalDateInterval> postingPeriodIntervals = this.savingsHelper.determineInterestPostingPeriods(
+            final List<LocalDateInterval> postingPeriodIntervals = SavingsInterestCalculationUtil.determineInterestPostingPeriods(
                     getStartInterestCalculationDate(), upToInterestCalculationDate, postingPeriodType, financialYearBeginningMonth,
                     postedAsOnDates);
 
@@ -757,7 +740,7 @@ public class SavingsAccount extends AbstractAuditableWithUTCDateTimeCustom<Long>
                     .fromInt(this.interestCalculationType);
             final BigDecimal interestRateAsFraction = getEffectiveInterestRateAsFraction(mc, upToInterestCalculationDate);
             final BigDecimal overdraftInterestRateAsFraction = getEffectiveOverdraftInterestRateAsFraction(mc);
-            final Collection<Long> interestPostTransactions = this.savingsHelper.fetchPostInterestTransactionIds(getId());
+            final Collection<Long> interestPostTransactions = savingsHelper.fetchPostInterestTransactionIds(getId());
             final Money minBalanceForInterestCalculation = Money.of(getCurrency(), minBalanceForInterestCalculation());
             final Money minOverdraftForInterestCalculation = Money.of(getCurrency(), this.minOverdraftForInterestCalculation);
 
@@ -790,17 +773,16 @@ public class SavingsAccount extends AbstractAuditableWithUTCDateTimeCustom<Long>
                 allPostingPeriods.add(postingPeriod);
             }
 
-            this.savingsHelper.calculateInterestForAllPostingPeriods(this.currency, allPostingPeriods, getLockedInUntilDate(),
+            SavingsInterestCalculationUtil.calculateInterestForAllPostingPeriods(this.currency, allPostingPeriods, getLockedInUntilDate(),
                     isTransferInterestToOtherAccount());
 
             this.summary.updateFromInterestPeriodSummaries(this.currency, allPostingPeriods);
         }
 
         if (backdatedTxnsAllowedTill) {
-            this.summary.updateSummaryWithPivotConfig(this.currency, this.savingsAccountTransactionSummaryWrapper, null,
-                    this.savingsAccountTransactions);
+            this.summary.updateSummaryWithPivotConfig(this.currency, null, this.savingsAccountTransactions);
         } else {
-            this.summary.updateSummary(this.currency, this.savingsAccountTransactionSummaryWrapper, this.transactions);
+            this.summary.updateSummary(this.currency, this.transactions);
         }
 
         return allPostingPeriods;
@@ -1063,8 +1045,7 @@ public class SavingsAccount extends AbstractAuditableWithUTCDateTimeCustom<Long>
         }
 
         if (backdatedTxnsAllowedTill) {
-            this.summary.updateSummaryWithPivotConfig(this.currency, this.savingsAccountTransactionSummaryWrapper, transaction,
-                    this.savingsAccountTransactions);
+            this.summary.updateSummaryWithPivotConfig(this.currency, transaction, this.savingsAccountTransactions);
         }
 
         return transaction;
@@ -1198,8 +1179,7 @@ public class SavingsAccount extends AbstractAuditableWithUTCDateTimeCustom<Long>
             this.sub_status = SavingsAccountSubStatusEnum.NONE.getValue();
         }
         if (backdatedTxnsAllowedTill) {
-            this.summary.updateSummaryWithPivotConfig(this.currency, this.savingsAccountTransactionSummaryWrapper, transaction,
-                    this.savingsAccountTransactions);
+            this.summary.updateSummaryWithPivotConfig(this.currency, transaction, this.savingsAccountTransactions);
         }
         return transaction;
     }
@@ -1339,7 +1319,7 @@ public class SavingsAccount extends AbstractAuditableWithUTCDateTimeCustom<Long>
 
     public void validateAccountBalanceConstraints(final BigDecimal transactionAmount, final boolean isException,
             final List<DepositAccountOnHoldTransaction> depositAccountOnHoldTransactions, final boolean backdatedTxnsAllowedTill,
-            final boolean isForceWithdrawal) {
+            final boolean isForceWithdrawal, final boolean forceWithdrawalEnabled, final Long forceWithdrawalLimit) {
 
         List<SavingsAccountTransaction> transactionsSortedByDate = backdatedTxnsAllowedTill ? retrieveSortedTransactions()
                 : retrieveListOfTransactions();
@@ -1368,7 +1348,7 @@ public class SavingsAccount extends AbstractAuditableWithUTCDateTimeCustom<Long>
             // enforceMinRequiredBalance
             if (!isException && transaction.canProcessBalanceCheck() && !isOverdraft()) {
                 if (violatesMinRequiredBalance(runningBalance, minRequiredBalance)
-                        && !isForceWithdrawalAllowed(isForceWithdrawal, runningBalance)) {
+                        && !isForceWithdrawalAllowed(isForceWithdrawal, runningBalance, forceWithdrawalEnabled, forceWithdrawalLimit)) {
                     throw new InsufficientAccountBalanceException("transactionAmount", getAccountBalance(), withdrawalFee,
                             transactionAmount);
                 }
@@ -1382,7 +1362,7 @@ public class SavingsAccount extends AbstractAuditableWithUTCDateTimeCustom<Long>
         // and should be checked after processing all transactions
         if (isOverdraft()) {
             if (violatesMinRequiredBalance(runningBalance, minRequiredBalance)
-                    && !isForceWithdrawalAllowed(isForceWithdrawal, runningBalance)) {
+                    && !isForceWithdrawalAllowed(isForceWithdrawal, runningBalance, forceWithdrawalEnabled, forceWithdrawalLimit)) {
                 throw new InsufficientAccountBalanceException("transactionAmount", getAccountBalance(), withdrawalFee, transactionAmount);
             }
         }
@@ -1441,17 +1421,18 @@ public class SavingsAccount extends AbstractAuditableWithUTCDateTimeCustom<Long>
      *            whether the current transaction is a force withdrawal
      * @param runningBalance
      *            the current running balance of the account
+     * @param forceWithdrawalEnabled
+     *            whether force withdrawal on savings accounts is globally enabled
+     * @param forceWithdrawalLimit
+     *            the configured negative balance limit allowed for a force withdrawal
      * @return true if force withdrawal is enabled and the running balance is within the allowed negative limit
      */
-    private boolean isForceWithdrawalAllowed(final boolean isForceWithdrawal, final Money runningBalance) {
-        if (!isForceWithdrawal || this.configurationDomainService == null) {
+    private boolean isForceWithdrawalAllowed(final boolean isForceWithdrawal, final Money runningBalance,
+            final boolean forceWithdrawalEnabled, final Long forceWithdrawalLimit) {
+        if (!isForceWithdrawal || !forceWithdrawalEnabled || forceWithdrawalLimit == null) {
             return false;
         }
-        if (!this.configurationDomainService.isForceWithdrawalOnSavingsAccountEnabled()) {
-            return false;
-        }
-        Long limit = this.configurationDomainService.retrieveForceWithdrawalOnSavingsAccountLimit();
-        BigDecimal limitBd = BigDecimal.valueOf(limit);
+        BigDecimal limitBd = BigDecimal.valueOf(forceWithdrawalLimit);
         if (limitBd.compareTo(BigDecimal.ZERO) > 0) {
             limitBd = limitBd.negate();
         }
@@ -3094,8 +3075,7 @@ public class SavingsAccount extends AbstractAuditableWithUTCDateTimeCustom<Long>
         transaction.getSavingsAccountChargesPaid().add(chargePaidBy);
         if (backdatedTxnsAllowedTill) {
             this.savingsAccountTransactions.add(transaction);
-            this.summary.updateSummaryWithPivotConfig(this.currency, this.savingsAccountTransactionSummaryWrapper, transaction,
-                    this.savingsAccountTransactions);
+            this.summary.updateSummaryWithPivotConfig(this.currency, transaction, this.savingsAccountTransactions);
         } else {
             this.transactions.add(transaction);
         }
@@ -3346,7 +3326,7 @@ public class SavingsAccount extends AbstractAuditableWithUTCDateTimeCustom<Long>
             final boolean backdatedTxnsAllowedTill) {
         final List<SavingsAccountTransaction> withholdTransactions = findWithHoldTransactions();
         SavingsAccountTransaction withholdTransaction = findTransactionFor(interestPostingUpToDate, withholdTransactions);
-        final BigDecimal totalInterestPosted = this.savingsAccountTransactionSummaryWrapper.calculateTotalInterestPosted(this.currency,
+        final BigDecimal totalInterestPosted = SavingsAccountTransactionSummaryWrapper.calculateTotalInterestPosted(this.currency,
                 this.transactions);
         if (withholdTransaction == null && this.withHoldTax()) {
             boolean isWithholdTaxAdded = createWithHoldTransaction(totalInterestPosted, interestPostingUpToDate, backdatedTxnsAllowedTill);
@@ -3372,7 +3352,7 @@ public class SavingsAccount extends AbstractAuditableWithUTCDateTimeCustom<Long>
         }
         boolean postReversals = false;
         recalculateDailyBalances(Money.zero(this.currency), transactionDate, backdatedTxnsAllowedTill, postReversals);
-        this.summary.updateSummary(this.currency, this.savingsAccountTransactionSummaryWrapper, this.transactions);
+        this.summary.updateSummary(this.currency, this.transactions);
     }
 
     public void setSubStatusDormant() {
@@ -3392,7 +3372,7 @@ public class SavingsAccount extends AbstractAuditableWithUTCDateTimeCustom<Long>
             this.transactions.add(transaction);
         }
         recalculateDailyBalances(Money.zero(this.currency), transactionDate, false, postReversals);
-        this.summary.updateSummary(this.currency, this.savingsAccountTransactionSummaryWrapper, this.transactions);
+        this.summary.updateSummary(this.currency, this.transactions);
     }
 
     public void loadLazyCollections() {
@@ -3405,7 +3385,7 @@ public class SavingsAccount extends AbstractAuditableWithUTCDateTimeCustom<Long>
     }
 
     public void updateSavingsAccountSummary(final List<SavingsAccountTransaction> transactions) {
-        this.summary.updateSummary(this.currency, this.savingsAccountTransactionSummaryWrapper, transactions);
+        this.summary.updateSummary(this.currency, transactions);
     }
 
     public void updateReason(final String reasonForBlock) {

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountSummary.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountSummary.java
@@ -90,20 +90,20 @@ public final class SavingsAccountSummary {
         //
     }
 
-    public void updateSummary(final MonetaryCurrency currency, final SavingsAccountTransactionSummaryWrapper wrapper,
-            final List<SavingsAccountTransaction> transactions) {
+    public void updateSummary(final MonetaryCurrency currency, final List<SavingsAccountTransaction> transactions) {
 
-        this.totalDeposits = wrapper.calculateTotalDeposits(currency, transactions);
-        this.totalWithdrawals = wrapper.calculateTotalWithdrawals(currency, transactions);
-        this.totalInterestPosted = wrapper.calculateTotalInterestPosted(currency, transactions);
-        this.totalWithdrawalFees = wrapper.calculateTotalWithdrawalFees(currency, transactions);
-        this.totalAnnualFees = wrapper.calculateTotalAnnualFees(currency, transactions);
-        this.totalFeeCharge = wrapper.calculateTotalFeesCharge(currency, transactions);
-        this.totalPenaltyCharge = wrapper.calculateTotalPenaltyCharge(currency, transactions);
-        this.totalFeeChargesWaived = wrapper.calculateTotalFeesChargeWaived(currency, transactions);
-        this.totalPenaltyChargesWaived = wrapper.calculateTotalPenaltyChargeWaived(currency, transactions);
-        this.totalOverdraftInterestDerived = wrapper.calculateTotalOverdraftInterest(currency, transactions);
-        this.totalWithholdTax = wrapper.calculateTotalWithholdTaxWithdrawal(currency, transactions);
+        this.totalDeposits = SavingsAccountTransactionSummaryWrapper.calculateTotalDeposits(currency, transactions);
+        this.totalWithdrawals = SavingsAccountTransactionSummaryWrapper.calculateTotalWithdrawals(currency, transactions);
+        this.totalInterestPosted = SavingsAccountTransactionSummaryWrapper.calculateTotalInterestPosted(currency, transactions);
+        this.totalWithdrawalFees = SavingsAccountTransactionSummaryWrapper.calculateTotalWithdrawalFees(currency, transactions);
+        this.totalAnnualFees = SavingsAccountTransactionSummaryWrapper.calculateTotalAnnualFees(currency, transactions);
+        this.totalFeeCharge = SavingsAccountTransactionSummaryWrapper.calculateTotalFeesCharge(currency, transactions);
+        this.totalPenaltyCharge = SavingsAccountTransactionSummaryWrapper.calculateTotalPenaltyCharge(currency, transactions);
+        this.totalFeeChargesWaived = SavingsAccountTransactionSummaryWrapper.calculateTotalFeesChargeWaived(currency, transactions);
+        this.totalPenaltyChargesWaived = SavingsAccountTransactionSummaryWrapper.calculateTotalPenaltyChargeWaived(currency, transactions);
+        this.totalOverdraftInterestDerived = SavingsAccountTransactionSummaryWrapper.calculateTotalOverdraftInterest(currency,
+                transactions);
+        this.totalWithholdTax = SavingsAccountTransactionSummaryWrapper.calculateTotalWithholdTaxWithdrawal(currency, transactions);
 
         updateRunningBalanceAndPivotDate(false, transactions, null, null, null, currency);
 
@@ -112,8 +112,8 @@ public final class SavingsAccountSummary {
                 .minus(totalOverdraftInterestDerived).minus(totalWithholdTax).getAmount();
     }
 
-    public void updateSummaryWithPivotConfig(final MonetaryCurrency currency, final SavingsAccountTransactionSummaryWrapper wrapper,
-            final SavingsAccountTransaction transaction, final List<SavingsAccountTransaction> savingsAccountTransactions) {
+    public void updateSummaryWithPivotConfig(final MonetaryCurrency currency, final SavingsAccountTransaction transaction,
+            final List<SavingsAccountTransaction> savingsAccountTransactions) {
 
         if (transaction != null) {
             if (transaction.isReversalTransaction()) {
@@ -187,8 +187,8 @@ public final class SavingsAccountSummary {
             Money interestTotal = Money.zero(currency);
             Money withHoldTaxTotal = Money.zero(currency);
             Money overdraftInterestTotal = Money.zero(currency);
-            this.totalDeposits = wrapper.calculateTotalDeposits(currency, savingsAccountTransactions);
-            this.totalWithdrawals = wrapper.calculateTotalWithdrawals(currency, savingsAccountTransactions);
+            this.totalDeposits = SavingsAccountTransactionSummaryWrapper.calculateTotalDeposits(currency, savingsAccountTransactions);
+            this.totalWithdrawals = SavingsAccountTransactionSummaryWrapper.calculateTotalWithdrawals(currency, savingsAccountTransactions);
 
             final HashMap<String, Money> map = updateRunningBalanceAndPivotDate(true, savingsAccountTransactions, interestTotal,
                     overdraftInterestTotal, withHoldTaxTotal, currency);

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountTransactionSummaryWrapper.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountTransactionSummaryWrapper.java
@@ -22,16 +22,17 @@ import java.math.BigDecimal;
 import java.util.List;
 import org.apache.fineract.organisation.monetary.domain.MonetaryCurrency;
 import org.apache.fineract.organisation.monetary.domain.Money;
-import org.springframework.stereotype.Component;
 
 /**
- * A wrapper for dealing with side-effect free functionality related to a {@link SavingsAccount}'s
- * {@link SavingsAccountTransaction}'s.
+ * A utility for dealing with side-effect free functionality related to a {@link SavingsAccount}'s
+ * {@link SavingsAccountTransaction}'s. All methods are static as they are pure functions over the supplied
+ * transactions.
  */
-@Component
 public final class SavingsAccountTransactionSummaryWrapper {
 
-    public BigDecimal calculateTotalDeposits(final MonetaryCurrency currency, final List<SavingsAccountTransaction> transactions) {
+    private SavingsAccountTransactionSummaryWrapper() {}
+
+    public static BigDecimal calculateTotalDeposits(final MonetaryCurrency currency, final List<SavingsAccountTransaction> transactions) {
         Money total = Money.zero(currency);
         for (final SavingsAccountTransaction transaction : transactions) {
             if ((transaction.isDepositAndNotReversed() || transaction.isDividendPayoutAndNotReversed())
@@ -42,7 +43,8 @@ public final class SavingsAccountTransactionSummaryWrapper {
         return total.getAmountDefaultedToNullIfZero();
     }
 
-    public BigDecimal calculateTotalWithdrawals(final MonetaryCurrency currency, final List<SavingsAccountTransaction> transactions) {
+    public static BigDecimal calculateTotalWithdrawals(final MonetaryCurrency currency,
+            final List<SavingsAccountTransaction> transactions) {
         Money total = Money.zero(currency);
         for (final SavingsAccountTransaction transaction : transactions) {
             if (transaction.isWithdrawal() && transaction.isNotReversed() && !transaction.isReversalTransaction()) {
@@ -52,7 +54,8 @@ public final class SavingsAccountTransactionSummaryWrapper {
         return total.getAmountDefaultedToNullIfZero();
     }
 
-    public BigDecimal calculateTotalInterestPosted(final MonetaryCurrency currency, final List<SavingsAccountTransaction> transactions) {
+    public static BigDecimal calculateTotalInterestPosted(final MonetaryCurrency currency,
+            final List<SavingsAccountTransaction> transactions) {
         Money total = Money.zero(currency);
         for (final SavingsAccountTransaction transaction : transactions) {
             if (transaction.isInterestPostingAndNotReversed() && transaction.isNotReversed() && !transaction.isReversalTransaction()) {
@@ -62,7 +65,7 @@ public final class SavingsAccountTransactionSummaryWrapper {
         return total.getAmountDefaultedToNullIfZero();
     }
 
-    public BigDecimal calculateTotalInterestPosted(final MonetaryCurrency currency, final BigDecimal currentInterestPosted,
+    public static BigDecimal calculateTotalInterestPosted(final MonetaryCurrency currency, final BigDecimal currentInterestPosted,
             final List<SavingsAccountTransaction> savingsAccountTransactions) {
         Money total = Money.of(currency, currentInterestPosted);
         for (final SavingsAccountTransaction transaction : savingsAccountTransactions) {
@@ -73,7 +76,8 @@ public final class SavingsAccountTransactionSummaryWrapper {
         return total.getAmountDefaultedToNullIfZero();
     }
 
-    public BigDecimal calculateTotalWithdrawalFees(final MonetaryCurrency currency, final List<SavingsAccountTransaction> transactions) {
+    public static BigDecimal calculateTotalWithdrawalFees(final MonetaryCurrency currency,
+            final List<SavingsAccountTransaction> transactions) {
         Money total = Money.zero(currency);
         for (final SavingsAccountTransaction transaction : transactions) {
             if (transaction.isWithdrawalFeeAndNotReversed() && transaction.isNotReversed() && !transaction.isReversalTransaction()) {
@@ -83,7 +87,7 @@ public final class SavingsAccountTransactionSummaryWrapper {
         return total.getAmountDefaultedToNullIfZero();
     }
 
-    public BigDecimal calculateTotalAnnualFees(final MonetaryCurrency currency, final List<SavingsAccountTransaction> transactions) {
+    public static BigDecimal calculateTotalAnnualFees(final MonetaryCurrency currency, final List<SavingsAccountTransaction> transactions) {
         Money total = Money.zero(currency);
         for (final SavingsAccountTransaction transaction : transactions) {
             if (transaction.isAnnualFeeAndNotReversed() && transaction.isNotReversed() && !transaction.isReversalTransaction()) {
@@ -93,7 +97,7 @@ public final class SavingsAccountTransactionSummaryWrapper {
         return total.getAmountDefaultedToNullIfZero();
     }
 
-    public BigDecimal calculateTotalFeesCharge(final MonetaryCurrency currency, final List<SavingsAccountTransaction> transactions) {
+    public static BigDecimal calculateTotalFeesCharge(final MonetaryCurrency currency, final List<SavingsAccountTransaction> transactions) {
         Money total = Money.zero(currency);
         for (final SavingsAccountTransaction transaction : transactions) {
             if (transaction.isFeeChargeAndNotReversed() && !transaction.isReversalTransaction()) {
@@ -103,7 +107,8 @@ public final class SavingsAccountTransactionSummaryWrapper {
         return total.getAmountDefaultedToNullIfZero();
     }
 
-    public BigDecimal calculateTotalFeesChargeWaived(final MonetaryCurrency currency, final List<SavingsAccountTransaction> transactions) {
+    public static BigDecimal calculateTotalFeesChargeWaived(final MonetaryCurrency currency,
+            final List<SavingsAccountTransaction> transactions) {
         Money total = Money.zero(currency);
         for (final SavingsAccountTransaction transaction : transactions) {
             if (transaction.isWaiveFeeChargeAndNotReversed() && !transaction.isReversalTransaction()) {
@@ -113,7 +118,8 @@ public final class SavingsAccountTransactionSummaryWrapper {
         return total.getAmountDefaultedToNullIfZero();
     }
 
-    public BigDecimal calculateTotalPenaltyCharge(final MonetaryCurrency currency, final List<SavingsAccountTransaction> transactions) {
+    public static BigDecimal calculateTotalPenaltyCharge(final MonetaryCurrency currency,
+            final List<SavingsAccountTransaction> transactions) {
         Money total = Money.zero(currency);
         for (final SavingsAccountTransaction transaction : transactions) {
             if (transaction.isPenaltyChargeAndNotReversed() && !transaction.isReversalTransaction()) {
@@ -123,7 +129,7 @@ public final class SavingsAccountTransactionSummaryWrapper {
         return total.getAmountDefaultedToNullIfZero();
     }
 
-    public BigDecimal calculateTotalPenaltyChargeWaived(final MonetaryCurrency currency,
+    public static BigDecimal calculateTotalPenaltyChargeWaived(final MonetaryCurrency currency,
             final List<SavingsAccountTransaction> transactions) {
         Money total = Money.zero(currency);
         for (final SavingsAccountTransaction transaction : transactions) {
@@ -134,7 +140,7 @@ public final class SavingsAccountTransactionSummaryWrapper {
         return total.getAmountDefaultedToNullIfZero();
     }
 
-    public BigDecimal calculateTotalOverdraftInterest(MonetaryCurrency currency, BigDecimal overdraftPosted,
+    public static BigDecimal calculateTotalOverdraftInterest(MonetaryCurrency currency, BigDecimal overdraftPosted,
             List<SavingsAccountTransaction> transactions) {
         Money total = Money.of(currency, overdraftPosted);
         for (final SavingsAccountTransaction transaction : transactions) {
@@ -145,7 +151,7 @@ public final class SavingsAccountTransactionSummaryWrapper {
         return total.getAmountDefaultedToNullIfZero();
     }
 
-    public BigDecimal calculateTotalOverdraftInterest(MonetaryCurrency currency, List<SavingsAccountTransaction> transactions) {
+    public static BigDecimal calculateTotalOverdraftInterest(MonetaryCurrency currency, List<SavingsAccountTransaction> transactions) {
         Money total = Money.zero(currency);
         for (final SavingsAccountTransaction transaction : transactions) {
             if (transaction.isOverdraftInterestAndNotReversed() && !transaction.isReversalTransaction()) {
@@ -155,7 +161,7 @@ public final class SavingsAccountTransactionSummaryWrapper {
         return total.getAmountDefaultedToNullIfZero();
     }
 
-    public BigDecimal calculateTotalWithholdTaxWithdrawal(MonetaryCurrency currency, List<SavingsAccountTransaction> transactions) {
+    public static BigDecimal calculateTotalWithholdTaxWithdrawal(MonetaryCurrency currency, List<SavingsAccountTransaction> transactions) {
         Money total = Money.zero(currency);
         for (final SavingsAccountTransaction transaction : transactions) {
             if (transaction.isWithHoldTaxAndNotReversed() && !transaction.isReversalTransaction()) {

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountActivationServiceImpl.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountActivationServiceImpl.java
@@ -25,6 +25,7 @@ import lombok.RequiredArgsConstructor;
 import org.apache.fineract.infrastructure.core.service.DateUtils;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccount;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountCharge;
+import org.apache.fineract.portfolio.savings.domain.SavingsHelper;
 
 /**
  * Default implementation of {@link SavingsAccountActivationService}. The bodies of {@code processAccountUponActivation}
@@ -36,6 +37,7 @@ import org.apache.fineract.portfolio.savings.domain.SavingsAccountCharge;
 public class SavingsAccountActivationServiceImpl implements SavingsAccountActivationService {
 
     private final SavingsAccountPostInterestService savingsAccountPostInterestService;
+    private final SavingsHelper savingsHelper;
 
     @Override
     public void processAccountUponActivation(final SavingsAccount account, final boolean isSavingsInterestPostingAtCurrentPeriodEnd,
@@ -76,7 +78,7 @@ public class SavingsAccountActivationServiceImpl implements SavingsAccountActiva
             } else {
                 final LocalDate today = DateUtils.getBusinessLocalDate();
                 account.calculateInterestUsing(mc, today, isInterestTransfer, isSavingsInterestPostingAtCurrentPeriodEnd,
-                        financialYearBeginningMonth, postInterestAsOnDate, backdatedTxnsAllowedTill, postReversals);
+                        financialYearBeginningMonth, postInterestAsOnDate, backdatedTxnsAllowedTill, postReversals, this.savingsHelper);
             }
         }
     }

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountInterestPostingServiceImpl.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountInterestPostingServiceImpl.java
@@ -45,6 +45,7 @@ import org.apache.fineract.portfolio.savings.data.SavingsAccountTransactionData;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountChargesPaidByData;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountTransactionDataComparator;
 import org.apache.fineract.portfolio.savings.domain.SavingsHelper;
+import org.apache.fineract.portfolio.savings.domain.SavingsInterestCalculationUtil;
 import org.apache.fineract.portfolio.savings.domain.interest.PostingPeriod;
 import org.apache.fineract.portfolio.tax.data.TaxComponentData;
 import org.apache.fineract.portfolio.tax.service.TaxUtils;
@@ -267,7 +268,7 @@ public class SavingsAccountInterestPostingServiceImpl implements SavingsAccountI
         if (postInterestOnDate != null) {
             postedAsOnDates.add(postInterestOnDate);
         }
-        final List<LocalDateInterval> postingPeriodIntervals = this.savingsHelper.determineInterestPostingPeriods(
+        final List<LocalDateInterval> postingPeriodIntervals = SavingsInterestCalculationUtil.determineInterestPostingPeriods(
                 savingsAccountData.getStartInterestCalculationDate(), upToInterestCalculationDate, postingPeriodType,
                 financialYearBeginningMonth, postedAsOnDates);
 
@@ -342,7 +343,7 @@ public class SavingsAccountInterestPostingServiceImpl implements SavingsAccountI
             }
         }
 
-        this.savingsHelper.calculateInterestForAllPostingPeriods(monetaryCurrency, allPostingPeriods,
+        SavingsInterestCalculationUtil.calculateInterestForAllPostingPeriods(monetaryCurrency, allPostingPeriods,
                 getLockedInUntilLocalDate(savingsAccountData), false);
 
         savingsAccountData.getSummary().updateFromInterestPeriodSummaries(monetaryCurrency, allPostingPeriods);

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountPostInterestServiceImpl.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountPostInterestServiceImpl.java
@@ -27,20 +27,21 @@ import org.apache.fineract.infrastructure.core.service.DateUtils;
 import org.apache.fineract.organisation.monetary.domain.Money;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccount;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccountTransaction;
-import org.apache.fineract.portfolio.savings.domain.SavingsAccountTransactionSummaryWrapper;
+import org.apache.fineract.portfolio.savings.domain.SavingsHelper;
 import org.apache.fineract.portfolio.savings.domain.interest.PostingPeriod;
 
 /**
  * Default implementation of {@link SavingsAccountPostInterestService}. The body of this {@code postInterest} method was
  * extracted from {@code SavingsAccount.postInterest}; behaviour is intentionally unchanged. Account state is
- * read/written through the public API of the {@link SavingsAccount} entity, while the stateless
- * {@link SavingsAccountTransactionSummaryWrapper} collaborator is injected here (rather than read off the entity's
- * transient field) to keep that dependency out of the domain entity.
+ * read/written through the public API of the {@link SavingsAccount} entity; transaction-summary totals are computed
+ * through the stateless static {@code SavingsAccountTransactionSummaryWrapper} utility, and the thin
+ * {@link SavingsHelper} service supplies the interest-transaction lookups the entity needs, keeping both dependencies
+ * out of the domain entity.
  */
 @RequiredArgsConstructor
 public class SavingsAccountPostInterestServiceImpl implements SavingsAccountPostInterestService {
 
-    private final SavingsAccountTransactionSummaryWrapper savingsAccountTransactionSummaryWrapper;
+    private final SavingsHelper savingsHelper;
 
     @Override
     public void postInterest(final SavingsAccount account, final MathContext mc, final LocalDate postingDate,
@@ -54,7 +55,7 @@ public class SavingsAccountPostInterestServiceImpl implements SavingsAccountPost
         final LocalDate interestPostingUpToDate = account.interestPostingUpToDate(postingDate);
         final List<PostingPeriod> postingPeriods = account.calculateInterestUsing(mc, interestPostingUpToDate, isInterestTransfer,
                 isSavingsInterestPostingAtCurrentPeriodEnd, financialYearBeginningMonth, postInterestOnDate, backdatedTxnsAllowedTill,
-                postReversals);
+                postReversals, this.savingsHelper);
         if (postingPeriods.isEmpty()) {
             return;
         }
@@ -180,10 +181,9 @@ public class SavingsAccountPostInterestServiceImpl implements SavingsAccountPost
         }
 
         if (!backdatedTxnsAllowedTill) {
-            account.getSummary().updateSummary(account.getCurrency(), this.savingsAccountTransactionSummaryWrapper,
-                    account.getTransactions());
+            account.getSummary().updateSummary(account.getCurrency(), account.getTransactions());
         } else {
-            account.getSummary().updateSummaryWithPivotConfig(account.getCurrency(), this.savingsAccountTransactionSummaryWrapper, null,
+            account.getSummary().updateSummaryWithPivotConfig(account.getCurrency(), null,
                     account.getSavingsAccountTransactionsWithPivotConfig());
         }
     }


### PR DESCRIPTION
## Description

Removes runtime service collaborators that were stored as @Transient/transient fields on the SavingsAccount JPA entity and injected after hydration via setHelpers(...). This kept infrastructure/config dependencies out of the domain entity's state.

- Removed transient fields savingsAccountTransactionSummaryWrapper, savingsHelper, and configurationDomainService from SavingsAccount, along with the setHelpers(...) post-hydration injection method.
- SavingsAccountTransactionSummaryWrapper: converted from a Spring @Component into a final utility class with a private constructor; all calculateTotal* methods are now static pure functions over the supplied transactions.
- SavingsHelper: reduced to a thin service exposing only the DB-backed interest-transaction lookups. The stateless interest posting-period math (determineInterestPostingPeriods, calculateInterestForAllPostingPeriods) was extracted into the new static SavingsInterestCalculationUtil.
- Explicit parameter passing replaces the injected state:
  - calculateInterestUsing(...) now receives SavingsHelper as an argument.
  - validateAccountBalanceConstraints(...) / isForceWithdrawalAllowed(...) now take the resolved forceWithdrawalEnabled flag and forceWithdrawalLimit value instead of reaching into ConfigurationDomainService.
  - SavingsAccountSummary.updateSummary(...) / updateSummaryWithPivotConfig(...) no longer take a wrapper argument and call the static methods directly.
- Callers updated across savings/deposit services, assemblers, and Spring configuration to stop calling setHelpers(...), resolve the config values up front, and pass collaborators as method parameters.

No functional/behavioral change — pure refactor to decouple transient elements from the persistent entity.

[FINERACT-2684](https://issues.apache.org/jira/browse/FINERACT-2684)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [ ] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).
- [ ] If merging this PR resolves a JIRA issue, I will mark that issue as resolved and set "Fix Version/s" appropriately.

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
