### PR TITLE
FINERACT-2726: Saving accounts - Unable to create, edit a saving product

### DIFF
--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/saving/SavingsAccountStepDef.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/saving/SavingsAccountStepDef.java
@@ -23,8 +23,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 import io.cucumber.datatable.DataTable;
+import io.cucumber.java.After;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 import java.math.BigDecimal;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -32,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.fineract.client.feign.FineractFeignClient;
+import org.apache.fineract.client.models.GetSavingsProductsResponse;
 import org.apache.fineract.client.models.PostClientsResponse;
 import org.apache.fineract.client.models.PostSavingsAccountTransactionsRequest;
 import org.apache.fineract.client.models.PostSavingsAccountTransactionsResponse;
@@ -47,6 +50,7 @@ import org.apache.fineract.test.factory.SavingsAccountRequestFactory;
 import org.apache.fineract.test.factory.SavingsProductRequestFactory;
 import org.apache.fineract.test.helper.ErrorMessageHelper;
 import org.apache.fineract.test.helper.ErrorResponse;
+import org.apache.fineract.test.helper.GlobalConfigurationHelper;
 import org.apache.fineract.test.helper.Utils;
 import org.apache.fineract.test.stepdef.AbstractStepDef;
 import org.apache.fineract.test.support.TestContextKey;
