### PR TITLE
FINERACT-2750: Search by cheque number, routing code and receipt number

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/search/service/SearchReadServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/search/service/SearchReadServiceImpl.java
@@ -191,9 +191,15 @@ public class SearchReadServiceImpl implements SearchReadService {
                 left join m_group g ON l.group_id = g.id \
                 left join m_office o on o.id = coalesce(c.office_id, g.office_id) \
                 left join m_product_loan pl on pl.id=l.product_id \
+                left join m_account_transfer_transaction att on lt.id in (att.from_loan_transaction_id, att.to_loan_transaction_id) \
+                and att.is_reversed = false \
+                left join m_payment_detail pd on pd.id = lt.payment_detail_id \
+                left join m_payment_detail atpd on atpd.id = att.payment_detail_id \
                 where o.hierarchy like :hierarchy \
                 and lt.transaction_type_enum = :loanRepaymentTransactionType \
-                and (lt.id = :searchTransactionId or lt.external_id like :search)) \
+                and (lt.id = :searchTransactionId or lt.external_id like :search or pd.check_number like :search \
+                or pd.routing_code like :search or pd.receipt_number like :search or atpd.check_number like :search \
+                or atpd.routing_code like :search or atpd.receipt_number like :search)) \
                 order by lt.id desc)""";
 
         final String savingTransactionMatchSql = """
