### PR TITLE
FINERACT-2731: Add web-app-primary-color global configuration

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/configuration/api/GlobalConfigurationConstants.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/configuration/api/GlobalConfigurationConstants.java
@@ -94,6 +94,7 @@ public final class GlobalConfigurationConstants {
     public static final String RETAINED_EARNING_GL_ACCOUNT = "retained-gl-account";
     public static final String RETAINED_EARNING_USED_BY_REPORT_NAME = "retained-earning-used-by-report-name";
     public static final String OFFICE_ID = "office-id";
+    public static final String WEB_APP_PRIMARY_COLOR = "web-app-primary-color";
 
     private GlobalConfigurationConstants() {}
 }

--- a/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
@@ -261,4 +261,5 @@
     <include file="parts/0240_add_retained_earning_global_configuration.xml" relativeToChangelogFile="true"/>
     <include file="parts/0242_fix_group_summary_report_parameters.xml" relativeToChangelogFile="true"/>
     <include file="parts/0242_update_m_tellers_unique_key.xml" relativeToChangelogFile="true" />
+    <include file="parts/0243_add_web_app_primary_color_global_configuration.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0243_add_web_app_primary_color_global_configuration.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0243_add_web_app_primary_color_global_configuration.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet author="fineract" id="1">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(1) from c_configuration where name = 'web-app-primary-color'</sqlCheck>
+        </preConditions>
+        <insert tableName="c_configuration">
+            <column name="name" value="web-app-primary-color"/>
+            <column name="value"/>
+            <column name="date_value"/>
+            <column name="string_value" value="blue"/>
+            <column name="enabled" valueBoolean="true"/>
+            <column name="is_trap_door" valueBoolean="false"/>
+            <column name="description" value="Primary colour used for web application branding across this tenant. Allowed values: blue, green, purple, orange, red, yellow. Clients fall back to blue when the value is missing or not recognised."/>
+        </insert>
+    </changeSet>
+</databaseChangeLog>

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/GlobalConfigurationHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/common/GlobalConfigurationHelper.java
@@ -694,6 +694,14 @@ public class GlobalConfigurationHelper {
         retainedEarningUsedByReportName.put("string_value", "Trial Balance Summary Report with Asset Owner");
         defaults.add(retainedEarningUsedByReportName);
 
+        HashMap<String, Object> webAppPrimaryColor = new HashMap<>();
+        webAppPrimaryColor.put("name", GlobalConfigurationConstants.WEB_APP_PRIMARY_COLOR);
+        webAppPrimaryColor.put("value", 0L);
+        webAppPrimaryColor.put("enabled", true);
+        webAppPrimaryColor.put("trapDoor", false);
+        webAppPrimaryColor.put("string_value", "blue");
+        defaults.add(webAppPrimaryColor);
+
         return defaults;
     }
 


### PR DESCRIPTION
## Description

This PR introduces a new tenant-level global configuration property:

`web-app-primary-color`

The configuration is seeded through a Liquibase migration and stored in the existing `c_configuration` table using `string_value`.

This property enables the Mifos web application to store and retrieve the tenant's primary branding color using the existing Global Configuration API without introducing any new REST endpoints or configuration mechanisms.

This change is intended to support tenant-level branding in the web application, where all users of the same tenant share the configured primary color.

## Checklist

- [x] Write the commit message as per our guidelines
- [x] Acknowledge that this PR must pass the build before review
- [ ] Create/update unit or integration tests for verifying the changes made (Not applicable – Liquibase migration only)
- [x] Follow our coding conventions
- [ ] Add required Swagger annotation and update API documentation (Not applicable – no API changes)
- [x] This PR is not a code dump
- [x] If merging this PR resolves a JIRA issue, I will mark that issue as resolved and set "Fix Version/s" appropriately.