### PR TITLE
FINERACT-2730: add loan and savings transaction search

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/search/SearchConstants.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/search/SearchConstants.java
@@ -47,7 +47,16 @@ public final class SearchConstants {
         PARENT_ID("parentId"), //
         PARENT_NAME("parentName"), //
         ENTITY_MOBILE_NO("entityMobileNo"), //
-        ENTITY_STATUS("entityStatus"); //
+        ENTITY_STATUS("entityStatus"), //
+        PARENT_TYPE("parentType"), //
+        SUB_ENTITY_TYPE("subEntityType"), //
+        TRANSACTION_ID("transactionId"), //
+        TRANSACTION_TYPE("transactionType"), //
+        TRANSACTION_EXTERNAL_ID("transactionExternalId"), //
+        TRANSACTION_REF_NO("transactionRefNo"), //
+        ACCOUNT_ID("accountId"), //
+        ACCOUNT_NO("accountNo"), //
+        ACCOUNT_TYPE("accountType"); //
 
         private final String value;
 
@@ -118,7 +127,9 @@ public final class SearchConstants {
         LOANS("loans"), //
         SAVINGS("savings"), //
         SHARES("shares"), //
-        CLIENTIDENTIFIERS("clientIdentifiers"); //
+        CLIENTIDENTIFIERS("clientIdentifiers"), //
+        LOANTRANSACTIONS("loanTransactions"), //
+        SAVINGSTRANSACTIONS("savingsTransactions"); //
 
         private final String value;
 

--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/search/data/SearchConditions.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/search/data/SearchConditions.java
@@ -18,6 +18,7 @@
  */
 package org.apache.fineract.portfolio.search.data;
 
+import java.util.Arrays;
 import org.apache.fineract.portfolio.search.SearchConstants.SearchSupportedResources;
 
 public class SearchConditions {
@@ -30,6 +31,8 @@ public class SearchConditions {
     private final Boolean savingSeach;
     private final Boolean shareSeach;
     private final Boolean clientIdentifierSearch;
+    private final Boolean loanTransactionSearch;
+    private final Boolean savingTransactionSearch;
     private Boolean exactMatch;
     private final String hierarchy;
 
@@ -38,23 +41,27 @@ public class SearchConditions {
         this.searchResource = searchResource;
         this.exactMatch = exactMatch;
         this.hierarchy = hierarchy;
-        this.clientSearch = null == searchResource
-                || searchResource.toLowerCase().contains(SearchSupportedResources.CLIENTS.name().toLowerCase());
-        this.groupSearch = null == searchResource
-                || searchResource.toLowerCase().contains(SearchSupportedResources.GROUPS.name().toLowerCase());
-        this.loanSeach = null == searchResource
-                || searchResource.toLowerCase().contains(SearchSupportedResources.LOANS.name().toLowerCase());
-        this.savingSeach = null == searchResource
-                || searchResource.toLowerCase().contains(SearchSupportedResources.SAVINGS.name().toLowerCase());
-        this.shareSeach = null == searchResource
-                || searchResource.toLowerCase().contains(SearchSupportedResources.SHARES.name().toLowerCase());
-        this.clientIdentifierSearch = null == searchResource
-                || searchResource.toLowerCase().contains(SearchSupportedResources.CLIENTIDENTIFIERS.name().toLowerCase());
+        this.clientSearch = isResourceSelected(searchResource, SearchSupportedResources.CLIENTS);
+        this.groupSearch = isResourceSelected(searchResource, SearchSupportedResources.GROUPS);
+        this.loanSeach = isResourceSelected(searchResource, SearchSupportedResources.LOANS);
+        this.savingSeach = isResourceSelected(searchResource, SearchSupportedResources.SAVINGS);
+        this.shareSeach = isResourceSelected(searchResource, SearchSupportedResources.SHARES);
+        this.clientIdentifierSearch = isResourceSelected(searchResource, SearchSupportedResources.CLIENTIDENTIFIERS);
+        this.loanTransactionSearch = isResourceSelected(searchResource, SearchSupportedResources.LOANTRANSACTIONS);
+        this.savingTransactionSearch = isResourceSelected(searchResource, SearchSupportedResources.SAVINGSTRANSACTIONS);
     }
 
     public SearchConditions(final String searchQueryParam, final String searchResource, final Boolean clientSearch,
             final Boolean groupSearch, final Boolean loanSeach, final Boolean savingSeach, final Boolean shareSeach,
             final Boolean clientIdentifierSearch, Boolean exactMatch, final String hierarchy) {
+        this(searchQueryParam, searchResource, clientSearch, groupSearch, loanSeach, savingSeach, shareSeach, clientIdentifierSearch, false,
+                false, exactMatch, hierarchy);
+    }
+
+    public SearchConditions(final String searchQueryParam, final String searchResource, final Boolean clientSearch,
+            final Boolean groupSearch, final Boolean loanSeach, final Boolean savingSeach, final Boolean shareSeach,
+            final Boolean clientIdentifierSearch, final Boolean loanTransactionSearch, final Boolean savingTransactionSearch,
+            Boolean exactMatch, final String hierarchy) {
         this.searchQuery = searchQueryParam;
         this.searchResource = searchResource;
         this.clientSearch = clientSearch;
@@ -63,6 +70,8 @@ public class SearchConditions {
         this.savingSeach = savingSeach;
         this.shareSeach = shareSeach;
         this.clientIdentifierSearch = clientIdentifierSearch;
+        this.loanTransactionSearch = loanTransactionSearch;
+        this.savingTransactionSearch = savingTransactionSearch;
         this.exactMatch = exactMatch;
         this.hierarchy = hierarchy;
     }
@@ -103,8 +112,21 @@ public class SearchConditions {
         return this.clientIdentifierSearch;
     }
 
+    public Boolean isLoanTransactionSearch() {
+        return this.loanTransactionSearch;
+    }
+
+    public Boolean isSavingTransactionSearch() {
+        return this.savingTransactionSearch;
+    }
+
     public String getHierarchy() {
         return this.hierarchy;
+    }
+
+    private boolean isResourceSelected(final String searchResource, final SearchSupportedResources supportedResource) {
+        return searchResource == null || Arrays.stream(searchResource.split(",")).map(String::trim)
+                .anyMatch(resource -> resource.equalsIgnoreCase(supportedResource.getValue()));
     }
 
 }

--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/search/data/SearchData.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/search/data/SearchData.java
@@ -35,10 +35,26 @@ public class SearchData {
     private final EnumOptionData entityStatus;
     private final String parentType;
     private final String subEntityType;
+    private final Long transactionId;
+    private final String transactionType;
+    private final String transactionExternalId;
+    private final String transactionRefNo;
+    private final Long accountId;
+    private final String accountNo;
+    private final String accountType;
 
     public SearchData(final Long entityId, final String entityAccountNo, final String entityExternalId, final String entityName,
             final String entityType, final Long parentId, final String parentName, final String parentType, final String entityMobileNo,
             final EnumOptionData entityStatus, final String subEntityType) {
+        this(entityId, entityAccountNo, entityExternalId, entityName, entityType, parentId, parentName, parentType, entityMobileNo,
+                entityStatus, subEntityType, null, null, null, null, null, null, null);
+    }
+
+    public SearchData(final Long entityId, final String entityAccountNo, final String entityExternalId, final String entityName,
+            final String entityType, final Long parentId, final String parentName, final String parentType, final String entityMobileNo,
+            final EnumOptionData entityStatus, final String subEntityType, final Long transactionId, final String transactionType,
+            final String transactionExternalId, final String transactionRefNo, final Long accountId, final String accountNo,
+            final String accountType) {
 
         this.entityId = entityId;
         this.entityAccountNo = entityAccountNo;
@@ -51,6 +67,13 @@ public class SearchData {
         this.entityMobileNo = entityMobileNo;
         this.entityStatus = entityStatus;
         this.subEntityType = subEntityType;
+        this.transactionId = transactionId;
+        this.transactionType = transactionType;
+        this.transactionExternalId = transactionExternalId;
+        this.transactionRefNo = transactionRefNo;
+        this.accountId = accountId;
+        this.accountNo = accountNo;
+        this.accountType = accountType;
     }
 
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/search/api/SearchApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/search/api/SearchApiResource.java
@@ -76,7 +76,10 @@ public class SearchApiResource {
             search?query=Petra&resource=clients,groups
 
 
-            search?query=Petra&resource=clients,groups&exactMatch=true""")
+            search?query=Petra&resource=clients,groups&exactMatch=true
+
+
+            search?query=7253&resource=loanTransactions,savingsTransactions""")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = SearchApiResourceSwagger.GetSearchResponse.class))))
     public List<SearchData> searchData(@QueryParam("query") @Parameter(description = "query") final String query,
             @QueryParam("resource") @Parameter(description = "resource") final String resource,

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/search/api/SearchApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/search/api/SearchApiResourceSwagger.java
@@ -52,7 +52,25 @@ final class SearchApiResourceSwagger {
         public Long parentId;
         @Schema(example = "Head Office")
         public String parentName;
+        @Schema(example = "client")
+        public String parentType;
+        @Schema(example = "depositAccountType.savingsDeposit")
+        public String subEntityType;
         public EnumOptionData entityStatus;
+        @Schema(example = "7253")
+        public Long transactionId;
+        @Schema(example = "deposit")
+        public String transactionType;
+        @Schema(example = "txn-external-id-1")
+        public String transactionExternalId;
+        @Schema(example = "69da9027-653d-45e0-9a5a-cbd7c8507237")
+        public String transactionRefNo;
+        @Schema(example = "42")
+        public Long accountId;
+        @Schema(example = "000000042")
+        public String accountNo;
+        @Schema(example = "savings")
+        public String accountType;
     }
 
     @Schema(description = "PostAdhocQuerySearchRequest")

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/search/service/SearchReadServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/search/service/SearchReadServiceImpl.java
@@ -35,9 +35,11 @@ import org.apache.fineract.organisation.office.service.OfficeReadPlatformService
 import org.apache.fineract.portfolio.client.domain.ClientEnumerations;
 import org.apache.fineract.portfolio.group.domain.GroupingTypeEnumerations;
 import org.apache.fineract.portfolio.loanaccount.data.LoanStatusEnumData;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanTransactionType;
 import org.apache.fineract.portfolio.loanproduct.data.LoanProductData;
 import org.apache.fineract.portfolio.loanproduct.service.LoanEnumerations;
 import org.apache.fineract.portfolio.loanproduct.service.LoanProductReadPlatformService;
+import org.apache.fineract.portfolio.savings.SavingsAccountTransactionType;
 import org.apache.fineract.portfolio.savings.data.SavingsAccountStatusEnumData;
 import org.apache.fineract.portfolio.savings.service.SavingsEnumerations;
 import org.apache.fineract.portfolio.search.SearchConstants;
@@ -79,6 +81,10 @@ public class SearchReadServiceImpl implements SearchReadService {
         } else {
             params.addValue("search", "%" + searchConditions.getSearchQuery() + "%");
         }
+        params.addValue("searchTransactionId", parseSearchTransactionId(searchConditions.getSearchQuery()));
+        params.addValue("loanRepaymentTransactionType", LoanTransactionType.REPAYMENT.getValue());
+        params.addValue("savingsDepositTransactionType", SavingsAccountTransactionType.DEPOSIT.getValue());
+        params.addValue("savingsWithdrawalTransactionType", SavingsAccountTransactionType.WITHDRAWAL.getValue());
         return namedParameterJdbcTemplate.query(searchSchema(searchConditions), params, rm);
     }
 
@@ -89,7 +95,9 @@ public class SearchReadServiceImpl implements SearchReadService {
                 ( (select 'CLIENT' as entityType, c.id as entityId, c.display_name as entityName, \
                 c.external_id as entityExternalId, c.account_no as entityAccountNo, \
                 c.office_id as parentId, o.name as parentName, c.mobile_no as entityMobileNo, \
-                c.status_enum as entityStatusEnum, null as subEntityType, null as parentType \
+                c.status_enum as entityStatusEnum, null as subEntityType, null as parentType, \
+                null as transactionId, null as transactionType, null as transactionExternalId, null as transactionRefNo, \
+                null as accountId, null as accountNo, null as accountType \
                 from m_client c join m_office o on o.id = c.office_id \
                 where o.hierarchy like :hierarchy \
                 and (c.account_no like :search or c.display_name like :search \
@@ -101,7 +109,9 @@ public class SearchReadServiceImpl implements SearchReadService {
                 l.external_id as entityExternalId, l.account_no as entityAccountNo, \
                 coalesce(c.id,g.id) as parentId, coalesce(c.display_name,g.display_name) as parentName, \
                 null as entityMobileNo, l.loan_status_id as entityStatusEnum, null as subEntityType, \
-                CASE WHEN g.id is null THEN 'client' ELSE 'group' END as parentType \
+                CASE WHEN g.id is null THEN 'client' ELSE 'group' END as parentType, \
+                null as transactionId, null as transactionType, null as transactionExternalId, null as transactionRefNo, \
+                null as accountId, null as accountNo, null as accountType \
                 from m_loan l left join m_client c on l.client_id = c.id \
                 left join m_group g ON l.group_id = g.id \
                 left join m_office o on o.id = c.office_id \
@@ -116,7 +126,9 @@ public class SearchReadServiceImpl implements SearchReadService {
                 coalesce(c.id,g.id) as parentId, coalesce(c.display_name, g.display_name) as parentName, \
                 null as entityMobileNo, s.status_enum as entityStatusEnum, \
                 concat(s.deposit_type_enum, '') as subEntityType, \
-                CASE WHEN g.id is null THEN 'client' ELSE 'group' END as parentType \
+                CASE WHEN g.id is null THEN 'client' ELSE 'group' END as parentType, \
+                null as transactionId, null as transactionType, null as transactionExternalId, null as transactionRefNo, \
+                null as accountId, null as accountNo, null as accountType \
                 from m_savings_account s left join m_client c on s.client_id = c.id \
                 left join m_group g ON s.group_id = g.id \
                 left join m_office o on o.id = c.office_id \
@@ -129,7 +141,9 @@ public class SearchReadServiceImpl implements SearchReadService {
                 ( (select 'SHARE' as entityType, s.id as entityId, sp.name as entityName, \
                 s.external_id as entityExternalId, s.account_no as entityAccountNo, \
                 c.id as parentId, c.display_name as parentName, null as entityMobileNo, \
-                s.status_enum as entityStatusEnum, null as subEntityType, 'client' as parentType \
+                s.status_enum as entityStatusEnum, null as subEntityType, 'client' as parentType, \
+                null as transactionId, null as transactionType, null as transactionExternalId, null as transactionRefNo, \
+                null as accountId, null as accountNo, null as accountType \
                 from m_share_account s left join m_client c on s.client_id = c.id \
                 left join m_office o on o.id = c.office_id \
                 left join m_share_product sp on sp.id=s.product_id \
@@ -141,7 +155,9 @@ public class SearchReadServiceImpl implements SearchReadService {
                 ( (select 'CLIENTIDENTIFIER' as entityType, ci.id as entityId, ci.document_key as entityName, \
                 null as entityExternalId, null as entityAccountNo, c.id as parentId, \
                 c.display_name as parentName, null as entityMobileNo, \
-                c.status_enum as entityStatusEnum, null as subEntityType, null as parentType \
+                c.status_enum as entityStatusEnum, null as subEntityType, null as parentType, \
+                null as transactionId, null as transactionType, null as transactionExternalId, null as transactionRefNo, \
+                null as accountId, null as accountNo, null as accountType \
                 from m_client_identifier ci join m_client c on ci.client_id=c.id \
                 join m_office o on o.id = c.office_id \
                 where o.hierarchy like :hierarchy and ci.document_key like :search) \
@@ -152,12 +168,53 @@ public class SearchReadServiceImpl implements SearchReadService {
                 g.id as entityId, g.display_name as entityName, \
                 g.external_id as entityExternalId, g.account_no as entityAccountNo, \
                 g.office_id as parentId, o.name as parentName, null as entityMobileNo, \
-                g.status_enum as entityStatusEnum, null as subEntityType, null as parentType \
+                g.status_enum as entityStatusEnum, null as subEntityType, null as parentType, \
+                null as transactionId, null as transactionType, null as transactionExternalId, null as transactionRefNo, \
+                null as accountId, null as accountNo, null as accountType \
                 from m_group g join m_office o on o.id = g.office_id \
                 where o.hierarchy like :hierarchy \
                 and (g.account_no like :search or g.display_name like :search \
                 or g.external_id like :search)) \
                 order by g.id desc)""";
+
+        final String loanTransactionMatchSql = """
+                ( (select 'LOAN_TRANSACTION' as entityType, l.id as entityId, pl.name as entityName, \
+                lt.external_id as entityExternalId, l.account_no as entityAccountNo, \
+                coalesce(c.id,g.id) as parentId, coalesce(c.display_name,g.display_name) as parentName, \
+                null as entityMobileNo, l.loan_status_id as entityStatusEnum, null as subEntityType, \
+                CASE WHEN g.id is null THEN 'client' ELSE 'group' END as parentType, \
+                lt.id as transactionId, 'repayment' as transactionType, lt.external_id as transactionExternalId, \
+                null as transactionRefNo, l.id as accountId, l.account_no as accountNo, 'loan' as accountType \
+                from m_loan_transaction lt join m_loan l on l.id = lt.loan_id \
+                left join m_client c on l.client_id = c.id \
+                left join m_group g ON l.group_id = g.id \
+                left join m_office o on o.id = coalesce(c.office_id, g.office_id) \
+                left join m_product_loan pl on pl.id=l.product_id \
+                where o.hierarchy like :hierarchy \
+                and lt.transaction_type_enum = :loanRepaymentTransactionType \
+                and (lt.id = :searchTransactionId or lt.external_id like :search)) \
+                order by lt.id desc)""";
+
+        final String savingTransactionMatchSql = """
+                ( (select 'SAVINGS_TRANSACTION' as entityType, s.id as entityId, sp.name as entityName, \
+                st.external_id as entityExternalId, s.account_no as entityAccountNo, \
+                coalesce(c.id,g.id) as parentId, coalesce(c.display_name, g.display_name) as parentName, \
+                null as entityMobileNo, s.status_enum as entityStatusEnum, \
+                concat(s.deposit_type_enum, '') as subEntityType, \
+                CASE WHEN g.id is null THEN 'client' ELSE 'group' END as parentType, \
+                st.id as transactionId, CASE WHEN st.transaction_type_enum = :savingsDepositTransactionType THEN 'deposit' ELSE 'withdrawal' END as transactionType, \
+                st.external_id as transactionExternalId, st.ref_no as transactionRefNo, \
+                s.id as accountId, s.account_no as accountNo, 'savings' as accountType \
+                from m_savings_account_transaction st join m_savings_account s on s.id = st.savings_account_id \
+                left join m_client c on s.client_id = c.id \
+                left join m_group g ON s.group_id = g.id \
+                left join m_office o on o.id = coalesce(c.office_id, g.office_id) \
+                left join m_savings_product sp on sp.id=s.product_id \
+                where o.hierarchy like :hierarchy \
+                and st.transaction_type_enum in (:savingsDepositTransactionType, :savingsWithdrawalTransactionType) \
+                and st.is_reversal = false \
+                and (st.id = :searchTransactionId or st.external_id like :search or st.ref_no like :search)) \
+                order by st.id desc)""";
 
         final StringBuilder sql = new StringBuilder();
 
@@ -185,6 +242,25 @@ public class SearchReadServiceImpl implements SearchReadService {
             sql.append(groupMatchSql).append(union);
         }
 
+        if (searchConditions.isLoanTransactionSearch()) {
+            sql.append(loanTransactionMatchSql).append(union);
+        }
+
+        if (searchConditions.isSavingTransactionSearch()) {
+            sql.append(savingTransactionMatchSql).append(union);
+        }
+
+        if (sql.isEmpty()) {
+            sql.append("""
+                    select null as entityType, null as entityId, null as entityName, null as entityExternalId, \
+                    null as entityAccountNo, null as parentId, null as parentName, null as entityMobileNo, \
+                    null as entityStatusEnum, null as subEntityType, null as parentType, null as transactionId, \
+                    null as transactionType, null as transactionExternalId, null as transactionRefNo, null as accountId, \
+                    null as accountNo, null as accountType where 1 = 0""");
+            sql.append(" ").append(sqlGenerator.limit(50, 0));
+            return sql.toString();
+        }
+
         // remove last occurrence of "union all" string
         sql.replace(sql.lastIndexOf(union), sql.length(), "");
 
@@ -209,6 +285,13 @@ public class SearchReadServiceImpl implements SearchReadService {
             final String parentType = rs.getString("parentType");
             final Integer subEntityTypeValue = JdbcSupport.getInteger(rs, "subEntityType");
             final EnumOptionData subEntityTypeCode = SavingsEnumerations.depositType(subEntityTypeValue);
+            final Long transactionId = JdbcSupport.getLong(rs, "transactionId");
+            final String transactionType = rs.getString("transactionType");
+            final String transactionExternalId = rs.getString("transactionExternalId");
+            final String transactionRefNo = rs.getString("transactionRefNo");
+            final Long accountId = JdbcSupport.getLong(rs, "accountId");
+            final String accountNo = rs.getString("accountNo");
+            final String accountType = rs.getString("accountType");
 
             EnumOptionData entityStatus = new EnumOptionData(0L, "", "");
 
@@ -216,11 +299,11 @@ public class SearchReadServiceImpl implements SearchReadService {
                 entityStatus = ClientEnumerations.status(entityStatusEnum);
             } else if (entityType.equalsIgnoreCase("group") || entityType.equalsIgnoreCase("center")) {
                 entityStatus = GroupingTypeEnumerations.status(entityStatusEnum);
-            } else if (entityType.equalsIgnoreCase("loan")) {
+            } else if (entityType.equalsIgnoreCase("loan") || entityType.equalsIgnoreCase("loan_transaction")) {
                 LoanStatusEnumData loanStatusEnumData = LoanEnumerations.status(entityStatusEnum);
 
                 entityStatus = LoanEnumerations.status(loanStatusEnumData);
-            } else if (entityType.equalsIgnoreCase("saving")) {
+            } else if (entityType.equalsIgnoreCase("saving") || entityType.equalsIgnoreCase("savings_transaction")) {
                 SavingsAccountStatusEnumData savingsAccountStatusEnumData = SavingsEnumerations.status(entityStatusEnum);
 
                 entityStatus = SavingsEnumerations.status(savingsAccountStatusEnumData);
@@ -231,9 +314,21 @@ public class SearchReadServiceImpl implements SearchReadService {
             }
 
             return new SearchData(entityId, entityAccountNo, entityExternalId, entityName, entityType, parentId, parentName, parentType,
-                    entityMobileNo, entityStatus, subEntityTypeCode.getCode());
+                    entityMobileNo, entityStatus, subEntityTypeCode.getCode(), transactionId, transactionType, transactionExternalId,
+                    transactionRefNo, accountId, accountNo, accountType);
         }
 
+    }
+
+    private static Long parseSearchTransactionId(final String searchQuery) {
+        if (StringUtils.isBlank(searchQuery)) {
+            return -1L;
+        }
+        try {
+            return Long.valueOf(searchQuery);
+        } catch (final NumberFormatException e) {
+            return -1L;
+        }
     }
 
     @Override

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/SearchResourcesTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/SearchResourcesTest.java
@@ -26,15 +26,23 @@ import io.restassured.builder.ResponseSpecBuilder;
 import io.restassured.http.ContentType;
 import io.restassured.specification.RequestSpecification;
 import io.restassured.specification.ResponseSpecification;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.apache.fineract.client.models.GetClientsClientIdResponse;
 import org.apache.fineract.client.models.GetSearchResponse;
 import org.apache.fineract.client.models.PostClientsResponse;
+import org.apache.fineract.client.models.PostLoansLoanIdTransactionsRequest;
+import org.apache.fineract.client.models.PostLoansLoanIdTransactionsResponse;
+import org.apache.fineract.client.models.PostSavingsAccountTransactionsRequest;
+import org.apache.fineract.client.models.PostSavingsAccountTransactionsResponse;
 import org.apache.fineract.integrationtests.client.feign.helpers.FeignSearchHelper;
 import org.apache.fineract.integrationtests.common.ClientHelper;
 import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
+import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
+import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
 import org.apache.fineract.integrationtests.common.savings.SavingsAccountHelper;
 import org.apache.fineract.integrationtests.common.shares.ShareAccountHelper;
 import org.apache.fineract.integrationtests.common.shares.ShareAccountTransactionHelper;
@@ -42,6 +50,7 @@ import org.apache.fineract.integrationtests.common.shares.ShareProductHelper;
 import org.apache.fineract.integrationtests.common.shares.ShareProductTransactionHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import retrofit2.Response;
 
 public class SearchResourcesTest {
 
@@ -177,5 +186,146 @@ public class SearchResourcesTest {
         assertNotNull(result.getEntityStatus().getId());
         assertNotNull(result.getEntityStatus().getCode());
         assertNotNull(result.getEntityStatus().getValue());
+    }
+
+    @Test
+    public void searchOverLoanTransactionResources() {
+        final String resources = "loanTransactions";
+        final Long clientId = ClientHelper.addClientAsPerson(ClientHelper.DEFAULT_OFFICE_ID, ClientHelper.LEGALFORM_ID_PERSON, null)
+                .getClientId();
+        final LoanTransactionHelper loanTransactionHelper = new LoanTransactionHelper(requestSpec, responseSpec);
+        final Integer loanProductId = loanTransactionHelper.createLoanProduct(null, "2", LoanApplicationTestBuilder.DEFAULT_STRATEGY, "1");
+        final Integer loanId = createLoanAccount(clientId, loanProductId, loanTransactionHelper);
+
+        final String disbursementExternalId = "disbursement-" + UUID.randomUUID();
+        loanTransactionHelper.disburseLoan("01 January 2026", loanId, "1000", disbursementExternalId);
+
+        final String repaymentExternalId = "repayment-" + UUID.randomUUID();
+        final PostLoansLoanIdTransactionsResponse repayment = loanTransactionHelper.makeLoanRepayment(loanId.longValue(),
+                new PostLoansLoanIdTransactionsRequest().transactionDate("01 February 2026").dateFormat("dd MMMM yyyy").locale("en")
+                        .transactionAmount(100.0).externalId(repaymentExternalId));
+        final Long repaymentTransactionId = repayment.getResourceId();
+
+        assertEquals(0, searchHelper.search(disbursementExternalId, resources, Boolean.TRUE).size());
+
+        GetSearchResponse result = assertSingleSearchResult(
+                searchHelper.search(String.valueOf(repaymentTransactionId), resources, Boolean.TRUE));
+        assertLoanTransactionSearchResult(result, clientId, loanId.longValue(), repaymentTransactionId, repaymentExternalId);
+
+        result = assertSingleSearchResult(searchHelper.search(repaymentExternalId, resources, Boolean.TRUE));
+        assertLoanTransactionSearchResult(result, clientId, loanId.longValue(), repaymentTransactionId, repaymentExternalId);
+
+        final String partialExternalId = repaymentExternalId.substring(0, repaymentExternalId.length() - 4);
+        result = assertSingleSearchResult(searchHelper.search(partialExternalId, resources, Boolean.FALSE));
+        assertLoanTransactionSearchResult(result, clientId, loanId.longValue(), repaymentTransactionId, repaymentExternalId);
+        assertEquals(0, searchHelper.search(partialExternalId, resources, Boolean.TRUE).size());
+    }
+
+    @Test
+    public void searchOverSavingsDepositTransactionResources() {
+        final String resources = "savingsTransactions";
+        final Long clientId = ClientHelper.addClientAsPerson(ClientHelper.DEFAULT_OFFICE_ID, ClientHelper.LEGALFORM_ID_PERSON, null)
+                .getClientId();
+        final Integer savingsId = SavingsAccountHelper.openSavingsAccount(requestSpec, responseSpec, clientId.intValue(), "1000");
+        final SavingsAccountHelper savingsAccountHelper = new SavingsAccountHelper(requestSpec, responseSpec);
+        final String externalId = "savings-deposit-" + UUID.randomUUID();
+        final PostSavingsAccountTransactionsResponse deposit = executeSavingsTransaction(
+                savingsAccountHelper.depositIntoSavingsAccount(savingsId.longValue(),
+                        new PostSavingsAccountTransactionsRequest().transactionDate("02 March 2013").dateFormat("dd MMMM yyyy").locale("en")
+                                .transactionAmount(BigDecimal.valueOf(100)).paymentTypeId(1).externalId(externalId)));
+        final Long transactionId = deposit.getResourceId();
+
+        GetSearchResponse result = assertSingleSearchResult(searchHelper.search(String.valueOf(transactionId), resources, Boolean.TRUE));
+        assertSavingsTransactionSearchResult(result, clientId, savingsId.longValue(), transactionId, "deposit", externalId);
+
+        result = assertSingleSearchResult(searchHelper.search(externalId, resources, Boolean.TRUE));
+        assertSavingsTransactionSearchResult(result, clientId, savingsId.longValue(), transactionId, "deposit", externalId);
+
+        final String refNo = result.getTransactionRefNo();
+        assertNotNull(refNo);
+        result = assertSingleSearchResult(searchHelper.search(refNo, resources, Boolean.TRUE));
+        assertSavingsTransactionSearchResult(result, clientId, savingsId.longValue(), transactionId, "deposit", externalId);
+    }
+
+    @Test
+    public void searchOverSavingsWithdrawalTransactionResources() {
+        final String resources = "savingsTransactions";
+        final Long clientId = ClientHelper.addClientAsPerson(ClientHelper.DEFAULT_OFFICE_ID, ClientHelper.LEGALFORM_ID_PERSON, null)
+                .getClientId();
+        final Integer savingsId = SavingsAccountHelper.openSavingsAccount(requestSpec, responseSpec, clientId.intValue(), "1000");
+        final SavingsAccountHelper savingsAccountHelper = new SavingsAccountHelper(requestSpec, responseSpec);
+        executeSavingsTransaction(savingsAccountHelper.depositIntoSavingsAccount(savingsId.longValue(),
+                new PostSavingsAccountTransactionsRequest().transactionDate("02 March 2013").dateFormat("dd MMMM yyyy").locale("en")
+                        .transactionAmount(BigDecimal.valueOf(200)).paymentTypeId(1).externalId("savings-deposit-" + UUID.randomUUID())));
+
+        final String externalId = "savings-withdrawal-" + UUID.randomUUID();
+        final PostSavingsAccountTransactionsResponse withdrawal = executeSavingsTransaction(
+                savingsAccountHelper.withdrawalFromSavingsAccount(savingsId.longValue(),
+                        new PostSavingsAccountTransactionsRequest().transactionDate("03 March 2013").dateFormat("dd MMMM yyyy").locale("en")
+                                .transactionAmount(BigDecimal.valueOf(50)).paymentTypeId(1).externalId(externalId)));
+        final Long transactionId = withdrawal.getResourceId();
+
+        GetSearchResponse result = assertSingleSearchResult(searchHelper.search(String.valueOf(transactionId), resources, Boolean.TRUE));
+        assertSavingsTransactionSearchResult(result, clientId, savingsId.longValue(), transactionId, "withdrawal", externalId);
+
+        result = assertSingleSearchResult(searchHelper.search(externalId, resources, Boolean.TRUE));
+        assertSavingsTransactionSearchResult(result, clientId, savingsId.longValue(), transactionId, "withdrawal", externalId);
+
+        final String refNo = result.getTransactionRefNo();
+        assertNotNull(refNo);
+        result = assertSingleSearchResult(searchHelper.search(refNo.substring(0, refNo.length() - 4), resources, Boolean.FALSE));
+        assertSavingsTransactionSearchResult(result, clientId, savingsId.longValue(), transactionId, "withdrawal", externalId);
+    }
+
+    private Integer createLoanAccount(final Long clientId, final Integer loanProductId, final LoanTransactionHelper loanTransactionHelper) {
+        final String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal("1000").withLoanTermFrequency("2")
+                .withLoanTermFrequencyAsMonths().withNumberOfRepayments("2").withRepaymentEveryAfter("1")
+                .withRepaymentFrequencyTypeAsMonths().withInterestRatePerPeriod("0").withInterestTypeAsFlatBalance()
+                .withInterestCalculationPeriodTypeSameAsRepaymentPeriod().withExpectedDisbursementDate("01 January 2026")
+                .withSubmittedOnDate("01 January 2026").withRepaymentStrategy(LoanApplicationTestBuilder.DEFAULT_STRATEGY)
+                .build(clientId.toString(), loanProductId.toString(), null);
+        final Integer loanId = loanTransactionHelper.getLoanId(loanApplicationJSON);
+        loanTransactionHelper.approveLoan("01 January 2026", loanId);
+        return loanId;
+    }
+
+    private PostSavingsAccountTransactionsResponse executeSavingsTransaction(
+            final Response<PostSavingsAccountTransactionsResponse> response) {
+        assertEquals(200, response.code());
+        assertNotNull(response.body());
+        return response.body();
+    }
+
+    private GetSearchResponse assertSingleSearchResult(final List<GetSearchResponse> searchResponse) {
+        assertNotNull(searchResponse);
+        assertEquals(1, searchResponse.size());
+        return searchResponse.getFirst();
+    }
+
+    private void assertLoanTransactionSearchResult(final GetSearchResponse result, final Long clientId, final Long loanId,
+            final Long transactionId, final String transactionExternalId) {
+        assertEquals("LOAN_TRANSACTION", result.getEntityType());
+        assertEquals(loanId, result.getEntityId());
+        assertEquals(clientId, result.getParentId());
+        assertEquals("client", result.getParentType());
+        assertEquals(transactionId, result.getTransactionId());
+        assertEquals("repayment", result.getTransactionType());
+        assertEquals(transactionExternalId, result.getTransactionExternalId());
+        assertEquals(loanId, result.getAccountId());
+        assertEquals("loan", result.getAccountType());
+    }
+
+    private void assertSavingsTransactionSearchResult(final GetSearchResponse result, final Long clientId, final Long savingsId,
+            final Long transactionId, final String transactionType, final String transactionExternalId) {
+        assertEquals("SAVINGS_TRANSACTION", result.getEntityType());
+        assertEquals(savingsId, result.getEntityId());
+        assertEquals(clientId, result.getParentId());
+        assertEquals("client", result.getParentType());
+        assertEquals(transactionId, result.getTransactionId());
+        assertEquals(transactionType, result.getTransactionType());
+        assertEquals(transactionExternalId, result.getTransactionExternalId());
+        assertNotNull(result.getTransactionRefNo());
+        assertEquals(savingsId, result.getAccountId());
+        assertEquals("savings", result.getAccountType());
     }
 }


### PR DESCRIPTION
## Description

This PR extends the global search functionality to support searching loan repayment and savings transactions.

Users can now search transactions using existing transaction identifiers without changing the current search endpoint or affecting existing search behavior.

### Supported searches

**Loan repayments**
- Transaction ID
- External ID

**Savings deposits and withdrawals**
- Transaction ID
- External ID
- Reference Number (refNo)

### Changes

- Added `loanTransactions` and `savingsTransactions` search resources.
- Extended the global search SQL to return matching loan repayment and savings transaction results.
- Added transaction metadata to the search response, including transaction ID, transaction type, account ID, account number, account type, external ID, and reference number where applicable.
- Preserved backward compatibility by adding nullable response fields without changing the existing API contract.
- Added integration tests covering transaction searches by transaction ID, external ID, and reference number.

## Related Issue

FINERACT-2730

## Screenshots

N/A

## Checklist

- [ ] If you have multiple commits, they have been squashed into a single commit.
- [ ] Read and understood the contribution guidelines.
- [ ] Added or updated tests for the implemented functionality.
- [ ] Verified that existing search functionality continues to work.