@@ -56,6 +60,9 @@ public class SavingsAccountStepDef extends AbstractStepDef {
 
     @Autowired
     private FineractFeignClient fineractClient;
+
+    @Autowired
+    private GlobalConfigurationHelper globalConfigurationHelper;
 
     public static final String DATE_FORMAT = "dd MMMM yyyy";
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern(DATE_FORMAT);
@@ -67,6 +74,18 @@ public class SavingsAccountStepDef extends AbstractStepDef {
         PostSavingsProductsResponse savingsProductResponse = ok(
                 () -> fineractClient.savingsProduct().createSavingsProduct(savingsProductRequest));
         testContext().set(TestContextKey.DEFAULT_SAVINGS_PRODUCT_CREATE_RESPONSE_EUR, savingsProductResponse);
+    }
+
+    @After("@SavingsProductOfficeRestrictionFeature")
+    public void restoreOfficeSpecificProductRestrictionConfig() {
+        globalConfigurationHelper.disableGlobalConfiguration("restrict-products-to-user-office", 0L);
+        globalConfigurationHelper.disableGlobalConfiguration("office-specific-products-enabled", 0L);
+    }
+
+    @When("Savings products are retrieved successfully")
+    public void retrieveSavingsProductsSuccessfully() {
+        List<GetSavingsProductsResponse> savingsProducts = ok(() -> fineractClient.savingsProduct().retrieveAllSavingsProducts());
+        assertThat(savingsProducts).isNotNull();
     }
 
     @And("Client creates a new EUR savings account with {string} submitted on date")

--- a/fineract-e2e-tests-runner/src/test/resources/features/SavingsProduct.feature
+++ b/fineract-e2e-tests-runner/src/test/resources/features/SavingsProduct.feature
@@ -1,0 +1,8 @@
+@SavingsProduct
+Feature: SavingsProduct
+
+  @SavingsProductOfficeRestrictionFeature
+  Scenario: As a user I would like to retrieve savings products when office-specific product restriction is enabled and my office has no explicit product mapping
+    Given Global configuration "office-specific-products-enabled" is enabled
+    And Global configuration "restrict-products-to-user-office" is enabled
+    When Savings products are retrieved successfully

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/entityaccess/service/FineractEntityAccessReadServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/entityaccess/service/FineractEntityAccessReadServiceImpl.java
@@ -96,8 +96,8 @@ public class FineractEntityAccessReadServiceImpl implements FineractEntityAccess
         } else {
 
             accessListCSVStrBuf = new StringBuilder();
-            accessListCSVStrBuf.append("false"); // Append false so that no rows
-                                                 // will be returned
+            accessListCSVStrBuf.append("-1"); // Append -1 so that no rows
+                                              // will be returned
         }
         if (accessListCSVStrBuf != null) {
             returnIdListStr = accessListCSVStrBuf.toString();

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/SavingsProductCreationIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/SavingsProductCreationIntegrationTest.java
@@ -24,6 +24,8 @@ import io.restassured.http.ContentType;
 import io.restassured.specification.RequestSpecification;
 import io.restassured.specification.ResponseSpecification;
 import org.apache.fineract.client.models.GetSavingsProductsProductIdResponse;
+import org.apache.fineract.infrastructure.configuration.api.GlobalConfigurationConstants;
+import org.apache.fineract.integrationtests.common.GlobalConfigurationHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.common.accounting.Account;
 import org.apache.fineract.integrationtests.common.accounting.AccountHelper;
@@ -137,6 +139,21 @@ public class SavingsProductCreationIntegrationTest {
         Assertions.assertNotEquals(interestReceivableAccount.getAccountID(),
                 savingsProductsResponseUpdate.getAccountingMappings().getInterestReceivableAccount().getId().intValue());
 
+    }
+
+    @Test
+    public void testRetrieveSavingsProductsWithOfficeSpecificRestrictionEnabledAndNoEntityAccessMapping() {
+        final GlobalConfigurationHelper globalConfigurationHelper = new GlobalConfigurationHelper();
+        try {
+            globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.OFFICE_SPECIFIC_PRODUCTS_ENABLED, true);
+            globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.RESTRICT_PRODUCTS_TO_USER_OFFICE, true);
+
+            final String savingsProducts = SavingsProductHelper.retrieveAllSavingsProducts(requestSpec, responseSpec);
+            Assertions.assertNotNull(savingsProducts);
+        } finally {
+            globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.RESTRICT_PRODUCTS_TO_USER_OFFICE, false);
+            globalConfigurationHelper.manageConfigurations(GlobalConfigurationConstants.OFFICE_SPECIFIC_PRODUCTS_ENABLED, false);
+        }
     }
 
     public static Integer createSavingsProductWithAccrualAccountingWithOverdraftAllowed(final String interestReceivableAccount,

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/savings/SavingsProductHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/savings/SavingsProductHelper.java
@@ -503,4 +503,10 @@ public class SavingsProductHelper {
         return GSON.fromJson(response, GetSavingsProductsProductIdResponse.class);
     }
 
+    @Deprecated(forRemoval = true)
+    public static String retrieveAllSavingsProducts(final RequestSpecification requestSpec, final ResponseSpecification responseSpec) {
+        LOG.info("-------------------- RETRIEVING ALL SAVINGS PRODUCTS --------------------------");
+        return Utils.performServerGet(requestSpec, responseSpec, CREATE_SAVINGS_PRODUCT_URL);
+    }
+
 }


### PR DESCRIPTION
**Issue: FineractEntityAccessReadServiceImpl – Invalid SQL Query When User Has No Entity Access Mappings**

**Root Cause:**
In `FineractEntityAccessReadServiceImpl#getSQLQueryInClause_WithListOfIDsForEntityAccess`, when a user has no entity-access mappings for a specific entity type (for example, office-restricted savings products), the method generates a comma-separated ID list to be used inside a SQL `IN (...)` clause.

When the access list is empty, the method appends the literal value `"false"` instead of a numeric ID. Since the SQL query expects numeric IDs, this results in an invalid query and database failure.

**Example Error:**

```
PostgreSQL: invalid input syntax for type bigint: "false"
```

**Impact:**
With entity/office-specific access restrictions enabled, users without mapped offices for a given entity type cannot create or edit entities filtered through this helper (such as savings products). The operation fails instead of returning an empty/restricted result set.

**Fix:**
Replace `"false"` with `"-1"` when the access list is empty.

`-1` is a valid numeric value that does not match any existing entity ID, allowing the SQL query to execute successfully while returning zero rows.
This PR  :(https://issues.apache.org/jira/browse/FINERACT-2726)