### PR TITLE
FINERACT-2753: Improve Maker-Checker Action Endpoint Handling and Permission Responses

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/commands/domain/CommandSourceRepository.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/domain/CommandSourceRepository.java
@@ -19,6 +19,7 @@
 package org.apache.fineract.commands.domain;
 
 import java.time.OffsetDateTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
@@ -28,6 +29,9 @@ import org.springframework.data.repository.query.Param;
 public interface CommandSourceRepository extends JpaRepository<CommandSource, Long>, JpaSpecificationExecutor<CommandSource> {
 
     CommandSource findByActionNameAndEntityNameAndIdempotencyKey(String actionName, String entityName, String idempotencyKey);
+
+    List<CommandSource> findByActionNameAndEntityNameAndResourceIdAndStatus(String actionName, String entityName, Long resourceId,
+            Integer status);
 
     @Modifying(flushAutomatically = true)
     @Query("delete from CommandSource c where c.status = :status and c.madeOnDate is not null and c.madeOnDate <= :dateForPurgeCriteria")

--- a/fineract-core/src/main/java/org/apache/fineract/commands/exception/MakerCheckerCheckerOnlyInitiationException.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/exception/MakerCheckerCheckerOnlyInitiationException.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.commands.exception;
+
+import org.apache.fineract.infrastructure.core.exception.AbstractPlatformException;
+
+/**
+ * Thrown when a user who only holds the checker (`_CHECKER`) permission for a maker-checker enabled task - without the
+ * base permission - attempts to initiate that task directly, instead of approving an existing pending submission.
+ */
+public class MakerCheckerCheckerOnlyInitiationException extends AbstractPlatformException {
+
+    public MakerCheckerCheckerOnlyInitiationException(final String taskPermissionName) {
+        super("error.msg.maker.checker.checker.only.cannot.initiate",
+                "You have checker-only permission for this action. You cannot initiate it. Use maker-checker approval flow to approve a pending submission.",
+                new Object[] { taskPermissionName });
+    }
+}

--- a/fineract-core/src/main/java/org/apache/fineract/commands/exception/MakerCheckerDuplicatePendingSubmissionException.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/exception/MakerCheckerDuplicatePendingSubmissionException.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.commands.exception;
+
+import org.apache.fineract.infrastructure.core.exception.AbstractPlatformException;
+
+/**
+ * Thrown when a maker-only user submits a maker-checker enabled action for which a submission is already awaiting
+ * checker approval for the same action, entity and resource.
+ */
+public class MakerCheckerDuplicatePendingSubmissionException extends AbstractPlatformException {
+
+    public MakerCheckerDuplicatePendingSubmissionException(final String actionName, final String entityName) {
+        super("error.msg.maker.checker.duplicate.pending.submission",
+                "This action is already pending checker approval. Please wait for it to be approved or rejected before resubmitting.",
+                new Object[] { actionName, entityName });
+    }
+}

--- a/fineract-core/src/main/java/org/apache/fineract/commands/service/PortfolioCommandSourceWritePlatformServiceImpl.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/service/PortfolioCommandSourceWritePlatformServiceImpl.java
@@ -23,11 +23,14 @@ import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.commands.domain.CommandProcessingResultType;
 import org.apache.fineract.commands.domain.CommandSource;
 import org.apache.fineract.commands.domain.CommandSourceRepository;
 import org.apache.fineract.commands.domain.CommandWrapper;
 import org.apache.fineract.commands.exception.CommandNotAwaitingApprovalException;
 import org.apache.fineract.commands.exception.CommandNotFoundException;
+import org.apache.fineract.commands.exception.MakerCheckerCheckerOnlyInitiationException;
+import org.apache.fineract.commands.exception.MakerCheckerDuplicatePendingSubmissionException;
 import org.apache.fineract.commands.exception.UnsupportedCommandException;
 import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
@@ -67,7 +70,29 @@ public class PortfolioCommandSourceWritePlatformServiceImpl implements Portfolio
         } else {
             // if not user changing their own details - check user has
             // permission to perform specific task.
-            this.context.authenticatedUser(wrapper).validateHasPermissionTo(wrapper.getTaskPermissionName());
+            final AppUser currentUser = this.context.authenticatedUser(wrapper);
+            final String taskPermission = wrapper.getTaskPermissionName();
+            final boolean makerCheckerEnabledForTask = configurationService.isMakerCheckerEnabledForTask(taskPermission);
+            final boolean hasBasePermission = !currentUser.hasNotPermissionForAnyOf(taskPermission);
+            final boolean hasCheckerPermission = currentUser.isCheckerSuperUser()
+                    || currentUser.hasSpecificPermissionTo(taskPermission + "_CHECKER");
+
+            if (makerCheckerEnabledForTask && !hasBasePermission && hasCheckerPermission) {
+                // Checker-only user with no base permission: refuse initiation with a clear message
+                // instead of falling through to the generic "not authorized" response below.
+                throw new MakerCheckerCheckerOnlyInitiationException(taskPermission);
+            }
+
+            currentUser.validateHasPermissionTo(taskPermission);
+
+            if (makerCheckerEnabledForTask && !hasCheckerPermission && wrapper.getEntityId() != null) {
+                final List<CommandSource> pendingCommands = this.commandSourceRepository
+                        .findByActionNameAndEntityNameAndResourceIdAndStatus(wrapper.getActionName(), wrapper.getEntityName(),
+                                wrapper.getEntityId(), CommandProcessingResultType.AWAITING_APPROVAL.getValue());
+                if (!pendingCommands.isEmpty()) {
+                    throw new MakerCheckerDuplicatePendingSubmissionException(wrapper.getActionName(), wrapper.getEntityName());
+                }
+            }
         }
         validateIsUpdateAllowed();
 

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/exceptionmapper/MakerCheckerCheckerOnlyInitiationExceptionMapper.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/exceptionmapper/MakerCheckerCheckerOnlyInitiationExceptionMapper.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.core.exceptionmapper;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.commands.exception.MakerCheckerCheckerOnlyInitiationException;
+import org.apache.fineract.infrastructure.core.data.ApiGlobalErrorResponse;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+/**
+ * An {@link ExceptionMapper} to map {@link MakerCheckerCheckerOnlyInitiationException} thrown by platform into a HTTP
+ * API friendly format.
+ */
+@Provider
+@Component
+@Scope("singleton")
+@Slf4j
+public class MakerCheckerCheckerOnlyInitiationExceptionMapper
+        implements FineractExceptionMapper, ExceptionMapper<MakerCheckerCheckerOnlyInitiationException> {
+
+    @Override
+    public Response toResponse(final MakerCheckerCheckerOnlyInitiationException exception) {
+        log.warn("Checker-only user attempted to initiate an action: {}", exception.getDefaultUserMessage());
+        final ApiGlobalErrorResponse errorResponse = ApiGlobalErrorResponse.domainRuleViolation(exception.getGlobalisationMessageCode(),
+                exception.getDefaultUserMessage(), exception.getDefaultUserMessageArgs());
+        return Response.status(Response.Status.FORBIDDEN).entity(errorResponse).type(MediaType.APPLICATION_JSON).build();
+    }
+
+    @Override
+    public int errorCode() {
+        return 4030;
+    }
+}

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/exceptionmapper/MakerCheckerDuplicatePendingSubmissionExceptionMapper.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/exceptionmapper/MakerCheckerDuplicatePendingSubmissionExceptionMapper.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.core.exceptionmapper;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.commands.exception.MakerCheckerDuplicatePendingSubmissionException;
+import org.apache.fineract.infrastructure.core.data.ApiGlobalErrorResponse;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+/**
+ * An {@link ExceptionMapper} to map {@link MakerCheckerDuplicatePendingSubmissionException} thrown by platform into a
+ * HTTP API friendly format.
+ */
+@Provider
+@Component
+@Scope("singleton")
+@Slf4j
+public class MakerCheckerDuplicatePendingSubmissionExceptionMapper
+        implements FineractExceptionMapper, ExceptionMapper<MakerCheckerDuplicatePendingSubmissionException> {
+
+    @Override
+    public Response toResponse(final MakerCheckerDuplicatePendingSubmissionException exception) {
+        log.warn("Duplicate maker-checker pending submission rejected: {}", exception.getDefaultUserMessage());
+        final ApiGlobalErrorResponse errorResponse = ApiGlobalErrorResponse.domainRuleViolation(exception.getGlobalisationMessageCode(),
+                exception.getDefaultUserMessage(), exception.getDefaultUserMessageArgs());
+        return Response.status(Response.Status.CONFLICT).entity(errorResponse).type(MediaType.APPLICATION_JSON).build();
+    }
+
+    @Override
+    public int errorCode() {
+        return 4029;
+    }
+}

