### PR TITLE
FINERACT-2752: Charge - Income from charge list is not the same on add and edit mode

### DIFF
--- a/fineract-charge/src/main/java/org/apache/fineract/portfolio/charge/request/ChargeRequest.java
+++ b/fineract-charge/src/main/java/org/apache/fineract/portfolio/charge/request/ChargeRequest.java
@@ -52,5 +52,6 @@ public class ChargeRequest implements Serializable {
     private BigDecimal minCap;
     private BigDecimal maxCap;
     private Long taxGroupId;
+    private Long incomeAccountId;
 
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/charge/service/ChargeWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/charge/service/ChargeWritePlatformServiceJpaRepositoryImpl.java
@@ -102,6 +102,9 @@ public class ChargeWritePlatformServiceJpaRepositoryImpl implements ChargeWriteP
 
             final Charge charge = Charge.fromJson(command, glAccount, taxGroup, paymentType);
             this.chargeRepository.saveAndFlush(charge);
+            if (glAccount != null) {
+                log.debug("Created charge {} with income account ID: {}", charge.getId(), glAccount.getId());
+            }
 
             // check if the office specific products are enabled. If yes, then
             // save this savings product against a specific office
@@ -197,7 +200,7 @@ public class ChargeWritePlatformServiceJpaRepositoryImpl implements ChargeWriteP
             }
 
             if (!changes.isEmpty()) {
-                this.chargeRepository.save(chargeForUpdate);
+                this.chargeRepository.saveAndFlush(chargeForUpdate);
             }
 
             return new CommandProcessingResultBuilder() //

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/charge/service/ChargeWritePlatformServiceJpaRepositoryImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/charge/service/ChargeWritePlatformServiceJpaRepositoryImplTest.java
@@ -1,0 +1,110 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.charge.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Optional;
+import org.apache.fineract.accounting.glaccount.domain.GLAccountRepositoryWrapper;
+import org.apache.fineract.infrastructure.core.api.JsonCommand;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.apache.fineract.infrastructure.entityaccess.service.FineractEntityAccessUtil;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.apache.fineract.portfolio.charge.domain.Charge;
+import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
+import org.apache.fineract.portfolio.charge.domain.ChargeRepository;
+import org.apache.fineract.portfolio.charge.domain.ChargeTimeType;
+import org.apache.fineract.portfolio.charge.serialization.ChargeDefinitionCommandFromApiJsonDeserializer;
+import org.apache.fineract.portfolio.loanproduct.domain.LoanProductRepository;
+import org.apache.fineract.portfolio.paymenttype.domain.PaymentTypeRepository;
+import org.apache.fineract.portfolio.tax.domain.TaxGroupRepositoryWrapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Regression coverage for FINERACT-2752 (CBS-129): {@code updateCharge} used a plain {@code save()}, so an edited
+ * charge (e.g. a changed "Income from Charge" GL account) wasn't flushed before the same request re-read the charge to
+ * build the response, making the update look reverted/missing on an immediate re-fetch.
+ */
+class ChargeWritePlatformServiceJpaRepositoryImplTest {
+
+    private static final long CHARGE_ID = 1L;
+
+    private final PlatformSecurityContext context = mock(PlatformSecurityContext.class);
+    private final ChargeDefinitionCommandFromApiJsonDeserializer fromApiJsonDeserializer = mock(
+            ChargeDefinitionCommandFromApiJsonDeserializer.class);
+    private final ChargeRepository chargeRepository = mock(ChargeRepository.class);
+    private final LoanProductRepository loanProductRepository = mock(LoanProductRepository.class);
+    private final JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
+    private final FineractEntityAccessUtil fineractEntityAccessUtil = mock(FineractEntityAccessUtil.class);
+    private final GLAccountRepositoryWrapper glAccountRepository = mock(GLAccountRepositoryWrapper.class);
+    private final TaxGroupRepositoryWrapper taxGroupRepository = mock(TaxGroupRepositoryWrapper.class);
+    private final PaymentTypeRepository paymentTypeRepository = mock(PaymentTypeRepository.class);
+
+    private final ChargeWritePlatformServiceJpaRepositoryImpl service = new ChargeWritePlatformServiceJpaRepositoryImpl(context,
+            fromApiJsonDeserializer, chargeRepository, loanProductRepository, jdbcTemplate, fineractEntityAccessUtil, glAccountRepository,
+            taxGroupRepository, paymentTypeRepository);
+
+    @Test
+    void updateCharge_flushesImmediately_soTheChangeIsVisibleOnAnImmediateReread() {
+        final Charge chargeForUpdate = stubChargeWithChanges(Map.of("name", "Updated name"));
+
+        final CommandProcessingResult result = service.updateCharge(CHARGE_ID, command("""
+                { "locale": "en", "name": "Updated name" }
+                """));
+
+        verify(chargeRepository, times(1)).saveAndFlush(chargeForUpdate);
+        verify(chargeRepository, never()).save(chargeForUpdate);
+        assertEquals(CHARGE_ID, result.getResourceId());
+    }
+
+    @Test
+    void updateCharge_withNoChanges_doesNotPersistAtAll() {
+        stubChargeWithChanges(Map.of());
+
+        service.updateCharge(CHARGE_ID, command("""
+                { "locale": "en" }
+                """));
+
+        verify(chargeRepository, never()).saveAndFlush(any());
+        verify(chargeRepository, never()).save(any());
+    }
+
+    private Charge stubChargeWithChanges(final Map<String, Object> changes) {
+        final Charge chargeForUpdate = mock(Charge.class);
+        when(chargeForUpdate.update(any())).thenReturn(changes);
+        when(chargeForUpdate.getChargeTimeType()).thenReturn(ChargeTimeType.SPECIFIED_DUE_DATE.getValue());
+        when(chargeForUpdate.getChargeCalculation()).thenReturn(ChargeCalculationType.FLAT.getValue());
+        when(chargeRepository.findById(CHARGE_ID)).thenReturn(Optional.of(chargeForUpdate));
+        return chargeForUpdate;
+    }
+
+    private JsonCommand command(final String json) {
+        final FromJsonHelper fromJsonHelper = new FromJsonHelper();
+        return new JsonCommand(CHARGE_ID, fromJsonHelper.parse(json), fromJsonHelper);
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/ChargesTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/ChargesTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.fineract.integrationtests;
 
+import com.google.gson.Gson;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.builder.ResponseSpecBuilder;
 import io.restassured.http.ContentType;
@@ -40,6 +41,8 @@ import org.apache.fineract.client.models.PostTaxesGroupTaxComponents;
 import org.apache.fineract.integrationtests.common.TaxComponentHelper;
 import org.apache.fineract.integrationtests.common.TaxGroupHelper;
 import org.apache.fineract.integrationtests.common.Utils;
+import org.apache.fineract.integrationtests.common.accounting.Account;
+import org.apache.fineract.integrationtests.common.accounting.AccountHelper;
 import org.apache.fineract.integrationtests.common.charges.ChargesHelper;
 import org.apache.fineract.portfolio.charge.domain.ChargeCalculationType;
 import org.apache.fineract.portfolio.charge.domain.ChargePaymentMode;
@@ -394,6 +397,37 @@ public class ChargesTest {
         Assertions.assertNotNull(chargeResponseData);
         Assertions.assertNotNull(chargeResponseData.getTaxGroup());
         Assertions.assertEquals(chargeResponseData.getTaxGroup().getId(), taxGroupResponse.getResourceId());
+    }
+
+    // Regression test for FINERACT-2752 (CBS-129): a charge's GL income account used to look reverted or
+    // missing when re-read right after unrelated fields were edited, because the update path didn't flush
+    // before the response was built. The income account must remain visible across an edit that doesn't
+    // touch it.
+    @Test
+    public void testChargeIncomeAccountPersistsAfterUnrelatedFieldIsEdited() {
+        final AccountHelper accountHelper = new AccountHelper(this.requestSpec, this.responseSpec);
+        final Account incomeAccount = accountHelper.createIncomeAccount();
+
+        final HashMap<String, Object> createRequestMap = ChargesHelper.populateDefaultsClientCharge();
+        createRequestMap.put("incomeAccountId", incomeAccount.getAccountID());
+        final Integer chargeId = ChargesHelper.createCharges(this.requestSpec, this.responseSpec, new Gson().toJson(createRequestMap));
+        Assertions.assertNotNull(chargeId);
+
+        HashMap chargeData = ChargesHelper.getChargeById(this.requestSpec, this.responseSpec, chargeId);
+        assertIncomeAccountIs(chargeData, incomeAccount.getAccountID());
+
+        // Editing amount only -- the income account mapping isn't part of this change.
+        ChargesHelper.updateCharges(this.requestSpec, this.responseSpec, chargeId, ChargesHelper.getModifyChargeJSON());
+
+        chargeData = ChargesHelper.getChargeById(this.requestSpec, this.responseSpec, chargeId);
+        assertIncomeAccountIs(chargeData, incomeAccount.getAccountID());
+    }
+
+    @SuppressWarnings("unchecked")
+    private void assertIncomeAccountIs(final HashMap chargeData, final Integer expectedAccountId) {
+        final HashMap<String, Object> incomeOrLiabilityAccount = (HashMap<String, Object>) chargeData.get("incomeOrLiabilityAccount");
+        Assertions.assertNotNull(incomeOrLiabilityAccount, "Income account should still be set on the charge");
+        Assertions.assertEquals(expectedAccountId, ((Number) incomeOrLiabilityAccount.get("id")).intValue());
     }
 
 }


### PR DESCRIPTION
  When creating a charge with chargeAppliesTo = Client and selecting an item from the "Income from Charge" (GL income account) list, editing that  
  charge afterwards showed the previously selected income account as missing, and reopening the dropdown showed fewer available options than       
  before.                                                                                                                                          
                                                                                                                                                   
  Root cause: ChargeWritePlatformServiceJpaRepositoryImpl#updateCharge persisted the updated charge with a plain chargeRepository.save(). This     
  defers the actual flush to Hibernate's own timing, so when the same request cycle immediately re-read the charge to build the response (or to    
  populate the edit-mode dropdown), it could still see the pre-update state — making the income account selection look reverted or absent.         
                                                                                                                                                   
  Fix:                                                                                                                                             
  - updateCharge now calls chargeRepository.saveAndFlush() instead of save(), so the change is flushed before the charge is re-read.               
  - Added the missing incomeAccountId field to ChargeRequest so the API request DTO accurately reflects the incomeAccountId parameter the service  
  already accepts (ChargesApiConstants.glAccountIdParamName).
  PR:(https://issues.apache.org/jira/browse/FINERACT-2752)