### PR TITLE
FINERACT-2748:  Tax Group – Adjust error message

### DIFF
--- a/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/serialization/TaxValidator.java
+++ b/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/serialization/TaxValidator.java
@@ -192,6 +192,10 @@ public class TaxValidator {
         final JsonObject topLevelJsonElement = element.getAsJsonObject();
         if (topLevelJsonElement.get(TaxApiConstants.taxComponentsParamName).isJsonArray()) {
             final JsonArray array = topLevelJsonElement.get(TaxApiConstants.taxComponentsParamName).getAsJsonArray();
+            if (array.isEmpty()) {
+                dataValidationErrors.add(ApiParameterError.parameterError("validation.msg.at.least.one.tax.component.required",
+                        "Please add at least one Tax Component before submitting the Tax Group.", TaxApiConstants.taxComponentsParamName));
+            }
             baseDataValidator.reset().parameter(TaxApiConstants.taxComponentsParamName).value(array.size()).integerGreaterThanZero();
             for (int i = 1; i <= array.size(); i++) {
                 final JsonObject taxComponent = array.get(i - 1).getAsJsonObject();

--- a/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/serialization/TaxValidator.java
+++ b/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/serialization/TaxValidator.java
@@ -192,6 +192,15 @@ public class TaxValidator {
         final JsonObject topLevelJsonElement = element.getAsJsonObject();
         if (topLevelJsonElement.get(TaxApiConstants.taxComponentsParamName).isJsonArray()) {
             final JsonArray array = topLevelJsonElement.get(TaxApiConstants.taxComponentsParamName).getAsJsonArray();
+            if (array.isEmpty()) {
+                dataValidationErrors.add(
+                        ApiParameterError.parameterError(
+                                "validation.msg.at.least.one.tax.component.required",
+                                "Please add at least one Tax Component before submitting the Tax Group.",
+                                TaxApiConstants.taxComponentsParamName
+                        )
+                );
+            }
             baseDataValidator.reset().parameter(TaxApiConstants.taxComponentsParamName).value(array.size()).integerGreaterThanZero();
             for (int i = 1; i <= array.size(); i++) {
                 final JsonObject taxComponent = array.get(i - 1).getAsJsonObject();

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/TaxesTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/TaxesTest.java
@@ -151,4 +151,18 @@ public class TaxesTest {
                 "Response should contain the error code for tax component not found");
     }
 
+    @Test
+    void createTaxGroupWithoutTaxComponent_shouldReturnValidationError() {
+        final PostTaxesGroupRequest taxGroupRequest = new PostTaxesGroupRequest().name(Utils.randomStringGenerator("TAX_GRP_", 4))
+                .taxComponents(new HashSet<>()).dateFormat("dd MMMM yyyy").locale("en");
+
+        CallFailedRuntimeException exception = taxGroupHelper.createTaxGroupExpectingError(taxGroupRequest);
+
+        assertEquals(400, exception.getStatus());
+        assertTrue(exception.getMessage().contains("validation.msg.at.least.one.tax.component.required"),
+                "Response should contain the error code requiring at least one tax component");
+        assertTrue(exception.getMessage().contains("Please add at least one Tax Component before submitting the Tax Group."),
+                "Response should contain the user friendly validation message");
+    }
+
 }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignTaxGroupHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/feign/helpers/FeignTaxGroupHelper.java
@@ -51,4 +51,8 @@ public class FeignTaxGroupHelper {
     public CallFailedRuntimeException retrieveTaxGroupExpectingError(Long taxGroupId) {
         return fail(() -> fineractClient.taxGroup().retrieveOneTaxGroup(taxGroupId));
     }
+
+    public CallFailedRuntimeException createTaxGroupExpectingError(PostTaxesGroupRequest request) {
+        return fail(() -> fineractClient.taxGroup().createTaxGroup(request));
+    }
 }


### PR DESCRIPTION
 Submitting a Tax Group without any tax components previously failed only on the generic integerGreaterThanZero check, without a clear message.   
  This adds an explicit validation error (validation.msg.at.least.one.tax.component.required) with a user-friendly message ("Please add at least   
  one Tax Component before submitting the Tax Group.") when the taxComponents array is empty.                                                      
                                                                                                                                                   
  Added an integration test (TaxesTest#createTaxGroupWithoutTaxComponent_shouldReturnValidationError) covering the new validation path.
  PR:(https://issues.apache.org/jira/browse/FINERACT-2748)