### PR TITLE
FINERACT-2744: Tax (VAT) on savings account charges is not calculated or posted to the correct GL account

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/tax/request/TaxGroupComponent.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/tax/request/TaxGroupComponent.java
@@ -32,6 +32,9 @@ public class TaxGroupComponent implements Serializable {
     @Serial
     private static final long serialVersionUID = 1L;
 
+    private Long id;
     private Long taxComponentId;
     private String startDate;
+    private String endDate;
+
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/AccountingProcessorHelper.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/AccountingProcessorHelper.java
@@ -814,6 +814,16 @@ public class AccountingProcessorHelper {
             final Long savingsProductId, final Long paymentTypeId, final Long loanId, final String transactionId,
             final LocalDate transactionDate, final BigDecimal totalAmount, final Boolean isReversal,
             final List<ChargePaymentDTO> chargePaymentDTOs) {
+        createCashBasedJournalEntriesAndReversalsForSavingsCharges(office, currencyCode, accountTypeToBeDebited, accountTypeToBeCredited,
+                savingsProductId, paymentTypeId, loanId, transactionId, transactionDate, totalAmount, isReversal, chargePaymentDTOs,
+                List.of());
+    }
+
+    public void createCashBasedJournalEntriesAndReversalsForSavingsCharges(final Office office, final String currencyCode,
+            final CashAccountsForSavings accountTypeToBeDebited, CashAccountsForSavings accountTypeToBeCredited,
+            final Long savingsProductId, final Long paymentTypeId, final Long loanId, final String transactionId,
+            final LocalDate transactionDate, final BigDecimal totalAmount, final Boolean isReversal,
+            final List<ChargePaymentDTO> chargePaymentDTOs, final List<TaxPaymentDTO> taxPayments) {
         // TODO Vishwas: Remove this validation, as and when appropriate Junit
         // tests are written for accounting
         /**
@@ -831,16 +841,42 @@ public class AccountingProcessorHelper {
 
         final GLAccount savingsControlAccount = getLinkedGLAccountForSavingsProduct(savingsProductId, accountTypeToBeDebited.getValue(),
                 paymentTypeId);
+
+        // Compute total tax to separate the net charge from the VAT
+        final BigDecimal totalTax = taxPayments.stream().map(TaxPaymentDTO::getAmount).filter(Objects::nonNull).reduce(BigDecimal.ZERO,
+                BigDecimal::add);
+        final BigDecimal netChargeAmount = totalAmount.subtract(totalTax);
+
         if (isReversal) {
+            // Debit income GL with net charge amount
             createDebitJournalEntryForSavings(office, currencyCode, chargeSpecificAccount, loanId, transactionId, transactionDate,
-                    totalAmount);
+                    netChargeAmount);
+            // Debit VAT payable GL for each tax component
+            for (TaxPaymentDTO taxPayment : taxPayments) {
+                if (taxPayment.getAmount() != null && taxPayment.getCreditAccountId() != null) {
+                    final GLAccount vatPayableAccount = getGLAccountById(taxPayment.getCreditAccountId());
+                    createDebitJournalEntryForSavings(office, currencyCode, vatPayableAccount, loanId, transactionId, transactionDate,
+                            taxPayment.getAmount());
+                }
+            }
+            // Credit savings control with full amount
             createCreditJournalEntryForSavings(office, currencyCode, savingsControlAccount, loanId, transactionId, transactionDate,
                     totalAmount);
         } else {
+            // Debit savings control with full amount
             createDebitJournalEntryForSavings(office, currencyCode, savingsControlAccount, loanId, transactionId, transactionDate,
                     totalAmount);
+            // Credit income GL with net charge amount
             createCreditJournalEntryForSavings(office, currencyCode, chargeSpecificAccount, loanId, transactionId, transactionDate,
-                    totalAmount);
+                    netChargeAmount);
+            // Credit VAT payable GL for each tax component
+            for (TaxPaymentDTO taxPayment : taxPayments) {
+                if (taxPayment.getAmount() != null && taxPayment.getCreditAccountId() != null) {
+                    final GLAccount vatPayableAccount = getGLAccountById(taxPayment.getCreditAccountId());
+                    createCreditJournalEntryForSavings(office, currencyCode, vatPayableAccount, loanId, transactionId, transactionDate,
+                            taxPayment.getAmount());
+                }
+            }
         }
     }
 
@@ -849,6 +885,17 @@ public class AccountingProcessorHelper {
             final AccountingConstants.AccrualAccountsForSavings accountTypeToBeCredited, final Long savingsProductId,
             final Long paymentTypeId, final Long loanId, final String transactionId, final LocalDate transactionDate,
             final BigDecimal totalAmount, final Boolean isReversal, final List<ChargePaymentDTO> chargePaymentDTOs) {
+        createAccrualBasedJournalEntriesAndReversalsForSavingsCharges(office, currencyCode, accountTypeToBeDebited, accountTypeToBeCredited,
+                savingsProductId, paymentTypeId, loanId, transactionId, transactionDate, totalAmount, isReversal, chargePaymentDTOs,
+                List.of());
+    }
+
+    public void createAccrualBasedJournalEntriesAndReversalsForSavingsCharges(final Office office, final String currencyCode,
+            final AccountingConstants.AccrualAccountsForSavings accountTypeToBeDebited,
+            final AccountingConstants.AccrualAccountsForSavings accountTypeToBeCredited, final Long savingsProductId,
+            final Long paymentTypeId, final Long loanId, final String transactionId, final LocalDate transactionDate,
+            final BigDecimal totalAmount, final Boolean isReversal, final List<ChargePaymentDTO> chargePaymentDTOs,
+            final List<TaxPaymentDTO> taxPayments) {
         // TODO Vishwas: Remove this validation, as and when appropriate Junit
         // tests are written for accounting
         /**
@@ -866,16 +913,42 @@ public class AccountingProcessorHelper {
 
         final GLAccount savingsControlAccount = getLinkedGLAccountForSavingsProduct(savingsProductId, accountTypeToBeDebited.getValue(),
                 paymentTypeId);
+
+        // Compute total tax to separate the net charge from the VAT
+        final BigDecimal totalTax = taxPayments.stream().map(TaxPaymentDTO::getAmount).filter(Objects::nonNull).reduce(BigDecimal.ZERO,
+                BigDecimal::add);
+        final BigDecimal netChargeAmount = totalAmount.subtract(totalTax);
+
         if (isReversal) {
+            // Debit income GL with net charge amount
             createDebitJournalEntryForSavings(office, currencyCode, chargeSpecificAccount, loanId, transactionId, transactionDate,
-                    totalAmount);
+                    netChargeAmount);
+            // Debit VAT payable GL for each tax component
+            for (TaxPaymentDTO taxPayment : taxPayments) {
+                if (taxPayment.getAmount() != null && taxPayment.getCreditAccountId() != null) {
+                    final GLAccount vatPayableAccount = getGLAccountById(taxPayment.getCreditAccountId());
+                    createDebitJournalEntryForSavings(office, currencyCode, vatPayableAccount, loanId, transactionId, transactionDate,
+                            taxPayment.getAmount());
+                }
+            }
+            // Credit savings control with full amount
             createCreditJournalEntryForSavings(office, currencyCode, savingsControlAccount, loanId, transactionId, transactionDate,
                     totalAmount);
         } else {
+            // Debit savings control with full amount
             createDebitJournalEntryForSavings(office, currencyCode, savingsControlAccount, loanId, transactionId, transactionDate,
                     totalAmount);
+            // Credit income GL with net charge amount
             createCreditJournalEntryForSavings(office, currencyCode, chargeSpecificAccount, loanId, transactionId, transactionDate,
-                    totalAmount);
+                    netChargeAmount);
+            // Credit VAT payable GL for each tax component
+            for (TaxPaymentDTO taxPayment : taxPayments) {
+                if (taxPayment.getAmount() != null && taxPayment.getCreditAccountId() != null) {
+                    final GLAccount vatPayableAccount = getGLAccountById(taxPayment.getCreditAccountId());
+                    createCreditJournalEntryForSavings(office, currencyCode, vatPayableAccount, loanId, transactionId, transactionDate,
+                            taxPayment.getAmount());
+                }
+            }
         }
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/AccrualBasedAccountingProcessorForSavings.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/AccrualBasedAccountingProcessorForSavings.java
@@ -216,23 +216,23 @@ public class AccrualBasedAccountingProcessorForSavings implements AccountingProc
                     this.helper.createAccrualBasedJournalEntriesAndReversalsForSavingsCharges(office, currencyCode,
                             AccrualAccountsForSavings.OVERDRAFT_PORTFOLIO_CONTROL, AccrualAccountsForSavings.INCOME_FROM_PENALTIES,
                             savingsProductId, paymentTypeId, savingsId, transactionId, transactionDate, overdraftAmount, isReversal,
-                            penaltyPayments);
+                            penaltyPayments, savingsTransactionDTO.getTaxPayments());
                     if (isPositive) {
                         this.helper.createAccrualBasedJournalEntriesAndReversalsForSavingsCharges(office, currencyCode,
                                 AccrualAccountsForSavings.SAVINGS_CONTROL, AccrualAccountsForSavings.INCOME_FROM_PENALTIES,
                                 savingsProductId, paymentTypeId, savingsId, transactionId, transactionDate,
-                                amount.subtract(overdraftAmount), isReversal, penaltyPayments);
+                                amount.subtract(overdraftAmount), isReversal, penaltyPayments, savingsTransactionDTO.getTaxPayments());
                     }
                 } else {
                     this.helper.createAccrualBasedJournalEntriesAndReversalsForSavingsCharges(office, currencyCode,
                             AccrualAccountsForSavings.OVERDRAFT_PORTFOLIO_CONTROL, AccrualAccountsForSavings.INCOME_FROM_FEES,
                             savingsProductId, paymentTypeId, savingsId, transactionId, transactionDate, overdraftAmount, isReversal,
-                            feePayments);
+                            feePayments, savingsTransactionDTO.getTaxPayments());
                     if (isPositive) {
                         this.helper.createAccrualBasedJournalEntriesAndReversalsForSavingsCharges(office, currencyCode,
                                 AccrualAccountsForSavings.SAVINGS_CONTROL, AccrualAccountsForSavings.INCOME_FROM_FEES, savingsProductId,
                                 paymentTypeId, savingsId, transactionId, transactionDate, amount.subtract(overdraftAmount), isReversal,
-                                feePayments);
+                                feePayments, savingsTransactionDTO.getTaxPayments());
                     }
                 }
             }
@@ -242,11 +242,13 @@ public class AccrualBasedAccountingProcessorForSavings implements AccountingProc
                 if (penaltyPayments.size() > 0) {
                     this.helper.createAccrualBasedJournalEntriesAndReversalsForSavingsCharges(office, currencyCode,
                             AccrualAccountsForSavings.SAVINGS_CONTROL, AccrualAccountsForSavings.INCOME_FROM_PENALTIES, savingsProductId,
-                            paymentTypeId, savingsId, transactionId, transactionDate, amount, isReversal, penaltyPayments);
+                            paymentTypeId, savingsId, transactionId, transactionDate, amount, isReversal, penaltyPayments,
+                            savingsTransactionDTO.getTaxPayments());
                 } else {
                     this.helper.createAccrualBasedJournalEntriesAndReversalsForSavingsCharges(office, currencyCode,
                             AccrualAccountsForSavings.SAVINGS_CONTROL, AccrualAccountsForSavings.INCOME_FROM_FEES, savingsProductId,
-                            paymentTypeId, savingsId, transactionId, transactionDate, amount, isReversal, feePayments);
+                            paymentTypeId, savingsId, transactionId, transactionDate, amount, isReversal, feePayments,
+                            savingsTransactionDTO.getTaxPayments());
                 }
             }
 
@@ -278,7 +280,8 @@ public class AccrualBasedAccountingProcessorForSavings implements AccountingProc
             } else if (savingsTransactionDTO.getTransactionType().isOverdraftFee()) {
                 this.helper.createAccrualBasedJournalEntriesAndReversalsForSavingsCharges(office, currencyCode,
                         AccrualAccountsForSavings.SAVINGS_REFERENCE, AccrualAccountsForSavings.INCOME_FROM_FEES, savingsProductId,
-                        paymentTypeId, savingsId, transactionId, transactionDate, amount, isReversal, feePayments);
+                        paymentTypeId, savingsId, transactionId, transactionDate, amount, isReversal, feePayments,
+                        savingsTransactionDTO.getTaxPayments());
             }
         }
     }

--- a/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/CashBasedAccountingProcessorForSavings.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/CashBasedAccountingProcessorForSavings.java
@@ -188,22 +188,23 @@ public class CashBasedAccountingProcessorForSavings implements AccountingProcess
                     this.helper.createCashBasedJournalEntriesAndReversalsForSavingsCharges(office, currencyCode,
                             CashAccountsForSavings.OVERDRAFT_PORTFOLIO_CONTROL, CashAccountsForSavings.INCOME_FROM_PENALTIES,
                             savingsProductId, paymentTypeId, savingsId, transactionId, transactionDate, overdraftAmount, isReversal,
-                            penaltyPayments);
+                            penaltyPayments, savingsTransactionDTO.getTaxPayments());
                     if (isPositive) {
                         this.helper.createCashBasedJournalEntriesAndReversalsForSavingsCharges(office, currencyCode,
                                 CashAccountsForSavings.SAVINGS_CONTROL, CashAccountsForSavings.INCOME_FROM_PENALTIES, savingsProductId,
                                 paymentTypeId, savingsId, transactionId, transactionDate, amount.subtract(overdraftAmount), isReversal,
-                                penaltyPayments);
+                                penaltyPayments, savingsTransactionDTO.getTaxPayments());
                     }
                 } else {
                     this.helper.createCashBasedJournalEntriesAndReversalsForSavingsCharges(office, currencyCode,
                             CashAccountsForSavings.OVERDRAFT_PORTFOLIO_CONTROL, CashAccountsForSavings.INCOME_FROM_FEES, savingsProductId,
-                            paymentTypeId, savingsId, transactionId, transactionDate, overdraftAmount, isReversal, feePayments);
+                            paymentTypeId, savingsId, transactionId, transactionDate, overdraftAmount, isReversal, feePayments,
+                            savingsTransactionDTO.getTaxPayments());
                     if (isPositive) {
                         this.helper.createCashBasedJournalEntriesAndReversalsForSavingsCharges(office, currencyCode,
                                 CashAccountsForSavings.SAVINGS_CONTROL, CashAccountsForSavings.INCOME_FROM_FEES, savingsProductId,
                                 paymentTypeId, savingsId, transactionId, transactionDate, amount.subtract(overdraftAmount), isReversal,
-                                feePayments);
+                                feePayments, savingsTransactionDTO.getTaxPayments());
                     }
                 }
             }
@@ -213,11 +214,13 @@ public class CashBasedAccountingProcessorForSavings implements AccountingProcess
                 if (penaltyPayments.size() > 0) {
                     this.helper.createCashBasedJournalEntriesAndReversalsForSavingsCharges(office, currencyCode,
                             CashAccountsForSavings.SAVINGS_CONTROL, CashAccountsForSavings.INCOME_FROM_PENALTIES, savingsProductId,
-                            paymentTypeId, savingsId, transactionId, transactionDate, amount, isReversal, penaltyPayments);
+                            paymentTypeId, savingsId, transactionId, transactionDate, amount, isReversal, penaltyPayments,
+                            savingsTransactionDTO.getTaxPayments());
                 } else {
                     this.helper.createCashBasedJournalEntriesAndReversalsForSavingsCharges(office, currencyCode,
                             CashAccountsForSavings.SAVINGS_CONTROL, CashAccountsForSavings.INCOME_FROM_FEES, savingsProductId,
-                            paymentTypeId, savingsId, transactionId, transactionDate, amount, isReversal, feePayments);
+                            paymentTypeId, savingsId, transactionId, transactionDate, amount, isReversal, feePayments,
+                            savingsTransactionDTO.getTaxPayments());
                 }
             }
 
@@ -248,7 +251,7 @@ public class CashBasedAccountingProcessorForSavings implements AccountingProcess
             } else if (savingsTransactionDTO.getTransactionType().isOverdraftFee()) {
                 this.helper.createCashBasedJournalEntriesAndReversalsForSavingsCharges(office, currencyCode,
                         CashAccountsForSavings.SAVINGS_REFERENCE, CashAccountsForSavings.INCOME_FROM_FEES, savingsProductId, paymentTypeId,
-                        savingsId, transactionId, transactionDate, amount, isReversal, feePayments);
+                        savingsId, transactionId, transactionDate, amount, isReversal, feePayments, savingsTransactionDTO.getTaxPayments());
             }
         }
     }

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccount.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccount.java
@@ -3058,8 +3058,21 @@ public class SavingsAccount extends AbstractAuditableWithUTCDateTimeCustom<Long>
 
     public SavingsAccountTransaction payCharge(final SavingsAccountCharge savingsAccountCharge, final Money amountPaid,
             final LocalDate transactionDate, final boolean backdatedTxnsAllowedTill, String refNo) {
-        savingsAccountCharge.pay(getCurrency(), amountPaid);
-        return handlePayChargeTransactions(savingsAccountCharge, amountPaid, transactionDate, backdatedTxnsAllowedTill, refNo);
+        final BigDecimal baseAmount = amountPaid.getAmount();
+        final TaxGroup taxGroup = savingsAccountCharge.getCharge().getTaxGroup();
+        final BigDecimal chargeAmountWithTax = TaxUtils.calculateChargeAmountWithTax(baseAmount, taxGroup, transactionDate,
+                getCurrency().getDigitsAfterDecimal());
+        final Money taxInclusiveAmount = Money.of(getCurrency(), chargeAmountWithTax);
+        savingsAccountCharge.pay(getCurrency(), taxInclusiveAmount);
+        final SavingsAccountTransaction chargeTransaction = handlePayChargeTransactions(savingsAccountCharge, taxInclusiveAmount,
+                transactionDate, backdatedTxnsAllowedTill, refNo);
+        if (taxGroup != null) {
+            // Use tax-inclusive amount to calculate tax split so amounts match the gross total
+            final Map<TaxComponent, BigDecimal> taxSplit = TaxUtils.splitTax(chargeAmountWithTax, transactionDate,
+                    taxGroup.getTaxGroupMappings(), getCurrency().getDigitsAfterDecimal());
+            SavingsAccountTransaction.updateTaxDetails(taxSplit, chargeTransaction);
+        }
+        return chargeTransaction;
     }
 
     private SavingsAccountTransaction handlePayChargeTransactions(SavingsAccountCharge savingsAccountCharge, Money transactionAmount,

--- a/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/domain/TaxComponent.java
+++ b/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/domain/TaxComponent.java
@@ -72,8 +72,7 @@ public class TaxComponent extends AbstractAuditableCustom {
     @Column(name = "start_date", nullable = false)
     private LocalDate startDate;
 
-    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
-    @JoinColumn(name = "tax_component_id", referencedColumnName = "id", nullable = false)
+    @OneToMany(mappedBy = "taxComponent", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     private Set<TaxComponentHistory> taxComponentHistories = new HashSet<>();
 
     @OneToMany(cascade = CascadeType.DETACH, mappedBy = "taxComponent", orphanRemoval = false, fetch = FetchType.EAGER)
@@ -120,7 +119,7 @@ public class TaxComponent extends AbstractAuditableCustom {
             updateStartDate(command, changes, true);
             LocalDate newStartDate = this.startDate;
 
-            TaxComponentHistory history = TaxComponentHistory.createTaxComponentHistory(this.percentage, oldStartDate, newStartDate);
+            TaxComponentHistory history = TaxComponentHistory.createTaxComponentHistory(this, this.percentage, oldStartDate, newStartDate);
             this.taxComponentHistories.add(history);
             this.percentage = newValue;
 

--- a/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/domain/TaxComponentHistory.java
+++ b/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/domain/TaxComponentHistory.java
@@ -20,6 +20,8 @@ package org.apache.fineract.portfolio.tax.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -29,6 +31,10 @@ import org.apache.fineract.infrastructure.core.service.DateUtils;
 @Entity
 @Table(name = "m_tax_component_history")
 public class TaxComponentHistory extends AbstractAuditableCustom {
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "tax_component_id", referencedColumnName = "id", nullable = false)
+    private TaxComponent taxComponent;
 
     @Column(name = "percentage", scale = 6, precision = 19, nullable = false)
     private BigDecimal percentage;
@@ -43,15 +49,17 @@ public class TaxComponentHistory extends AbstractAuditableCustom {
 
     }
 
-    private TaxComponentHistory(final BigDecimal percentage, final LocalDate startDate, final LocalDate endDate) {
+    private TaxComponentHistory(final TaxComponent taxComponent, final BigDecimal percentage, final LocalDate startDate,
+            final LocalDate endDate) {
+        this.taxComponent = taxComponent;
         this.percentage = percentage;
         this.startDate = startDate;
         this.endDate = endDate;
     }
 
-    public static TaxComponentHistory createTaxComponentHistory(final BigDecimal percentage, final LocalDate startDate,
-            final LocalDate endDate) {
-        return new TaxComponentHistory(percentage, startDate, endDate);
+    public static TaxComponentHistory createTaxComponentHistory(final TaxComponent taxComponent, final BigDecimal percentage,
+            final LocalDate startDate, final LocalDate endDate) {
+        return new TaxComponentHistory(taxComponent, percentage, startDate, endDate);
     }
 
     public LocalDate startDate() {

--- a/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/serialization/TaxValidator.java
+++ b/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/serialization/TaxValidator.java
@@ -192,6 +192,10 @@ public class TaxValidator {
         final JsonObject topLevelJsonElement = element.getAsJsonObject();
         if (topLevelJsonElement.get(TaxApiConstants.taxComponentsParamName).isJsonArray()) {
             final JsonArray array = topLevelJsonElement.get(TaxApiConstants.taxComponentsParamName).getAsJsonArray();
+            if (array.isEmpty()) {
+                dataValidationErrors.add(ApiParameterError.parameterError("validation.msg.at.least.one.tax.component.required",
+                        "Please add at least one Tax Component before submitting the Tax Group.", TaxApiConstants.taxComponentsParamName));
+            }
             baseDataValidator.reset().parameter(TaxApiConstants.taxComponentsParamName).value(array.size()).integerGreaterThanZero();
             for (int i = 1; i <= array.size(); i++) {
                 final JsonObject taxComponent = array.get(i - 1).getAsJsonObject();

--- a/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/service/TaxUtils.java
+++ b/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/service/TaxUtils.java
@@ -20,6 +20,7 @@ package org.apache.fineract.portfolio.tax.service;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,6 +29,7 @@ import org.apache.fineract.organisation.monetary.domain.MoneyHelper;
 import org.apache.fineract.portfolio.tax.data.TaxComponentData;
 import org.apache.fineract.portfolio.tax.data.TaxGroupMappingsData;
 import org.apache.fineract.portfolio.tax.domain.TaxComponent;
+import org.apache.fineract.portfolio.tax.domain.TaxGroup;
 import org.apache.fineract.portfolio.tax.domain.TaxGroupMappings;
 
 public final class TaxUtils {
@@ -125,5 +127,22 @@ public final class TaxUtils {
             totalAmount = BigDecimal.valueOf(total).setScale(scale, MoneyHelper.getRoundingMode());
         }
         return totalAmount;
+    }
+
+    public static BigDecimal calculateChargeAmountWithTax(final BigDecimal baseAmount, final TaxGroup taxGroup,
+            final LocalDate transactionDate, final int scale) {
+        if (baseAmount == null) {
+            return null;
+        }
+        if (taxGroup == null) {
+            return baseAmount;
+        }
+        final Set<TaxGroupMappings> taxGroupMappings = taxGroup.getTaxGroupMappings();
+        if (taxGroupMappings == null || taxGroupMappings.isEmpty()) {
+            return baseAmount;
+        }
+        final List<TaxGroupMappings> mappingsList = new ArrayList<>(taxGroupMappings);
+        final BigDecimal totalAmount = addTax(baseAmount, transactionDate, mappingsList, scale);
+        return totalAmount != null ? totalAmount : baseAmount;
     }
 }


### PR DESCRIPTION
## Problem

When a **Charge** linked to a **Tax Group** was applied to a **Savings Account**, tax was not calculated on the charge. The charge was applied using only its base amount, and no per-component tax breakdown was stored on the transaction.

Even after calculating the tax-inclusive amount, the accounting layer did not split the posting correctly. The full gross amount (charge + tax) was credited to the charge's income GL account instead of separating the tax into the configured **Tax/VAT Payable** GL account. As a result:

* The income GL was overstated by the tax amount.
* The tax liability was never recorded in its designated GL account.

This issue affected both **cash-based** and **accrual-based** accounting for **fees**, **penalties**, and their **reversals**.

## Fix

* Added tax calculation during savings charge payment by introducing `TaxUtils.calculateChargeAmountWithTax(...)`, ensuring the tax-inclusive amount is calculated and the per-component tax breakdown is stored on the `SavingsAccountTransaction`.
* Updated the cash-based and accrual-based accounting processors to split journal entries correctly by posting:

  * the net charge amount to the charge income GL account, and
  * each tax component to its configured **Tax/VAT Payable** GL account, including reversal entries.
* Updated the savings accounting processors to pass the transaction tax breakdown through the fee and penalty posting flows.

## Related Fixes

While implementing the above, several related issues in the Tax Group/Component domain were also resolved:

* Fixed the `TaxComponent` ↔ `TaxComponentHistory` JPA relationship by replacing the incorrect unidirectional mapping with a proper bidirectional mapping.
* Added the missing `id` and `endDate` fields to the `TaxGroupComponent` request DTO to support updating existing tax group mappings.
* Improved validation by returning a clear error message when creating a Tax Group with an empty `tax-components` array.

PR:(https://issues.apache.org/jira/browse/FINERACT-2744)