### PR TITLE
FINERACT-2751: Implement interoperation transfer query

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/interoperation/api/InteropApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/interoperation/api/InteropApiResource.java
@@ -20,6 +20,7 @@ package org.apache.fineract.interoperation.api;
 
 import static org.apache.fineract.interoperation.util.InteropUtil.ENTITY_NAME_QUOTE;
 import static org.apache.fineract.interoperation.util.InteropUtil.ENTITY_NAME_REQUEST;
+import static org.apache.fineract.interoperation.util.InteropUtil.ENTITY_NAME_TRANSFER;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -312,9 +313,10 @@ public class InteropApiResource {
     @Path("transactions/{transactionCode}/transfers/{transferCode}")
     @Operation(summary = "Query Interoperation Transfer", description = "")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = InteropTransferResponseData.class)))
+    @ApiResponse(responseCode = "404", description = "Transfer not found")
     public String getTransfer(@PathParam("transactionCode") @Parameter(description = "transactionCode") String transactionCode,
             @PathParam("transferCode") @Parameter(description = "transferCode") String transferCode, @Context UriInfo uriInfo) {
-        context.authenticatedUser().validateHasReadPermission(ENTITY_NAME_QUOTE);
+        context.authenticatedUser().validateHasReadPermission(ENTITY_NAME_TRANSFER);
 
         InteropTransferResponseData result = interopService.getTransfer(transactionCode, transferCode);
         ApiRequestJsonSerializationSettings settings = this.apiRequestParameterHelper.process(uriInfo.getQueryParameters());

--- a/fineract-provider/src/main/java/org/apache/fineract/interoperation/domain/InteropTransferRepository.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/interoperation/domain/InteropTransferRepository.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.interoperation.domain;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface InteropTransferRepository extends JpaRepository<InteropTransfer, Long> {
+
+    Optional<InteropTransfer> findByTransactionCodeAndTransferCode(String transactionCode, String transferCode);
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/interoperation/exception/InteropTransferNotFoundException.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/interoperation/exception/InteropTransferNotFoundException.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.interoperation.exception;
+
+import org.apache.fineract.infrastructure.core.exception.AbstractPlatformResourceNotFoundException;
+
+public class InteropTransferNotFoundException extends AbstractPlatformResourceNotFoundException {
+
+    public InteropTransferNotFoundException(String transactionCode, String transferCode) {
+        super("error.msg.interop.transfer.not.found",
+                "No transfer found with transactionCode " + transactionCode + " and transferCode " + transferCode);
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/interoperation/service/InteropServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/interoperation/service/InteropServiceImpl.java
@@ -75,12 +75,15 @@ import org.apache.fineract.interoperation.domain.InteropActionState;
 import org.apache.fineract.interoperation.domain.InteropIdentifier;
 import org.apache.fineract.interoperation.domain.InteropIdentifierRepository;
 import org.apache.fineract.interoperation.domain.InteropIdentifierType;
+import org.apache.fineract.interoperation.domain.InteropTransfer;
+import org.apache.fineract.interoperation.domain.InteropTransferRepository;
 import org.apache.fineract.interoperation.exception.InteropAccountNotFoundException;
 import org.apache.fineract.interoperation.exception.InteropAccountTransactionNotAllowedException;
 import org.apache.fineract.interoperation.exception.InteropKycDataNotFoundException;
 import org.apache.fineract.interoperation.exception.InteropTransferAlreadyCommittedException;
 import org.apache.fineract.interoperation.exception.InteropTransferAlreadyOnHoldException;
 import org.apache.fineract.interoperation.exception.InteropTransferMissingException;
+import org.apache.fineract.interoperation.exception.InteropTransferNotFoundException;
 import org.apache.fineract.interoperation.serialization.InteropDataValidator;
 import org.apache.fineract.organisation.monetary.domain.ApplicationCurrency;
 import org.apache.fineract.organisation.monetary.domain.ApplicationCurrencyRepository;
@@ -129,6 +132,7 @@ public class InteropServiceImpl implements InteropService {
     private final NoteRepository noteRepository;
     private final PaymentTypeRepository paymentTypeRepository;
     private final InteropIdentifierRepository identifierRepository;
+    private final InteropTransferRepository transferRepository;
     private final LoanRepositoryWrapper loanRepositoryWrapper;
 
     private final SavingsHelper savingsHelper;
@@ -363,8 +367,12 @@ public class InteropServiceImpl implements InteropService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public InteropTransferResponseData getTransfer(@NonNull String transactionCode, @NonNull String transferCode) {
-        return null;
+        InteropTransfer transfer = transferRepository.findByTransactionCodeAndTransferCode(transactionCode, transferCode)
+                .orElseThrow(() -> new InteropTransferNotFoundException(transactionCode, transferCode));
+        return InteropTransferResponseData.build(transfer.getTransactionCode(), transfer.getState(), null, transfer.getTransferCode(),
+                transfer.getCompletedTimestamp());
     }
 
     @Override
@@ -406,8 +414,11 @@ public class InteropServiceImpl implements InteropService {
             savingsAccountRepository.save(savingsAccount);
         }
 
-        return InteropTransferResponseData.build(command.commandId(), request.getTransactionCode(), InteropActionState.ACCEPTED,
-                request.getExpiration(), request.getExtensionList(), transferCode, DateUtils.getLocalDateTimeOfTenant());
+        LocalDateTime completedTimestamp = DateUtils.getLocalDateTimeOfTenant();
+        InteropTransferResponseData response = InteropTransferResponseData.build(command.commandId(), request.getTransactionCode(),
+                InteropActionState.ACCEPTED, request.getExpiration(), request.getExtensionList(), transferCode, completedTimestamp);
+        recordTransfer(request.getTransactionCode(), transferCode, completedTimestamp);
+        return response;
     }
 
     @Override
@@ -470,8 +481,11 @@ public class InteropServiceImpl implements InteropService {
             noteRepository.save(Note.savingsTransactionNote(savingsAccount, transaction, note));
         }
 
-        return InteropTransferResponseData.build(command.commandId(), request.getTransactionCode(), InteropActionState.ACCEPTED,
-                request.getExpiration(), request.getExtensionList(), request.getTransferCode(), transactionDateTime);
+        InteropTransferResponseData response = InteropTransferResponseData.build(command.commandId(), request.getTransactionCode(),
+                InteropActionState.ACCEPTED, request.getExpiration(), request.getExtensionList(), request.getTransferCode(),
+                transactionDateTime);
+        recordTransfer(request.getTransactionCode(), request.getTransferCode(), transactionDateTime);
+        return response;
     }
 
     @Override
@@ -501,8 +515,18 @@ public class InteropServiceImpl implements InteropService {
             throw new InteropTransferMissingException(savingsAccount.getExternalId().getValue(), request.getTransferCode());
         }
 
-        return InteropTransferResponseData.build(command.commandId(), request.getTransactionCode(), InteropActionState.ACCEPTED,
-                request.getExpiration(), request.getExtensionList(), request.getTransferCode(), transactionDateTime);
+        InteropTransferResponseData response = InteropTransferResponseData.build(command.commandId(), request.getTransactionCode(),
+                InteropActionState.ACCEPTED, request.getExpiration(), request.getExtensionList(), request.getTransferCode(),
+                transactionDateTime);
+        recordTransfer(request.getTransactionCode(), request.getTransferCode(), transactionDateTime);
+        return response;
+    }
+
+    private void recordTransfer(String transactionCode, String transferCode, LocalDateTime completedTimestamp) {
+        InteropTransfer transfer = transferRepository.findByTransactionCodeAndTransferCode(transactionCode, transferCode)
+                .orElseGet(() -> new InteropTransfer(transactionCode, transferCode, InteropActionState.ACCEPTED, completedTimestamp));
+        transfer.update(InteropActionState.ACCEPTED, completedTimestamp);
+        transferRepository.save(transfer);
     }
 
     @Override

--- a/fineract-provider/src/main/java/org/apache/fineract/interoperation/starter/InteroperationConfiguration.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/interoperation/starter/InteroperationConfiguration.java
@@ -24,6 +24,7 @@ import org.apache.fineract.infrastructure.core.serialization.DefaultToApiJsonSer
 import org.apache.fineract.infrastructure.core.service.database.DatabaseSpecificSQLGenerator;
 import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
 import org.apache.fineract.interoperation.domain.InteropIdentifierRepository;
+import org.apache.fineract.interoperation.domain.InteropTransferRepository;
 import org.apache.fineract.interoperation.serialization.InteropDataValidator;
 import org.apache.fineract.interoperation.service.InteropService;
 import org.apache.fineract.interoperation.service.InteropServiceImpl;
@@ -51,14 +52,14 @@ public class InteroperationConfiguration {
             SavingsAccountRepository savingsAccountRepository, SavingsAccountTransactionRepository savingsAccountTransactionRepository,
             ApplicationCurrencyRepository applicationCurrencyRepository, NoteRepository noteRepository,
             PaymentTypeRepository paymentTypeRepository, InteropIdentifierRepository identifierRepository,
-            LoanRepositoryWrapper loanRepositoryWrapper, SavingsHelper savingsHelper,
+            InteropTransferRepository transferRepository, LoanRepositoryWrapper loanRepositoryWrapper, SavingsHelper savingsHelper,
             SavingsAccountTransactionSummaryWrapper savingsAccountTransactionSummaryWrapper,
             SavingsAccountDomainService savingsAccountService, ConfigurationDomainService configurationDomainService,
             JdbcTemplate jdbcTemplate, PortfolioCommandSourceWritePlatformService commandsSourceWritePlatformService,
             DefaultToApiJsonSerializer<LoanAccountData> toApiJsonSerializer, DatabaseSpecificSQLGenerator sqlGenerator) {
         return new InteropServiceImpl(securityContext, interopDataValidator, savingsAccountRepository, savingsAccountTransactionRepository,
-                applicationCurrencyRepository, noteRepository, paymentTypeRepository, identifierRepository, loanRepositoryWrapper,
-                savingsHelper, savingsAccountTransactionSummaryWrapper, savingsAccountService, configurationDomainService, jdbcTemplate,
-                commandsSourceWritePlatformService, toApiJsonSerializer, sqlGenerator);
+                applicationCurrencyRepository, noteRepository, paymentTypeRepository, identifierRepository, transferRepository,
+                loanRepositoryWrapper, savingsHelper, savingsAccountTransactionSummaryWrapper, savingsAccountService,
+                configurationDomainService, jdbcTemplate, commandsSourceWritePlatformService, toApiJsonSerializer, sqlGenerator);
     }
 }

