### PR TITLE
FINERACT-2743: Fix standing instruction not created at loan disbursem…

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/service/StandingInstructionReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/account/service/StandingInstructionReadPlatformServiceImpl.java
@@ -299,8 +299,21 @@ public class StandingInstructionReadPlatformServiceImpl implements StandingInstr
                 sqlBuilder.append(" fromsavacc.id=? ");
                 paramObj.add(standingInstructionDTO.fromAccount());
             } else if (PortfolioAccountType.LOAN.equals(accountType)) {
-                sqlBuilder.append(" fromloanacc.id=? ");
-                paramObj.add(standingInstructionDTO.fromAccount());
+                // For LOAN_REPAYMENT transfers, loan is stored in to_loan_account_id (FROM=SAVINGS, TO=LOAN)
+                // For other transfer types, loan is stored in from_loan_account_id
+                // Defensive fallback: if transferType is null, check both columns to handle UI inconsistencies
+                Integer transferTypeValue = standingInstructionDTO.transferType();
+                if (transferTypeValue != null && transferTypeValue.equals(AccountTransferType.LOAN_REPAYMENT.getValue())) {
+                    sqlBuilder.append(" toloanacc.id=? ");
+                    paramObj.add(standingInstructionDTO.fromAccount());
+                } else if (transferTypeValue == null) {
+                    sqlBuilder.append(" (toloanacc.id=? OR fromloanacc.id=?) ");
+                    paramObj.add(standingInstructionDTO.fromAccount());
+                    paramObj.add(standingInstructionDTO.fromAccount());
+                } else {
+                    sqlBuilder.append(" fromloanacc.id=? ");
+                    paramObj.add(standingInstructionDTO.fromAccount());
+                }
             }
             addAndCaluse = true;
         }
@@ -358,7 +371,7 @@ public class StandingInstructionReadPlatformServiceImpl implements StandingInstr
     public StandingInstructionDuesData retriveLoanDuesData(final Long loanId) {
         final StandingInstructionLoanDuesMapper rm = new StandingInstructionLoanDuesMapper();
         final String sql = "select " + rm.schema() + " where ml.id= ? and ls.duedate <= " + sqlGenerator.currentBusinessDate()
-                + " and ls.completed_derived <> 1";
+                + " and ls.completed_derived IS FALSE";
         return this.jdbcTemplate.queryForObject(sql, rm, new Object[] { loanId }); // NOSONAR
     }
 

--- a/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
@@ -263,4 +263,5 @@
     <include file="parts/0242_update_m_tellers_unique_key.xml" relativeToChangelogFile="true" />
     <include file="parts/0243_add_client_lifecycle_event_configuration.xml" relativeToChangelogFile="true" />
     <include file="parts/0244_add_payment_detail_to_account_transfer_transaction.xml" relativeToChangelogFile="true" />
+    <include file="parts/0245_delete_trailing_space_standinginstruction_permissions.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0245_delete_trailing_space_standinginstruction_permissions.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0245_delete_trailing_space_standinginstruction_permissions.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+    Liquibase changeSet to safely delete duplicate m_permission rows
+    for Standing Instruction permissions WITHOUT trailing spaces,
+    keeping the legacy trailing-space versions.
+
+    Deletes ONLY:
+      - 'CREATE_STANDINGINSTRUCTION'
+      - 'UPDATE_STANDINGINSTRUCTION'
+      - 'DELETE_STANDINGINSTRUCTION'
+
+    Safety rules:
+    - Delete ONLY if a trailing-space version already exists.
+    - Do NOT modify or insert any permissions.
+    - Do NOT touch m_role_permission.
+    - Idempotent and safe to re-run.
+    - PostgreSQL only.
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet id="0245_delete_non_spaced_standinginstruction_permissions"
+               author="Samer Melhem"
+               failOnError="true">
+
+        <!-- Run only on PostgreSQL -->
+        <preConditions onFail="MARK_RAN" onError="HALT">
+            <dbms type="postgresql"/>
+        </preConditions>
+
+        <sql>
+            DELETE FROM m_permission p
+            WHERE p.code IN (
+            'CREATE_STANDINGINSTRUCTION',
+            'UPDATE_STANDINGINSTRUCTION',
+            'DELETE_STANDINGINSTRUCTION'
+            )
+            AND EXISTS (
+            SELECT 1
+            FROM m_permission p2
+            WHERE p2.code = p.code || ' '
+            );
+        </sql>
+
+        <rollback>
+            <!--
+                No rollback.
+                Deleted rows are duplicates of existing trailing-space permissions.
+                Restoring them would reintroduce duplicate logical permissions.
+            -->
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountTransactionRepository.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountTransactionRepository.java
@@ -47,7 +47,7 @@ public interface SavingsAccountTransactionRepository
             @Param("transactionDate") LocalDate transactionDate);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("select st from SavingsAccountTransaction st where st.savingsAccount = :savingsAccount and st.dateOf = :date and st.reversalTransaction <> 1 and st.reversed <> 1 order by st.id")
+    @Query("select st from SavingsAccountTransaction st where st.savingsAccount = :savingsAccount and st.dateOf = :date and st.reversalTransaction = false and st.reversed = false order by st.id")
     List<SavingsAccountTransaction> findTransactionRunningBalanceBeforePivotDate(@Param("savingsAccount") SavingsAccount savingsAccount,
             @Param("date") LocalDate date);
 


### PR DESCRIPTION
Fixes two issues in the Standing Instruction (SI) feature:

1. **Standing Instruction not created during loan disbursement**

   * Fixed the lookup logic in `StandingInstructionReadPlatformServiceImpl` to correctly identify the loan account based on the transfer type.
   * For `LOAN_REPAYMENT` transfers, the loan account is stored in `to_loan_account_id` rather than `from_loan_account_id`.
   * Added a defensive fallback to check both columns when the transfer type is unknown, ensuring the standing instruction is found and persisted correctly.

2. **Standing Instruction batch job failure on PostgreSQL**

   * Fixed PostgreSQL-incompatible boolean comparisons by replacing integer comparisons (`<> 1`) with proper boolean predicates (`IS FALSE` / `= false`).
   * This resolves the batch job failure while maintaining compatibility with PostgreSQL.

Additionally, added a Liquibase changeset to remove duplicate `m_permission` entries for `CREATE_STANDINGINSTRUCTION`, `UPDATE_STANDINGINSTRUCTION`, and `DELETE_STANDINGINSTRUCTION` that differ only by a trailing space in their permission code. The changeset is PostgreSQL-only, idempotent, and safely executes only when duplicates exist.

PR:(https://issues.apache.org/jira/browse/FINERACT-2743)

### Testing

* `./gradlew :fineract-provider:compileJava` — Passed
* `./gradlew :fineract-core:compileTestJava :fineract-provider:compileTestJava` — Passed
* Verified existing tests (`StandingInstructionDataSerializationTest` and `ExecuteOverdueAndCurrentStandingInstructionsTest`) all pass.
* Manually verified that enabling **Create Standing Instructions at Disbursement**, activating, and disbursing a loan correctly creates and persists the standing instruction, and that the SI batch job executes successfully on PostgreSQL.
