### PR TITLE
FINERACT-2725: Fix case-insensitive LIMIT/OFFSET removal in countQueryResult

### DIFF
--- a/fineract-core/src/test/java/org/apache/fineract/infrastructure/core/service/database/DatabaseSpecificSQLGeneratorTest.java
+++ b/fineract-core/src/test/java/org/apache/fineract/infrastructure/core/service/database/DatabaseSpecificSQLGeneratorTest.java
@@ -82,4 +82,18 @@ public class DatabaseSpecificSQLGeneratorTest {
         Mockito.verify(connection).createArrayOf("bigint", new Long[] { 1L, 2L, 3L });
         Mockito.verify(connection).close();
     }
+
+    @Test
+    public void testCountQueryResultOnSqlWithLowercaseLimit() {
+        String sql = "SELECT 1 FROM test_table WHERE asd=2 limit 25";
+        String countQuery = databaseSpecificSQLGenerator.countQueryResult(sql);
+        Assertions.assertEquals("SELECT COUNT(*) FROM (SELECT 1 FROM test_table WHERE asd=2) AS temp", countQuery);
+    }
+
+    @Test
+    public void testCountQueryResultOnSqlWithLowercaseLimitAndOffset() {
+        String sql = "SELECT 1 FROM test_table WHERE asd=2 limit 25 offset 180";
+        String countQuery = databaseSpecificSQLGenerator.countQueryResult(sql);
+        Assertions.assertEquals("SELECT COUNT(*) FROM (SELECT 1 FROM test_table WHERE asd=2) AS temp", countQuery);
+    }
 }


### PR DESCRIPTION
 Fixes FINERACT-2725.                                                                                                                                                              
                                                                                                                                                                                    
  `PaginationParameters.limitSql()` generates lowercase SQL clauses (`limit`/`offset`).                                                                                             
  `DatabaseSpecificSQLGenerator.countQueryResult` was stripping these using                                                                                                         
  case-sensitive regex, so on PostgreSQL the LIMIT clause survived into the                                                                                                         
  `SELECT COUNT(*) FROM (...) AS temp` wrapper — causing paginated endpoints                                                                                                        
  to return a `totalFilteredRecords` value capped at the page size instead of                                                                                                       
  the true total.                                                                                                                                                                   
                                                                                                                                                                                    
  Made both patterns case-insensitive (`(?i)`) and use `\s+` for whitespace.   