--- a/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
@@ -267,4 +267,5 @@
     <include file="parts/0245_standardize_email_address_column_length.xml" relativeToChangelogFile="true" />
     <include file="parts/0246_drop_request_audit_table.xml" relativeToChangelogFile="true" />
     <include file="parts/0247_add_payment_detail_search_indexes.xml" relativeToChangelogFile="true" />
+    <include file="parts/0248_create_interop_transfer.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0248_create_interop_transfer.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0248_create_interop_transfer.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet author="fineract" id="1">
+        <createTable tableName="interop_transfer">
+            <column autoIncrement="true" name="id" type="BIGINT">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="transaction_code" type="VARCHAR(128)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="transfer_code" type="VARCHAR(128)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="state" type="VARCHAR(16)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="completed_timestamp" type="timestamp(6)"/>
+        </createTable>
+        <addUniqueConstraint columnNames="transaction_code, transfer_code" constraintName="uk_interop_transfer_codes"
+                             tableName="interop_transfer"/>
+    </changeSet>
+</databaseChangeLog>

--- a/fineract-savings/src/main/java/org/apache/fineract/interoperation/domain/InteropTransfer.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/interoperation/domain/InteropTransfer.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.interoperation.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.apache.fineract.infrastructure.core.domain.AbstractPersistableCustom;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "interop_transfer", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_interop_transfer_codes", columnNames = { "transaction_code", "transfer_code" }) })
+public class InteropTransfer extends AbstractPersistableCustom<Long> {
+
+    @Column(name = "transaction_code", nullable = false, length = 128)
+    private String transactionCode;
+
+    @Column(name = "transfer_code", nullable = false, length = 128)
+    private String transferCode;
+
+    @Column(name = "state", nullable = false, length = 16)
+    @Enumerated(EnumType.STRING)
+    private InteropActionState state;
+
+    @Column(name = "completed_timestamp")
+    private LocalDateTime completedTimestamp;
+
+    public InteropTransfer(@NotNull String transactionCode, @NotNull String transferCode, @NotNull InteropActionState state,
+            LocalDateTime completedTimestamp) {
+        this.transactionCode = transactionCode;
+        this.transferCode = transferCode;
+        update(state, completedTimestamp);
+    }
+
+    public void update(@NotNull InteropActionState state, LocalDateTime completedTimestamp) {
+        this.state = state;
+        this.completedTimestamp = completedTimestamp;
+    }
+}

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/interoperation/InteropHelper.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/interoperation/InteropHelper.java
@@ -360,12 +360,23 @@ public class InteropHelper {
     // org.apache.fineract.client.models.PostLoansLoanIdRequest)
     @Deprecated(forRemoval = true)
     public String getTransfer(String transferCode) {
+        return getJsonAttribute(getTransfer(transactionCode, transferCode), InteropUtil.PARAM_TRANSFER_CODE);
+    }
+
+    /**
+     * @return response json
+     */
+    // TODO: Rewrite to use fineract-client instead!
+    // Example: org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper.disburseLoan(java.lang.Long,
+    // org.apache.fineract.client.models.PostLoansLoanIdRequest)
+    @Deprecated(forRemoval = true)
+    public String getTransfer(String transactionCode, String transferCode) {
         String url = buildUrl(TRANSACTIONS_URL + '/' + transactionCode + '/' + TRANSFERS_URL_PARAM + '/' + transferCode);
         LOG.debug("Calling Interoperable GET Transfer: {}", url);
 
         String response = Utils.performServerGet(requestSpec, responseSpec, url, null);
         LOG.debug("Response Interoperable GET Transfer: {}", response);
-        return getJsonAttribute(response, InteropUtil.PARAM_TRANSFER_CODE);
+        return response;
     }
 
     /**
@@ -388,6 +399,17 @@ public class InteropHelper {
     @Deprecated(forRemoval = true)
     public String createTransfer(String transferCode, InteropTransactionRole role) {
         return postTransfer(transferCode, InteropTransferActionType.CREATE, role);
+    }
+
+    /**
+     * @return response json
+     */
+    // TODO: Rewrite to use fineract-client instead!
+    // Example: org.apache.fineract.integrationtests.common.loans.LoanTransactionHelper.disburseLoan(java.lang.Long,
+    // org.apache.fineract.client.models.PostLoansLoanIdRequest)
+    @Deprecated(forRemoval = true)
+    public String releaseTransfer(String transferCode) {
+        return postTransfer(transferCode, InteropTransferActionType.RELEASE, InteropTransactionRole.PAYER);
     }
 
     /**

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/interoperation/InteropTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/interoperation/InteropTest.java
@@ -20,6 +20,7 @@ package org.apache.fineract.integrationtests.interoperation;
 
 import static org.apache.fineract.integrationtests.common.savings.SavingsAccountHelper.ACCOUNT_TYPE_INDIVIDUAL;
 import static org.apache.fineract.integrationtests.interoperation.InteropHelper.PARAM_ACCOUNT_BALANCE;
+import static org.apache.fineract.interoperation.data.InteropResponseData.ISO_DATE_TIME_FORMATTER;
 
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.builder.ResponseSpecBuilder;
@@ -31,6 +32,7 @@ import io.restassured.specification.ResponseSpecification;
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -121,6 +123,30 @@ public class InteropTest {
         testRequests();
         testQuotes();
         testTransfers();
+    }
+
+    @Test
+    public void testReleaseTransferQuery() {
+        createClient();
+        createSavingsProduct();
+        createCharge();
+        openSavingsAccount();
+
+        String releaseTransferCode = UUID.randomUUID().toString();
+        interopHelper.prepareTransfer(releaseTransferCode);
+
+        String response = interopHelper.releaseTransfer(releaseTransferCode);
+        JsonPath json = JsonPath.from(response);
+        Assertions.assertEquals(releaseTransferCode, json.getString(InteropUtil.PARAM_TRANSFER_CODE));
+        Assertions.assertEquals(InteropActionState.ACCEPTED.toString(), json.getString(InteropHelper.PARAM_ACTION_STATE));
+        LocalDateTime completedTimestamp = completedTimestamp(json);
+
+        String transfer = interopHelper.getTransfer(interopHelper.getTransactionCode(), releaseTransferCode);
+        json = JsonPath.from(transfer);
+        Assertions.assertEquals(interopHelper.getTransactionCode(), json.getString(InteropUtil.PARAM_TRANSACTION_CODE));
+        Assertions.assertEquals(releaseTransferCode, json.getString(InteropUtil.PARAM_TRANSFER_CODE));
+        Assertions.assertEquals(InteropActionState.ACCEPTED.toString(), json.getString(InteropHelper.PARAM_ACTION_STATE));
+        Assertions.assertEquals(completedTimestamp, completedTimestamp(json));
     }
 
     private void createClient() {
@@ -248,6 +274,20 @@ public class InteropTest {
         JsonPath json = JsonPath.from(response);
         Assertions.assertEquals(transferCode, json.getString(InteropUtil.PARAM_TRANSFER_CODE));
         Assertions.assertEquals(InteropActionState.ACCEPTED.toString(), json.getString(InteropHelper.PARAM_ACTION_STATE));
+        LocalDateTime prepareCompletedTimestamp = completedTimestamp(json);
+
+        String transfer = interopHelper.getTransfer(interopHelper.getTransactionCode(), transferCode);
+        json = JsonPath.from(transfer);
+        Assertions.assertEquals(interopHelper.getTransactionCode(), json.getString(InteropUtil.PARAM_TRANSACTION_CODE));
+        Assertions.assertEquals(transferCode, json.getString(InteropUtil.PARAM_TRANSFER_CODE));
+        Assertions.assertEquals(InteropActionState.ACCEPTED.toString(), json.getString(InteropHelper.PARAM_ACTION_STATE));
+        Assertions.assertEquals(prepareCompletedTimestamp, completedTimestamp(json));
+
+        interopHelper.setResponseSpec(responseNotFoundErrorSpec);
+        interopHelper.getTransfer(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        interopHelper.getTransfer(UUID.randomUUID().toString(), transferCode);
+        interopHelper.getTransfer(interopHelper.getTransactionCode(), UUID.randomUUID().toString());
+        interopHelper.setResponseSpec(responseSpec);
 
         // prepare
         savings = (String) savingsAccountHelper.getSavingsAccountDetail(savingsId, null);
@@ -269,6 +309,14 @@ public class InteropTest {
         json = JsonPath.from(response);
         Assertions.assertEquals(transferCode, json.getString(InteropUtil.PARAM_TRANSFER_CODE));
         Assertions.assertEquals(InteropActionState.ACCEPTED.toString(), json.getString(InteropHelper.PARAM_ACTION_STATE));
+        LocalDateTime completedTimestamp = completedTimestamp(json);
+
+        transfer = interopHelper.getTransfer(interopHelper.getTransactionCode(), transferCode);
+        json = JsonPath.from(transfer);
+        Assertions.assertEquals(interopHelper.getTransactionCode(), json.getString(InteropUtil.PARAM_TRANSACTION_CODE));
+        Assertions.assertEquals(transferCode, json.getString(InteropUtil.PARAM_TRANSFER_CODE));
+        Assertions.assertEquals(InteropActionState.ACCEPTED.toString(), json.getString(InteropHelper.PARAM_ACTION_STATE));
+        Assertions.assertEquals(completedTimestamp, completedTimestamp(json));
 
         savings = (String) savingsAccountHelper.getSavingsAccountDetail(savingsId, null);
         LOG.debug("Response Interoperable GET Saving: {}", savings);
@@ -294,5 +342,9 @@ public class InteropTest {
         Assertions.assertTrue(MathUtil.isEqualTo(onHold, onHold4), "On hold amount expected: " + onHold + ", actual: " + onHold4);
         Assertions.assertTrue(MathUtil.isEqualTo(balance, balance4),
                 "Balance amount expected: " + expectedBalance + ", actual: " + balance4);
+    }
+
+    private LocalDateTime completedTimestamp(JsonPath json) {
+        return LocalDateTime.parse(json.getString("completedTimestamp"), ISO_DATE_TIME_FORMATTER);
     }
 }


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/FINERACT-2751

## Problem

`GET /interoperation/transactions/{transactionCode}/transfers/{transferCode}` previously returned no result because an Interoperation transfer did not retain a durable association to its transaction code.

## Change

Adds a small tenant-scoped `interop_transfer` lookup record containing only the transaction code, transfer code, action state, and latest completion timestamp. Successful PREPARE, CREATE/COMMIT, and RELEASE actions create or update that exact pair in their existing transaction. The GET endpoint performs an exact-pair lookup and returns 404 for an unknown or mismatched pair.

The endpoint permission is corrected from `READ_INTERQUOTE` to `READ_INTERTRANSFER`.

## Migration and compatibility

The additive Liquibase migration creates a composite unique constraint on `(transaction_code, transfer_code)`. Existing transfer behavior and the response route/schema are preserved. Legacy transfers cannot be backfilled reliably because their transaction-code association was never durably stored; therefore, they return 404.

## Tests and checks

- Added Interoperation integration coverage for prepared and committed transfer lookup, response fields/completed timestamp, unknown pairs, and both mismatch directions.
- `:fineract-provider:compileJava` completed during focused compilation.
- `git diff --check` passed.

The full Interoperation integration test and complete quality matrix have not completed locally in this environment; GitHub CI will be monitored and any branch-caused failure will be fixed.

## Scope exclusions

No `PaymentDetail` or `m_payment_detail` changes, quote/transaction-request persistence, audit-command queries, broad refactoring, dependencies, CI workflow changes, or historical backfill are included.