### PR TITLE
FINERACT-2754: Drop orphaned request_audit_table left behind by self-service removal

### DIFF
--- a/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
@@ -265,4 +265,5 @@
     <include file="parts/0243_add_client_lifecycle_event_configuration.xml" relativeToChangelogFile="true" />
     <include file="parts/0244_add_payment_detail_to_account_transfer_transaction.xml" relativeToChangelogFile="true" />
     <include file="parts/0245_standardize_email_address_column_length.xml" relativeToChangelogFile="true" />
+    <include file="parts/0246_drop_request_audit_table.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0246_drop_request_audit_table.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0246_drop_request_audit_table.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <!-- FINERACT-2754: Drop orphaned request_audit_table left behind by FINERACT-2480 self-service removal.
+         This table backed the SelfServiceRegistration entity (@Table(name = "request_audit_table")),
+         deleted in PR #5498. It was missed by the 0219 cleanup changeset because its table name
+         did not match the "self"/"pocket" naming pattern used to find related tables. -->
+    <changeSet author="fineract" id="1">
+        <dropTable tableName="request_audit_table"/>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
JIRA
https://issues.apache.org/jira/browse/FINERACT-2754

Problem
When I removed the self-service feature in FINERACT-2480 (PR #5498), the accompanying changeset 0219_remove_self_service_feature.xml dropped five self-service related tables:

m_selfservice_user_client_mapping
m_selfservice_beneficiaries_tpt
m_pocket_accounts_mapping
m_pocket
client_device_registration

I missed request_audit_table in that cleanup. It backed the SelfServiceRegistration entity, but was mapped with @Table(name = "request_audit_table") instead of a name following the self/pocket convention used elsewhere, so it didn't show up when I was going through the codebase looking for self-service tables to drop.

I came across it again while working on PR #6234 (FINERACT-2741, email column length standardization), where @adamsaghy flagged that request_audit_table had no backing entity or code reference. That's what prompted this follow-up.

Fix
Added a new Liquibase changeset (0246_drop_request_audit_table.xml, registered in changelog-tenant.xml) that drops request_audit_table with cascadeConstraints, following the same pattern as 0219.

No changes required. SelfServiceRegistration.java, the only class that ever referenced this table, was already deleted in FINERACT-2480.

Verification
grep -rn "request_audit_table" across the full repo (excluding build/bin) returns only its own createTable, index, and foreign key definitions in 0001_initial_schema.xml.
grep -rn "RequestAudit" across the full repo returns no results.
git log --all -S"request_audit_table" confirms the table was created in afdc665b52 ("self service registration"), carried through the Flyway-to-Liquibase migration in 45bed0a05a, and never touched again until now.