### PR TITLE
FINERACT-2846: Remove dead code block in TellerWritePlatformServiceJpaImpl

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/teller/service/TellerWritePlatformServiceJpaImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/teller/service/TellerWritePlatformServiceJpaImpl.java
@@ -353,32 +353,6 @@ public class TellerWritePlatformServiceJpaImpl implements TellerWritePlatformSer
             final Cashier cashier = this.cashierRepository.findById(cashierId).orElseThrow(() -> new CashierNotFoundException(cashierId));
 
             this.fromApiJsonDeserializer.validateForCashTxnForCashier(command.json());
-
-            // TODO: can we please remove this whole block?!? this is 20 lines of dead code!!!
-            final String entityType = command.stringValueOfParameterNamed("entityType");
-            if (entityType != null) {
-                if (entityType.equals("loan account")) {
-                    // TODO : Check if loan account exists
-                    // LoanAccount loan = null;
-                    // if (loan == null) { throw new
-                    // LoanAccountFoundException(entityId); }
-                } else if (entityType.equals("savings account")) {
-                    // TODO : Check if loan account exists
-                    // SavingsAccount savingsaccount = null;
-                    // if (savingsaccount == null) { throw new
-                    // SavingsAccountNotFoundException(entityId); }
-
-                }
-                if (entityType.equals("client")) {
-                    // TODO: Check if client exists
-                    // Client client = null;
-                    // if (client == null) { throw new
-                    // ClientNotFoundException(entityId); }
-                } else {
-                    // TODO : Invalid type handling
-                }
-            }
-
             final CashierTransaction cashierTxn = CashierTransaction.fromJson(cashier, command);
             cashierTxn.setTxnType(txnType.getId());
 


### PR DESCRIPTION
## What

Removes an unreachable/no-op code block inside `doTransactionForCashier()` in`TellerWritePlatformServiceJpaImpl.java`.

## Why

The block read an `entityType` parameter from the request and branched on its value ("loan account", "savings account", "client"), but every branch was either empty or entirely commented-out code. `entityType` was never referenced again anywhere else in the method or the file, so the block had zero effect on runtime behavior. The original
author had already flagged it themselves:

​```java
// TODO: can we please remove this whole block?!? this is 20 lines of dead code!!!
​```

This PR simply deletes that block. No behavior change.

## JIRA

[FINERACT-2846](https://mifosforge.jira.com/browse/FINERACT-2846)

## Checklist

- [x] No behavior change — verified `entityType` is unused elsewhere in the file
- [ ] Existing tests pass locally (pending — fixing local `JAVA_HOME` setup; will confirm once CI runs / once resolved locally)
- [x] Not a "code dump" — single, focused change