### PR TITLE
FINERACT-2741: Standardize email address column length across most tables

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/organisation/staff/domain/Staff.java
+++ b/fineract-core/src/main/java/org/apache/fineract/organisation/staff/domain/Staff.java
@@ -53,7 +53,7 @@ public class Staff extends AbstractPersistableCustom<Long> {
     @Column(name = "external_id", length = 100, unique = true)
     private String externalId;
 
-    @Column(name = "email_address", length = 50, unique = true)
+    @Column(name = "email_address", length = 254, unique = true)
     private String emailAddress;
 
     @ManyToOne

--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/client/domain/Client.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/client/domain/Client.java
@@ -104,7 +104,7 @@ public class Client extends AbstractAuditableWithUTCDateTimeCustom<Long> {
     @Column(name = "mobile_no", length = 50, unique = true)
     private String mobileNo;
 
-    @Column(name = "email_address", length = 50, unique = true)
+    @Column(name = "email_address", length = 254, unique = true)
     private String emailAddress;
 
     @Column(name = "is_staff", nullable = false)

--- a/fineract-core/src/main/java/org/apache/fineract/useradministration/domain/AppUser.java
+++ b/fineract-core/src/main/java/org/apache/fineract/useradministration/domain/AppUser.java
@@ -63,7 +63,7 @@ import org.springframework.security.core.userdetails.User;
 public class AppUser extends AbstractPersistableCustom<Long> implements PlatformUser {
 
     @Getter
-    @Column(name = "email", nullable = false, length = 100)
+    @Column(name = "email", nullable = false, length = 254)
     private String email;
 
     @Column(name = "username", nullable = false, length = 100)

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/campaigns/email/domain/EmailMessage.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/campaigns/email/domain/EmailMessage.java
@@ -65,7 +65,7 @@ public class EmailMessage extends AbstractPersistableCustom<Long> {
     @Column(name = "status_enum", nullable = false)
     private Integer statusType;
 
-    @Column(name = "email_address", nullable = false, length = 50)
+    @Column(name = "email_address", nullable = false, length = 254)
     private String emailAddress;
 
     @Column(name = "email_subject", nullable = false, length = 50)

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/staff/data/StaffCreateRequest.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/staff/data/StaffCreateRequest.java
@@ -52,7 +52,7 @@ public class StaffCreateRequest implements Serializable {
     @Length(max = 100, message = "{org.apache.fineract.organisation.staff.external-id.max}")
     // @NotBlank(message = "{org.apache.fineract.organisation.staff.external-id.not-blank}")
     private String externalId;
-    @Length(max = 50, message = "{org.apache.fineract.organisation.staff.email.max}")
+    @Length(max = 254, message = "{org.apache.fineract.organisation.staff.email.max}")
     private String emailAddress;
     @Length(max = 50, message = "{org.apache.fineract.organisation.staff.mobile-no.max}")
     // @NotBlank(message = "{org.apache.fineract.organisation.staff.mobile-no.not-blank}")

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/staff/data/StaffUpdateRequest.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/staff/data/StaffUpdateRequest.java
@@ -58,7 +58,7 @@ public class StaffUpdateRequest implements Serializable {
     @Length(max = 100, message = "{org.apache.fineract.organisation.staff.external-id.max}")
     // @NotBlank(message = "{org.apache.fineract.organisation.staff.external-id.not-blank}")
     private String externalId;
-    @Length(max = 50, message = "{org.apache.fineract.organisation.staff.email.max}")
+    @Length(max = 254, message = "{org.apache.fineract.organisation.staff.email.max}")
     private String emailAddress;
     @Length(max = 50, message = "{org.apache.fineract.organisation.staff.mobile-no.max}")
     // @NotBlank(message = "{org.apache.fineract.organisation.staff.mobile-no.not-blank}")

--- a/fineract-provider/src/main/java/org/apache/fineract/useradministration/service/UserDataValidator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/useradministration/service/UserDataValidator.java
@@ -106,7 +106,7 @@ public final class UserDataValidator {
         if (sendPasswordToEmail != null) {
             if (sendPasswordToEmail.booleanValue()) {
                 final String email = this.fromApiJsonHelper.extractStringNamed(EMAIL, element);
-                baseDataValidator.reset().parameter(EMAIL).value(email).notBlank().notExceedingLengthOf(100);
+                baseDataValidator.reset().parameter(EMAIL).value(email).notBlank().notExceedingLengthOf(254);
             } else {
                 validatePassword(baseDataValidator, element);
             }
@@ -245,7 +245,7 @@ public final class UserDataValidator {
 
         if (this.fromApiJsonHelper.parameterExists(EMAIL, element)) {
             final String email = this.fromApiJsonHelper.extractStringNamed(EMAIL, element);
-            baseDataValidator.reset().parameter(EMAIL).value(email).notBlank().notExceedingLengthOf(100);
+            baseDataValidator.reset().parameter(EMAIL).value(email).notBlank().notExceedingLengthOf(254);
         }
 
         if (this.fromApiJsonHelper.parameterExists(ROLES, element)) {

--- a/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
@@ -263,4 +263,5 @@
     <include file="parts/0242_update_m_tellers_unique_key.xml" relativeToChangelogFile="true" />
     <include file="parts/0243_add_client_lifecycle_event_configuration.xml" relativeToChangelogFile="true" />
     <include file="parts/0244_add_payment_detail_to_account_transfer_transaction.xml" relativeToChangelogFile="true" />
+    <include file="parts/0245_standardize_email_address_column_length.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0245_standardize_email_address_column_length.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0245_standardize_email_address_column_length.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <!-- FINERACT-2741: Standardize email address column length to VARCHAR(254) (RFC 5321 max) -->
+    <changeSet author="fineract" id="1">
+        <modifyDataType tableName="m_appuser" columnName="email" newDataType="VARCHAR(254)"/>
+        <modifyDataType tableName="m_client" columnName="email_address" newDataType="VARCHAR(254)"/>
+        <modifyDataType tableName="m_staff" columnName="email_address" newDataType="VARCHAR(254)"/>
+        <modifyDataType tableName="scheduled_email_messages_outbound" columnName="email_address" newDataType="VARCHAR(254)"/>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
## JIRA
https://issues.apache.org/jira/browse/FINERACT-2741

## Problem
Email address columns across Fineract tables (`m_client`, `m_staff`, `m_appuser`, etc.) are currently capped at 50–150 characters, falling short of the RFC 5321 maximum of 254 characters. This risks truncating or rejecting valid, longer email addresses.

## Fix
Widened the following columns to `VARCHAR(254)`:

| Table | Column | Before | After |
|---|---|---|---|
| `m_appuser` | `email` | VARCHAR(100) | VARCHAR(254) |
| `m_client` | `email_address` | VARCHAR(150) | VARCHAR(254) |
| `m_staff` | `email_address` | VARCHAR(150) | VARCHAR(254) |
| `scheduled_email_messages_outbound` | `email_address` | VARCHAR(50) | VARCHAR(254) |

Added a new Liquibase changeset (`0245_standardize_email_address_column_length.xml`, registered in `changelog-tenant.xml`) rather than editing `0001_initial_schema.xml`, since that file is already-released history.

Updated the following to stay in lockstep with the new column widths:
- JPA `@Column(length=...)` on `AppUser`, `Client`, `Staff`, `EmailMessage`
- `UserDataValidator.notExceedingLengthOf(...)` (create + update paths)
- `@Length(max=...)` on `StaffCreateRequest` and `StaffUpdateRequest`

**Out of scope:**
- `m_adhoc.email` (already `VARCHAR(500)`) — exceeds the new standard already; ticket specifies no column sizes are reduced, so left as-is.
- `request_audit_table.email` (`VARCHAR(100)`) — no backing JPA entity or code reference found anywhere in the repo. Appears to be dead/legacy schema. Flagging here for reviewer input on whether to widen for consistency or leave untouched.