--- a/fineract-core/src/test/java/org/apache/fineract/commands/service/PortfolioCommandSourceWritePlatformServiceImplTest.java
+++ b/fineract-core/src/test/java/org/apache/fineract/commands/service/PortfolioCommandSourceWritePlatformServiceImplTest.java
@@ -1,0 +1,164 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.commands.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.gson.JsonElement;
+import java.util.Collections;
+import java.util.List;
+import org.apache.fineract.commands.domain.CommandProcessingResultType;
+import org.apache.fineract.commands.domain.CommandSource;
+import org.apache.fineract.commands.domain.CommandSourceRepository;
+import org.apache.fineract.commands.domain.CommandWrapper;
+import org.apache.fineract.commands.exception.MakerCheckerCheckerOnlyInitiationException;
+import org.apache.fineract.commands.exception.MakerCheckerDuplicatePendingSubmissionException;
+import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.apache.fineract.infrastructure.jobs.service.SchedulerJobRunnerReadService;
+import org.apache.fineract.infrastructure.security.exception.NoAuthorizationException;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.apache.fineract.useradministration.domain.AppUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class PortfolioCommandSourceWritePlatformServiceImplTest {
+
+    @Mock
+    private PlatformSecurityContext context;
+    @Mock
+    private CommandSourceRepository commandSourceRepository;
+    @Mock
+    private FromJsonHelper fromApiJsonHelper;
+    @Mock
+    private CommandProcessingService processAndLogCommandService;
+    @Mock
+    private SchedulerJobRunnerReadService schedulerJobRunnerReadService;
+    @Mock
+    private ConfigurationDomainService configurationService;
+    @Mock
+    private AppUser currentUser;
+
+    private PortfolioCommandSourceWritePlatformServiceImpl underTest;
+
+    @BeforeEach
+    public void setUp() {
+        underTest = new PortfolioCommandSourceWritePlatformServiceImpl(context, commandSourceRepository, fromApiJsonHelper,
+                processAndLogCommandService, schedulerJobRunnerReadService, configurationService, Collections.emptyList());
+
+        this.wrapper = CommandWrapper.wrap("DISBURSE", "LOAN", 1L, null);
+        when(context.authenticatedUser(any(CommandWrapper.class))).thenReturn(currentUser);
+        when(currentUser.getId()).thenReturn(100L);
+    }
+
+    private CommandWrapper wrapper;
+
+    private void stubSuccessfulExecution() {
+        when(fromApiJsonHelper.parse(any())).thenReturn(mock(JsonElement.class));
+        when(processAndLogCommandService.executeCommand(any(), any(), anyBoolean())).thenReturn(CommandProcessingResult.empty());
+    }
+
+    @Test
+    public void makerOnlyUserWithNoPendingSubmissionIsAllowedToSubmit() {
+        when(configurationService.isMakerCheckerEnabledForTask("DISBURSE_LOAN")).thenReturn(true);
+        when(currentUser.hasNotPermissionForAnyOf("DISBURSE_LOAN")).thenReturn(false);
+        when(currentUser.isCheckerSuperUser()).thenReturn(false);
+        when(currentUser.hasSpecificPermissionTo("DISBURSE_LOAN_CHECKER")).thenReturn(false);
+        when(commandSourceRepository.findByActionNameAndEntityNameAndResourceIdAndStatus("DISBURSE", "LOAN", 1L,
+                CommandProcessingResultType.AWAITING_APPROVAL.getValue())).thenReturn(Collections.emptyList());
+        stubSuccessfulExecution();
+
+        underTest.logCommandSource(wrapper);
+
+        verify(processAndLogCommandService).executeCommand(any(), any(), eq(false));
+    }
+
+    @Test
+    public void makerOnlyUserWithExistingPendingSubmissionIsBlocked() {
+        when(configurationService.isMakerCheckerEnabledForTask("DISBURSE_LOAN")).thenReturn(true);
+        when(currentUser.hasNotPermissionForAnyOf("DISBURSE_LOAN")).thenReturn(false);
+        when(currentUser.isCheckerSuperUser()).thenReturn(false);
+        when(currentUser.hasSpecificPermissionTo("DISBURSE_LOAN_CHECKER")).thenReturn(false);
+        when(commandSourceRepository.findByActionNameAndEntityNameAndResourceIdAndStatus("DISBURSE", "LOAN", 1L,
+                CommandProcessingResultType.AWAITING_APPROVAL.getValue())).thenReturn(List.of(mock(CommandSource.class)));
+
+        assertThrows(MakerCheckerDuplicatePendingSubmissionException.class, () -> underTest.logCommandSource(wrapper));
+    }
+
+    @Test
+    public void checkerOnlyUserCannotInitiateAndGetsAClearRefusalMessage() {
+        when(configurationService.isMakerCheckerEnabledForTask("DISBURSE_LOAN")).thenReturn(true);
+        when(currentUser.hasNotPermissionForAnyOf("DISBURSE_LOAN")).thenReturn(true);
+        when(currentUser.isCheckerSuperUser()).thenReturn(false);
+        when(currentUser.hasSpecificPermissionTo("DISBURSE_LOAN_CHECKER")).thenReturn(true);
+
+        assertThrows(MakerCheckerCheckerOnlyInitiationException.class, () -> underTest.logCommandSource(wrapper));
+    }
+
+    @Test
+    public void userWithBothBaseAndCheckerPermissionSkipsTheDuplicateCheck() {
+        when(configurationService.isMakerCheckerEnabledForTask("DISBURSE_LOAN")).thenReturn(true);
+        when(currentUser.hasNotPermissionForAnyOf("DISBURSE_LOAN")).thenReturn(false);
+        when(currentUser.isCheckerSuperUser()).thenReturn(false);
+        when(currentUser.hasSpecificPermissionTo("DISBURSE_LOAN_CHECKER")).thenReturn(true);
+        stubSuccessfulExecution();
+
+        underTest.logCommandSource(wrapper);
+
+        verify(commandSourceRepository, never()).findByActionNameAndEntityNameAndResourceIdAndStatus(any(), any(), any(), any());
+        verify(processAndLogCommandService).executeCommand(any(), any(), eq(false));
+    }
+
+    @Test
+    public void nonMakerCheckerTaskIsUnaffectedByTheNewChecks() {
+        when(configurationService.isMakerCheckerEnabledForTask("DISBURSE_LOAN")).thenReturn(false);
+        when(currentUser.hasNotPermissionForAnyOf("DISBURSE_LOAN")).thenReturn(false);
+        stubSuccessfulExecution();
+
+        underTest.logCommandSource(wrapper);
+
+        verify(commandSourceRepository, never()).findByActionNameAndEntityNameAndResourceIdAndStatus(any(), any(), any(), any());
+        verify(processAndLogCommandService).executeCommand(any(), any(), eq(false));
+    }
+
+    @Test
+    public void userWithNeitherPermissionGetsTheGenericAuthorizationFailure() {
+        when(configurationService.isMakerCheckerEnabledForTask("DISBURSE_LOAN")).thenReturn(true);
+        when(currentUser.hasNotPermissionForAnyOf("DISBURSE_LOAN")).thenReturn(true);
+        when(currentUser.isCheckerSuperUser()).thenReturn(false);
+        when(currentUser.hasSpecificPermissionTo("DISBURSE_LOAN_CHECKER")).thenReturn(false);
+        doThrow(new NoAuthorizationException("User has no authority to: DISBURSE_LOAN")).when(currentUser)
+                .validateHasPermissionTo("DISBURSE_LOAN");
+
+        assertThrows(NoAuthorizationException.class, () -> underTest.logCommandSource(wrapper));
+    }
+}


