### PR TITLE
FINERACT-2759: Add issuance and expiry dates to client identifiers

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/client/domain/ClientIdentifier.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/client/domain/ClientIdentifier.java
@@ -24,6 +24,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDate;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -55,6 +56,12 @@ public class ClientIdentifier extends AbstractAuditableWithUTCDateTimeCustom<Lon
     @Column(name = "description", length = 1000)
     private String description;
 
+    @Column(name = "issuance_date")
+    private LocalDate issuanceDate;
+
+    @Column(name = "expiry_date")
+    private LocalDate expiryDate;
+
     @Column(name = "active")
     private Integer active;
 
@@ -62,7 +69,9 @@ public class ClientIdentifier extends AbstractAuditableWithUTCDateTimeCustom<Lon
         final String documentKey = command.stringValueOfParameterNamed("documentKey");
         final String description = command.stringValueOfParameterNamed("description");
         final String status = command.stringValueOfParameterNamed("status");
-        return new ClientIdentifier(client, documentType, documentKey, status, description);
+        final LocalDate issuanceDate = command.localDateValueOfParameterNamed("issuanceDate");
+        final LocalDate expiryDate = command.localDateValueOfParameterNamed("expiryDate");
+        return new ClientIdentifier(client, documentType, documentKey, status, description, issuanceDate, expiryDate);
     }
 
     protected ClientIdentifier() {
@@ -70,11 +79,13 @@ public class ClientIdentifier extends AbstractAuditableWithUTCDateTimeCustom<Lon
     }
 
     private ClientIdentifier(final Client client, final CodeValue documentType, final String documentKey, final String statusName,
-            String description) {
+            final String description, final LocalDate issuanceDate, final LocalDate expiryDate) {
         this.client = client;
         this.documentType = documentType;
         this.documentKey = StringUtils.defaultIfEmpty(documentKey, null);
         this.description = StringUtils.defaultIfEmpty(description, null);
+        this.issuanceDate = issuanceDate;
+        this.expiryDate = expiryDate;
         ClientIdentifierStatus statusEnum = ClientIdentifierStatus.valueOf(statusName.toUpperCase(Locale.ROOT));
         this.active = null;
         if (statusEnum.isActive()) {
@@ -116,6 +127,20 @@ public class ClientIdentifier extends AbstractAuditableWithUTCDateTimeCustom<Lon
             final String newValue = command.stringValueOfParameterNamed(statusParamName);
             actualChanges.put(statusParamName, ClientIdentifierStatus.valueOf(newValue));
             this.status = ClientIdentifierStatus.valueOf(newValue).getValue();
+        }
+
+        final String issuanceDateParamName = "issuanceDate";
+        if (command.isChangeInLocalDateParameterNamed(issuanceDateParamName, this.issuanceDate)) {
+            final LocalDate newValue = command.localDateValueOfParameterNamed(issuanceDateParamName);
+            actualChanges.put(issuanceDateParamName, newValue);
+            this.issuanceDate = newValue;
+        }
+
+        final String expiryDateParamName = "expiryDate";
+        if (command.isChangeInLocalDateParameterNamed(expiryDateParamName, this.expiryDate)) {
+            final LocalDate newValue = command.localDateValueOfParameterNamed(expiryDateParamName);
+            actualChanges.put(expiryDateParamName, newValue);
+            this.expiryDate = newValue;
         }
 
         return actualChanges;

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/api/ClientIdentifiersApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/api/ClientIdentifiersApiResource.java
@@ -68,8 +68,8 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ClientIdentifiersApiResource {
 
-    private static final Set<String> CLIENT_IDENTIFIER_DATA_PARAMETERS = new HashSet<>(
-            Arrays.asList("id", "clientId", "documentType", "documentKey", "description", "allowedDocumentTypes"));
+    private static final Set<String> CLIENT_IDENTIFIER_DATA_PARAMETERS = new HashSet<>(Arrays.asList("id", "clientId", "documentType",
+            "documentKey", "description", "issuanceDate", "expiryDate", "allowedDocumentTypes"));
 
     private static final String RESOURCE_NAME_FOR_PERMISSIONS = "CLIENTIDENTIFIER";
 
@@ -117,11 +117,11 @@ public class ClientIdentifiersApiResource {
     @RequestBody(required = true, content = @Content(schema = @Schema(implementation = ClientIdentifiersApiResourceSwagger.PostClientsClientIdIdentifiersRequest.class)))
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = ClientIdentifiersApiResourceSwagger.PostClientsClientIdIdentifiersResponse.class)))
     public CommandProcessingResult createClientIdentifier(@PathParam("clientId") @Parameter(description = "clientId") final Long clientId,
-            @Parameter(hidden = true) final ClientIdentifierRequest clientIdentifierRequest) {
+            @Parameter(hidden = true) final String apiRequestBodyAsJson) {
 
         try {
             final CommandWrapper commandRequest = new CommandWrapperBuilder().createClientIdentifier(clientId)
-                    .withJson(toApiJsonSerializer.serialize(clientIdentifierRequest)).build();
+                    .withJson(apiRequestBodyAsJson).build();
 
             return this.commandsSourceWritePlatformService.logCommandSource(commandRequest);
         } catch (final DuplicateClientIdentifierException e) {
@@ -173,11 +173,11 @@ public class ClientIdentifiersApiResource {
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = ClientIdentifiersApiResourceSwagger.PutClientsClientIdIdentifiersIdentifierIdResponse.class)))
     public CommandProcessingResult updateClientIdentifer(@PathParam("clientId") @Parameter(description = "clientId") final Long clientId,
             @PathParam("identifierId") @Parameter(description = "identifierId") final Long clientIdentifierId,
-            @Parameter(hidden = true) final ClientIdentifierRequest clientIdentifierRequest) {
+            @Parameter(hidden = true) final String apiRequestBodyAsJson) {
 
         try {
             final CommandWrapper commandRequest = new CommandWrapperBuilder().updateClientIdentifier(clientId, clientIdentifierId)
-                    .withJson(toApiJsonSerializer.serialize(clientIdentifierRequest)).build();
+                    .withJson(apiRequestBodyAsJson).build();
 
             return this.commandsSourceWritePlatformService.logCommandSource(commandRequest);
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/api/ClientIdentifiersApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/api/ClientIdentifiersApiResourceSwagger.java
@@ -19,6 +19,7 @@
 package org.apache.fineract.portfolio.client.api;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
 import org.apache.fineract.portfolio.client.data.ClientIdentifierRequest;
 
 /**
@@ -52,6 +53,10 @@ final class ClientIdentifiersApiResourceSwagger {
         public String documentKey;
         @Schema(example = "Issued in the year 2--7")
         public String description;
+        @Schema(example = "01 January 2024")
+        public LocalDate issuanceDate;
+        @Schema(example = "01 January 2034")
+        public LocalDate expiryDate;
     }
 
     @Schema(description = "PostClientsClientIdIdentifiersRequest")
@@ -67,6 +72,14 @@ final class ClientIdentifiersApiResourceSwagger {
         public String description;
         @Schema(example = "Active")
         public String status;
+        @Schema(example = "01 January 2024")
+        public String issuanceDate;
+        @Schema(example = "01 January 2034")
+        public String expiryDate;
+        @Schema(example = "dd MMMM yyyy")
+        public String dateFormat;
+        @Schema(example = "en")
+        public String locale;
     }
 
     @Schema(description = "PutClientsClientIdIdentifiersIdentifierIdResponse")

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/command/ClientIdentifierCommand.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/command/ClientIdentifierCommand.java
@@ -18,6 +18,7 @@
  */
 package org.apache.fineract.portfolio.client.command;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.fineract.infrastructure.core.data.ApiParameterError;
@@ -33,13 +34,22 @@ public class ClientIdentifierCommand {
     private final String documentKey;
     private final String description;
     private final String status;
+    private final LocalDate issuanceDate;
+    private final LocalDate expiryDate;
+    private final boolean issuanceDateParameterProvided;
+    private final boolean expiryDateParameterProvided;
 
-    public ClientIdentifierCommand(final Long documentTypeId, final String documentKey, final String statusString,
-            final String description) {
+    public ClientIdentifierCommand(final Long documentTypeId, final String documentKey, final String statusString, final String description,
+            final LocalDate issuanceDate, final LocalDate expiryDate, final boolean issuanceDateParameterProvided,
+            final boolean expiryDateParameterProvided) {
         this.documentTypeId = documentTypeId;
         this.documentKey = documentKey;
         this.status = statusString;
         this.description = description;
+        this.issuanceDate = issuanceDate;
+        this.expiryDate = expiryDate;
+        this.issuanceDateParameterProvided = issuanceDateParameterProvided;
+        this.expiryDateParameterProvided = expiryDateParameterProvided;
     }
 
     public Long getDocumentTypeId() {
@@ -52,6 +62,14 @@ public class ClientIdentifierCommand {
 
     public String getDescription() {
         return this.description;
+    }
+
+    public LocalDate getIssuanceDate() {
+        return this.issuanceDate;
+    }
+
+    public LocalDate getExpiryDate() {
+        return this.expiryDate;
     }
 
     public void validateForCreate() {
@@ -80,7 +98,8 @@ public class ClientIdentifierCommand {
         // baseDataValidator.reset().parameter("documentTypeId").value(command.getDocumentTypeId()).notNull().integerGreaterThanZero();
         // }
 
-        baseDataValidator.reset().anyOfNotNull(this.documentTypeId, this.documentKey);
+        baseDataValidator.reset().anyOfNotNull(this.documentTypeId, this.documentKey, this.issuanceDate, this.expiryDate,
+                this.issuanceDateParameterProvided ? Boolean.TRUE : null, this.expiryDateParameterProvided ? Boolean.TRUE : null);
 
         if (!dataValidationErrors.isEmpty()) {
             throw new PlatformApiDataValidationException("validation.msg.validation.errors.exist", "Validation errors exist.",

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/data/ClientIdentifierData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/data/ClientIdentifierData.java
@@ -20,6 +20,7 @@ package org.apache.fineract.portfolio.client.data;
 
 import java.io.Serial;
 import java.io.Serializable;
+import java.time.LocalDate;
 import java.util.Collection;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -41,20 +42,23 @@ public class ClientIdentifierData implements Serializable {
     private final String documentKey;
     private final String description;
     private final String status;
+    private final LocalDate issuanceDate;
+    private final LocalDate expiryDate;
     @SuppressWarnings("unused")
     private final Collection<CodeValueData> allowedDocumentTypes;
 
     public static ClientIdentifierData singleItem(final Long id, final Long clientId, final CodeValueData documentType,
-            final String documentKey, final String status, final String description) {
-        return new ClientIdentifierData(id, clientId, documentType, documentKey, description, status, null);
+            final String documentKey, final String status, final String description, final LocalDate issuanceDate,
+            final LocalDate expiryDate) {
+        return new ClientIdentifierData(id, clientId, documentType, documentKey, description, status, issuanceDate, expiryDate, null);
     }
 
     public static ClientIdentifierData template(final Collection<CodeValueData> codeValues) {
-        return new ClientIdentifierData(null, null, null, null, null, null, codeValues);
+        return new ClientIdentifierData(null, null, null, null, null, null, null, null, codeValues);
     }
 
     public static ClientIdentifierData template(final ClientIdentifierData data, final Collection<CodeValueData> codeValues) {
         return new ClientIdentifierData(data.id, data.clientId, data.documentType, data.documentKey, data.description, data.status,
-                codeValues);
+                data.issuanceDate, data.expiryDate, codeValues);
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/data/ClientIdentifierRequest.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/data/ClientIdentifierRequest.java
@@ -43,5 +43,13 @@ public class ClientIdentifierRequest implements Serializable {
     public String description;
     @Schema(example = "Active")
     public String status;
+    @Schema(example = "01 January 2024")
+    public String issuanceDate;
+    @Schema(example = "01 January 2034")
+    public String expiryDate;
+    @Schema(example = "dd MMMM yyyy")
+    public String dateFormat;
+    @Schema(example = "en")
+    public String locale;
 
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/serialization/ClientIdentifierCommandFromApiJsonDeserializer.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/serialization/ClientIdentifierCommandFromApiJsonDeserializer.java
@@ -21,6 +21,7 @@ package org.apache.fineract.portfolio.client.serialization;
 import com.google.gson.JsonElement;
 import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Type;
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
@@ -45,11 +46,15 @@ public final class ClientIdentifierCommandFromApiJsonDeserializer extends Abstra
     public static final String STATUS = "status";
     public static final String DESCRIPTION = "description";
     public static final String DOCUMENT_DESCRIPTION = "documentDescription";
+    public static final String ISSUANCE_DATE = "issuanceDate";
+    public static final String EXPIRY_DATE = "expiryDate";
+    public static final String LOCALE = "locale";
+    public static final String DATE_FORMAT = "dateFormat";
     /**
      * The parameters supported for this command.
      */
     private static final Set<String> SUPPORTED_PARAMETERS = new HashSet<>(
-            Arrays.asList(DOCUMENT_TYPE_ID, DOCUMENT_KEY, STATUS, DESCRIPTION));
+            Arrays.asList(DOCUMENT_TYPE_ID, DOCUMENT_KEY, STATUS, DESCRIPTION, ISSUANCE_DATE, EXPIRY_DATE, LOCALE, DATE_FORMAT));
     private final FromJsonHelper fromApiJsonHelper;
 
     @Autowired
@@ -74,6 +79,11 @@ public final class ClientIdentifierCommandFromApiJsonDeserializer extends Abstra
         final String documentKey = this.fromApiJsonHelper.extractStringNamed(DOCUMENT_KEY, element);
         final String documentDescription = this.fromApiJsonHelper.extractStringNamed(DOCUMENT_DESCRIPTION, element);
         final String statusString = this.fromApiJsonHelper.extractStringNamed(STATUS, element);
-        return new ClientIdentifierCommand(documentTypeId, documentKey, statusString, documentDescription);
+        final LocalDate issuanceDate = this.fromApiJsonHelper.extractLocalDateNamed(ISSUANCE_DATE, element);
+        final LocalDate expiryDate = this.fromApiJsonHelper.extractLocalDateNamed(EXPIRY_DATE, element);
+        final boolean issuanceDateParameterProvided = this.fromApiJsonHelper.parameterExists(ISSUANCE_DATE, element);
+        final boolean expiryDateParameterProvided = this.fromApiJsonHelper.parameterExists(EXPIRY_DATE, element);
+        return new ClientIdentifierCommand(documentTypeId, documentKey, statusString, documentDescription, issuanceDate, expiryDate,
+                issuanceDateParameterProvided, expiryDateParameterProvided);
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/service/ClientIdentifierReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/service/ClientIdentifierReadPlatformServiceImpl.java
@@ -20,6 +20,7 @@ package org.apache.fineract.portfolio.client.service;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.apache.fineract.infrastructure.codes.data.CodeValueData;
@@ -86,8 +87,8 @@ public class ClientIdentifierReadPlatformServiceImpl implements ClientIdentifier
 
         public String schema() {
             return "ci.id as id, ci.client_id as clientId, ci.document_type_id as documentTypeId, ci.status as status, ci.document_key as documentKey,"
-                    + " ci.description as description, cv.code_value as documentType "
-                    + " from m_client_identifier ci, m_client c, m_office o, m_code_value cv"
+                    + " ci.description as description, ci.issuance_date as issuanceDate, ci.expiry_date as expiryDate,"
+                    + " cv.code_value as documentType " + " from m_client_identifier ci, m_client c, m_office o, m_code_value cv"
                     + " where ci.client_id=c.id and c.office_id=o.id" + " and ci.document_type_id=cv.id"
                     + " and ci.client_id = ? and o.hierarchy like ? ";
         }
@@ -100,10 +101,12 @@ public class ClientIdentifierReadPlatformServiceImpl implements ClientIdentifier
             final Long documentTypeId = JdbcSupport.getLong(rs, "documentTypeId");
             final String documentKey = rs.getString("documentKey");
             final String description = rs.getString("description");
+            final LocalDate issuanceDate = JdbcSupport.getLocalDate(rs, "issuanceDate");
+            final LocalDate expiryDate = JdbcSupport.getLocalDate(rs, "expiryDate");
             final String documentTypeName = rs.getString("documentType");
             final CodeValueData documentType = CodeValueData.instance(documentTypeId, documentTypeName);
             final String status = ClientIdentifierStatus.fromInt(rs.getInt("status")).getCode();
-            return ClientIdentifierData.singleItem(id, clientId, documentType, documentKey, status, description);
+            return ClientIdentifierData.singleItem(id, clientId, documentType, documentKey, status, description, issuanceDate, expiryDate);
         }
 
     }

--- a/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
@@ -267,4 +267,5 @@
     <include file="parts/0245_standardize_email_address_column_length.xml" relativeToChangelogFile="true" />
     <include file="parts/0246_drop_request_audit_table.xml" relativeToChangelogFile="true" />
     <include file="parts/0247_add_payment_detail_search_indexes.xml" relativeToChangelogFile="true" />
+    <include file="parts/0248_add_dates_to_client_identifier.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0248_add_dates_to_client_identifier.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0248_add_dates_to_client_identifier.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+    <changeSet author="fineract" id="1">
+        <addColumn tableName="m_client_identifier">
+            <column name="issuance_date" type="date"/>
+            <column name="expiry_date" type="date"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm
+++ b/fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm
@@ -7035,6 +7035,8 @@ GET https://DomainName/api/v1/clients/{clientId}/identifiers
       "name": "Drivers License"
     },
     "documentKey": "12345",
+    "issuanceDate": [2024, 1, 1],
+    "expiryDate": [2034, 1, 1],
     "description": "Issued in the year 2--7"
   }
 ]
@@ -7120,6 +7122,8 @@ GET https://DomainName/api/v1/clients/{clientId}/identifiers/{identifierId}
     "name": "Drivers License"
   },
   "documentKey": "12345",
+  "issuanceDate": [2024, 1, 1],
+  "expiryDate": [2034, 1, 1],
   "description": "Issued in 2007"
 }
 					</code>
@@ -7151,7 +7155,11 @@ Request Body:
 {
 "documentTypeId":"1",
 "documentKey":"KA-54677",
-"description":"Document has been verified"
+"description":"Document has been verified",
+"issuanceDate":"01 January 2024",
+"expiryDate":"01 January 2034",
+"dateFormat":"dd MMMM yyyy",
+"locale":"en"
 }
 					</code>
 					<code class="method-response">
@@ -7180,7 +7188,11 @@ Request Body:
 {
 "documentTypeId":"4",
 "documentKey":"KA-94667",
-"description":"Document has been updated"
+"description":"Document has been updated",
+"issuanceDate":"01 February 2024",
+"expiryDate":"01 February 2034",
+"dateFormat":"dd MMMM yyyy",
+"locale":"en"
 }
 					</code>
 					<code class="method-response">
@@ -7191,7 +7203,9 @@ Request Body:
   "changes": {
     "documentTypeId": 4,
     "documentKey": "KA-94667",
-    "description": "Document has been updated"
+    "description": "Document has been updated",
+    "issuanceDate": [2024, 2, 1],
+    "expiryDate": [2034, 2, 1]
   }
 }
 					</code>

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/ClientIdentifierTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/client/ClientIdentifierTest.java
@@ -1,0 +1,152 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.integrationtests.client;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.builder.ResponseSpecBuilder;
+import io.restassured.http.ContentType;
+import io.restassured.path.json.JsonPath;
+import io.restassured.specification.RequestSpecification;
+import io.restassured.specification.ResponseSpecification;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.fineract.client.models.PostClientsResponse;
+import org.apache.fineract.integrationtests.common.ClientHelper;
+import org.apache.fineract.integrationtests.common.Utils;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ClientIdentifierTest extends IntegrationTest {
+
+    private static final Gson GSON = new Gson();
+    private static final Gson GSON_WITH_NULLS = new GsonBuilder().serializeNulls().create();
+    private static final Long DOCUMENT_TYPE_ID = 1L;
+    private static final String DATE_FORMAT = "dd MMMM yyyy";
+    private static final String LOCALE = "en";
+
+    private ResponseSpecification responseSpec;
+    private RequestSpecification requestSpec;
+    private ClientHelper clientHelper;
+
+    @BeforeEach
+    public void setup() {
+        Utils.initializeRESTAssured();
+        requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
+        requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
+        responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
+        clientHelper = new ClientHelper(requestSpec, responseSpec);
+    }
+
+    @Test
+    public void testClientIdentifierIssuanceAndExpiryDatesCrudFlow() {
+        PostClientsResponse client = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+
+        String documentKey = Utils.randomStringGenerator("ID_DATES_", 10);
+        Map<String, Object> createRequest = identifierRequest(documentKey, "01 January 2024", "01 January 2034", true);
+        Long identifierId = ((Number) Utils.performServerPost(requestSpec, responseSpec, identifierUrl(client.getClientId()),
+                GSON.toJson(createRequest), "resourceId")).longValue();
+
+        JsonPath createdIdentifier = retrieveIdentifier(client.getClientId(), identifierId);
+        assertThat(createdIdentifier.getLong("id")).isEqualTo(identifierId);
+        assertThat(createdIdentifier.getLong("clientId")).isEqualTo(client.getClientId());
+        assertThat(createdIdentifier.getString("documentKey")).isEqualTo(documentKey);
+        assertThat(createdIdentifier.getString("description")).isEqualTo(createRequest.get("description"));
+        assertThat(createdIdentifier.getList("issuanceDate", Integer.class)).isEqualTo(List.of(2024, 1, 1));
+        assertThat(createdIdentifier.getList("expiryDate", Integer.class)).isEqualTo(List.of(2034, 1, 1));
+
+        Map<String, Object> updateRequest = identifierRequest(documentKey, "01 February 2024", "01 February 2034", false);
+        JsonPath updateResponse = JsonPath.from(Utils.performServerPut(requestSpec, responseSpec,
+                identifierUrl(client.getClientId(), identifierId), GSON.toJson(updateRequest)));
+        assertThat(updateResponse.getLong("resourceId")).isEqualTo(identifierId);
+        assertThat(updateResponse.getList("changes.issuanceDate", Integer.class)).isEqualTo(List.of(2024, 2, 1));
+        assertThat(updateResponse.getList("changes.expiryDate", Integer.class)).isEqualTo(List.of(2034, 2, 1));
+
+        JsonPath updatedIdentifier = retrieveIdentifier(client.getClientId(), identifierId);
+        assertThat(updatedIdentifier.getString("documentKey")).isEqualTo(documentKey);
+        assertThat(updatedIdentifier.getString("description")).isEqualTo(updateRequest.get("description"));
+        assertThat(updatedIdentifier.getList("issuanceDate", Integer.class)).isEqualTo(List.of(2024, 2, 1));
+        assertThat(updatedIdentifier.getList("expiryDate", Integer.class)).isEqualTo(List.of(2034, 2, 1));
+
+        Map<String, Object> clearDatesRequest = new LinkedHashMap<>();
+        clearDatesRequest.put("issuanceDate", null);
+        clearDatesRequest.put("expiryDate", null);
+        JsonPath clearDatesResponse = JsonPath.from(Utils.performServerPut(requestSpec, responseSpec,
+                identifierUrl(client.getClientId(), identifierId), GSON_WITH_NULLS.toJson(clearDatesRequest)));
+        assertThat(clearDatesResponse.getLong("resourceId")).isEqualTo(identifierId);
+
+        JsonPath clearedIdentifier = retrieveIdentifier(client.getClientId(), identifierId);
+        assertThat(clearedIdentifier.getString("documentKey")).isEqualTo(documentKey);
+        Assertions.assertThat((Object) clearedIdentifier.get("issuanceDate")).isNull();
+        Assertions.assertThat((Object) clearedIdentifier.get("expiryDate")).isNull();
+    }
+
+    @Test
+    public void testClientIdentifierWithoutIssuanceAndExpiryDatesRemainsValid() {
+        PostClientsResponse client = ClientHelper.createClient(ClientHelper.defaultClientCreationRequest());
+
+        String documentKey = Utils.randomStringGenerator("ID_NO_DATES_", 10);
+        Map<String, Object> createRequest = new LinkedHashMap<>();
+        createRequest.put("documentTypeId", DOCUMENT_TYPE_ID);
+        createRequest.put("documentKey", documentKey);
+        createRequest.put("description", "Document without date fields");
+        createRequest.put("status", "Active");
+
+        Long identifierId = ((Number) Utils.performServerPost(requestSpec, responseSpec, identifierUrl(client.getClientId()),
+                GSON.toJson(createRequest), "resourceId")).longValue();
+
+        JsonPath identifier = retrieveIdentifier(client.getClientId(), identifierId);
+        assertThat(identifier.getString("documentKey")).isEqualTo(documentKey);
+        assertThat(identifier.getString("description")).isEqualTo(createRequest.get("description"));
+        Assertions.assertThat((Object) identifier.get("issuanceDate")).isNull();
+        Assertions.assertThat((Object) identifier.get("expiryDate")).isNull();
+    }
+
+    private Map<String, Object> identifierRequest(final String documentKey, final String issuanceDate, final String expiryDate,
+            final boolean includeStatus) {
+        Map<String, Object> request = new LinkedHashMap<>();
+        request.put("documentTypeId", DOCUMENT_TYPE_ID);
+        request.put("documentKey", documentKey);
+        request.put("description", Utils.randomStringGenerator("Identifier Description ", 10));
+        if (includeStatus) {
+            request.put("status", "Active");
+        }
+        request.put("issuanceDate", issuanceDate);
+        request.put("expiryDate", expiryDate);
+        request.put("dateFormat", DATE_FORMAT);
+        request.put("locale", LOCALE);
+        return request;
+    }
+
+    private JsonPath retrieveIdentifier(final Long clientId, final Long identifierId) {
+        String response = Utils.performServerGet(requestSpec, responseSpec, identifierUrl(clientId, identifierId), null);
+        return JsonPath.from(response);
+    }
+
+    private String identifierUrl(final Long clientId) {
+        return "/fineract-provider/api/v1/clients/" + clientId + "/identifiers?" + Utils.TENANT_IDENTIFIER;
+    }
+
+    private String identifierUrl(final Long clientId, final Long identifierId) {
+        return "/fineract-provider/api/v1/clients/" + clientId + "/identifiers/" + identifierId + "?" + Utils.TENANT_IDENTIFIER;
+    }
+}


### PR DESCRIPTION
## Description

Adds optional issuance and expiry dates to client identifiers.

This change:
- Adds `issuance_date` and `expiry_date` to `m_client_identifier`
- Exposes `issuanceDate` and `expiryDate` through create, retrieve, and update APIs
- Supports clearing the dates using explicit `null`
- Updates API documentation and Swagger models
- Adds integration coverage for create, retrieve, update, and optional date behavior

Existing client identifiers remain backward compatible.

## Related Issue

FINERACT-2759