### PR TITLE
FINERACT-2737: Return collateral name, unit price and percentage on l…

### DIFF
--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/data/LoanCollateralManagementData.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/data/LoanCollateralManagementData.java
@@ -19,11 +19,9 @@
 package org.apache.fineract.portfolio.loanaccount.data;
 
 import java.math.BigDecimal;
-import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
-@AllArgsConstructor
 public class LoanCollateralManagementData {
 
     private Long clientCollateralId;
@@ -35,4 +33,22 @@ public class LoanCollateralManagementData {
     private BigDecimal totalCollateral;
 
     private Long id;
+
+    private String name;
+
+    private BigDecimal unitPrice;
+
+    private BigDecimal pctToBase;
+
+    public LoanCollateralManagementData(Long clientCollateralId, BigDecimal quantity, BigDecimal total, BigDecimal totalCollateral, Long id,
+            String name, BigDecimal unitPrice, BigDecimal pctToBase) {
+        this.clientCollateralId = clientCollateralId;
+        this.quantity = quantity;
+        this.total = total;
+        this.totalCollateral = totalCollateral;
+        this.id = id;
+        this.name = name;
+        this.unitPrice = unitPrice;
+        this.pctToBase = pctToBase;
+    }
 }

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanCollateralManagement.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanCollateralManagement.java
@@ -118,7 +118,8 @@ public class LoanCollateralManagement extends AbstractPersistableCustom<Long> {
     }
 
     public LoanCollateralManagementData toCommand() {
-        return new LoanCollateralManagementData(this.clientCollateralManagement.getId(), this.getQuantity(), null, null, getId());
+        return new LoanCollateralManagementData(this.clientCollateralManagement.getId(), this.getQuantity(), null, null, getId(), null,
+                null, null);
     }
 
 }

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/mapper/LoanCollateralManagementMapper.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/mapper/LoanCollateralManagementMapper.java
@@ -33,6 +33,9 @@ public interface LoanCollateralManagementMapper {
     @Mapping(target = "quantity", source = "quantity")
     @Mapping(target = "total", ignore = true)
     @Mapping(target = "totalCollateral", ignore = true)
+    @Mapping(target = "name", ignore = true)
+    @Mapping(target = "unitPrice", ignore = true)
+    @Mapping(target = "pctToBase", ignore = true)
     LoanCollateralManagementData map(LoanCollateralManagement loanCollateralManagement);
 
     Set<LoanCollateralManagementData> map(Set<LoanCollateralManagement> loanCollateralManagements);

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/importhandler/loan/LoanImportHandler.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/bulkimport/importhandler/loan/LoanImportHandler.java
@@ -331,8 +331,8 @@ public class LoanImportHandler implements ImportHandler {
         if (collateralId != null) {
             if (ImportHandlerUtils.readAsDouble(LoanConstants.LOAN_COLLATERAL_QUANTITY, row) != null) {
                 loanCollateralManagementData.add(new LoanCollateralManagementData(collateralId,
-                        BigDecimal.valueOf(ImportHandlerUtils.readAsDouble(LoanConstants.LOAN_COLLATERAL_QUANTITY, row)), null, null,
-                        null));
+                        BigDecimal.valueOf(ImportHandlerUtils.readAsDouble(LoanConstants.LOAN_COLLATERAL_QUANTITY, row)), null, null, null,
+                        null, null, null));
             } else {
                 throw new InvalidAmountOfCollateralQuantity(null);
             }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/collateralmanagement/data/LoanCollateralResponseData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/collateralmanagement/data/LoanCollateralResponseData.java
@@ -38,14 +38,20 @@ public final class LoanCollateralResponseData {
 
     private Long clientCollateralId;
 
+    private String name;
+
+    private BigDecimal unitPrice;
+
+    private BigDecimal pctToBase;
+
     public static LoanCollateralResponseData instanceOf(final LoanCollateralManagement loanCollateralManagement, final BigDecimal total,
-            final BigDecimal totalCollateral) {
+            final BigDecimal totalCollateral, final String name, final BigDecimal unitPrice, final BigDecimal pctToBase) {
         return new LoanCollateralResponseData(loanCollateralManagement.getId(), loanCollateralManagement.getQuantity(), total,
-                totalCollateral, loanCollateralManagement.getClientCollateralManagement().getId());
+                totalCollateral, loanCollateralManagement.getClientCollateralManagement().getId(), name, unitPrice, pctToBase);
     }
 
     public LoanCollateralManagementData toCommand() {
-        return new LoanCollateralManagementData(this.clientCollateralId, this.quantity, this.total, this.totalCollateral,
-                this.collateralId);
+        return new LoanCollateralManagementData(this.clientCollateralId, this.quantity, this.total, this.totalCollateral, this.collateralId,
+                this.name, this.unitPrice, this.pctToBase);
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/collateralmanagement/service/LoanCollateralManagementReadServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/collateralmanagement/service/LoanCollateralManagementReadServiceImpl.java
@@ -55,7 +55,10 @@ public class LoanCollateralManagementReadServiceImpl implements LoanCollateralMa
         BigDecimal quantity = loanCollateralManagement.getQuantity();
         BigDecimal total = quantity.multiply(collateralManagementDomain.getBasePrice());
         BigDecimal totalCollateral = total.multiply(collateralManagementDomain.getPctToBase()).divide(BigDecimal.valueOf(100));
-        return LoanCollateralResponseData.instanceOf(loanCollateralManagement, total, totalCollateral);
+        String name = collateralManagementDomain.getName();
+        BigDecimal unitPrice = collateralManagementDomain.getBasePrice();
+        BigDecimal pctToBase = collateralManagementDomain.getPctToBase();
+        return LoanCollateralResponseData.instanceOf(loanCollateralManagement, total, totalCollateral, name, unitPrice, pctToBase);
     }
 
     @Override
@@ -69,8 +72,11 @@ public class LoanCollateralManagementReadServiceImpl implements LoanCollateralMa
             BigDecimal quantity = loanCollateralManagement.getQuantity();
             BigDecimal total = quantity.multiply(collateralManagementDomain.getBasePrice());
             BigDecimal totalCollateral = total.multiply(collateralManagementDomain.getPctToBase()).divide(BigDecimal.valueOf(100));
-            loanCollateralResponseDataCollection
-                    .add(LoanCollateralResponseData.instanceOf(loanCollateralManagement, total, totalCollateral));
+            String name = collateralManagementDomain.getName();
+            BigDecimal unitPrice = collateralManagementDomain.getBasePrice();
+            BigDecimal pctToBase = collateralManagementDomain.getPctToBase();
+            loanCollateralResponseDataCollection.add(
+                    LoanCollateralResponseData.instanceOf(loanCollateralManagement, total, totalCollateral, name, unitPrice, pctToBase));
         }
         return loanCollateralResponseDataCollection;
     }


### PR DESCRIPTION


Loan collateral responses previously exposed only the collateral quantity and calculated values (`quantity`, `total`, and `totalCollateral`), while omitting collateral metadata that is already available in the client collateral API.

This change adds the following fields to the loan collateral response:

* `name` – the collateral type name
* `unitPrice` – the base price per unit
* `pctToBase` – the percentage applied to the base price when calculating the collateral value

This aligns the loan collateral API with the client collateral API, provides a consistent representation of collateral data across endpoints, and removes the need for clients to make additional API calls to retrieve collateral type and pricing information.
PR:(https://issues.apache.org/jira/browse/FINERACT-2737)