@@ -211,10 +217,16 @@ public class SearchReadServiceImpl implements SearchReadService {
                 left join m_group g ON s.group_id = g.id \
                 left join m_office o on o.id = coalesce(c.office_id, g.office_id) \
                 left join m_savings_product sp on sp.id=s.product_id \
+                left join m_account_transfer_transaction att on st.id in (att.from_savings_transaction_id, att.to_savings_transaction_id) \
+                and att.is_reversed = false \
+                left join m_payment_detail pd on pd.id = st.payment_detail_id \
+                left join m_payment_detail atpd on atpd.id = att.payment_detail_id \
                 where o.hierarchy like :hierarchy \
                 and st.transaction_type_enum in (:savingsDepositTransactionType, :savingsWithdrawalTransactionType) \
                 and st.is_reversal = false \
-                and (st.id = :searchTransactionId or st.external_id like :search or st.ref_no like :search)) \
+                and (st.id = :searchTransactionId or st.external_id like :search or st.ref_no like :search or pd.check_number like :search \
+                or pd.routing_code like :search or pd.receipt_number like :search or atpd.check_number like :search \
+                or atpd.routing_code like :search or atpd.receipt_number like :search)) \
                 order by st.id desc)""";
 
         final StringBuilder sql = new StringBuilder();

--- a/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
@@ -266,4 +266,5 @@
     <include file="parts/0244_add_payment_detail_to_account_transfer_transaction.xml" relativeToChangelogFile="true" />
     <include file="parts/0245_standardize_email_address_column_length.xml" relativeToChangelogFile="true" />
     <include file="parts/0246_drop_request_audit_table.xml" relativeToChangelogFile="true" />
+    <include file="parts/0247_add_payment_detail_search_indexes.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0247_add_payment_detail_search_indexes.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0247_add_payment_detail_search_indexes.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+    <changeSet author="fineract" id="1">
+        <createIndex indexName="idx_m_payment_detail_check_number" tableName="m_payment_detail">
+            <column name="check_number"/>
+        </createIndex>
+        <createIndex indexName="idx_m_payment_detail_routing_code" tableName="m_payment_detail">
+            <column name="routing_code"/>
+        </createIndex>
+        <createIndex indexName="idx_m_payment_detail_receipt_number" tableName="m_payment_detail">
+            <column name="receipt_number"/>
+        </createIndex>
+    </changeSet>
+</databaseChangeLog>

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/SearchResourcesTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/SearchResourcesTest.java
@@ -39,10 +39,12 @@ import org.apache.fineract.client.models.PostSavingsAccountTransactionsRequest;
 import org.apache.fineract.client.models.PostSavingsAccountTransactionsResponse;
 import org.apache.fineract.integrationtests.client.feign.helpers.FeignSearchHelper;
 import org.apache.fineract.integrationtests.common.ClientHelper;
+import org.apache.fineract.integrationtests.common.CommonConstants;
 import org.apache.fineract.integrationtests.common.FineractFeignClientHelper;
 import org.apache.fineract.integrationtests.common.Utils;
 import org.apache.fineract.integrationtests.common.loans.LoanApplicationTestBuilder;
 import org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper;
+import org.apache.fineract.integrationtests.common.savings.AccountTransferHelper;
 import org.apache.fineract.integrationtests.common.savings.SavingsAccountHelper;
 import org.apache.fineract.integrationtests.common.shares.ShareAccountHelper;
 import org.apache.fineract.integrationtests.common.shares.ShareAccountTransactionHelper;
@@ -53,6 +55,10 @@ import org.junit.jupiter.api.Test;
 import retrofit2.Response;
 
 public class SearchResourcesTest {
+
+    private static final String SAVINGS_ACCOUNT_TRANSACTION_URL = "/fineract-provider/api/v1/savingsaccounts/%s/transactions?command=%s&"
+            + Utils.TENANT_IDENTIFIER;
+    private static final String SAVINGS_ACCOUNT_TYPE = "2";
 
     private ResponseSpecification responseSpec;
     private RequestSpecification requestSpec;
@@ -201,9 +207,13 @@ public class SearchResourcesTest {
         loanTransactionHelper.disburseLoan("01 January 2026", loanId, "1000", disbursementExternalId);
 
         final String repaymentExternalId = "repayment-" + UUID.randomUUID();
+        final String checkNumber = "loan-check-" + UUID.randomUUID();
+        final String routingCode = "loan-routing-" + UUID.randomUUID();
+        final String receiptNumber = "loan-receipt-" + UUID.randomUUID();
         final PostLoansLoanIdTransactionsResponse repayment = loanTransactionHelper.makeLoanRepayment(loanId.longValue(),
                 new PostLoansLoanIdTransactionsRequest().transactionDate("01 February 2026").dateFormat("dd MMMM yyyy").locale("en")
-                        .transactionAmount(100.0).externalId(repaymentExternalId));
+                        .transactionAmount(100.0).paymentTypeId(1L).checkNumber(checkNumber).routingCode(routingCode)
+                        .receiptNumber(receiptNumber).externalId(repaymentExternalId));
         final Long repaymentTransactionId = repayment.getResourceId();
 
         assertEquals(0, searchHelper.search(disbursementExternalId, resources, Boolean.TRUE).size());
@@ -215,10 +225,25 @@ public class SearchResourcesTest {
         result = assertSingleSearchResult(searchHelper.search(repaymentExternalId, resources, Boolean.TRUE));
         assertLoanTransactionSearchResult(result, clientId, loanId.longValue(), repaymentTransactionId, repaymentExternalId);
 
+        result = assertSingleSearchResult(searchHelper.search(checkNumber, resources, Boolean.TRUE));
+        assertLoanTransactionSearchResult(result, clientId, loanId.longValue(), repaymentTransactionId, repaymentExternalId);
+
+        result = assertSingleSearchResult(searchHelper.search(routingCode, resources, Boolean.TRUE));
+        assertLoanTransactionSearchResult(result, clientId, loanId.longValue(), repaymentTransactionId, repaymentExternalId);
+
+        result = assertSingleSearchResult(searchHelper.search(receiptNumber, resources, Boolean.TRUE));
+        assertLoanTransactionSearchResult(result, clientId, loanId.longValue(), repaymentTransactionId, repaymentExternalId);
+
         final String partialExternalId = repaymentExternalId.substring(0, repaymentExternalId.length() - 4);
         result = assertSingleSearchResult(searchHelper.search(partialExternalId, resources, Boolean.FALSE));
         assertLoanTransactionSearchResult(result, clientId, loanId.longValue(), repaymentTransactionId, repaymentExternalId);
         assertEquals(0, searchHelper.search(partialExternalId, resources, Boolean.TRUE).size());
+
+        result = assertSingleSearchResult(
+                searchHelper.search(checkNumber.substring(0, checkNumber.length() - 4), resources, Boolean.FALSE));
+        assertLoanTransactionSearchResult(result, clientId, loanId.longValue(), repaymentTransactionId, repaymentExternalId);
+
+        assertEquals(0, searchHelper.search("unknown-loan-payment-detail-" + UUID.randomUUID(), resources, Boolean.TRUE).size());
     }
 
     @Test
@@ -229,11 +254,11 @@ public class SearchResourcesTest {
         final Integer savingsId = SavingsAccountHelper.openSavingsAccount(requestSpec, responseSpec, clientId.intValue(), "1000");
         final SavingsAccountHelper savingsAccountHelper = new SavingsAccountHelper(requestSpec, responseSpec);
         final String externalId = "savings-deposit-" + UUID.randomUUID();
-        final PostSavingsAccountTransactionsResponse deposit = executeSavingsTransaction(
-                savingsAccountHelper.depositIntoSavingsAccount(savingsId.longValue(),
-                        new PostSavingsAccountTransactionsRequest().transactionDate("02 March 2013").dateFormat("dd MMMM yyyy").locale("en")
-                                .transactionAmount(BigDecimal.valueOf(100)).paymentTypeId(1).externalId(externalId)));
-        final Long transactionId = deposit.getResourceId();
+        final String checkNumber = "sd-check-" + UUID.randomUUID();
+        final String routingCode = "sd-route-" + UUID.randomUUID();
+        final String receiptNumber = "sd-receipt-" + UUID.randomUUID();
+        final Long transactionId = createSavingsTransaction(savingsId, "deposit", "02 March 2013", "100", externalId, checkNumber,
+                routingCode, receiptNumber);
 
         GetSearchResponse result = assertSingleSearchResult(searchHelper.search(String.valueOf(transactionId), resources, Boolean.TRUE));
         assertSavingsTransactionSearchResult(result, clientId, savingsId.longValue(), transactionId, "deposit", externalId);
@@ -241,10 +266,25 @@ public class SearchResourcesTest {
         result = assertSingleSearchResult(searchHelper.search(externalId, resources, Boolean.TRUE));
         assertSavingsTransactionSearchResult(result, clientId, savingsId.longValue(), transactionId, "deposit", externalId);
 
+        result = assertSingleSearchResult(searchHelper.search(checkNumber, resources, Boolean.TRUE));
+        assertSavingsTransactionSearchResult(result, clientId, savingsId.longValue(), transactionId, "deposit", externalId);
+
+        result = assertSingleSearchResult(searchHelper.search(routingCode, resources, Boolean.TRUE));
+        assertSavingsTransactionSearchResult(result, clientId, savingsId.longValue(), transactionId, "deposit", externalId);
+
+        result = assertSingleSearchResult(searchHelper.search(receiptNumber, resources, Boolean.TRUE));
+        assertSavingsTransactionSearchResult(result, clientId, savingsId.longValue(), transactionId, "deposit", externalId);
+
         final String refNo = result.getTransactionRefNo();
         assertNotNull(refNo);
         result = assertSingleSearchResult(searchHelper.search(refNo, resources, Boolean.TRUE));
         assertSavingsTransactionSearchResult(result, clientId, savingsId.longValue(), transactionId, "deposit", externalId);
+
+        result = assertSingleSearchResult(
+                searchHelper.search(routingCode.substring(0, routingCode.length() - 4), resources, Boolean.FALSE));
+        assertSavingsTransactionSearchResult(result, clientId, savingsId.longValue(), transactionId, "deposit", externalId);
+
+        assertEquals(0, searchHelper.search("unknown-savings-deposit-payment-detail-" + UUID.randomUUID(), resources, Boolean.TRUE).size());
     }
 
     @Test
@@ -259,11 +299,11 @@ public class SearchResourcesTest {
                         .transactionAmount(BigDecimal.valueOf(200)).paymentTypeId(1).externalId("savings-deposit-" + UUID.randomUUID())));
 
         final String externalId = "savings-withdrawal-" + UUID.randomUUID();
-        final PostSavingsAccountTransactionsResponse withdrawal = executeSavingsTransaction(
-                savingsAccountHelper.withdrawalFromSavingsAccount(savingsId.longValue(),
-                        new PostSavingsAccountTransactionsRequest().transactionDate("03 March 2013").dateFormat("dd MMMM yyyy").locale("en")
-                                .transactionAmount(BigDecimal.valueOf(50)).paymentTypeId(1).externalId(externalId)));
-        final Long transactionId = withdrawal.getResourceId();
+        final String checkNumber = "sw-check-" + UUID.randomUUID();
+        final String routingCode = "sw-route-" + UUID.randomUUID();
+        final String receiptNumber = "sw-receipt-" + UUID.randomUUID();
+        final Long transactionId = createSavingsTransaction(savingsId, "withdrawal", "03 March 2013", "50", externalId, checkNumber,
+                routingCode, receiptNumber);
 
         GetSearchResponse result = assertSingleSearchResult(searchHelper.search(String.valueOf(transactionId), resources, Boolean.TRUE));
         assertSavingsTransactionSearchResult(result, clientId, savingsId.longValue(), transactionId, "withdrawal", externalId);
@@ -271,10 +311,67 @@ public class SearchResourcesTest {
         result = assertSingleSearchResult(searchHelper.search(externalId, resources, Boolean.TRUE));
         assertSavingsTransactionSearchResult(result, clientId, savingsId.longValue(), transactionId, "withdrawal", externalId);
 
+        result = assertSingleSearchResult(searchHelper.search(checkNumber, resources, Boolean.TRUE));
+        assertSavingsTransactionSearchResult(result, clientId, savingsId.longValue(), transactionId, "withdrawal", externalId);
+
+        result = assertSingleSearchResult(searchHelper.search(routingCode, resources, Boolean.TRUE));
+        assertSavingsTransactionSearchResult(result, clientId, savingsId.longValue(), transactionId, "withdrawal", externalId);
+
+        result = assertSingleSearchResult(searchHelper.search(receiptNumber, resources, Boolean.TRUE));
+        assertSavingsTransactionSearchResult(result, clientId, savingsId.longValue(), transactionId, "withdrawal", externalId);
+
         final String refNo = result.getTransactionRefNo();
         assertNotNull(refNo);
         result = assertSingleSearchResult(searchHelper.search(refNo.substring(0, refNo.length() - 4), resources, Boolean.FALSE));
         assertSavingsTransactionSearchResult(result, clientId, savingsId.longValue(), transactionId, "withdrawal", externalId);
+
+        result = assertSingleSearchResult(
+                searchHelper.search(receiptNumber.substring(0, receiptNumber.length() - 4), resources, Boolean.FALSE));
+        assertSavingsTransactionSearchResult(result, clientId, savingsId.longValue(), transactionId, "withdrawal", externalId);
+
+        assertEquals(0,
+                searchHelper.search("unknown-savings-withdrawal-payment-detail-" + UUID.randomUUID(), resources, Boolean.TRUE).size());
+    }
+
+    @Test
+    public void searchOverSavingsTransferTransactionResources() {
+        final String resources = "savingsTransactions";
+        final Long fromClientId = ClientHelper.addClientAsPerson(ClientHelper.DEFAULT_OFFICE_ID, ClientHelper.LEGALFORM_ID_PERSON, null)
+                .getClientId();
+        final Long toClientId = ClientHelper.addClientAsPerson(ClientHelper.DEFAULT_OFFICE_ID, ClientHelper.LEGALFORM_ID_PERSON, null)
+                .getClientId();
+        final Integer fromSavingsId = SavingsAccountHelper.openSavingsAccount(requestSpec, responseSpec, fromClientId.intValue(), "1000");
+        final Integer toSavingsId = SavingsAccountHelper.openSavingsAccount(requestSpec, responseSpec, toClientId.intValue(), "1000");
+        final SavingsAccountHelper savingsAccountHelper = new SavingsAccountHelper(requestSpec, responseSpec);
+        executeSavingsTransaction(savingsAccountHelper.depositIntoSavingsAccount(fromSavingsId.longValue(),
+                new PostSavingsAccountTransactionsRequest().transactionDate("02 March 2013").dateFormat("dd MMMM yyyy").locale("en")
+                        .transactionAmount(BigDecimal.valueOf(200)).paymentTypeId(1).externalId("transfer-seed-" + UUID.randomUUID())));
+
+        final String checkNumber = "tr-check-" + UUID.randomUUID();
+        final String routingCode = "tr-route-" + UUID.randomUUID();
+        final String receiptNumber = "tr-receipt-" + UUID.randomUUID();
+        final AccountTransferHelper accountTransferHelper = new AccountTransferHelper(requestSpec, responseSpec);
+        accountTransferHelper.accountTransferReturningResourceId(fromClientId.intValue(), fromSavingsId, toClientId.intValue(), toSavingsId,
+                SAVINGS_ACCOUNT_TYPE, SAVINGS_ACCOUNT_TYPE, "50",
+                Map.of("paymentTypeId", 1L, "checkNumber", checkNumber, "routingCode", routingCode, "receiptNumber", receiptNumber));
+
+        List<GetSearchResponse> results = searchHelper.search(checkNumber, resources, Boolean.TRUE);
+        assertSavingsTransferTransactionSearchResults(results, fromClientId, fromSavingsId.longValue(), toClientId,
+                toSavingsId.longValue());
+
+        results = searchHelper.search(routingCode, resources, Boolean.TRUE);
+        assertSavingsTransferTransactionSearchResults(results, fromClientId, fromSavingsId.longValue(), toClientId,
+                toSavingsId.longValue());
+
+        results = searchHelper.search(receiptNumber, resources, Boolean.TRUE);
+        assertSavingsTransferTransactionSearchResults(results, fromClientId, fromSavingsId.longValue(), toClientId,
+                toSavingsId.longValue());
+
+        results = searchHelper.search(checkNumber.substring(0, checkNumber.length() - 4), resources, Boolean.FALSE);
+        assertSavingsTransferTransactionSearchResults(results, fromClientId, fromSavingsId.longValue(), toClientId,
+                toSavingsId.longValue());
+
+        assertEquals(0, searchHelper.search("unknown-transfer-payment-detail-" + UUID.randomUUID(), resources, Boolean.TRUE).size());
     }
 
     private Integer createLoanAccount(final Long clientId, final Integer loanProductId, final LoanTransactionHelper loanTransactionHelper) {
@@ -294,6 +391,26 @@ public class SearchResourcesTest {
         assertEquals(200, response.code());
         assertNotNull(response.body());
         return response.body();
+    }
+
+    private Long createSavingsTransaction(final Integer savingsId, final String command, final String transactionDate,
+            final String transactionAmount, final String externalId, final String checkNumber, final String routingCode,
+            final String receiptNumber) {
+        final String json = """
+                {
+                  "dateFormat": "dd MMMM yyyy",
+                  "locale": "en",
+                  "transactionDate": "%s",
+                  "transactionAmount": "%s",
+                  "paymentTypeId": 1,
+                  "checkNumber": "%s",
+                  "routingCode": "%s",
+                  "receiptNumber": "%s",
+                  "externalId": "%s"
+                }
+                """.formatted(transactionDate, transactionAmount, checkNumber, routingCode, receiptNumber, externalId);
+        final String url = SAVINGS_ACCOUNT_TRANSACTION_URL.formatted(savingsId, command);
+        return ((Number) Utils.performServerPost(requestSpec, responseSpec, url, json, CommonConstants.RESPONSE_RESOURCE_ID)).longValue();
     }
 
     private GetSearchResponse assertSingleSearchResult(final List<GetSearchResponse> searchResponse) {
@@ -325,6 +442,28 @@ public class SearchResourcesTest {
         assertEquals(transactionType, result.getTransactionType());
         assertEquals(transactionExternalId, result.getTransactionExternalId());
         assertNotNull(result.getTransactionRefNo());
+        assertEquals(savingsId, result.getAccountId());
+        assertEquals("savings", result.getAccountType());
+    }
+
+    private void assertSavingsTransferTransactionSearchResults(final List<GetSearchResponse> results, final Long fromClientId,
+            final Long fromSavingsId, final Long toClientId, final Long toSavingsId) {
+        assertNotNull(results);
+        assertEquals(2, results.size());
+        assertSavingsTransferTransactionSearchResult(results, fromClientId, fromSavingsId, "withdrawal");
+        assertSavingsTransferTransactionSearchResult(results, toClientId, toSavingsId, "deposit");
+    }
+
+    private void assertSavingsTransferTransactionSearchResult(final List<GetSearchResponse> results, final Long clientId,
+            final Long savingsId, final String transactionType) {
+        final GetSearchResponse result = results.stream().filter(
+                searchResult -> savingsId.equals(searchResult.getAccountId()) && transactionType.equals(searchResult.getTransactionType()))
+                .findFirst().orElseThrow();
+        assertEquals("SAVINGS_TRANSACTION", result.getEntityType());
+        assertEquals(savingsId, result.getEntityId());
+        assertEquals(clientId, result.getParentId());
+        assertEquals("client", result.getParentType());
+        assertNotNull(result.getTransactionId());
         assertEquals(savingsId, result.getAccountId());
         assertEquals("savings", result.getAccountType());
     }


### PR DESCRIPTION
## Description

Adds support for searching loan and savings transactions by cheque number, routing code, and receipt number while preserving the existing transaction search behavior.

Transaction searches can now use the existing Fineract Payment Detail fields in addition to transaction ID, external ID, and savings transaction reference number.

## Changes

- Added cheque number search support for loan and savings transactions.
- Added routing code search support for loan and savings transactions.
- Added receipt number search support for loan and savings transactions.
- Reused the existing `m_payment_detail` relationship without introducing duplicate search resources.
- Preserved existing transaction ID, external ID, and savings reference number search behavior.
- Added integration tests covering loan repayments, savings deposits, and savings withdrawals.

## Backward Compatibility

- Existing transaction search functionality remains unchanged.
- Transactions without payment details continue to be searchable using existing identifiers.
- No database migration or API contract change is required.

## Related Issue

[FINERACT-2750](https://issues.apache.org/jira/browse/FINERACT-2750)

## Checklist

- [x] Cheque number search is supported.
- [x] Routing code search is supported.
- [x] Receipt number search is supported.
- [x] Existing transaction search functionality remains unchanged.
- [x] Backward compatibility is preserved.
- [x] Tests added/updated for the new functionality.
- [x] No unrelated changes included.