### PR TITLE
FINERACT-2729: Accept .xlsx files in bulk import, not just legacy .xls

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/service/BulkImportWorkbookServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/service/BulkImportWorkbookServiceImpl.java
@@ -46,8 +46,8 @@ import org.apache.fineract.infrastructure.documentmanagement.data.DocumentCreate
 import org.apache.fineract.infrastructure.documentmanagement.data.DocumentCreateResponse;
 import org.apache.fineract.infrastructure.documentmanagement.service.DocumentWritePlatformService;
 import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
-import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
 import org.apache.tika.Tika;
 import org.apache.tika.io.TikaInputStream;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
@@ -81,7 +81,8 @@ public class BulkImportWorkbookServiceImpl implements BulkImportWorkbookService 
                 final Tika tika = new Tika();
                 final TikaInputStream tikaInputStream = TikaInputStream.get(bis);
                 final String fileType = tika.detect(tikaInputStream);
-                if (!fileType.contains("msoffice") && !fileType.contains("application/vnd.ms-excel")) {
+                if (!fileType.contains("msoffice") && !fileType.contains("application/vnd.ms-excel")
+                        && !fileType.contains("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")) {
                     // We had a problem where we tried to upload the downloaded
                     // file from the import options, it was somehow changed the
                     // extension we use this fix.
@@ -89,7 +90,7 @@ public class BulkImportWorkbookServiceImpl implements BulkImportWorkbookService 
                             "Uploaded file extension is not recognized.");
 
                 }
-                Workbook workbook = new HSSFWorkbook(clonedInputStream);
+                Workbook workbook = WorkbookFactory.create(clonedInputStream);
                 GlobalEntityType entityType = null;
                 int primaryColumn = 0;
                 if (entity.trim().equalsIgnoreCase(GlobalEntityType.CLIENTS_PERSON.toString())) {


### PR DESCRIPTION
Bulk import validated the uploaded file's MIME type but only accepted the legacy Excel (`.xls`) format, rejecting valid OOXML (`.xlsx`) files such as those downloaded from Google Sheets. Additionally, the implementation always parsed uploaded files using `HSSFWorkbook`, which only supports the `.xls` format.

This change adds support for the OOXML spreadsheet MIME type and replaces the hardcoded `HSSFWorkbook` with `WorkbookFactory.create()`, allowing Apache POI to automatically detect and parse both `.xls` and `.xlsx` workbooks.


This PR : https://issues.apache.org/jira/browse/FINERACT-2729