### PR TITLE
FINERACT-2727: Fix loan product visibility when office-specific-products-enabled is on

### DIFF
--- a/fineract-charge/src/main/java/org/apache/fineract/portfolio/charge/service/ChargeReadPlatformService.java
+++ b/fineract-charge/src/main/java/org/apache/fineract/portfolio/charge/service/ChargeReadPlatformService.java
@@ -42,11 +42,21 @@ public interface ChargeReadPlatformService {
     List<ChargeData> retrieveAllChargesApplicableToClients();
 
     /**
+     * Office-scoped variant used by client/group-level templates.
+     */
+    List<ChargeData> retrieveAllChargesApplicableToClients(Long officeId);
+
+    /**
      * Returns all Fees (excluding penalties) applicable for loans
      *
      * @return
      */
     List<ChargeData> retrieveLoanApplicableFees();
+
+    /**
+     * Office-scoped variant used by client/group-level templates.
+     */
+    List<ChargeData> retrieveLoanApplicableFees(Long officeId);
 
     /**
      * Returns all charges applicable for a given loan account
@@ -67,11 +77,22 @@ public interface ChargeReadPlatformService {
     List<ChargeData> retrieveLoanProductApplicableCharges(Long loanProductId, ChargeTimeType[] excludeChargeTimes);
 
     /**
+     * Office-scoped variant: filters by product currency AND the given office's visibility (for client-level templates
+     * where a product is already selected).
+     */
+    List<ChargeData> retrieveLoanProductApplicableCharges(Long loanProductId, ChargeTimeType[] excludeChargeTimes, Long officeId);
+
+    /**
      * Returns all Penalties applicable for loans
      *
      * @return
      */
     List<ChargeData> retrieveLoanApplicablePenalties();
+
+    /**
+     * Office-scoped variant used by client/group-level templates.
+     */
+    List<ChargeData> retrieveLoanApplicablePenalties(Long officeId);
 
     /**
      * Returns all Charges associated with a given Loan Product
@@ -80,6 +101,13 @@ public interface ChargeReadPlatformService {
      * @return
      */
     List<ChargeData> retrieveLoanProductCharges(Long loanProductId);
+
+    /**
+     * Office-scoped variant: returns pre-selected charges for a loan product filtered by what the given office can see.
+     * Used when rendering a new-loan template for a specific client so that pre-selected product charges are restricted
+     * to the client's own office, not the logged-in user's office.
+     */
+    List<ChargeData> retrieveLoanProductCharges(Long loanProductId, Long officeId);
 
     /**
      * Returns all charges applicable for a given loan product
@@ -91,6 +119,8 @@ public interface ChargeReadPlatformService {
      */
     List<ChargeData> retrieveLoanProductCharges(Long loanProductId, ChargeTimeType chargeTime);
 
+    List<ChargeData> retrieveLoanProductCharges(Long loanProductId, ChargeTimeType chargeTime, Long officeId);
+
     /**
      * Returns all charges applicable for savings
      *
@@ -100,11 +130,21 @@ public interface ChargeReadPlatformService {
     List<ChargeData> retrieveSavingsProductApplicableCharges(boolean feeChargesOnly);
 
     /**
+     * Office-scoped variant used by client/group-level templates.
+     */
+    List<ChargeData> retrieveSavingsProductApplicableCharges(boolean feeChargesOnly, Long officeId);
+
+    /**
      * Returns all penalties applicable for savings
      *
      * @return
      */
     List<ChargeData> retrieveSavingsApplicablePenalties();
+
+    /**
+     * Office-scoped variant used by client/group-level templates.
+     */
+    List<ChargeData> retrieveSavingsApplicablePenalties(Long officeId);
 
     /**
      * Returns all charges applicable for a given savings product
@@ -114,6 +154,13 @@ public interface ChargeReadPlatformService {
      */
     List<ChargeData> retrieveSavingsProductCharges(Long savingsProductId);
 
+    /**
+     * Office-scoped variant: returns pre-selected charges for a savings product filtered by what the given office can
+     * see. Used when rendering a new savings/deposit account template for a specific client so that pre-selected
+     * product charges are restricted to the client's own office, not the logged-in user's office.
+     */
+    List<ChargeData> retrieveSavingsProductCharges(Long savingsProductId, Long officeId);
+
     /** Retrieve savings account charges **/
     List<ChargeData> retrieveSavingsAccountApplicableCharges(Long savingsId);
 
@@ -122,7 +169,18 @@ public interface ChargeReadPlatformService {
      */
     List<ChargeData> retrieveSharesApplicableCharges();
 
+    /**
+     * Office-scoped variant used by client/group-level templates.
+     */
+    List<ChargeData> retrieveSharesApplicableCharges(Long officeId);
+
     List<ChargeData> retrieveShareProductCharges(Long shareProductId);
+
+    /**
+     * Office-scoped variant: filters share product charges by product AND the given office's visibility. Used by
+     * client-level share account templates where both clientId and productId are provided.
+     */
+    List<ChargeData> retrieveShareProductCharges(Long shareProductId, Long officeId);
 
     List<ChargeData> retrieveWorkingCapitalLoanAccountApplicableCharges(Long resolvedLoanId);
 }

--- a/fineract-charge/src/main/java/org/apache/fineract/portfolio/charge/service/ChargeReadPlatformService.java
+++ b/fineract-charge/src/main/java/org/apache/fineract/portfolio/charge/service/ChargeReadPlatformService.java
@@ -42,11 +42,21 @@ public interface ChargeReadPlatformService {
     List<ChargeData> retrieveAllChargesApplicableToClients();
 
     /**
+     * Office-scoped variant used by client/group-level templates.
+     */
+    List<ChargeData> retrieveAllChargesApplicableToClients(Long officeId);
+
+    /**
      * Returns all Fees (excluding penalties) applicable for loans
      *
      * @return
      */
     List<ChargeData> retrieveLoanApplicableFees();
+
+    /**
+     * Office-scoped variant used by client/group-level templates.
+     */
+    List<ChargeData> retrieveLoanApplicableFees(Long officeId);
 
     /**
      * Returns all charges applicable for a given loan account
@@ -67,11 +77,22 @@ public interface ChargeReadPlatformService {
     List<ChargeData> retrieveLoanProductApplicableCharges(Long loanProductId, ChargeTimeType[] excludeChargeTimes);
 
     /**
+     * Office-scoped variant: filters by product currency AND the given office's visibility (for client-level templates
+     * where a product is already selected).
+     */
+    List<ChargeData> retrieveLoanProductApplicableCharges(Long loanProductId, ChargeTimeType[] excludeChargeTimes, Long officeId);
+
+    /**
      * Returns all Penalties applicable for loans
      *
      * @return
      */
     List<ChargeData> retrieveLoanApplicablePenalties();
+
+    /**
+     * Office-scoped variant used by client/group-level templates.
+     */
+    List<ChargeData> retrieveLoanApplicablePenalties(Long officeId);
 
     /**
      * Returns all Charges associated with a given Loan Product
@@ -80,6 +101,13 @@ public interface ChargeReadPlatformService {
      * @return
      */
     List<ChargeData> retrieveLoanProductCharges(Long loanProductId);
+
+    /**
+     * Office-scoped variant: returns pre-selected charges for a loan product filtered by what the given office can see.
+     * Used when rendering a new-loan template for a specific client so that pre-selected product charges are restricted
+     * to the client's own office, not the logged-in user's office.
+     */
+    List<ChargeData> retrieveLoanProductCharges(Long loanProductId, Long officeId);
 
     /**
      * Returns all charges applicable for a given loan product
@@ -91,6 +119,8 @@ public interface ChargeReadPlatformService {
      */
     List<ChargeData> retrieveLoanProductCharges(Long loanProductId, ChargeTimeType chargeTime);
 
+    List<ChargeData> retrieveLoanProductCharges(Long loanProductId, ChargeTimeType chargeTime, Long officeId);
+
     /**
      * Returns all charges applicable for savings
      *
@@ -100,11 +130,21 @@ public interface ChargeReadPlatformService {
     List<ChargeData> retrieveSavingsProductApplicableCharges(boolean feeChargesOnly);
 
     /**
+     * Office-scoped variant used by client/group-level templates.
+     */
+    List<ChargeData> retrieveSavingsProductApplicableCharges(boolean feeChargesOnly, Long officeId);
+
+    /**
      * Returns all penalties applicable for savings
      *
      * @return
      */
     List<ChargeData> retrieveSavingsApplicablePenalties();
+
+    /**
+     * Office-scoped variant used by client/group-level templates.
+     */
+    List<ChargeData> retrieveSavingsApplicablePenalties(Long officeId);
 
     /**
      * Returns all charges applicable for a given savings product
@@ -114,6 +154,13 @@ public interface ChargeReadPlatformService {
      */
     List<ChargeData> retrieveSavingsProductCharges(Long savingsProductId);
 
+    /**
+     * Office-scoped variant: returns pre-selected charges for a savings product filtered by what the given office can
+     * see. Used when rendering a new savings/deposit account template for a specific client so that pre-selected
+     * product charges are restricted to the client's own office, not the logged-in user's office.
+     */
+    List<ChargeData> retrieveSavingsProductCharges(Long savingsProductId, Long officeId);
+
     /** Retrieve savings account charges **/
     List<ChargeData> retrieveSavingsAccountApplicableCharges(Long savingsId);
 
@@ -122,7 +169,18 @@ public interface ChargeReadPlatformService {
      */
     List<ChargeData> retrieveSharesApplicableCharges();
 
+    /**
+     * Office-scoped variant used by client/group-level templates.
+     */
+    List<ChargeData> retrieveSharesApplicableCharges(Long officeId);
+
     List<ChargeData> retrieveShareProductCharges(Long shareProductId);
+
+    /**
+     * Office-scoped variant: filters share product charges by product AND the given office's visibility.
+     * Used by client-level share account templates where both clientId and productId are provided.
+     */
+    List<ChargeData> retrieveShareProductCharges(Long shareProductId, Long officeId);
 
     List<ChargeData> retrieveWorkingCapitalLoanAccountApplicableCharges(Long resolvedLoanId);
 }

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanReadPlatformService.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanReadPlatformService.java
@@ -80,7 +80,7 @@ public interface LoanReadPlatformService {
 
     LoanAccountData retrieveTemplateWithCompleteGroupAndProductDetails(Long groupId, Long productId);
 
-    LoanAccountData retrieveLoanProductDetailsTemplate(Long productId, Long clientId, Long groupId);
+    LoanAccountData retrieveLoanProductDetailsTemplate(Long productId, Long clientId, Long groupId, Long officeId);
 
     Collection<CalendarData> retrieveCalendars(Long groupId);
 

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/service/LoanProductReadPlatformService.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/service/LoanProductReadPlatformService.java
@@ -58,4 +58,10 @@ public interface LoanProductReadPlatformService {
 
     LoanProductData retrieveLoanProductFloatingDetails(Long loanProductId);
 
+    Collection<LoanProductData> retrieveAllLoanProductsV2();
+
+    Collection<LoanProductData> retrieveAllLoanProductsForLookupV2(boolean activeOnly);
+
+    Collection<LoanProductData> retrieveAllLoanProductsForLookupV2(boolean activeOnly, Long officeId);
+
 }

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/service/LoanProductReadPlatformService.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/service/LoanProductReadPlatformService.java
@@ -57,5 +57,10 @@ public interface LoanProductReadPlatformService {
     Collection<CreditAllocationData> retrieveCreditAllocationData(Long loanProductId);
 
     LoanProductData retrieveLoanProductFloatingDetails(Long loanProductId);
+    Collection<LoanProductData> retrieveAllLoanProductsV2();
+
+    Collection<LoanProductData> retrieveAllLoanProductsForLookupV2(boolean activeOnly);
+
+    Collection<LoanProductData> retrieveAllLoanProductsForLookupV2(boolean activeOnly, Long officeId);
 
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/service/BulkImportWorkbookPopulatorServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/service/BulkImportWorkbookPopulatorServiceImpl.java
@@ -406,7 +406,7 @@ public class BulkImportWorkbookPopulatorServiceImpl implements BulkImportWorkboo
     }
 
     private List<LoanProductData> fetchLoanProducts() {
-        return (List<LoanProductData>) this.loanProductReadPlatformService.retrieveAllLoanProducts();
+        return (List<LoanProductData>) this.loanProductReadPlatformService.retrieveAllLoanProductsV2();
     }
 
     private List<GroupGeneralData> fetchGroups(Long officeId) {

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/entityaccess/service/FineractEntityAccessReadService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/entityaccess/service/FineractEntityAccessReadService.java
@@ -37,10 +37,15 @@ public interface FineractEntityAccessReadService {
 
     String getSQLQueryInClauseIDList_ForChargesForOffice(Long officeId, boolean includeAllOffices);
 
+    String getSQLQueryInClauseIDList_ForChargesVisibleToOffice(Long officeId);
+
     Collection<FineractEntityRelationData> retrieveAllSupportedMappingTypes();
 
     Collection<FineractEntityToEntityMappingData> retrieveOneMapping(Long mapId);
 
     Collection<FineractEntityToEntityMappingData> retrieveEntityToEntityMappings(Long mapId, Long fromoId, Long toId);
 
+    String getSQLQueryInClauseIDList_ForLoanProductsVisibleToOffice(Long officeId);
+
+    boolean isLoanProductVisibleToOffice(Long productId, Long officeId);
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/entityaccess/service/FineractEntityAccessReadService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/entityaccess/service/FineractEntityAccessReadService.java
@@ -43,4 +43,7 @@ public interface FineractEntityAccessReadService {
 
     Collection<FineractEntityToEntityMappingData> retrieveEntityToEntityMappings(Long mapId, Long fromoId, Long toId);
 
+    String getSQLQueryInClauseIDList_ForLoanProductsVisibleToOffice(Long officeId);
+
+    boolean isLoanProductVisibleToOffice(Long productId, Long officeId);
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/entityaccess/service/FineractEntityAccessReadService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/entityaccess/service/FineractEntityAccessReadService.java
@@ -36,6 +36,7 @@ public interface FineractEntityAccessReadService {
     String getSQLQueryInClauseIDList_ForSavingsProductsForOffice(Long savingsProductId, boolean includeAllOffices);
 
     String getSQLQueryInClauseIDList_ForChargesForOffice(Long officeId, boolean includeAllOffices);
+    String getSQLQueryInClauseIDList_ForChargesVisibleToOffice(Long officeId);
 
     Collection<FineractEntityRelationData> retrieveAllSupportedMappingTypes();
 

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/entityaccess/service/FineractEntityAccessReadServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/entityaccess/service/FineractEntityAccessReadServiceImpl.java
@@ -204,6 +204,19 @@ public class FineractEntityAccessReadServiceImpl implements FineractEntityAccess
     @Override
     public Collection<FineractEntityToEntityMappingData> retrieveEntityToEntityMappings(Long mapId, Long fromId, Long toId) {
 
+        if (fromId == 0) {
+            final String fromEntityTypeSql = "SELECT er.from_entity_type FROM m_entity_relation er WHERE er.id = ?";
+            Integer fromEntityType = jdbcTemplate.queryForObject(fromEntityTypeSql, Integer.class, mapId);
+            if (fromEntityType != null && fromEntityType == 1) {
+                final AppUser currentUser = this.context.authenticatedUser();
+                final Long userOfficeId = currentUser.getOffice().getId();
+
+                EntityToEntityMapper entityToEntityMapper = new EntityToEntityMapper();
+                String officeScopedSql = entityToEntityMapper.schemaWithOfficeScopedFromId();
+                return this.jdbcTemplate.query(officeScopedSql, entityToEntityMapper, new Object[] { userOfficeId, mapId, toId, toId });
+            }
+        }
+
         EntityToEntityMapper entityToEntityMapper = new EntityToEntityMapper();
         String sql = entityToEntityMapper.schema();
         final Collection<FineractEntityToEntityMappingData> mapTypes = this.jdbcTemplate.query(sql, entityToEntityMapper,
@@ -302,6 +315,46 @@ public class FineractEntityAccessReadServiceImpl implements FineractEntityAccess
             return ENTITY_TO_ENTITY_SCHEMA;
         }
 
+        public String schemaWithOfficeScopedFromId() {
+            StringBuilder str = new StringBuilder("WITH RECURSIVE office_descendants AS ( ");
+            str.append("SELECT id FROM m_office WHERE id = ? ");
+            str.append("UNION ALL ");
+            str.append("SELECT o.id FROM m_office o JOIN office_descendants d ON o.parent_id = d.id ");
+            str.append(") ");
+            str.append("select eem.id as mapId, ");
+            str.append("eem.rel_id as relId, ");
+            str.append("eem.from_id as from_id, ");
+            str.append("eem.to_id as to_id, ");
+            str.append("eem.start_date as startDate, ");
+            str.append("eem.end_date as endDate, ");
+            str.append("case er.code_name ");
+            str.append("when 'office_access_to_loan_products' then o.name ");
+            str.append("when 'office_access_to_savings_products' then o.name ");
+            str.append("when 'office_access_to_fees/charges' then o.name ");
+            str.append("when 'role_access_to_loan_products' then r.name ");
+            str.append("when 'role_access_to_savings_products' then r.name ");
+            str.append("end as from_name, ");
+            str.append("case er.code_name ");
+            str.append("when 'office_access_to_loan_products' then lp.name ");
+            str.append("when 'office_access_to_savings_products' then sp.name ");
+            str.append("when 'office_access_to_fees/charges' then charge.name ");
+            str.append("when 'role_access_to_loan_products' then lp.name ");
+            str.append("when 'role_access_to_savings_products' then sp.name ");
+            str.append("end as to_name, ");
+            str.append("er.code_name ");
+            str.append("from m_entity_to_entity_mapping eem ");
+            str.append("join m_entity_relation er on eem.rel_id = er.id ");
+            str.append("left join m_office o on er.from_entity_type = 1 and eem.from_id = o.id ");
+            str.append("left join m_role r on er.from_entity_type = 5 and eem.from_id = r.id ");
+            str.append("left join m_product_loan lp on er.to_entity_type = 2 and eem.to_id = lp.id ");
+            str.append("left join m_savings_product sp on er.to_entity_type = 3 and eem.to_id = sp.id ");
+            str.append("left join m_charge charge on er.to_entity_type = 4 and eem.to_id = charge.id ");
+            str.append("where er.id = ? ");
+            str.append("and eem.from_id IN (SELECT id FROM office_descendants) ");
+            str.append("and ( ? = 0 or to_id = ? ) ");
+            return str.toString();
+        }
+
         @Override
         public FineractEntityToEntityMappingData mapRow(final ResultSet rs, @SuppressWarnings("unused") final int rowNum)
                 throws SQLException {
@@ -318,6 +371,51 @@ public class FineractEntityAccessReadServiceImpl implements FineractEntityAccess
             return FineractEntityToEntityMappingData.getRelatedEntities(mapId, relId, fromId, toId, startLocalDate, endLocalDate,
                     fromEntity, toEntity);
         }
+    }
+
+    @Override
+    public String getSQLQueryInClauseIDList_ForLoanProductsVisibleToOffice(final Long officeId) {
+        FineractEntityRelation fineractEntityRelation = fineractEntityRelationRepository
+                .findOneByCodeName(FineractEntityAccessType.OFFICE_ACCESS_TO_LOAN_PRODUCTS.getStr());
+        final Long relId = fineractEntityRelation.getId();
+        return "WITH RECURSIVE descendants AS ( " + "  SELECT id, parent_id FROM m_office WHERE id = " + officeId + " " + "  UNION ALL "
+                + "  SELECT o.id, o.parent_id FROM m_office o JOIN descendants d ON o.parent_id = d.id " + ") " + "select lp.id "
+                + "from m_product_loan lp " + "where lp.id not in ( " + "    select eem.to_id " + "    from m_entity_to_entity_mapping eem "
+                + "    where eem.rel_id = " + relId + " " + "    and eem.to_id <> 0 " + ") " + "or lp.id in ( " + "    select eem.to_id "
+                + "    from m_entity_to_entity_mapping eem " + "    where eem.rel_id = " + relId + " "
+                + "    and (eem.from_id in (select id from descendants) or eem.to_id = 0) " + ")";
+    }
+
+    @Override
+    public boolean isLoanProductVisibleToOffice(final Long productId, final Long officeId) {
+        FineractEntityRelation fineractEntityRelation = fineractEntityRelationRepository
+                .findOneByCodeName(FineractEntityAccessType.OFFICE_ACCESS_TO_LOAN_PRODUCTS.getStr());
+        final Long relId = fineractEntityRelation.getId();
+
+        final String isRestrictedSql = "SELECT COUNT(*) FROM m_entity_to_entity_mapping eem " + "WHERE eem.rel_id = ? AND eem.to_id = ?";
+        final Integer restrictedCount = jdbcTemplate.queryForObject(isRestrictedSql, Integer.class, relId, productId);
+        if (restrictedCount == null || restrictedCount == 0) {
+            return true;
+        }
+        final String visibleSql = "WITH RECURSIVE descendants AS ( " + "  SELECT id FROM m_office WHERE id = ? " + "  UNION ALL "
+                + "  SELECT o.id FROM m_office o JOIN descendants d ON o.parent_id = d.id " + ") "
+                + "SELECT COUNT(*) FROM m_entity_to_entity_mapping eem " + "WHERE eem.rel_id = ? AND eem.to_id = ? "
+                + "AND (eem.from_id IN (SELECT id FROM descendants) OR eem.from_id = 0)";
+        final Integer visibleCount = jdbcTemplate.queryForObject(visibleSql, Integer.class, officeId, relId, productId);
+        return visibleCount != null && visibleCount > 0;
+    }
+
+    @Override
+    public String getSQLQueryInClauseIDList_ForChargesVisibleToOffice(final Long officeId) {
+        FineractEntityRelation fineractEntityRelation = fineractEntityRelationRepository
+                .findOneByCodeName(FineractEntityAccessType.OFFICE_ACCESS_TO_CHARGES.getStr());
+        final Long relId = fineractEntityRelation.getId();
+        return "WITH RECURSIVE descendants AS ( " + "  SELECT id, parent_id FROM m_office WHERE id = " + officeId + " " + "  UNION ALL "
+                + "  SELECT o.id, o.parent_id FROM m_office o JOIN descendants d ON o.parent_id = d.id " + ") " + "select c.id "
+                + "from m_charge c " + "where c.id not in ( " + "    select eem.to_id " + "    from m_entity_to_entity_mapping eem "
+                + "    where eem.rel_id = " + relId + " " + "    and eem.to_id <> 0 " + ") " + "or c.id in ( " + "    select eem.to_id "
+                + "    from m_entity_to_entity_mapping eem " + "    where eem.rel_id = " + relId + " "
+                + "    and (eem.from_id in (select id from descendants) or eem.to_id = 0) " + ")";
     }
 
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/entityaccess/service/FineractEntityAccessReadServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/entityaccess/service/FineractEntityAccessReadServiceImpl.java
@@ -204,6 +204,20 @@ public class FineractEntityAccessReadServiceImpl implements FineractEntityAccess
     @Override
     public Collection<FineractEntityToEntityMappingData> retrieveEntityToEntityMappings(Long mapId, Long fromId, Long toId) {
 
+        if (fromId == 0) {
+            final String fromEntityTypeSql = "SELECT er.from_entity_type FROM m_entity_relation er WHERE er.id = ?";
+            Integer fromEntityType = jdbcTemplate.queryForObject(fromEntityTypeSql, Integer.class, mapId);
+            if (fromEntityType != null && fromEntityType == 1) {
+                final AppUser currentUser = this.context.authenticatedUser();
+                final Long userOfficeId = currentUser.getOffice().getId();
+
+                EntityToEntityMapper entityToEntityMapper = new EntityToEntityMapper();
+                String officeScopedSql = entityToEntityMapper.schemaWithOfficeScopedFromId();
+                return this.jdbcTemplate.query(officeScopedSql, entityToEntityMapper,
+                        new Object[] { userOfficeId, mapId, toId, toId });
+            }
+        }
+
         EntityToEntityMapper entityToEntityMapper = new EntityToEntityMapper();
         String sql = entityToEntityMapper.schema();
         final Collection<FineractEntityToEntityMappingData> mapTypes = this.jdbcTemplate.query(sql, entityToEntityMapper,
@@ -302,6 +316,46 @@ public class FineractEntityAccessReadServiceImpl implements FineractEntityAccess
             return ENTITY_TO_ENTITY_SCHEMA;
         }
 
+        public String schemaWithOfficeScopedFromId() {
+            StringBuilder str = new StringBuilder("WITH RECURSIVE office_descendants AS ( ");
+            str.append("SELECT id FROM m_office WHERE id = ? ");
+            str.append("UNION ALL ");
+            str.append("SELECT o.id FROM m_office o JOIN office_descendants d ON o.parent_id = d.id ");
+            str.append(") ");
+            str.append("select eem.id as mapId, ");
+            str.append("eem.rel_id as relId, ");
+            str.append("eem.from_id as from_id, ");
+            str.append("eem.to_id as to_id, ");
+            str.append("eem.start_date as startDate, ");
+            str.append("eem.end_date as endDate, ");
+            str.append("case er.code_name ");
+            str.append("when 'office_access_to_loan_products' then o.name ");
+            str.append("when 'office_access_to_savings_products' then o.name ");
+            str.append("when 'office_access_to_fees/charges' then o.name ");
+            str.append("when 'role_access_to_loan_products' then r.name ");
+            str.append("when 'role_access_to_savings_products' then r.name ");
+            str.append("end as from_name, ");
+            str.append("case er.code_name ");
+            str.append("when 'office_access_to_loan_products' then lp.name ");
+            str.append("when 'office_access_to_savings_products' then sp.name ");
+            str.append("when 'office_access_to_fees/charges' then charge.name ");
+            str.append("when 'role_access_to_loan_products' then lp.name ");
+            str.append("when 'role_access_to_savings_products' then sp.name ");
+            str.append("end as to_name, ");
+            str.append("er.code_name ");
+            str.append("from m_entity_to_entity_mapping eem ");
+            str.append("join m_entity_relation er on eem.rel_id = er.id ");
+            str.append("left join m_office o on er.from_entity_type = 1 and eem.from_id = o.id ");
+            str.append("left join m_role r on er.from_entity_type = 5 and eem.from_id = r.id ");
+            str.append("left join m_product_loan lp on er.to_entity_type = 2 and eem.to_id = lp.id ");
+            str.append("left join m_savings_product sp on er.to_entity_type = 3 and eem.to_id = sp.id ");
+            str.append("left join m_charge charge on er.to_entity_type = 4 and eem.to_id = charge.id ");
+            str.append("where er.id = ? ");
+            str.append("and eem.from_id IN (SELECT id FROM office_descendants) ");
+            str.append("and ( ? = 0 or to_id = ? ) ");
+            return str.toString();
+        }
+
         @Override
         public FineractEntityToEntityMappingData mapRow(final ResultSet rs, @SuppressWarnings("unused") final int rowNum)
                 throws SQLException {
@@ -318,6 +372,56 @@ public class FineractEntityAccessReadServiceImpl implements FineractEntityAccess
             return FineractEntityToEntityMappingData.getRelatedEntities(mapId, relId, fromId, toId, startLocalDate, endLocalDate,
                     fromEntity, toEntity);
         }
+    }
+
+    @Override
+    public String getSQLQueryInClauseIDList_ForLoanProductsVisibleToOffice(final Long officeId) {
+        FineractEntityRelation fineractEntityRelation = fineractEntityRelationRepository
+                .findOneByCodeName(FineractEntityAccessType.OFFICE_ACCESS_TO_LOAN_PRODUCTS.getStr());
+        final Long relId = fineractEntityRelation.getId();
+        return "WITH RECURSIVE descendants AS ( " +
+                "  SELECT id, parent_id FROM m_office WHERE id = " + officeId + " " +
+                "  UNION ALL " +
+                "  SELECT o.id, o.parent_id FROM m_office o JOIN descendants d ON o.parent_id = d.id " +
+                ") " +
+                "select lp.id " +
+                "from m_product_loan lp " +
+                "where lp.id not in ( " +
+                "    select eem.to_id " +
+                "    from m_entity_to_entity_mapping eem " +
+                "    where eem.rel_id = " + relId + " " +
+                "    and eem.to_id <> 0 " +
+                ") " +
+                "or lp.id in ( " +
+                "    select eem.to_id " +
+                "    from m_entity_to_entity_mapping eem " +
+                "    where eem.rel_id = " + relId + " " +
+                "    and (eem.from_id in (select id from descendants) or eem.to_id = 0) " +
+                ")";
+    }
+
+    @Override
+    public boolean isLoanProductVisibleToOffice(final Long productId, final Long officeId) {
+        FineractEntityRelation fineractEntityRelation = fineractEntityRelationRepository
+                .findOneByCodeName(FineractEntityAccessType.OFFICE_ACCESS_TO_LOAN_PRODUCTS.getStr());
+        final Long relId = fineractEntityRelation.getId();
+
+        final String isRestrictedSql = "SELECT COUNT(*) FROM m_entity_to_entity_mapping eem "
+                + "WHERE eem.rel_id = ? AND eem.to_id = ?";
+        final Integer restrictedCount = jdbcTemplate.queryForObject(isRestrictedSql, Integer.class, relId, productId);
+        if (restrictedCount == null || restrictedCount == 0) {
+            return true;
+        }
+        final String visibleSql = "WITH RECURSIVE descendants AS ( "
+                + "  SELECT id FROM m_office WHERE id = ? "
+                + "  UNION ALL "
+                + "  SELECT o.id FROM m_office o JOIN descendants d ON o.parent_id = d.id "
+                + ") "
+                + "SELECT COUNT(*) FROM m_entity_to_entity_mapping eem "
+                + "WHERE eem.rel_id = ? AND eem.to_id = ? "
+                + "AND (eem.from_id IN (SELECT id FROM descendants) OR eem.from_id = 0)";
+        final Integer visibleCount = jdbcTemplate.queryForObject(visibleSql, Integer.class, officeId, relId, productId);
+        return visibleCount != null && visibleCount > 0;
     }
 
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/entityaccess/service/FineractEntityAccessReadServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/entityaccess/service/FineractEntityAccessReadServiceImpl.java
@@ -424,4 +424,30 @@ public class FineractEntityAccessReadServiceImpl implements FineractEntityAccess
         return visibleCount != null && visibleCount > 0;
     }
 
+    @Override
+    public String getSQLQueryInClauseIDList_ForChargesVisibleToOffice(final Long officeId) {
+        FineractEntityRelation fineractEntityRelation = fineractEntityRelationRepository
+                .findOneByCodeName(FineractEntityAccessType.OFFICE_ACCESS_TO_CHARGES.getStr());
+        final Long relId = fineractEntityRelation.getId();
+        return "WITH RECURSIVE descendants AS ( " +
+                "  SELECT id, parent_id FROM m_office WHERE id = " + officeId + " " +
+                "  UNION ALL " +
+                "  SELECT o.id, o.parent_id FROM m_office o JOIN descendants d ON o.parent_id = d.id " +
+                ") " +
+                "select c.id " +
+                "from m_charge c " +
+                "where c.id not in ( " +
+                "    select eem.to_id " +
+                "    from m_entity_to_entity_mapping eem " +
+                "    where eem.rel_id = " + relId + " " +
+                "    and eem.to_id <> 0 " +
+                ") " +
+                "or c.id in ( " +
+                "    select eem.to_id " +
+                "    from m_entity_to_entity_mapping eem " +
+                "    where eem.rel_id = " + relId + " " +
+                "    and (eem.from_id in (select id from descendants) or eem.to_id = 0) " +
+                ")";
+    }
+
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/entityaccess/service/FineractEntityAccessUtil.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/entityaccess/service/FineractEntityAccessUtil.java
@@ -124,4 +124,39 @@ public class FineractEntityAccessUtil {
         return inClause;
     }
 
+    public String getSQLWhereClauseForVisibleProductIDsForUserOffice_ifGlobalConfigEnabled(final FineractEntityType fineractEntityType) {
+        String inClause = "";
+
+        final GlobalConfigurationProperty property = this.globalConfigurationRepository
+                .findOneByNameWithNotFoundDetection(GlobalConfigurationConstants.OFFICE_SPECIFIC_PRODUCTS_ENABLED);
+
+        if (property.isEnabled()) {
+            if (fineractEntityType.equals(FineractEntityType.LOAN_PRODUCT)) {
+                inClause = this.fineractEntityAccessReadService
+                        .getSQLQueryInClauseIDList_ForLoanProductsVisibleToOffice(this.context.authenticatedUser().getOffice().getId());
+            } else if (fineractEntityType.equals(FineractEntityType.CHARGE)) {
+                inClause = this.fineractEntityAccessReadService
+                        .getSQLQueryInClauseIDList_ForChargesVisibleToOffice(this.context.authenticatedUser().getOffice().getId());
+            }
+        }
+        return inClause;
+    }
+
+    public String getSQLWhereClauseForVisibleProductIDsForOffice_ifGlobalConfigEnabled(final FineractEntityType fineractEntityType,
+            final Long officeId) {
+        String inClause = "";
+
+        final GlobalConfigurationProperty property = this.globalConfigurationRepository
+                .findOneByNameWithNotFoundDetection(GlobalConfigurationConstants.OFFICE_SPECIFIC_PRODUCTS_ENABLED);
+
+        if (property.isEnabled()) {
+            if (fineractEntityType.equals(FineractEntityType.LOAN_PRODUCT)) {
+                inClause = this.fineractEntityAccessReadService.getSQLQueryInClauseIDList_ForLoanProductsVisibleToOffice(officeId);
+            } else if (fineractEntityType.equals(FineractEntityType.CHARGE)) {
+                inClause = this.fineractEntityAccessReadService.getSQLQueryInClauseIDList_ForChargesVisibleToOffice(officeId);
+            }
+        }
+        return inClause;
+    }
+
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/entityaccess/service/FineractEntityAccessUtil.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/entityaccess/service/FineractEntityAccessUtil.java
@@ -124,4 +124,34 @@ public class FineractEntityAccessUtil {
         return inClause;
     }
 
+    public String getSQLWhereClauseForVisibleProductIDsForUserOffice_ifGlobalConfigEnabled(final FineractEntityType fineractEntityType) {
+        String inClause = "";
+
+        final GlobalConfigurationProperty property = this.globalConfigurationRepository
+                .findOneByNameWithNotFoundDetection(GlobalConfigurationConstants.OFFICE_SPECIFIC_PRODUCTS_ENABLED);
+
+        if (property.isEnabled()) {
+            if (fineractEntityType.equals(FineractEntityType.LOAN_PRODUCT)) {
+                inClause = this.fineractEntityAccessReadService
+                        .getSQLQueryInClauseIDList_ForLoanProductsVisibleToOffice(this.context.authenticatedUser().getOffice().getId());
+            }
+        }
+        return inClause;
+    }
+
+    public String getSQLWhereClauseForVisibleProductIDsForOffice_ifGlobalConfigEnabled(final FineractEntityType fineractEntityType,
+            final Long officeId) {
+        String inClause = "";
+
+        final GlobalConfigurationProperty property = this.globalConfigurationRepository
+                .findOneByNameWithNotFoundDetection(GlobalConfigurationConstants.OFFICE_SPECIFIC_PRODUCTS_ENABLED);
+
+        if (property.isEnabled()) {
+            if (fineractEntityType.equals(FineractEntityType.LOAN_PRODUCT)) {
+                inClause = this.fineractEntityAccessReadService.getSQLQueryInClauseIDList_ForLoanProductsVisibleToOffice(officeId);
+            }
+        }
+        return inClause;
+    }
+
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/entityaccess/service/FineractEntityAccessUtil.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/entityaccess/service/FineractEntityAccessUtil.java
@@ -134,6 +134,9 @@ public class FineractEntityAccessUtil {
             if (fineractEntityType.equals(FineractEntityType.LOAN_PRODUCT)) {
                 inClause = this.fineractEntityAccessReadService
                         .getSQLQueryInClauseIDList_ForLoanProductsVisibleToOffice(this.context.authenticatedUser().getOffice().getId());
+            } else if (fineractEntityType.equals(FineractEntityType.CHARGE)) {
+                inClause = this.fineractEntityAccessReadService
+                        .getSQLQueryInClauseIDList_ForChargesVisibleToOffice(this.context.authenticatedUser().getOffice().getId());
             }
         }
         return inClause;
@@ -149,6 +152,8 @@ public class FineractEntityAccessUtil {
         if (property.isEnabled()) {
             if (fineractEntityType.equals(FineractEntityType.LOAN_PRODUCT)) {
                 inClause = this.fineractEntityAccessReadService.getSQLQueryInClauseIDList_ForLoanProductsVisibleToOffice(officeId);
+            } else if (fineractEntityType.equals(FineractEntityType.CHARGE)) {
+                inClause = this.fineractEntityAccessReadService.getSQLQueryInClauseIDList_ForChargesVisibleToOffice(officeId);
             }
         }
         return inClause;

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/charge/service/ChargeReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/charge/service/ChargeReadPlatformServiceImpl.java
@@ -78,7 +78,7 @@ public class ChargeReadPlatformServiceImpl implements ChargeReadPlatformService 
 
         String sql = "select " + rm.chargeSchema() + " where c.is_deleted=false ";
 
-        sql += addInClauseToSQL_toLimitChargesMappedToOffice_ifOfficeSpecificProductsEnabled();
+        sql += addInClauseToSQL_toLimitChargesVisibleToUserOffice_ifOfficeSpecificProductsEnabled();
 
         sql += " order by c.name ";
 
@@ -90,23 +90,16 @@ public class ChargeReadPlatformServiceImpl implements ChargeReadPlatformService 
         final ChargeMapper rm = new ChargeMapper();
 
         String sql = "select " + rm.chargeSchema() + " where c.is_deleted=false and c.currency_code= ? ";
-
-        sql += addInClauseToSQL_toLimitChargesMappedToOffice_ifOfficeSpecificProductsEnabled();
         sql += " order by c.name ";
 
-        return this.jdbcTemplate.query(sql, rm, new Object[] { currencyCode }); // NOSONAR
+        return this.jdbcTemplate.query(sql, rm, currencyCode); // NOSONAR
     }
 
     @Override
     public ChargeData retrieveCharge(final Long chargeId) {
         try {
             final ChargeMapper rm = new ChargeMapper();
-
-            String sql = "select " + rm.chargeSchema() + " where c.id = ? and c.is_deleted=false ";
-
-            sql += addInClauseToSQL_toLimitChargesMappedToOffice_ifOfficeSpecificProductsEnabled();
-
-            sql = sql + " ;";
+            String sql = "select " + rm.chargeSchema() + " where c.id = ? and c.is_deleted=false ;";
             return this.jdbcTemplate.queryForObject(sql, rm, new Object[] { chargeId }); // NOSONAR
         } catch (final EmptyResultDataAccessException e) {
             throw new ChargeNotFoundException(chargeId, e);
@@ -179,23 +172,42 @@ public class ChargeReadPlatformServiceImpl implements ChargeReadPlatformService 
     @Override
     public List<ChargeData> retrieveLoanProductCharges(final Long loanProductId) {
         final ChargeMapper rm = new ChargeMapper();
-
         String sql = "select " + rm.loanProductChargeSchema() + " where c.is_deleted=false and c.is_active=true and plc.product_loan_id=? ";
-
         sql += addInClauseToSQL_toLimitChargesMappedToOffice_ifOfficeSpecificProductsEnabled();
+        return this.jdbcTemplate.query(sql, rm, new Object[] { loanProductId }); // NOSONAR
+    }
 
+    @Override
+    public List<ChargeData> retrieveLoanProductCharges(final Long loanProductId, final Long officeId) {
+        final ChargeMapper rm = new ChargeMapper();
+        String sql = "select " + rm.loanProductChargeSchema() + " where c.is_deleted=false and c.is_active=true and plc.product_loan_id=? ";
+        if (officeId != null) {
+            sql += addInClauseToSQL_toLimitChargesVisibleToOffice_ifOfficeSpecificProductsEnabled(officeId);
+        } else {
+            sql += addInClauseToSQL_toLimitChargesMappedToOffice_ifOfficeSpecificProductsEnabled();
+        }
         return this.jdbcTemplate.query(sql, rm, new Object[] { loanProductId }); // NOSONAR
     }
 
     @Override
     public List<ChargeData> retrieveLoanProductCharges(final Long loanProductId, final ChargeTimeType chargeTime) {
-
         final ChargeMapper rm = new ChargeMapper();
-
         String sql = "select " + rm.loanProductChargeSchema()
                 + " where c.is_deleted=false and c.is_active=true and plc.product_loan_id=? and c.charge_time_enum=? ";
         sql += addInClauseToSQL_toLimitChargesMappedToOffice_ifOfficeSpecificProductsEnabled();
+        return this.jdbcTemplate.query(sql, rm, new Object[] { loanProductId, chargeTime.getValue() }); // NOSONAR
+    }
 
+    @Override
+    public List<ChargeData> retrieveLoanProductCharges(final Long loanProductId, final ChargeTimeType chargeTime, final Long officeId) {
+        final ChargeMapper rm = new ChargeMapper();
+        String sql = "select " + rm.loanProductChargeSchema()
+                + " where c.is_deleted=false and c.is_active=true and plc.product_loan_id=? and c.charge_time_enum=? ";
+        if (officeId != null) {
+            sql += addInClauseToSQL_toLimitChargesVisibleToOffice_ifOfficeSpecificProductsEnabled(officeId);
+        } else {
+            sql += addInClauseToSQL_toLimitChargesMappedToOffice_ifOfficeSpecificProductsEnabled();
+        }
         return this.jdbcTemplate.query(sql, rm, new Object[] { loanProductId, chargeTime.getValue() }); // NOSONAR
     }
 
@@ -221,7 +233,17 @@ public class ChargeReadPlatformServiceImpl implements ChargeReadPlatformService 
         processChargeExclusionsForLoans(excludeChargeTimes, excludeClause);
         String sql = "select " + rm.chargeSchema() + " join m_loan la on la.currency_code = c.currency_code" + " where la.id=:loanId"
                 + " and c.is_deleted=false and c.is_active=true and c.charge_applies_to_enum=:chargeAppliesTo" + excludeClause + " ";
-        sql += addInClauseToSQL_toLimitChargesMappedToOffice_ifOfficeSpecificProductsEnabled();
+
+        Long officeId = this.jdbcTemplate.queryForObject("select coalesce(c.office_id, g.office_id) from m_loan la "
+                + "left join m_client c on c.id = la.client_id " + "left join m_group g on g.id = la.group_id " + "where la.id = ?",
+                Long.class, loanId);
+
+        if (officeId == null) {
+            throw new IllegalStateException("Cannot resolve office for loan [id=" + loanId + "]. Charge visibility cannot be determined.");
+        }
+
+        sql += addInClauseToSQL_toLimitChargesVisibleToOffice_ifOfficeSpecificProductsEnabled(officeId);
+
         sql += " order by c.name ";
         return this.namedParameterJdbcTemplate.query(sql, paramMap, rm);
     }
@@ -246,6 +268,12 @@ public class ChargeReadPlatformServiceImpl implements ChargeReadPlatformService 
 
     @Override
     public List<ChargeData> retrieveLoanProductApplicableCharges(final Long loanProductId, ChargeTimeType[] excludeChargeTimes) {
+        return retrieveLoanProductApplicableCharges(loanProductId, excludeChargeTimes, null);
+    }
+
+    @Override
+    public List<ChargeData> retrieveLoanProductApplicableCharges(final Long loanProductId, ChargeTimeType[] excludeChargeTimes,
+            final Long officeId) {
         final ChargeMapper rm = new ChargeMapper();
         StringBuilder excludeClause = new StringBuilder("");
         Map<String, Object> paramMap = new HashMap<>();
@@ -255,7 +283,13 @@ public class ChargeReadPlatformServiceImpl implements ChargeReadPlatformService 
         String sql = "select " + rm.chargeSchema() + " join m_product_loan lp on lp.currency_code = c.currency_code"
                 + " where lp.id=:productId" + " and c.is_deleted=false and c.is_active=true and c.charge_applies_to_enum=:chargeAppliesTo"
                 + excludeClause + " ";
-        sql += addInClauseToSQL_toLimitChargesMappedToOffice_ifOfficeSpecificProductsEnabled();
+
+        if (officeId != null) {
+            sql += addInClauseToSQL_toLimitChargesVisibleToOffice_ifOfficeSpecificProductsEnabled(officeId);
+        } else {
+            sql += addInClauseToSQL_toLimitChargesVisibleToUserOffice_ifOfficeSpecificProductsEnabled();
+        }
+
         sql += " order by c.name ";
 
         return this.namedParameterJdbcTemplate.query(sql, paramMap, rm);
@@ -272,14 +306,42 @@ public class ChargeReadPlatformServiceImpl implements ChargeReadPlatformService 
         return this.jdbcTemplate.query(sql, rm, new Object[] { ChargeAppliesTo.LOAN.getValue() }); // NOSONAR
     }
 
+    private String addInClauseToSQL_toLimitChargesVisibleToUserOffice_ifOfficeSpecificProductsEnabled() {
+        String sql = "";
+
+        final String inClause = fineractEntityAccessUtil
+                .getSQLWhereClauseForVisibleProductIDsForUserOffice_ifGlobalConfigEnabled(FineractEntityType.CHARGE);
+
+        if (inClause != null && !inClause.trim().isEmpty()) {
+            sql += " and c.id in ( " + inClause + " ) ";
+        }
+
+        return sql;
+    }
+
+    private String addInClauseToSQL_toLimitChargesVisibleToOffice_ifOfficeSpecificProductsEnabled(final Long officeId) {
+        if (officeId == null) {
+            return addInClauseToSQL_toLimitChargesVisibleToUserOffice_ifOfficeSpecificProductsEnabled();
+        }
+
+        String sql = "";
+        final String inClause = fineractEntityAccessUtil
+                .getSQLWhereClauseForVisibleProductIDsForOffice_ifGlobalConfigEnabled(FineractEntityType.CHARGE, officeId);
+
+        if (inClause != null && !inClause.trim().isEmpty()) {
+            sql += " and c.id in ( " + inClause + " ) ";
+        }
+
+        return sql;
+    }
+
     private String addInClauseToSQL_toLimitChargesMappedToOffice_ifOfficeSpecificProductsEnabled() {
 
         String sql = "";
 
-        // Check if branch specific products are enabled. If yes, fetch only
-        // charges mapped to current user's office
-        String inClause = fineractEntityAccessUtil
-                .getSQLWhereClauseForProductIDsForUserOffice_ifGlobalConfigEnabled(FineractEntityType.CHARGE);
+        final String inClause = fineractEntityAccessUtil
+                .getSQLWhereClauseForVisibleProductIDsForUserOffice_ifGlobalConfigEnabled(FineractEntityType.CHARGE);
+
         if ((inClause != null) && !inClause.trim().isEmpty()) {
             sql += " and c.id in ( " + inClause + " ) ";
         }
@@ -406,29 +468,81 @@ public class ChargeReadPlatformServiceImpl implements ChargeReadPlatformService 
     }
 
     @Override
-    public List<ChargeData> retrieveSavingsProductApplicableCharges(final boolean feeChargesOnly) {
+    public List<ChargeData> retrieveAllChargesApplicableToClients() {
         final ChargeMapper rm = new ChargeMapper();
-
         String sql = "select " + rm.chargeSchema() + " where c.is_deleted=false and c.is_active=true and c.charge_applies_to_enum=? ";
-        if (feeChargesOnly) {
-            sql = "select " + rm.chargeSchema()
-                    + " where c.is_deleted=false and c.is_active=true and c.is_penalty=false and c.charge_applies_to_enum=? ";
-        }
         sql += addInClauseToSQL_toLimitChargesMappedToOffice_ifOfficeSpecificProductsEnabled();
         sql += " order by c.name ";
+        return this.jdbcTemplate.query(sql, rm, new Object[] { ChargeAppliesTo.CLIENT.getValue() }); // NOSONAR
+    }
 
-        return this.jdbcTemplate.query(sql, rm, new Object[] { ChargeAppliesTo.SAVINGS.getValue() }); // NOSONAR
+    @Override
+    public List<ChargeData> retrieveAllChargesApplicableToClients(Long officeId) {
+        final ChargeMapper rm = new ChargeMapper();
+        String sql = "select " + rm.chargeSchema() + " where c.is_deleted=false and c.is_active=true and c.charge_applies_to_enum=? ";
+        sql += addInClauseToSQL_toLimitChargesVisibleToOffice_ifOfficeSpecificProductsEnabled(officeId);
+        sql += " order by c.name ";
+        return this.jdbcTemplate.query(sql, rm, ChargeAppliesTo.CLIENT.getValue()); // NOSONAR
+    }
+
+    @Override
+    public List<ChargeData> retrieveLoanApplicableFees(Long officeId) {
+        final ChargeMapper rm = new ChargeMapper();
+        String sql = "select " + rm.chargeSchema()
+                + " where c.is_deleted=false and c.is_active=true and c.is_penalty=false and c.charge_applies_to_enum=? ";
+        sql += addInClauseToSQL_toLimitChargesVisibleToOffice_ifOfficeSpecificProductsEnabled(officeId);
+        sql += " order by c.name ";
+        return this.jdbcTemplate.query(sql, rm, ChargeAppliesTo.LOAN.getValue()); // NOSONAR
+    }
+
+    @Override
+    public List<ChargeData> retrieveLoanApplicablePenalties(Long officeId) {
+        final ChargeMapper rm = new ChargeMapper();
+        String sql = "select " + rm.chargeSchema()
+                + " where c.is_deleted=false and c.is_active=true and c.is_penalty=true and c.charge_applies_to_enum=? ";
+        sql += addInClauseToSQL_toLimitChargesVisibleToOffice_ifOfficeSpecificProductsEnabled(officeId);
+        sql += " order by c.name ";
+        return this.jdbcTemplate.query(sql, rm, ChargeAppliesTo.LOAN.getValue()); // NOSONAR
+    }
+
+    @Override
+    public List<ChargeData> retrieveSavingsProductApplicableCharges(final boolean feeChargesOnly) {
+        return retrieveSavingsProductApplicableCharges(feeChargesOnly, null);
     }
 
     @Override
     public List<ChargeData> retrieveSavingsApplicablePenalties() {
+        return retrieveSavingsApplicablePenalties(null);
+    }
+
+    @Override
+    public List<ChargeData> retrieveSharesApplicableCharges() {
+        return retrieveSharesApplicableCharges(null);
+    }
+
+    @Override
+    public List<ChargeData> retrieveSavingsProductApplicableCharges(final boolean feeChargesOnly, final Long officeId) {
         final ChargeMapper rm = new ChargeMapper();
 
+        String sql = "select " + rm.chargeSchema() + " where c.is_deleted=false and c.charge_applies_to_enum=? ";
+        if (feeChargesOnly) {
+            sql = "select " + rm.chargeSchema()
+                    + " where c.is_deleted=false and c.is_active=true and c.is_penalty=false and c.charge_applies_to_enum=? ";
+        }
+        sql += addInClauseToSQL_toLimitChargesVisibleToOffice_ifOfficeSpecificProductsEnabled(officeId);
+        sql += " order by c.name ";
+
+        return this.jdbcTemplate.query(sql, rm, ChargeAppliesTo.SAVINGS.getValue()); // NOSONAR
+    }
+
+    @Override
+    public List<ChargeData> retrieveSavingsApplicablePenalties(final Long officeId) {
+        final ChargeMapper rm = new ChargeMapper();
         String sql = "select " + rm.chargeSchema()
                 + " where c.is_deleted=false and c.is_active=true and c.is_penalty=true and c.charge_applies_to_enum=? ";
-        sql += addInClauseToSQL_toLimitChargesMappedToOffice_ifOfficeSpecificProductsEnabled();
+        sql += addInClauseToSQL_toLimitChargesVisibleToOffice_ifOfficeSpecificProductsEnabled(officeId);
         sql += " order by c.name ";
-        return this.jdbcTemplate.query(sql, rm, new Object[] { ChargeAppliesTo.SAVINGS.getValue() }); // NOSONAR
+        return this.jdbcTemplate.query(sql, rm, ChargeAppliesTo.SAVINGS.getValue()); // NOSONAR
     }
 
     @Override
@@ -443,12 +557,37 @@ public class ChargeReadPlatformServiceImpl implements ChargeReadPlatformService 
     }
 
     @Override
-    public List<ChargeData> retrieveShareProductCharges(final Long shareProductId) {
+    public List<ChargeData> retrieveSavingsProductCharges(final Long savingsProductId, final Long officeId) {
         final ChargeMapper rm = new ChargeMapper();
+        String sql = "select " + rm.savingsProductChargeSchema()
+                + " where c.is_deleted=false and c.is_active=true and spc.savings_product_id=? ";
+        if (officeId != null) {
+            sql += addInClauseToSQL_toLimitChargesVisibleToOffice_ifOfficeSpecificProductsEnabled(officeId);
+        } else {
+            sql += addInClauseToSQL_toLimitChargesMappedToOffice_ifOfficeSpecificProductsEnabled();
+        }
+        return this.jdbcTemplate.query(sql, rm, new Object[] { savingsProductId }); // NOSONAR
+    }
 
+    @Override
+    public List<ChargeData> retrieveSharesApplicableCharges(final Long officeId) {
+        final ChargeMapper rm = new ChargeMapper();
+        String sql = "select " + rm.chargeSchema() + " where c.is_deleted=false and c.is_active=true and c.charge_applies_to_enum=? ";
+        sql += addInClauseToSQL_toLimitChargesVisibleToOffice_ifOfficeSpecificProductsEnabled(officeId);
+        sql += " order by c.name ";
+        return this.jdbcTemplate.query(sql, rm, ChargeAppliesTo.SHARES.getValue()); // NOSONAR
+    }
+
+    @Override
+    public List<ChargeData> retrieveShareProductCharges(final Long shareProductId) {
+        return retrieveShareProductCharges(shareProductId, null);
+    }
+
+    @Override
+    public List<ChargeData> retrieveShareProductCharges(final Long shareProductId, final Long officeId) {
+        final ChargeMapper rm = new ChargeMapper();
         String sql = "select " + rm.shareProductChargeSchema() + " where c.is_deleted=false and c.is_active=true and mspc.product_id=? ";
-        sql += addInClauseToSQL_toLimitChargesMappedToOffice_ifOfficeSpecificProductsEnabled();
-
+        sql += addInClauseToSQL_toLimitChargesVisibleToOffice_ifOfficeSpecificProductsEnabled(officeId);
         return this.jdbcTemplate.query(sql, rm, new Object[] { shareProductId }); // NOSONAR
     }
 
@@ -469,32 +608,21 @@ public class ChargeReadPlatformServiceImpl implements ChargeReadPlatformService 
     public List<ChargeData> retrieveSavingsAccountApplicableCharges(Long savingsAccountId) {
 
         final ChargeMapper rm = new ChargeMapper();
+        Long officeId = this.jdbcTemplate.queryForObject("select coalesce(c.office_id, g.office_id) from m_savings_account sa "
+                + "left join m_client c on c.id = sa.client_id " + "left join m_group g on g.id = sa.group_id " + "where sa.id = ?",
+                Long.class, savingsAccountId);
+
+        if (officeId == null) {
+            throw new IllegalStateException(
+                    "Cannot resolve office for savings account [id=" + savingsAccountId + "]. Charge visibility cannot be determined.");
+        }
 
         String sql = "select " + rm.chargeSchema() + " join m_savings_account sa on sa.currency_code = c.currency_code"
                 + " where c.is_deleted=false and c.is_active=true and c.charge_applies_to_enum=? " + " and sa.id = ?";
-        sql += addInClauseToSQL_toLimitChargesMappedToOffice_ifOfficeSpecificProductsEnabled();
+
+        sql += addInClauseToSQL_toLimitChargesVisibleToOffice_ifOfficeSpecificProductsEnabled(officeId);
 
         return this.jdbcTemplate.query(sql, rm, new Object[] { ChargeAppliesTo.SAVINGS.getValue(), savingsAccountId }); // NOSONAR
 
-    }
-
-    @Override
-    public List<ChargeData> retrieveAllChargesApplicableToClients() {
-        final ChargeMapper rm = new ChargeMapper();
-        String sql = "select " + rm.chargeSchema() + " where c.is_deleted=false and c.is_active=true and c.charge_applies_to_enum=? ";
-        sql += addInClauseToSQL_toLimitChargesMappedToOffice_ifOfficeSpecificProductsEnabled();
-        sql += " order by c.name ";
-
-        return this.jdbcTemplate.query(sql, rm, new Object[] { ChargeAppliesTo.CLIENT.getValue() }); // NOSONAR
-    }
-
-    @Override
-    public List<ChargeData> retrieveSharesApplicableCharges() {
-        final ChargeMapper rm = new ChargeMapper();
-        String sql = "select " + rm.chargeSchema() + " where c.is_deleted=false and c.is_active=true and c.charge_applies_to_enum=? ";
-        sql += addInClauseToSQL_toLimitChargesMappedToOffice_ifOfficeSpecificProductsEnabled();
-        sql += " order by c.name ";
-
-        return this.jdbcTemplate.query(sql, rm, new Object[] { ChargeAppliesTo.SHARES.getValue() }); // NOSONAR
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/charge/service/ChargeReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/charge/service/ChargeReadPlatformServiceImpl.java
@@ -78,7 +78,7 @@ public class ChargeReadPlatformServiceImpl implements ChargeReadPlatformService 
 
         String sql = "select " + rm.chargeSchema() + " where c.is_deleted=false ";
 
-        sql += addInClauseToSQL_toLimitChargesMappedToOffice_ifOfficeSpecificProductsEnabled();
+        sql += addInClauseToSQL_toLimitChargesVisibleToUserOffice_ifOfficeSpecificProductsEnabled();
 
         sql += " order by c.name ";
 
@@ -90,23 +90,16 @@ public class ChargeReadPlatformServiceImpl implements ChargeReadPlatformService 
         final ChargeMapper rm = new ChargeMapper();
 
         String sql = "select " + rm.chargeSchema() + " where c.is_deleted=false and c.currency_code= ? ";
-
-        sql += addInClauseToSQL_toLimitChargesMappedToOffice_ifOfficeSpecificProductsEnabled();
         sql += " order by c.name ";
 
-        return this.jdbcTemplate.query(sql, rm, new Object[] { currencyCode }); // NOSONAR
+        return this.jdbcTemplate.query(sql, rm, currencyCode); // NOSONAR
     }
 
     @Override
     public ChargeData retrieveCharge(final Long chargeId) {
         try {
             final ChargeMapper rm = new ChargeMapper();
-
-            String sql = "select " + rm.chargeSchema() + " where c.id = ? and c.is_deleted=false ";
-
-            sql += addInClauseToSQL_toLimitChargesMappedToOffice_ifOfficeSpecificProductsEnabled();
-
-            sql = sql + " ;";
+            String sql = "select " + rm.chargeSchema() + " where c.id = ? and c.is_deleted=false ;";
             return this.jdbcTemplate.queryForObject(sql, rm, new Object[] { chargeId }); // NOSONAR
         } catch (final EmptyResultDataAccessException e) {
             throw new ChargeNotFoundException(chargeId, e);
@@ -179,23 +172,44 @@ public class ChargeReadPlatformServiceImpl implements ChargeReadPlatformService 
     @Override
     public List<ChargeData> retrieveLoanProductCharges(final Long loanProductId) {
         final ChargeMapper rm = new ChargeMapper();
-
-        String sql = "select " + rm.loanProductChargeSchema() + " where c.is_deleted=false and c.is_active=true and plc.product_loan_id=? ";
-
+        String sql = "select " + rm.loanProductChargeSchema()
+                + " where c.is_deleted=false and c.is_active=true and plc.product_loan_id=? ";
         sql += addInClauseToSQL_toLimitChargesMappedToOffice_ifOfficeSpecificProductsEnabled();
+        return this.jdbcTemplate.query(sql, rm, new Object[] { loanProductId }); // NOSONAR
+    }
 
+    @Override
+    public List<ChargeData> retrieveLoanProductCharges(final Long loanProductId, final Long officeId) {
+        final ChargeMapper rm = new ChargeMapper();
+        String sql = "select " + rm.loanProductChargeSchema()
+                + " where c.is_deleted=false and c.is_active=true and plc.product_loan_id=? ";
+        if (officeId != null) {
+            sql += addInClauseToSQL_toLimitChargesVisibleToOffice_ifOfficeSpecificProductsEnabled(officeId);
+        } else {
+            sql += addInClauseToSQL_toLimitChargesMappedToOffice_ifOfficeSpecificProductsEnabled();
+        }
         return this.jdbcTemplate.query(sql, rm, new Object[] { loanProductId }); // NOSONAR
     }
 
     @Override
     public List<ChargeData> retrieveLoanProductCharges(final Long loanProductId, final ChargeTimeType chargeTime) {
-
         final ChargeMapper rm = new ChargeMapper();
-
         String sql = "select " + rm.loanProductChargeSchema()
                 + " where c.is_deleted=false and c.is_active=true and plc.product_loan_id=? and c.charge_time_enum=? ";
         sql += addInClauseToSQL_toLimitChargesMappedToOffice_ifOfficeSpecificProductsEnabled();
+        return this.jdbcTemplate.query(sql, rm, new Object[] { loanProductId, chargeTime.getValue() }); // NOSONAR
+    }
 
+    @Override
+    public List<ChargeData> retrieveLoanProductCharges(final Long loanProductId, final ChargeTimeType chargeTime, final Long officeId) {
+        final ChargeMapper rm = new ChargeMapper();
+        String sql = "select " + rm.loanProductChargeSchema()
+                + " where c.is_deleted=false and c.is_active=true and plc.product_loan_id=? and c.charge_time_enum=? ";
+        if (officeId != null) {
+            sql += addInClauseToSQL_toLimitChargesVisibleToOffice_ifOfficeSpecificProductsEnabled(officeId);
+        } else {
+            sql += addInClauseToSQL_toLimitChargesMappedToOffice_ifOfficeSpecificProductsEnabled();
+        }
         return this.jdbcTemplate.query(sql, rm, new Object[] { loanProductId, chargeTime.getValue() }); // NOSONAR
     }
 
@@ -221,7 +235,21 @@ public class ChargeReadPlatformServiceImpl implements ChargeReadPlatformService 
         processChargeExclusionsForLoans(excludeChargeTimes, excludeClause);
         String sql = "select " + rm.chargeSchema() + " join m_loan la on la.currency_code = c.currency_code" + " where la.id=:loanId"
                 + " and c.is_deleted=false and c.is_active=true and c.charge_applies_to_enum=:chargeAppliesTo" + excludeClause + " ";
-        sql += addInClauseToSQL_toLimitChargesMappedToOffice_ifOfficeSpecificProductsEnabled();
+
+        Long officeId = this.jdbcTemplate.queryForObject(
+                "select coalesce(c.office_id, g.office_id) from m_loan la "
+                        + "left join m_client c on c.id = la.client_id "
+                        + "left join m_group g on g.id = la.group_id "
+                        + "where la.id = ?",
+                Long.class, loanId);
+
+        if (officeId == null) {
+            throw new IllegalStateException(
+                    "Cannot resolve office for loan [id=" + loanId + "]. Charge visibility cannot be determined.");
+        }
+
+        sql += addInClauseToSQL_toLimitChargesVisibleToOffice_ifOfficeSpecificProductsEnabled(officeId);
+
         sql += " order by c.name ";
         return this.namedParameterJdbcTemplate.query(sql, paramMap, rm);
     }
@@ -246,6 +274,12 @@ public class ChargeReadPlatformServiceImpl implements ChargeReadPlatformService 
 
     @Override
     public List<ChargeData> retrieveLoanProductApplicableCharges(final Long loanProductId, ChargeTimeType[] excludeChargeTimes) {
+        return retrieveLoanProductApplicableCharges(loanProductId, excludeChargeTimes, null);
+    }
+
+    @Override
+    public List<ChargeData> retrieveLoanProductApplicableCharges(final Long loanProductId, ChargeTimeType[] excludeChargeTimes,
+            final Long officeId) {
         final ChargeMapper rm = new ChargeMapper();
         StringBuilder excludeClause = new StringBuilder("");
         Map<String, Object> paramMap = new HashMap<>();
@@ -255,7 +289,13 @@ public class ChargeReadPlatformServiceImpl implements ChargeReadPlatformService 
         String sql = "select " + rm.chargeSchema() + " join m_product_loan lp on lp.currency_code = c.currency_code"
                 + " where lp.id=:productId" + " and c.is_deleted=false and c.is_active=true and c.charge_applies_to_enum=:chargeAppliesTo"
                 + excludeClause + " ";
-        sql += addInClauseToSQL_toLimitChargesMappedToOffice_ifOfficeSpecificProductsEnabled();
+
+        if (officeId != null) {
+            sql += addInClauseToSQL_toLimitChargesVisibleToOffice_ifOfficeSpecificProductsEnabled(officeId);
+        } else {
+            sql += addInClauseToSQL_toLimitChargesVisibleToUserOffice_ifOfficeSpecificProductsEnabled();
+        }
+
         sql += " order by c.name ";
 
         return this.namedParameterJdbcTemplate.query(sql, paramMap, rm);
@@ -272,14 +312,42 @@ public class ChargeReadPlatformServiceImpl implements ChargeReadPlatformService 
         return this.jdbcTemplate.query(sql, rm, new Object[] { ChargeAppliesTo.LOAN.getValue() }); // NOSONAR
     }
 
+    private String addInClauseToSQL_toLimitChargesVisibleToUserOffice_ifOfficeSpecificProductsEnabled() {
+        String sql = "";
+
+        final String inClause = fineractEntityAccessUtil
+                .getSQLWhereClauseForVisibleProductIDsForUserOffice_ifGlobalConfigEnabled(FineractEntityType.CHARGE);
+
+        if (inClause != null && !inClause.trim().isEmpty()) {
+            sql += " and c.id in ( " + inClause + " ) ";
+        }
+
+        return sql;
+    }
+
+    private String addInClauseToSQL_toLimitChargesVisibleToOffice_ifOfficeSpecificProductsEnabled(final Long officeId) {
+        if (officeId == null) {
+            return addInClauseToSQL_toLimitChargesVisibleToUserOffice_ifOfficeSpecificProductsEnabled();
+        }
+
+        String sql = "";
+        final String inClause = fineractEntityAccessUtil
+                .getSQLWhereClauseForVisibleProductIDsForOffice_ifGlobalConfigEnabled(FineractEntityType.CHARGE, officeId);
+
+        if (inClause != null && !inClause.trim().isEmpty()) {
+            sql += " and c.id in ( " + inClause + " ) ";
+        }
+
+        return sql;
+    }
+
     private String addInClauseToSQL_toLimitChargesMappedToOffice_ifOfficeSpecificProductsEnabled() {
 
         String sql = "";
 
-        // Check if branch specific products are enabled. If yes, fetch only
-        // charges mapped to current user's office
-        String inClause = fineractEntityAccessUtil
-                .getSQLWhereClauseForProductIDsForUserOffice_ifGlobalConfigEnabled(FineractEntityType.CHARGE);
+        final String inClause = fineractEntityAccessUtil
+                .getSQLWhereClauseForVisibleProductIDsForUserOffice_ifGlobalConfigEnabled(FineractEntityType.CHARGE);
+
         if ((inClause != null) && !inClause.trim().isEmpty()) {
             sql += " and c.id in ( " + inClause + " ) ";
         }
@@ -406,29 +474,81 @@ public class ChargeReadPlatformServiceImpl implements ChargeReadPlatformService 
     }
 
     @Override
-    public List<ChargeData> retrieveSavingsProductApplicableCharges(final boolean feeChargesOnly) {
+    public List<ChargeData> retrieveAllChargesApplicableToClients() {
         final ChargeMapper rm = new ChargeMapper();
-
         String sql = "select " + rm.chargeSchema() + " where c.is_deleted=false and c.is_active=true and c.charge_applies_to_enum=? ";
-        if (feeChargesOnly) {
-            sql = "select " + rm.chargeSchema()
-                    + " where c.is_deleted=false and c.is_active=true and c.is_penalty=false and c.charge_applies_to_enum=? ";
-        }
         sql += addInClauseToSQL_toLimitChargesMappedToOffice_ifOfficeSpecificProductsEnabled();
         sql += " order by c.name ";
+        return this.jdbcTemplate.query(sql, rm, new Object[] { ChargeAppliesTo.CLIENT.getValue() }); // NOSONAR
+    }
 
-        return this.jdbcTemplate.query(sql, rm, new Object[] { ChargeAppliesTo.SAVINGS.getValue() }); // NOSONAR
+    @Override
+    public List<ChargeData> retrieveAllChargesApplicableToClients(Long officeId) {
+        final ChargeMapper rm = new ChargeMapper();
+        String sql = "select " + rm.chargeSchema() + " where c.is_deleted=false and c.is_active=true and c.charge_applies_to_enum=? ";
+        sql += addInClauseToSQL_toLimitChargesVisibleToOffice_ifOfficeSpecificProductsEnabled(officeId);
+        sql += " order by c.name ";
+        return this.jdbcTemplate.query(sql, rm, ChargeAppliesTo.CLIENT.getValue()); // NOSONAR
+    }
+
+    @Override
+    public List<ChargeData> retrieveLoanApplicableFees(Long officeId) {
+        final ChargeMapper rm = new ChargeMapper();
+        String sql = "select " + rm.chargeSchema()
+                + " where c.is_deleted=false and c.is_active=true and c.is_penalty=false and c.charge_applies_to_enum=? ";
+        sql += addInClauseToSQL_toLimitChargesVisibleToOffice_ifOfficeSpecificProductsEnabled(officeId);
+        sql += " order by c.name ";
+        return this.jdbcTemplate.query(sql, rm, ChargeAppliesTo.LOAN.getValue()); // NOSONAR
+    }
+
+    @Override
+    public List<ChargeData> retrieveLoanApplicablePenalties(Long officeId) {
+        final ChargeMapper rm = new ChargeMapper();
+        String sql = "select " + rm.chargeSchema()
+                + " where c.is_deleted=false and c.is_active=true and c.is_penalty=true and c.charge_applies_to_enum=? ";
+        sql += addInClauseToSQL_toLimitChargesVisibleToOffice_ifOfficeSpecificProductsEnabled(officeId);
+        sql += " order by c.name ";
+        return this.jdbcTemplate.query(sql, rm, ChargeAppliesTo.LOAN.getValue()); // NOSONAR
+    }
+
+    @Override
+    public List<ChargeData> retrieveSavingsProductApplicableCharges(final boolean feeChargesOnly) {
+        return retrieveSavingsProductApplicableCharges(feeChargesOnly, null);
     }
 
     @Override
     public List<ChargeData> retrieveSavingsApplicablePenalties() {
+        return retrieveSavingsApplicablePenalties(null);
+    }
+
+    @Override
+    public List<ChargeData> retrieveSharesApplicableCharges() {
+        return retrieveSharesApplicableCharges(null);
+    }
+
+    @Override
+    public List<ChargeData> retrieveSavingsProductApplicableCharges(final boolean feeChargesOnly, final Long officeId) {
         final ChargeMapper rm = new ChargeMapper();
 
+        String sql = "select " + rm.chargeSchema() + " where c.is_deleted=false and c.charge_applies_to_enum=? ";
+        if (feeChargesOnly) {
+            sql = "select " + rm.chargeSchema()
+                    + " where c.is_deleted=false and c.is_active=true and c.is_penalty=false and c.charge_applies_to_enum=? ";
+        }
+        sql += addInClauseToSQL_toLimitChargesVisibleToOffice_ifOfficeSpecificProductsEnabled(officeId);
+        sql += " order by c.name ";
+
+        return this.jdbcTemplate.query(sql, rm, ChargeAppliesTo.SAVINGS.getValue()); // NOSONAR
+    }
+
+    @Override
+    public List<ChargeData> retrieveSavingsApplicablePenalties(final Long officeId) {
+        final ChargeMapper rm = new ChargeMapper();
         String sql = "select " + rm.chargeSchema()
                 + " where c.is_deleted=false and c.is_active=true and c.is_penalty=true and c.charge_applies_to_enum=? ";
-        sql += addInClauseToSQL_toLimitChargesMappedToOffice_ifOfficeSpecificProductsEnabled();
+        sql += addInClauseToSQL_toLimitChargesVisibleToOffice_ifOfficeSpecificProductsEnabled(officeId);
         sql += " order by c.name ";
-        return this.jdbcTemplate.query(sql, rm, new Object[] { ChargeAppliesTo.SAVINGS.getValue() }); // NOSONAR
+        return this.jdbcTemplate.query(sql, rm, ChargeAppliesTo.SAVINGS.getValue()); // NOSONAR
     }
 
     @Override
@@ -443,12 +563,37 @@ public class ChargeReadPlatformServiceImpl implements ChargeReadPlatformService 
     }
 
     @Override
-    public List<ChargeData> retrieveShareProductCharges(final Long shareProductId) {
+    public List<ChargeData> retrieveSavingsProductCharges(final Long savingsProductId, final Long officeId) {
         final ChargeMapper rm = new ChargeMapper();
+        String sql = "select " + rm.savingsProductChargeSchema()
+                + " where c.is_deleted=false and c.is_active=true and spc.savings_product_id=? ";
+        if (officeId != null) {
+            sql += addInClauseToSQL_toLimitChargesVisibleToOffice_ifOfficeSpecificProductsEnabled(officeId);
+        } else {
+            sql += addInClauseToSQL_toLimitChargesMappedToOffice_ifOfficeSpecificProductsEnabled();
+        }
+        return this.jdbcTemplate.query(sql, rm, new Object[] { savingsProductId }); // NOSONAR
+    }
 
+    @Override
+    public List<ChargeData> retrieveSharesApplicableCharges(final Long officeId) {
+        final ChargeMapper rm = new ChargeMapper();
+        String sql = "select " + rm.chargeSchema() + " where c.is_deleted=false and c.is_active=true and c.charge_applies_to_enum=? ";
+        sql += addInClauseToSQL_toLimitChargesVisibleToOffice_ifOfficeSpecificProductsEnabled(officeId);
+        sql += " order by c.name ";
+        return this.jdbcTemplate.query(sql, rm, ChargeAppliesTo.SHARES.getValue()); // NOSONAR
+    }
+
+    @Override
+    public List<ChargeData> retrieveShareProductCharges(final Long shareProductId) {
+        return retrieveShareProductCharges(shareProductId, null);
+    }
+
+    @Override
+    public List<ChargeData> retrieveShareProductCharges(final Long shareProductId, final Long officeId) {
+        final ChargeMapper rm = new ChargeMapper();
         String sql = "select " + rm.shareProductChargeSchema() + " where c.is_deleted=false and c.is_active=true and mspc.product_id=? ";
-        sql += addInClauseToSQL_toLimitChargesMappedToOffice_ifOfficeSpecificProductsEnabled();
-
+        sql += addInClauseToSQL_toLimitChargesVisibleToOffice_ifOfficeSpecificProductsEnabled(officeId);
         return this.jdbcTemplate.query(sql, rm, new Object[] { shareProductId }); // NOSONAR
     }
 
@@ -469,32 +614,24 @@ public class ChargeReadPlatformServiceImpl implements ChargeReadPlatformService 
     public List<ChargeData> retrieveSavingsAccountApplicableCharges(Long savingsAccountId) {
 
         final ChargeMapper rm = new ChargeMapper();
+        Long officeId = this.jdbcTemplate.queryForObject(
+                "select coalesce(c.office_id, g.office_id) from m_savings_account sa "
+                        + "left join m_client c on c.id = sa.client_id "
+                        + "left join m_group g on g.id = sa.group_id "
+                        + "where sa.id = ?",
+                Long.class, savingsAccountId);
+
+        if (officeId == null) {
+            throw new IllegalStateException(
+                    "Cannot resolve office for savings account [id=" + savingsAccountId + "]. Charge visibility cannot be determined.");
+        }
 
         String sql = "select " + rm.chargeSchema() + " join m_savings_account sa on sa.currency_code = c.currency_code"
                 + " where c.is_deleted=false and c.is_active=true and c.charge_applies_to_enum=? " + " and sa.id = ?";
-        sql += addInClauseToSQL_toLimitChargesMappedToOffice_ifOfficeSpecificProductsEnabled();
+
+        sql += addInClauseToSQL_toLimitChargesVisibleToOffice_ifOfficeSpecificProductsEnabled(officeId);
 
         return this.jdbcTemplate.query(sql, rm, new Object[] { ChargeAppliesTo.SAVINGS.getValue(), savingsAccountId }); // NOSONAR
 
-    }
-
-    @Override
-    public List<ChargeData> retrieveAllChargesApplicableToClients() {
-        final ChargeMapper rm = new ChargeMapper();
-        String sql = "select " + rm.chargeSchema() + " where c.is_deleted=false and c.is_active=true and c.charge_applies_to_enum=? ";
-        sql += addInClauseToSQL_toLimitChargesMappedToOffice_ifOfficeSpecificProductsEnabled();
-        sql += " order by c.name ";
-
-        return this.jdbcTemplate.query(sql, rm, new Object[] { ChargeAppliesTo.CLIENT.getValue() }); // NOSONAR
-    }
-
-    @Override
-    public List<ChargeData> retrieveSharesApplicableCharges() {
-        final ChargeMapper rm = new ChargeMapper();
-        String sql = "select " + rm.chargeSchema() + " where c.is_deleted=false and c.is_active=true and c.charge_applies_to_enum=? ";
-        sql += addInClauseToSQL_toLimitChargesMappedToOffice_ifOfficeSpecificProductsEnabled();
-        sql += " order by c.name ";
-
-        return this.jdbcTemplate.query(sql, rm, new Object[] { ChargeAppliesTo.SHARES.getValue() }); // NOSONAR
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/api/ClientChargesApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/api/ClientChargesApiResource.java
@@ -79,6 +79,7 @@ public class ClientChargesApiResource {
     private final DefaultToApiJsonSerializer<ClientChargeData> toApiJsonSerializer;
     private final ApiRequestParameterHelper apiRequestParameterHelper;
     private final PortfolioCommandSourceWritePlatformService commandsSourceWritePlatformService;
+    private final org.apache.fineract.portfolio.client.service.ClientReadPlatformService clientReadPlatformService;
 
     @GET
     @Produces({ MediaType.APPLICATION_JSON })
@@ -121,7 +122,8 @@ public class ClientChargesApiResource {
 
         this.context.authenticatedUser().validateHasReadPermission(ClientApiConstants.CLIENT_CHARGES_RESOURCE_NAME);
 
-        final Collection<ChargeData> chargeOptions = this.chargeReadPlatformService.retrieveAllChargesApplicableToClients();
+        final Long clientOfficeId = this.clientReadPlatformService.retrieveOne(clientId).getOfficeId();
+        final Collection<ChargeData> chargeOptions = this.chargeReadPlatformService.retrieveAllChargesApplicableToClients(clientOfficeId);
         final ClientChargeData clientChargeData = ClientChargeData.template(chargeOptions);
 
         final ApiRequestJsonSerializationSettings settings = this.apiRequestParameterHelper.process(uriInfo.getQueryParameters());

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/api/ClientChargesApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/api/ClientChargesApiResource.java
@@ -78,6 +78,7 @@ public class ClientChargesApiResource {
     private final DefaultToApiJsonSerializer<ClientChargeData> toApiJsonSerializer;
     private final ApiRequestParameterHelper apiRequestParameterHelper;
     private final PortfolioCommandSourceWritePlatformService commandsSourceWritePlatformService;
+    private final org.apache.fineract.portfolio.client.service.ClientReadPlatformService clientReadPlatformService;
 
     @GET
     @Produces({ MediaType.APPLICATION_JSON })
@@ -119,7 +120,8 @@ public class ClientChargesApiResource {
 
         this.context.authenticatedUser().validateHasReadPermission(ClientApiConstants.CLIENT_CHARGES_RESOURCE_NAME);
 
-        final Collection<ChargeData> chargeOptions = this.chargeReadPlatformService.retrieveAllChargesApplicableToClients();
+        final Long clientOfficeId = this.clientReadPlatformService.retrieveOne(clientId).getOfficeId();
+        final Collection<ChargeData> chargeOptions = this.chargeReadPlatformService.retrieveAllChargesApplicableToClients(clientOfficeId);
         final ClientChargeData clientChargeData = ClientChargeData.template(chargeOptions);
 
         final ApiRequestJsonSerializationSettings settings = this.apiRequestParameterHelper.process(uriInfo.getQueryParameters());

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoansApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoansApiResource.java
@@ -355,9 +355,6 @@ public class LoansApiResource {
 
         this.context.authenticatedUser().validateHasReadPermission(RESOURCE_NAME_FOR_PERMISSIONS);
 
-        // template
-        final Collection<LoanProductData> productOptions = this.loanProductReadPlatformService.retrieveAllLoanProductsForLookup(onlyActive);
-
         // options
         Collection<StaffData> allowedLoanOfficers;
         Collection<CodeValueData> loanCollateralOptions;
@@ -367,9 +364,14 @@ public class LoansApiResource {
         Long officeId = null;
         Collection<PortfolioAccountData> accountLinkingOptions = null;
         boolean isRatesEnabled = this.configurationDomainService.isSubRatesEnabled();
+        if (clientId != null && ("individual".equals(templateType) || "jlg".equals(templateType))) {
+            officeId = this.clientReadPlatformService.retrieveOne(clientId).getOfficeId();
+        } else if (groupId != null && ("group".equals(templateType) || "jlgbulk".equals(templateType))) {
+            officeId = this.groupReadPlatformService.retrieveOne(groupId).getOfficeId();
+        }
 
         if (productId != null) {
-            newLoanAccount = this.loanReadPlatformService.retrieveLoanProductDetailsTemplate(productId, clientId, groupId);
+            newLoanAccount = this.loanReadPlatformService.retrieveLoanProductDetailsTemplate(productId, clientId, groupId, officeId);
         }
 
         if (templateType == null) {
@@ -427,6 +429,10 @@ public class LoansApiResource {
                 }
             }
 
+            final Collection<LoanProductData> productOptions = officeId != null
+                    ? this.loanProductReadPlatformService.retrieveAllLoanProductsForLookupV2(onlyActive, officeId)
+                    : this.loanProductReadPlatformService.retrieveAllLoanProductsForLookupV2(onlyActive);
+
             allowedLoanOfficers = this.loanReadPlatformService.retrieveAllowedLoanOfficers(officeId, staffInSelectedOfficeOnly);
 
             if (clientId != null) {
@@ -437,6 +443,26 @@ public class LoansApiResource {
             // (calendar options will be null in individual loan)
             newLoanAccount = newLoanAccount.associationsAndTemplate(productOptions, allowedLoanOfficers, calendarOptions,
                     accountLinkingOptions, isRatesEnabled);
+            if (officeId != null) {
+                if (productId != null) {
+                    final Collection<ChargeData> clientScopedCharges;
+                    final LoanProductData loanProduct = newLoanAccount.getProduct();
+                    final boolean multiDisburse = loanProduct != null && Boolean.TRUE.equals(loanProduct.getMultiDisburseLoan());
+                    if (multiDisburse) {
+                        clientScopedCharges = this.chargeReadPlatformService.retrieveLoanProductApplicableCharges(productId,
+                                new ChargeTimeType[] { ChargeTimeType.OVERDUE_INSTALLMENT }, officeId);
+                    } else {
+                        clientScopedCharges = this.chargeReadPlatformService.retrieveLoanProductApplicableCharges(productId,
+                                new ChargeTimeType[] { ChargeTimeType.OVERDUE_INSTALLMENT, ChargeTimeType.TRANCHE_DISBURSEMENT }, officeId);
+                    }
+                    newLoanAccount = newLoanAccount.setChargeOptions(clientScopedCharges.isEmpty() ? null : clientScopedCharges);
+                } else {
+                    final List<ChargeData> clientScopedCharges = new java.util.ArrayList<>();
+                    clientScopedCharges.addAll(this.chargeReadPlatformService.retrieveLoanApplicableFees(officeId));
+                    clientScopedCharges.addAll(this.chargeReadPlatformService.retrieveLoanApplicablePenalties(officeId));
+                    newLoanAccount = newLoanAccount.setChargeOptions(clientScopedCharges.isEmpty() ? null : clientScopedCharges);
+                }
+            }
         }
         final List<DatatableData> datatableTemplates = this.entityDatatableChecksReadService.retrieveTemplates(StatusEnum.CREATE.getValue(),
                 EntityTables.LOAN.getName(), productId);
@@ -1209,6 +1235,10 @@ public class LoansApiResource {
         Collection<PortfolioAccountData> accountLinkingOptions = null;
         PaidInAdvanceData paidInAdvanceTemplate;
         Collection<LoanAccountSummaryData> clientActiveLoanOptions = null;
+        Long officeId = loanBasicDetails.getClientOfficeId();
+        if (officeId == null && loanBasicDetails.getGroup() != null) {
+            officeId = loanBasicDetails.getGroup().getOfficeId();
+        }
 
         final boolean template = ApiParameterHelper.template(uriInfo.getQueryParameters());
         if (template) {
@@ -1240,11 +1270,6 @@ public class LoansApiResource {
             }
             chargeTemplate = this.loanChargeReadPlatformService.retrieveLoanChargeTemplate();
 
-            Long officeId = loanBasicDetails.getClientOfficeId();
-
-            if (officeId == null && loanBasicDetails.getGroup() != null) {
-                officeId = loanBasicDetails.getGroup().getOfficeId();
-            }
             allowedLoanOfficers = this.loanReadPlatformService.retrieveAllowedLoanOfficers(officeId, staffInSelectedOfficeOnly);
 
             loanPurposeOptions = this.codeValueReadPlatformService.retrieveCodeValuesByCode("LoanPurpose");
@@ -1275,7 +1300,7 @@ public class LoansApiResource {
         }
 
         Collection<ChargeData> overdueCharges = this.chargeReadPlatformService
-                .retrieveLoanProductCharges(loanBasicDetails.getLoanProductId(), ChargeTimeType.OVERDUE_INSTALLMENT);
+                .retrieveLoanProductCharges(loanBasicDetails.getLoanProductId(), ChargeTimeType.OVERDUE_INSTALLMENT, officeId);
 
         paidInAdvanceTemplate = this.loanReadPlatformService.retrieveTotalPaidInAdvance(resolvedLoanId);
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoansApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoansApiResource.java
@@ -362,9 +362,15 @@ public class LoansApiResource {
         Long officeId = null;
         Collection<PortfolioAccountData> accountLinkingOptions = null;
         boolean isRatesEnabled = this.configurationDomainService.isSubRatesEnabled();
+        if (clientId != null && ("individual".equals(templateType) || "jlg".equals(templateType))) {
+            officeId = this.clientReadPlatformService.retrieveOne(clientId).getOfficeId();
+        } else if (groupId != null
+                && ("group".equals(templateType) || "jlgbulk".equals(templateType))) {
+            officeId = this.groupReadPlatformService.retrieveOne(groupId).getOfficeId();
+        }
 
         if (productId != null) {
-            newLoanAccount = this.loanReadPlatformService.retrieveLoanProductDetailsTemplate(productId, clientId, groupId);
+            newLoanAccount = this.loanReadPlatformService.retrieveLoanProductDetailsTemplate(productId, clientId, groupId, officeId);
         }
 
         if (templateType == null) {
@@ -436,6 +442,27 @@ public class LoansApiResource {
             // (calendar options will be null in individual loan)
             newLoanAccount = newLoanAccount.associationsAndTemplate(productOptions, allowedLoanOfficers, calendarOptions,
                     accountLinkingOptions, isRatesEnabled);
+            if (officeId != null) {
+                if (productId != null) {
+                    final Collection<ChargeData> clientScopedCharges;
+                    final LoanProductData loanProduct = newLoanAccount.getProduct();
+                    final boolean multiDisburse = loanProduct != null && Boolean.TRUE.equals(loanProduct.getMultiDisburseLoan());
+                    if (multiDisburse) {
+                        clientScopedCharges = this.chargeReadPlatformService.retrieveLoanProductApplicableCharges(productId,
+                                new ChargeTimeType[] { ChargeTimeType.OVERDUE_INSTALLMENT }, officeId);
+                    } else {
+                        clientScopedCharges = this.chargeReadPlatformService.retrieveLoanProductApplicableCharges(productId,
+                                new ChargeTimeType[] { ChargeTimeType.OVERDUE_INSTALLMENT, ChargeTimeType.TRANCHE_DISBURSEMENT },
+                                officeId);
+                    }
+                    newLoanAccount = newLoanAccount.setChargeOptions(clientScopedCharges.isEmpty() ? null : clientScopedCharges);
+                } else {
+                    final List<ChargeData> clientScopedCharges = new java.util.ArrayList<>();
+                    clientScopedCharges.addAll(this.chargeReadPlatformService.retrieveLoanApplicableFees(officeId));
+                    clientScopedCharges.addAll(this.chargeReadPlatformService.retrieveLoanApplicablePenalties(officeId));
+                    newLoanAccount = newLoanAccount.setChargeOptions(clientScopedCharges.isEmpty() ? null : clientScopedCharges);
+                }
+            }
         }
         final List<DatatableData> datatableTemplates = this.entityDatatableChecksReadService.retrieveTemplates(StatusEnum.CREATE.getValue(),
                 EntityTables.LOAN.getName(), productId);
@@ -1185,6 +1212,10 @@ public class LoansApiResource {
         Collection<PortfolioAccountData> accountLinkingOptions = null;
         PaidInAdvanceData paidInAdvanceTemplate;
         Collection<LoanAccountSummaryData> clientActiveLoanOptions = null;
+        Long officeId = loanBasicDetails.getClientOfficeId();
+        if (officeId == null && loanBasicDetails.getGroup() != null) {
+            officeId = loanBasicDetails.getGroup().getOfficeId();
+        }
 
         final boolean template = ApiParameterHelper.template(uriInfo.getQueryParameters());
         if (template) {
@@ -1216,11 +1247,6 @@ public class LoansApiResource {
             }
             chargeTemplate = this.loanChargeReadPlatformService.retrieveLoanChargeTemplate();
 
-            Long officeId = loanBasicDetails.getClientOfficeId();
-
-            if (officeId == null && loanBasicDetails.getGroup() != null) {
-                officeId = loanBasicDetails.getGroup().getOfficeId();
-            }
             allowedLoanOfficers = this.loanReadPlatformService.retrieveAllowedLoanOfficers(officeId, staffInSelectedOfficeOnly);
 
             loanPurposeOptions = this.codeValueReadPlatformService.retrieveCodeValuesByCode("LoanPurpose");
@@ -1251,7 +1277,7 @@ public class LoansApiResource {
         }
 
         Collection<ChargeData> overdueCharges = this.chargeReadPlatformService
-                .retrieveLoanProductCharges(loanBasicDetails.getLoanProductId(), ChargeTimeType.OVERDUE_INSTALLMENT);
+                .retrieveLoanProductCharges(loanBasicDetails.getLoanProductId(), ChargeTimeType.OVERDUE_INSTALLMENT, officeId);
 
         paidInAdvanceTemplate = this.loanReadPlatformService.retrieveTotalPaidInAdvance(resolvedLoanId);
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoansApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/api/LoansApiResource.java
@@ -353,9 +353,6 @@ public class LoansApiResource {
 
         this.context.authenticatedUser().validateHasReadPermission(RESOURCE_NAME_FOR_PERMISSIONS);
 
-        // template
-        final Collection<LoanProductData> productOptions = this.loanProductReadPlatformService.retrieveAllLoanProductsForLookup(onlyActive);
-
         // options
         Collection<StaffData> allowedLoanOfficers;
         Collection<CodeValueData> loanCollateralOptions;
@@ -424,6 +421,10 @@ public class LoansApiResource {
                     throw new NotSupportedLoanTemplateTypeException(errorMsg, templateType);
                 }
             }
+
+            final Collection<LoanProductData> productOptions = officeId != null
+                    ? this.loanProductReadPlatformService.retrieveAllLoanProductsForLookupV2(onlyActive, officeId)
+                    : this.loanProductReadPlatformService.retrieveAllLoanProductsForLookupV2(onlyActive);
 
             allowedLoanOfficers = this.loanReadPlatformService.retrieveAllowedLoanOfficers(officeId, staffInSelectedOfficeOnly);
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/LoanApplicationValidator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/LoanApplicationValidator.java
@@ -56,12 +56,8 @@ import org.apache.fineract.infrastructure.core.service.ExternalIdFactory;
 import org.apache.fineract.infrastructure.dataqueries.data.EntityTables;
 import org.apache.fineract.infrastructure.dataqueries.data.StatusEnum;
 import org.apache.fineract.infrastructure.dataqueries.service.EntityDatatableChecksWritePlatformService;
-import org.apache.fineract.infrastructure.entityaccess.domain.FineractEntityAccessType;
-import org.apache.fineract.infrastructure.entityaccess.domain.FineractEntityRelation;
-import org.apache.fineract.infrastructure.entityaccess.domain.FineractEntityRelationRepository;
-import org.apache.fineract.infrastructure.entityaccess.domain.FineractEntityToEntityMapping;
-import org.apache.fineract.infrastructure.entityaccess.domain.FineractEntityToEntityMappingRepository;
 import org.apache.fineract.infrastructure.entityaccess.exception.NotOfficeSpecificProductException;
+import org.apache.fineract.infrastructure.entityaccess.service.FineractEntityAccessReadService;
 import org.apache.fineract.organisation.holiday.domain.Holiday;
 import org.apache.fineract.organisation.holiday.domain.HolidayRepository;
 import org.apache.fineract.organisation.holiday.domain.HolidayStatusType;
@@ -192,8 +188,7 @@ public final class LoanApplicationValidator {
     private final LoanReadPlatformService loanReadPlatformService;
     private final LoanProductDataValidator loanProductDataValidator;
     private final GlobalConfigurationRepositoryWrapper globalConfigurationRepository;
-    private final FineractEntityToEntityMappingRepository entityMappingRepository;
-    private final FineractEntityRelationRepository fineractEntityRelationRepository;
+    private final FineractEntityAccessReadService fineractEntityAccessReadService;
     private final LoanRepositoryWrapper loanRepositoryWrapper;
     private final LoanProductReadPlatformService loanProductReadPlatformService;
     private final LoanCollateralAssembler collateralAssembler;
@@ -1854,11 +1849,7 @@ public final class LoanApplicationValidator {
         final GlobalConfigurationProperty restrictToUserOfficeProperty = this.globalConfigurationRepository
                 .findOneByNameWithNotFoundDetection(GlobalConfigurationConstants.OFFICE_SPECIFIC_PRODUCTS_ENABLED);
         if (restrictToUserOfficeProperty.isEnabled()) {
-            FineractEntityRelation fineractEntityRelation = fineractEntityRelationRepository
-                    .findOneByCodeName(FineractEntityAccessType.OFFICE_ACCESS_TO_LOAN_PRODUCTS.getStr());
-            FineractEntityToEntityMapping officeToLoanProductMappingList = this.entityMappingRepository
-                    .findListByProductId(fineractEntityRelation, productId, officeId);
-            if (officeToLoanProductMappingList == null) {
+            if (!fineractEntityAccessReadService.isLoanProductVisibleToOffice(productId, officeId)) {
                 throw new NotOfficeSpecificProductException(productId, officeId);
             }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanReadPlatformServiceImpl.java
@@ -100,6 +100,7 @@ import org.apache.fineract.portfolio.loanaccount.data.DisbursementData;
 import org.apache.fineract.portfolio.loanaccount.data.LoanAccountData;
 import org.apache.fineract.portfolio.loanaccount.data.LoanApplicationTimelineData;
 import org.apache.fineract.portfolio.loanaccount.data.LoanApprovalData;
+import org.apache.fineract.portfolio.loanaccount.data.LoanChargeData;
 import org.apache.fineract.portfolio.loanaccount.data.LoanChargePaidByData;
 import org.apache.fineract.portfolio.loanaccount.data.LoanInterestRecalculationData;
 import org.apache.fineract.portfolio.loanaccount.data.LoanRepaymentScheduleInstallmentData;
@@ -1459,7 +1460,8 @@ public class LoanReadPlatformServiceImpl implements LoanReadPlatformService, Loa
     }
 
     @Override
-    public LoanAccountData retrieveLoanProductDetailsTemplate(final Long productId, final Long clientId, final Long groupId) {
+    public LoanAccountData retrieveLoanProductDetailsTemplate(final Long productId, final Long clientId, final Long groupId,
+            final Long officeId) {
 
         this.context.authenticatedUser();
 
@@ -1493,10 +1495,10 @@ public class LoanReadPlatformServiceImpl implements LoanReadPlatformService, Loa
         Collection<ChargeData> chargeOptions = null;
         if (loanProduct.getMultiDisburseLoan()) {
             chargeOptions = this.chargeReadPlatformService.retrieveLoanProductApplicableCharges(productId,
-                    new ChargeTimeType[] { ChargeTimeType.OVERDUE_INSTALLMENT });
+                    new ChargeTimeType[] { ChargeTimeType.OVERDUE_INSTALLMENT }, officeId);
         } else {
             chargeOptions = this.chargeReadPlatformService.retrieveLoanProductApplicableCharges(productId,
-                    new ChargeTimeType[] { ChargeTimeType.OVERDUE_INSTALLMENT, ChargeTimeType.TRANCHE_DISBURSEMENT });
+                    new ChargeTimeType[] { ChargeTimeType.OVERDUE_INSTALLMENT, ChargeTimeType.TRANCHE_DISBURSEMENT }, officeId);
         }
 
         Integer loanCycleCounter = null;
@@ -1515,7 +1517,7 @@ public class LoanReadPlatformServiceImpl implements LoanReadPlatformService, Loa
             activeLoanOptions = this.accountDetailsReadPlatformService.retrieveGroupActiveLoanAccountSummary(groupId);
         }
 
-        return new LoanAccountData().withProductData(loanProduct, loanCycleCounter) //
+        LoanAccountData loanAccountData = new LoanAccountData().withProductData(loanProduct, loanCycleCounter) //
                 .setTermFrequencyTypeOptions(loanTermFrequencyTypeOptions) //
                 .setRepaymentFrequencyTypeOptions(repaymentFrequencyTypeOptions) //
                 .setRepaymentFrequencyNthDayTypeOptions(repaymentFrequencyNthDayTypeOptions) //
@@ -1532,6 +1534,32 @@ public class LoanReadPlatformServiceImpl implements LoanReadPlatformService, Loa
                 .setClientActiveLoanOptions(activeLoanOptions) //
                 .setLoanScheduleTypeOptions(LoanScheduleType.getValuesAsEnumOptionDataList()) //
                 .setLoanScheduleProcessingTypeOptions(LoanScheduleProcessingType.getValuesAsEnumOptionDataList()); //
+
+        // Bug fix: pre-selected product charges (loanProduct.charges()) were fetched using the logged-in user's office
+        // filter (Head Office sees all offices including Branch 004). When rendering a template for a client in a
+        // specific office, we must re-filter those charges by the client's officeId.
+        if (officeId != null) {
+            final List<ChargeData> officeFilteredProductCharges = this.chargeReadPlatformService.retrieveLoanProductCharges(productId,
+                    officeId);
+            final java.util.Set<Long> visibleChargeIds = officeFilteredProductCharges.stream().map(ChargeData::getId)
+                    .collect(java.util.stream.Collectors.toSet());
+            final Collection<LoanChargeData> currentCharges = loanAccountData.getCharges();
+            if (currentCharges != null && !currentCharges.isEmpty()) {
+                final Collection<LoanChargeData> filtered = currentCharges.stream()
+                        .filter(c -> c.getChargeId() != null && visibleChargeIds.contains(c.getChargeId()))
+                        .collect(java.util.stream.Collectors.toList());
+                loanAccountData.setCharges(filtered.isEmpty() ? null : filtered);
+            }
+            final Collection<ChargeData> currentOverdueCharges = loanAccountData.getOverdueCharges();
+            if (currentOverdueCharges != null && !currentOverdueCharges.isEmpty()) {
+                final Collection<ChargeData> filteredOverdue = currentOverdueCharges.stream()
+                        .filter(c -> c.getId() != null && visibleChargeIds.contains(c.getId()))
+                        .collect(java.util.stream.Collectors.toList());
+                loanAccountData.setOverdueCharges(filteredOverdue.isEmpty() ? null : filteredOverdue);
+            }
+        }
+
+        return loanAccountData;
     }
 
     @Override

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanReadPlatformServiceImpl.java
@@ -100,6 +100,7 @@ import org.apache.fineract.portfolio.loanaccount.data.DisbursementData;
 import org.apache.fineract.portfolio.loanaccount.data.LoanAccountData;
 import org.apache.fineract.portfolio.loanaccount.data.LoanApplicationTimelineData;
 import org.apache.fineract.portfolio.loanaccount.data.LoanApprovalData;
+import org.apache.fineract.portfolio.loanaccount.data.LoanChargeData;
 import org.apache.fineract.portfolio.loanaccount.data.LoanChargePaidByData;
 import org.apache.fineract.portfolio.loanaccount.data.LoanInterestRecalculationData;
 import org.apache.fineract.portfolio.loanaccount.data.LoanRepaymentScheduleInstallmentData;
@@ -1459,7 +1460,8 @@ public class LoanReadPlatformServiceImpl implements LoanReadPlatformService, Loa
     }
 
     @Override
-    public LoanAccountData retrieveLoanProductDetailsTemplate(final Long productId, final Long clientId, final Long groupId) {
+    public LoanAccountData retrieveLoanProductDetailsTemplate(final Long productId, final Long clientId, final Long groupId,
+            final Long officeId) {
 
         this.context.authenticatedUser();
 
@@ -1493,10 +1495,10 @@ public class LoanReadPlatformServiceImpl implements LoanReadPlatformService, Loa
         Collection<ChargeData> chargeOptions = null;
         if (loanProduct.getMultiDisburseLoan()) {
             chargeOptions = this.chargeReadPlatformService.retrieveLoanProductApplicableCharges(productId,
-                    new ChargeTimeType[] { ChargeTimeType.OVERDUE_INSTALLMENT });
+                    new ChargeTimeType[] { ChargeTimeType.OVERDUE_INSTALLMENT }, officeId);
         } else {
             chargeOptions = this.chargeReadPlatformService.retrieveLoanProductApplicableCharges(productId,
-                    new ChargeTimeType[] { ChargeTimeType.OVERDUE_INSTALLMENT, ChargeTimeType.TRANCHE_DISBURSEMENT });
+                    new ChargeTimeType[] { ChargeTimeType.OVERDUE_INSTALLMENT, ChargeTimeType.TRANCHE_DISBURSEMENT }, officeId);
         }
 
         Integer loanCycleCounter = null;
@@ -1515,7 +1517,7 @@ public class LoanReadPlatformServiceImpl implements LoanReadPlatformService, Loa
             activeLoanOptions = this.accountDetailsReadPlatformService.retrieveGroupActiveLoanAccountSummary(groupId);
         }
 
-        return new LoanAccountData().withProductData(loanProduct, loanCycleCounter) //
+        LoanAccountData loanAccountData = new LoanAccountData().withProductData(loanProduct, loanCycleCounter) //
                 .setTermFrequencyTypeOptions(loanTermFrequencyTypeOptions) //
                 .setRepaymentFrequencyTypeOptions(repaymentFrequencyTypeOptions) //
                 .setRepaymentFrequencyNthDayTypeOptions(repaymentFrequencyNthDayTypeOptions) //
@@ -1532,6 +1534,33 @@ public class LoanReadPlatformServiceImpl implements LoanReadPlatformService, Loa
                 .setClientActiveLoanOptions(activeLoanOptions) //
                 .setLoanScheduleTypeOptions(LoanScheduleType.getValuesAsEnumOptionDataList()) //
                 .setLoanScheduleProcessingTypeOptions(LoanScheduleProcessingType.getValuesAsEnumOptionDataList()); //
+
+        // Bug fix: pre-selected product charges (loanProduct.charges()) were fetched using the logged-in user's office
+        // filter (Head Office sees all offices including Branch 004). When rendering a template for a client in a
+        // specific office, we must re-filter those charges by the client's officeId.
+        if (officeId != null) {
+            final List<ChargeData> officeFilteredProductCharges = this.chargeReadPlatformService
+                    .retrieveLoanProductCharges(productId, officeId);
+            final java.util.Set<Long> visibleChargeIds = officeFilteredProductCharges.stream()
+                    .map(ChargeData::getId)
+                    .collect(java.util.stream.Collectors.toSet());
+            final Collection<LoanChargeData> currentCharges = loanAccountData.getCharges();
+            if (currentCharges != null && !currentCharges.isEmpty()) {
+                final Collection<LoanChargeData> filtered = currentCharges.stream()
+                        .filter(c -> c.getChargeId() != null && visibleChargeIds.contains(c.getChargeId()))
+                        .collect(java.util.stream.Collectors.toList());
+                loanAccountData.setCharges(filtered.isEmpty() ? null : filtered);
+            }
+            final Collection<ChargeData> currentOverdueCharges = loanAccountData.getOverdueCharges();
+            if (currentOverdueCharges != null && !currentOverdueCharges.isEmpty()) {
+                final Collection<ChargeData> filteredOverdue = currentOverdueCharges.stream()
+                        .filter(c -> c.getId() != null && visibleChargeIds.contains(c.getId()))
+                        .collect(java.util.stream.Collectors.toList());
+                loanAccountData.setOverdueCharges(filteredOverdue.isEmpty() ? null : filteredOverdue);
+            }
+        }
+
+        return loanAccountData;
     }
 
     @Override

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/api/LoanProductsApiResourceV2.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/api/LoanProductsApiResourceV2.java
@@ -1,0 +1,83 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.loanproduct.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.UriInfo;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.infrastructure.core.api.ApiRequestParameterHelper;
+import org.apache.fineract.infrastructure.core.serialization.ApiRequestJsonSerializationSettings;
+import org.apache.fineract.infrastructure.core.serialization.DefaultToApiJsonSerializer;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.apache.fineract.portfolio.loanproduct.data.LoanProductData;
+import org.apache.fineract.portfolio.loanproduct.service.LoanProductReadPlatformService;
+import org.springframework.stereotype.Component;
+
+@Path("/v2/loanproducts")
+@Component
+@Tag(name = "Loan Products", description = "A Loan product is a template that is used when creating a loan.")
+@RequiredArgsConstructor
+public class LoanProductsApiResourceV2 {
+
+    private static final Set<String> LOAN_PRODUCT_DATA_PARAMETERS = new HashSet<>(Arrays.asList("id", "name", "shortName", "description",
+            "fundId", "fundName", "includeInBorrowerCycle", "currency", "principal", "minPrincipal", "maxPrincipal", "numberOfRepayments",
+            "minNumberOfRepayments", "maxNumberOfRepayments", "repaymentEvery", "repaymentFrequencyType", "graceOnPrincipalPayment",
+            "recurringMoratoriumOnPrincipalPeriods", "graceOnInterestPayment", "graceOnInterestCharged", "interestRatePerPeriod",
+            "minInterestRatePerPeriod", "maxInterestRatePerPeriod", "interestRateFrequencyType", "annualInterestRate", "amortizationType",
+            "interestType", "interestCalculationPeriodType", "allowPartialPeriodInterestCalculation", "inArrearsTolerance",
+            "transactionProcessingStrategyCode", "transactionProcessingStrategyName", "charges", "accountingRule", "externalId",
+            "accountingMappings", "paymentChannelToFundSourceMappings", "fundOptions", "paymentTypeOptions", "currencyOptions",
+            "repaymentFrequencyTypeOptions", "interestRateFrequencyTypeOptions", "amortizationTypeOptions", "interestTypeOptions",
+            "interestCalculationPeriodTypeOptions"));
+
+    private static final String RESOURCE_NAME_FOR_PERMISSIONS = "LOANPRODUCT";
+
+    private final PlatformSecurityContext context;
+    private final LoanProductReadPlatformService loanProductReadPlatformService;
+    private final DefaultToApiJsonSerializer<LoanProductData> toApiJsonSerializer;
+    private final ApiRequestParameterHelper apiRequestParameterHelper;
+
+    @GET
+    @Consumes({ MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.APPLICATION_JSON })
+    @Operation(summary = "List Loan Products v2 (office-specific filtering)", description = "Lists Loan Products with office-specific filtering. If office-specific-products-enabled is OFF, returns all active products. If ON, returns products with: no mapping at all, mapped to 'All', or mapped to the user's office.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = LoanProductsApiResourceSwagger.GetLoanProductsResponse.class)))) })
+    public String retrieveAllLoanProductsV2(@Context final UriInfo uriInfo) {
+        this.context.authenticatedUser().validateHasReadPermission(RESOURCE_NAME_FOR_PERMISSIONS);
+        final ApiRequestJsonSerializationSettings settings = this.apiRequestParameterHelper.process(uriInfo.getQueryParameters());
+        final Collection<LoanProductData> products = this.loanProductReadPlatformService.retrieveAllLoanProductsV2();
+        return this.toApiJsonSerializer.serialize(settings, products, LOAN_PRODUCT_DATA_PARAMETERS);
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/api/LoanProductsApiResourceV2.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/api/LoanProductsApiResourceV2.java
@@ -1,0 +1,83 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.loanproduct.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.UriInfo;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.infrastructure.core.serialization.ApiRequestJsonSerializationSettings;
+import org.apache.fineract.infrastructure.core.serialization.DefaultToApiJsonSerializer;
+import org.apache.fineract.infrastructure.core.api.ApiRequestParameterHelper;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.apache.fineract.portfolio.loanproduct.data.LoanProductData;
+import org.apache.fineract.portfolio.loanproduct.service.LoanProductReadPlatformService;
+import org.springframework.stereotype.Component;
+
+@Path("/v2/loanproducts")
+@Component
+@Tag(name = "Loan Products", description = "A Loan product is a template that is used when creating a loan.")
+@RequiredArgsConstructor
+public class LoanProductsApiResourceV2 {
+
+    private static final Set<String> LOAN_PRODUCT_DATA_PARAMETERS = new HashSet<>(Arrays.asList("id", "name", "shortName", "description",
+            "fundId", "fundName", "includeInBorrowerCycle", "currency", "principal", "minPrincipal", "maxPrincipal", "numberOfRepayments",
+            "minNumberOfRepayments", "maxNumberOfRepayments", "repaymentEvery", "repaymentFrequencyType", "graceOnPrincipalPayment",
+            "recurringMoratoriumOnPrincipalPeriods", "graceOnInterestPayment", "graceOnInterestCharged", "interestRatePerPeriod",
+            "minInterestRatePerPeriod", "maxInterestRatePerPeriod", "interestRateFrequencyType", "annualInterestRate", "amortizationType",
+            "interestType", "interestCalculationPeriodType", "allowPartialPeriodInterestCalculation", "inArrearsTolerance", "transactionProcessingStrategyCode",
+            "transactionProcessingStrategyName", "charges", "accountingRule", "externalId", "accountingMappings", "paymentChannelToFundSourceMappings",
+            "fundOptions", "paymentTypeOptions", "currencyOptions", "repaymentFrequencyTypeOptions", "interestRateFrequencyTypeOptions",
+            "amortizationTypeOptions", "interestTypeOptions", "interestCalculationPeriodTypeOptions"));
+
+    private static final String RESOURCE_NAME_FOR_PERMISSIONS = "LOANPRODUCT";
+
+    private final PlatformSecurityContext context;
+    private final LoanProductReadPlatformService loanProductReadPlatformService;
+    private final DefaultToApiJsonSerializer<LoanProductData> toApiJsonSerializer;
+    private final ApiRequestParameterHelper apiRequestParameterHelper;
+
+    @GET
+    @Consumes({ MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.APPLICATION_JSON })
+    @Operation(summary = "List Loan Products v2 (office-specific filtering)", description = "Lists Loan Products with office-specific filtering. If office-specific-products-enabled is OFF, returns all active products. If ON, returns products with: no mapping at all, mapped to 'All', or mapped to the user's office.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = LoanProductsApiResourceSwagger.GetLoanProductsResponse.class))))
+    })
+    public String retrieveAllLoanProductsV2(@Context final UriInfo uriInfo) {
+        this.context.authenticatedUser().validateHasReadPermission(RESOURCE_NAME_FOR_PERMISSIONS);
+        final ApiRequestJsonSerializationSettings settings = this.apiRequestParameterHelper.process(uriInfo.getQueryParameters());
+        final Collection<LoanProductData> products = this.loanProductReadPlatformService.retrieveAllLoanProductsV2();
+        return this.toApiJsonSerializer.serialize(settings, products, LOAN_PRODUCT_DATA_PARAMETERS);
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/service/LoanProductReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/service/LoanProductReadPlatformServiceImpl.java
@@ -164,6 +164,77 @@ public class LoanProductReadPlatformServiceImpl implements LoanProductReadPlatfo
     }
 
     @Override
+    public Collection<LoanProductData> retrieveAllLoanProductsV2() {
+        this.context.authenticatedUser();
+
+        final LoanProductMapper rm = new LoanProductMapper(null, null, null, null, null, null);
+
+        String sql = "select " + rm.loanProductSchema();
+
+        final String inClause = this.fineractEntityAccessUtil
+                .getSQLWhereClauseForVisibleProductIDsForUserOffice_ifGlobalConfigEnabled(FineractEntityType.LOAN_PRODUCT);
+        if (inClause != null && !inClause.trim().isEmpty()) {
+            sql += " where lp.id in ( " + inClause + " ) ";
+        }
+
+        return this.jdbcTemplate.query(sql, rm); // NOSONAR
+    }
+
+    @Override
+    public Collection<LoanProductData> retrieveAllLoanProductsForLookupV2(final boolean activeOnly) {
+        this.context.authenticatedUser();
+
+        final LoanProductLookupMapper rm = new LoanProductLookupMapper(sqlGenerator);
+
+        String sql = "select ";
+        if (activeOnly) {
+            sql += rm.activeOnlySchema();
+        } else {
+            sql += rm.schema();
+        }
+
+        final String inClause = this.fineractEntityAccessUtil
+                .getSQLWhereClauseForVisibleProductIDsForUserOffice_ifGlobalConfigEnabled(FineractEntityType.LOAN_PRODUCT);
+
+        if (inClause != null && !inClause.trim().isEmpty()) {
+            if (activeOnly) {
+                sql += " and lp.id in ( " + inClause + " )";
+            } else {
+                sql += " where lp.id in ( " + inClause + " ) ";
+            }
+        }
+
+        return this.jdbcTemplate.query(sql, rm); // NOSONAR
+    }
+
+    @Override
+    public Collection<LoanProductData> retrieveAllLoanProductsForLookupV2(final boolean activeOnly, final Long officeId) {
+        this.context.authenticatedUser();
+
+        final LoanProductLookupMapper rm = new LoanProductLookupMapper(sqlGenerator);
+
+        String sql = "select ";
+        if (activeOnly) {
+            sql += rm.activeOnlySchema();
+        } else {
+            sql += rm.schema();
+        }
+
+        final String inClause = this.fineractEntityAccessUtil
+                .getSQLWhereClauseForVisibleProductIDsForOffice_ifGlobalConfigEnabled(FineractEntityType.LOAN_PRODUCT, officeId);
+
+        if (inClause != null && !inClause.trim().isEmpty()) {
+            if (activeOnly) {
+                sql += " and lp.id in ( " + inClause + " )";
+            } else {
+                sql += " where lp.id in ( " + inClause + " ) ";
+            }
+        }
+
+        return this.jdbcTemplate.query(sql, rm); // NOSONAR
+    }
+
+    @Override
     public Collection<LoanProductData> retrieveAllLoanProductsForLookup(String inClause) {
 
         this.context.authenticatedUser();

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/service/LoanProductReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanproduct/service/LoanProductReadPlatformServiceImpl.java
@@ -164,6 +164,76 @@ public class LoanProductReadPlatformServiceImpl implements LoanProductReadPlatfo
     }
 
     @Override
+    public Collection<LoanProductData> retrieveAllLoanProductsV2() {
+        this.context.authenticatedUser();
+
+        final LoanProductMapper rm = new LoanProductMapper(null, null, null, null, null, null);
+
+        String sql = "select " + rm.loanProductSchema();
+
+        final String inClause = this.fineractEntityAccessUtil
+                .getSQLWhereClauseForVisibleProductIDsForUserOffice_ifGlobalConfigEnabled(FineractEntityType.LOAN_PRODUCT);
+        if (inClause != null && !inClause.trim().isEmpty()) {
+            sql += " where lp.id in ( " + inClause + " ) ";
+        }
+
+        return this.jdbcTemplate.query(sql, rm); // NOSONAR
+    }
+    @Override
+    public Collection<LoanProductData> retrieveAllLoanProductsForLookupV2(final boolean activeOnly) {
+        this.context.authenticatedUser();
+
+        final LoanProductLookupMapper rm = new LoanProductLookupMapper(sqlGenerator);
+
+        String sql = "select ";
+        if (activeOnly) {
+            sql += rm.activeOnlySchema();
+        } else {
+            sql += rm.schema();
+        }
+
+        final String inClause = this.fineractEntityAccessUtil
+                .getSQLWhereClauseForVisibleProductIDsForUserOffice_ifGlobalConfigEnabled(FineractEntityType.LOAN_PRODUCT);
+
+        if (inClause != null && !inClause.trim().isEmpty()) {
+            if (activeOnly) {
+                sql += " and lp.id in ( " + inClause + " )";
+            } else {
+                sql += " where lp.id in ( " + inClause + " ) ";
+            }
+        }
+
+        return this.jdbcTemplate.query(sql, rm); // NOSONAR
+    }
+
+    @Override
+    public Collection<LoanProductData> retrieveAllLoanProductsForLookupV2(final boolean activeOnly, final Long officeId) {
+        this.context.authenticatedUser();
+
+        final LoanProductLookupMapper rm = new LoanProductLookupMapper(sqlGenerator);
+
+        String sql = "select ";
+        if (activeOnly) {
+            sql += rm.activeOnlySchema();
+        } else {
+            sql += rm.schema();
+        }
+
+        final String inClause = this.fineractEntityAccessUtil
+                .getSQLWhereClauseForVisibleProductIDsForOffice_ifGlobalConfigEnabled(FineractEntityType.LOAN_PRODUCT, officeId);
+
+        if (inClause != null && !inClause.trim().isEmpty()) {
+            if (activeOnly) {
+                sql += " and lp.id in ( " + inClause + " )";
+            } else {
+                sql += " where lp.id in ( " + inClause + " ) ";
+            }
+        }
+
+        return this.jdbcTemplate.query(sql, rm); // NOSONAR
+    }
+
+    @Override
     public Collection<LoanProductData> retrieveAllLoanProductsForLookup(String inClause) {
 
         this.context.authenticatedUser();

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/DepositAccountReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/DepositAccountReadPlatformServiceImpl.java
@@ -343,13 +343,13 @@ public class DepositAccountReadPlatformServiceImpl implements DepositAccountRead
                     .retrievewithdrawalFeeTypeOptions();
 
             final Collection<SavingsAccountTransactionData> transactions = null;
-            final Collection<ChargeData> productCharges = this.chargeReadPlatformService.retrieveSavingsProductCharges(productId);
+            final Collection<ChargeData> productCharges = this.chargeReadPlatformService.retrieveSavingsProductCharges(productId, officeId);
             // update charges from Product charges
             final Collection<SavingsAccountChargeData> charges = fromChargesToSavingsCharges(productCharges);
 
             final boolean feeChargesOnly = false;
             final Collection<ChargeData> chargeOptions = this.chargeReadPlatformService
-                    .retrieveSavingsProductApplicableCharges(feeChargesOnly);
+                    .retrieveSavingsProductApplicableCharges(feeChargesOnly, officeId);
 
             final Collection<EnumOptionData> maturityInstructionOptions = this.depositsDropdownReadPlatformService
                     .maturityInstructionOptions();
@@ -430,7 +430,7 @@ public class DepositAccountReadPlatformServiceImpl implements DepositAccountRead
 
             final boolean feeChargesOnly = true;
             final Collection<ChargeData> chargeOptions = this.chargeReadPlatformService
-                    .retrieveSavingsProductApplicableCharges(feeChargesOnly);
+                    .retrieveSavingsProductApplicableCharges(feeChargesOnly, officeId);
 
             if (depositAccountType == DepositAccountType.FIXED_DEPOSIT) {
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/DepositAccountReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/DepositAccountReadPlatformServiceImpl.java
@@ -343,13 +343,14 @@ public class DepositAccountReadPlatformServiceImpl implements DepositAccountRead
                     .retrievewithdrawalFeeTypeOptions();
 
             final Collection<SavingsAccountTransactionData> transactions = null;
-            final Collection<ChargeData> productCharges = this.chargeReadPlatformService.retrieveSavingsProductCharges(productId);
+            final Collection<ChargeData> productCharges = this.chargeReadPlatformService.retrieveSavingsProductCharges(productId,
+                    officeId);
             // update charges from Product charges
             final Collection<SavingsAccountChargeData> charges = fromChargesToSavingsCharges(productCharges);
 
             final boolean feeChargesOnly = false;
             final Collection<ChargeData> chargeOptions = this.chargeReadPlatformService
-                    .retrieveSavingsProductApplicableCharges(feeChargesOnly);
+                    .retrieveSavingsProductApplicableCharges(feeChargesOnly, officeId);
 
             final Collection<EnumOptionData> maturityInstructionOptions = this.depositsDropdownReadPlatformService
                     .maturityInstructionOptions();
@@ -430,7 +431,7 @@ public class DepositAccountReadPlatformServiceImpl implements DepositAccountRead
 
             final boolean feeChargesOnly = true;
             final Collection<ChargeData> chargeOptions = this.chargeReadPlatformService
-                    .retrieveSavingsProductApplicableCharges(feeChargesOnly);
+                    .retrieveSavingsProductApplicableCharges(feeChargesOnly, officeId);
 
             if (depositAccountType == DepositAccountType.FIXED_DEPOSIT) {
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountTemplateReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountTemplateReadPlatformServiceImpl.java
@@ -137,13 +137,13 @@ public class SavingsAccountTemplateReadPlatformServiceImpl implements SavingsAcc
             final Collection<EnumOptionData> withdrawalFeeTypeOptions = this.dropdownReadPlatformService.retrievewithdrawalFeeTypeOptions();
 
             final Collection<SavingsAccountTransactionData> transactions = null;
-            final Collection<ChargeData> productCharges = this.chargeReadPlatformService.retrieveSavingsProductCharges(productId);
+            final Collection<ChargeData> productCharges = this.chargeReadPlatformService.retrieveSavingsProductCharges(productId, officeId);
             // update charges from Product charges
             final Collection<SavingsAccountChargeData> charges = fromChargesToSavingsCharges(productCharges);
 
             final boolean feeChargesOnly = false;
             final Collection<ChargeData> chargeOptions = this.chargeReadPlatformService
-                    .retrieveSavingsProductApplicableCharges(feeChargesOnly);
+                    .retrieveSavingsProductApplicableCharges(feeChargesOnly, officeId);
 
             Collection<StaffData> fieldOfficerOptions = null;
 
@@ -202,7 +202,7 @@ public class SavingsAccountTemplateReadPlatformServiceImpl implements SavingsAcc
 
             final boolean feeChargesOnly = false;
             final Collection<ChargeData> chargeOptions = this.chargeReadPlatformService
-                    .retrieveSavingsProductApplicableCharges(feeChargesOnly);
+                    .retrieveSavingsProductApplicableCharges(feeChargesOnly, officeId);
 
             template = SavingsAccountData.withTemplateOptions(template, productOptions, fieldOfficerOptions,
                     interestCompoundingPeriodTypeOptions, interestPostingPeriodTypeOptions, interestCalculationTypeOptions,

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountTemplateReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountTemplateReadPlatformServiceImpl.java
@@ -137,13 +137,14 @@ public class SavingsAccountTemplateReadPlatformServiceImpl implements SavingsAcc
             final Collection<EnumOptionData> withdrawalFeeTypeOptions = this.dropdownReadPlatformService.retrievewithdrawalFeeTypeOptions();
 
             final Collection<SavingsAccountTransactionData> transactions = null;
-            final Collection<ChargeData> productCharges = this.chargeReadPlatformService.retrieveSavingsProductCharges(productId);
+            final Collection<ChargeData> productCharges = this.chargeReadPlatformService.retrieveSavingsProductCharges(productId,
+                    officeId);
             // update charges from Product charges
             final Collection<SavingsAccountChargeData> charges = fromChargesToSavingsCharges(productCharges);
 
             final boolean feeChargesOnly = false;
             final Collection<ChargeData> chargeOptions = this.chargeReadPlatformService
-                    .retrieveSavingsProductApplicableCharges(feeChargesOnly);
+                    .retrieveSavingsProductApplicableCharges(feeChargesOnly, officeId);
 
             Collection<StaffData> fieldOfficerOptions = null;
 
@@ -202,7 +203,7 @@ public class SavingsAccountTemplateReadPlatformServiceImpl implements SavingsAcc
 
             final boolean feeChargesOnly = false;
             final Collection<ChargeData> chargeOptions = this.chargeReadPlatformService
-                    .retrieveSavingsProductApplicableCharges(feeChargesOnly);
+                    .retrieveSavingsProductApplicableCharges(feeChargesOnly, officeId);
 
             template = SavingsAccountData.withTemplateOptions(template, productOptions, fieldOfficerOptions,
                     interestCompoundingPeriodTypeOptions, interestPostingPeriodTypeOptions, interestCalculationTypeOptions,

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/shareaccounts/service/ShareAccountReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/shareaccounts/service/ShareAccountReadPlatformServiceImpl.java
@@ -88,11 +88,18 @@ public class ShareAccountReadPlatformServiceImpl implements ShareAccountReadPlat
         String serviceName = "share" + ProductsApiConstants.READPLATFORM_NAME;
         ShareProductReadPlatformService service = (ShareProductReadPlatformService) this.applicationContext.getBean(serviceName);
         ClientData client = this.clientReadPlatformService.retrieveOne(clientId);
+        final Long clientOfficeId = client.getOfficeId();
+
+        if (clientOfficeId == null) {
+            throw new IllegalStateException(
+                    "Cannot resolve office for client [id=" + clientId + "]. Charge visibility cannot be determined.");
+        }
 
         if (productId != null) {
             final ShareProductData productData = (ShareProductData) service.retrieveOne(productId, false);
             final BigDecimal marketPrice = deriveMarketPrice(productData);
-            final Collection<ChargeData> productCharges = this.chargeReadPlatformService.retrieveShareProductCharges(productId);
+            final Collection<ChargeData> productCharges = this.chargeReadPlatformService.retrieveShareProductCharges(productId,
+                    clientOfficeId);
             final Collection<ShareAccountChargeData> charges = convertChargesToShareAccountCharges(productCharges);
             final Collection<EnumOptionData> lockinPeriodFrequencyTypeOptions = this.shareProductDropdownReadPlatformService
                     .retrieveLockinPeriodFrequencyTypeOptions();
@@ -105,7 +112,7 @@ public class ShareAccountReadPlatformServiceImpl implements ShareAccountReadPlat
                     productData.getNominalShares());
         } else {
             Collection<ProductData> productOptions = service.retrieveAllForLookup();
-            final Collection<ChargeData> chargeOptions = this.chargeReadPlatformService.retrieveSharesApplicableCharges();
+            final Collection<ChargeData> chargeOptions = this.chargeReadPlatformService.retrieveSharesApplicableCharges(clientOfficeId);
             toReturn = new ShareAccountData(client.getId(), client.getDisplayName(), productOptions, chargeOptions);
         }
         return toReturn;
@@ -150,7 +157,17 @@ public class ShareAccountReadPlatformServiceImpl implements ShareAccountReadPlat
             final Collection<SavingsAccountData> clientSavingsAccounts = this.savingsAccountReadPlatformService
                     .retrieveActiveForLookup(data.getClientId(), DepositAccountType.SAVINGS_DEPOSIT, productData.getCurrency().getCode());
             Collection<ProductData> productOptions = service.retrieveAllForLookup();
-            final Collection<ChargeData> chargeOptions = this.chargeReadPlatformService.retrieveSharesApplicableCharges();
+            final Long shareClientOfficeId = data.getClientId() != null
+                    ? this.clientReadPlatformService.retrieveOne(data.getClientId()).getOfficeId()
+                    : null;
+
+            if (shareClientOfficeId == null) {
+                throw new IllegalStateException(
+                        "Cannot resolve office for share account [id=" + id + "]. Charge visibility cannot be determined.");
+            }
+
+            final Collection<ChargeData> chargeOptions = this.chargeReadPlatformService
+                    .retrieveSharesApplicableCharges(shareClientOfficeId);
             data = ShareAccountData.template(data, productOptions, chargeOptions, clientSavingsAccounts, lockinPeriodFrequencyTypeOptions,
                     minimumActivePeriodFrequencyTypeOptions);
         }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/shareaccounts/service/ShareAccountReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/shareaccounts/service/ShareAccountReadPlatformServiceImpl.java
@@ -88,11 +88,18 @@ public class ShareAccountReadPlatformServiceImpl implements ShareAccountReadPlat
         String serviceName = "share" + ProductsApiConstants.READPLATFORM_NAME;
         ShareProductReadPlatformService service = (ShareProductReadPlatformService) this.applicationContext.getBean(serviceName);
         ClientData client = this.clientReadPlatformService.retrieveOne(clientId);
+        final Long clientOfficeId = client.getOfficeId();
+
+        if (clientOfficeId == null) {
+            throw new IllegalStateException(
+                    "Cannot resolve office for client [id=" + clientId + "]. Charge visibility cannot be determined.");
+        }
 
         if (productId != null) {
             final ShareProductData productData = (ShareProductData) service.retrieveOne(productId, false);
             final BigDecimal marketPrice = deriveMarketPrice(productData);
-            final Collection<ChargeData> productCharges = this.chargeReadPlatformService.retrieveShareProductCharges(productId);
+            final Collection<ChargeData> productCharges = this.chargeReadPlatformService.retrieveShareProductCharges(productId,
+                    clientOfficeId);
             final Collection<ShareAccountChargeData> charges = convertChargesToShareAccountCharges(productCharges);
             final Collection<EnumOptionData> lockinPeriodFrequencyTypeOptions = this.shareProductDropdownReadPlatformService
                     .retrieveLockinPeriodFrequencyTypeOptions();
@@ -105,7 +112,7 @@ public class ShareAccountReadPlatformServiceImpl implements ShareAccountReadPlat
                     productData.getNominalShares());
         } else {
             Collection<ProductData> productOptions = service.retrieveAllForLookup();
-            final Collection<ChargeData> chargeOptions = this.chargeReadPlatformService.retrieveSharesApplicableCharges();
+            final Collection<ChargeData> chargeOptions = this.chargeReadPlatformService.retrieveSharesApplicableCharges(clientOfficeId);
             toReturn = new ShareAccountData(client.getId(), client.getDisplayName(), productOptions, chargeOptions);
         }
         return toReturn;
@@ -150,7 +157,16 @@ public class ShareAccountReadPlatformServiceImpl implements ShareAccountReadPlat
             final Collection<SavingsAccountData> clientSavingsAccounts = this.savingsAccountReadPlatformService
                     .retrieveActiveForLookup(data.getClientId(), DepositAccountType.SAVINGS_DEPOSIT, productData.getCurrency().getCode());
             Collection<ProductData> productOptions = service.retrieveAllForLookup();
-            final Collection<ChargeData> chargeOptions = this.chargeReadPlatformService.retrieveSharesApplicableCharges();
+            final Long shareClientOfficeId = data.getClientId() != null
+                    ? this.clientReadPlatformService.retrieveOne(data.getClientId()).getOfficeId()
+                    : null;
+
+            if (shareClientOfficeId == null) {
+                throw new IllegalStateException(
+                        "Cannot resolve office for share account [id=" + id + "]. Charge visibility cannot be determined.");
+            }
+
+            final Collection<ChargeData> chargeOptions = this.chargeReadPlatformService.retrieveSharesApplicableCharges(shareClientOfficeId);
             data = ShareAccountData.template(data, productOptions, chargeOptions, clientSavingsAccounts, lockinPeriodFrequencyTypeOptions,
                     minimumActivePeriodFrequencyTypeOptions);
         }


### PR DESCRIPTION
Description:                                                                                                                                                                      
                                                                                                                                                                                    
  ## Bug                                                                                                                                                                            
                                                                                                                                                                                    
  Fineract has a global configuration flag `office-specific-products-enabled`                                                                                                       
  intended to restrict which loan products each office can offer. When enabled,                                                                                                     
  only the products explicitly mapped to an office (via Entity to Entity                                                                                                            
  Mapping) should be available to that office's users.                                                                                                                              
                                                                                                                                                                                    
  In practice, enabling this flag causes the opposite of the intended behavior:                                                                                                     
                                                                                                                                                                                    
  1. **Entity to Entity Mapping screen** — the Loan Product dropdown in                                                                                                             
     Admin → System → Entity to Entity Mapping → Offices → Loan Products                                                                                                            
     shows only "All" and no individual products. This makes it impossible                                                                                                          
     to create the mappings the feature depends on.                                                                                                                                 
                                                                                                                                                                                    
  2. **Loan product listing** — all loan products disappear from the listing                                                                                                        
     page for branch users, even products that should be visible (e.g. products                                                                                                     
     mapped to "All" or products with no mapping at all).                                                                                                                           
                                                                                                                                                                                    
  3. **Loan application template** — the `/loans/template` API returns an                                                                                                           
     empty product list, blocking any new loan application when the flag is on.    
The root cause is that `retrieveAllLoanProducts()` ignores the                                                                                                                    
  `office-specific-products-enabled` flag entirely. There is no code path that                                                                                                      
  filters or resolves the entity mappings to determine which products are                                                                                                           
  visible to a given office.                                                                                                                                                        
                                                                                                                                                                                    
  ## Fix                                                                                                                                                                            
                                                                                                                                                                                    
  Introduce office-aware loan product retrieval:                                                                                                                                    
                                                                                                                                                                                    
  - `FineractEntityAccessReadServiceImpl`: add                                                                                                                                      
    `getSQLQueryInClauseIDList_ForLoanProductsVisibleToOffice(officeId)` which                                                                                                      
    resolves the entity mappings for an office (including parent–child hierarchy,                                                                                                   
    so a product mapped to a parent office is also available to child branches).                                                                                                    
                                                                                                                                                                                    
  - `LoanProductReadPlatformService` / `LoanProductReadPlatformServiceImpl`:                                                                                                        
    add `retrieveAllLoanProductsV2()` and overloads that use the above query                                                                                                        
    when `office-specific-products-enabled` is on, falling back to the original                                                                                                     
    behavior when it is off.                                                                                                                                                        
                                                                                                                                                                                    
  - `LoanProductsApiResourceV2`: new API endpoint that calls                                                                                                                        
    `retrieveAllLoanProductsV2()`, used by the Entity to Entity Mapping screen                                                                                                      
    and the self-service loan products endpoint.                                                                                                                                    
                                                                                                                                                                                    
  - `LoansApiResource` and `BulkImportWorkbookPopulatorServiceImpl`: updated to                                                                                                     
    use the office-aware method so the loans template and bulk import respect                                                                                                       
    the same visibility rules.                                                                                                                                                      
                                                  
  ## Visibility rules when office-specific-products-enabled is ON                                                                                                                   
                                                                                                                                                                                    
  A loan product is visible to an office if:                                                                                                                                        
  - It has no entity mapping at all, OR                                                                                                                                             
  - It is mapped to "All", OR                                                                                                                                                       
  - It is explicitly mapped to the user's office or any office in its                                                                                                               
    parent hierarchy.                                                                                                                                                               
                         