### PR DESCRIPTION
  Today, maker-checker enabled actions have two rough edges:                                                                                       
                                                                                                                                                   
  1. A maker can resubmit the same action on the same resource any number of times while an earlier submission is still AWAITING_APPROVAL, silently
  creating multiple redundant pending entries for the same underlying change.                                                                      
  2. A user who only holds the checker permission for a task (e.g. DISBURSE_LOAN_CHECKER, but not DISBURSE_LOAN) and who tries to submit that      
  action directly currently falls through to the generic NoAuthorizationException ("User has no authority to: ...") — which reads like a           
  permissions-configuration bug rather than telling the user they should be approving a pending entry instead of initiating one.                   
                                                                                                                                                   
  This PR adds two targeted, backwards-compatible checks in PortfolioCommandSourceWritePlatformServiceImpl#logCommandSource, only for tasks that   
  have maker-checker enabled:                                                                                                                      
                                                                                                                                                   
  - Duplicate pending submission: if the current user has the base permission (a "maker") but not the task's _CHECKER permission, and a command    
  already exists with status AWAITING_APPROVAL for the same action name, entity name and resource id, the new submission is rejected with a new    
  MakerCheckerDuplicatePendingSubmissionException (HTTP 409) instead of being queued as another pending entry.                                     
  - Checker-only initiation: if the current user lacks the base permission but holds the task's _CHECKER permission (or is a CHECKER_SUPER_USER),  
  the request is rejected with a new MakerCheckerCheckerOnlyInitiationException (HTTP 403) telling them to use the approval flow instead.
  Users who hold both the base and _CHECKER permission for a task, and any non maker-checker-enabled action, are unaffected. This PR intentionally 
  does not change approveEntry or introduce any new self-approval semantics — it only tightens the initiation path.  
  PR:(https://issues.apache.org/jira/browse/FINERACT-2753)