### PR TITLE
FINERACT-2762: Client Approval/Activation Fails for Branch Manager Despite Having Required Permissions

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/commands/domain/CommandSourceRepository.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/domain/CommandSourceRepository.java
@@ -19,6 +19,7 @@
 package org.apache.fineract.commands.domain;
 
 import java.time.OffsetDateTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
@@ -28,6 +29,10 @@ import org.springframework.data.repository.query.Param;
 public interface CommandSourceRepository extends JpaRepository<CommandSource, Long>, JpaSpecificationExecutor<CommandSource> {
 
     CommandSource findByActionNameAndEntityNameAndIdempotencyKey(String actionName, String entityName, String idempotencyKey);
+
+    @Query("select c from CommandSource c where c.actionName = :actionName and c.entityName = :entityName and c.resourceId = :resourceId and c.status = :status order by c.madeOnDate desc")
+    List<CommandSource> findPendingByActionAndEntityAndResource(@Param("actionName") String actionName,
+            @Param("entityName") String entityName, @Param("resourceId") Long resourceId, @Param("status") Integer status);
 
     @Modifying(flushAutomatically = true)
     @Query("delete from CommandSource c where c.status = :status and c.madeOnDate is not null and c.madeOnDate <= :dateForPurgeCriteria")

--- a/fineract-core/src/main/java/org/apache/fineract/commands/service/PortfolioCommandSourceWritePlatformServiceImpl.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/service/PortfolioCommandSourceWritePlatformServiceImpl.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.commands.domain.CommandProcessingResultType;
 import org.apache.fineract.commands.domain.CommandSource;
 import org.apache.fineract.commands.domain.CommandSourceRepository;
 import org.apache.fineract.commands.domain.CommandWrapper;
@@ -56,18 +57,37 @@ public class PortfolioCommandSourceWritePlatformServiceImpl implements Portfolio
     @Override
     public CommandProcessingResult logCommandSource(final CommandWrapper wrapper) {
         boolean isApprovedByChecker = false;
+        final AppUser currentUser = this.context.authenticatedUser(wrapper);
 
         // check if is update of own account details
-        if (wrapper.isChangeOfOwnUserDetails(this.context.authenticatedUser(wrapper).getId())) {
+        if (wrapper.isChangeOfOwnUserDetails(currentUser.getId())) {
             // then allow this operation to proceed.
             // maker checker doesnt mean anything here.
             isApprovedByChecker = true; // set to true in case permissions have
                                         // been maker-checker enabled by
                                         // accident.
         } else {
-            // if not user changing their own details - check user has
-            // permission to perform specific task.
-            this.context.authenticatedUser(wrapper).validateHasPermissionTo(wrapper.getTaskPermissionName());
+            final String taskPermission = wrapper.getTaskPermissionName();
+            final boolean hasBasePermission = currentUser.hasSpecificPermissionTo(taskPermission);
+            final boolean hasCheckerPermission = currentUser.isCheckerSuperUser()
+                    || currentUser.hasSpecificPermissionTo(taskPermission + "_CHECKER");
+
+            if (!hasBasePermission && hasCheckerPermission) {
+                // Checker-only user: approve the pending entry for this action/entity/resource instead of
+                // refusing outright, since the checker-inbox approval flow isn't always reachable from the UI.
+                final Long resourceId = resolveResourceId(wrapper);
+                final List<CommandSource> pendingCommands = this.commandSourceRepository.findPendingByActionAndEntityAndResource(
+                        wrapper.actionName(), wrapper.entityName(), resourceId, CommandProcessingResultType.AWAITING_APPROVAL.getValue());
+                if (!pendingCommands.isEmpty()) {
+                    return approveEntry(pendingCommands.get(0).getId());
+                }
+                // No pending entry to approve — fall through to the standard permission check below.
+                currentUser.validateHasPermissionTo(taskPermission);
+            } else {
+                // if not user changing their own details - check user has
+                // permission to perform specific task.
+                currentUser.validateHasPermissionTo(taskPermission);
+            }
         }
         validateIsUpdateAllowed();
 
@@ -140,6 +160,25 @@ public class PortfolioCommandSourceWritePlatformServiceImpl implements Portfolio
 
     private void validateIsUpdateAllowed() {
         this.schedulerJobRunnerReadService.isUpdatesAllowed();
+    }
+
+    private Long resolveResourceId(final CommandWrapper wrapper) {
+        if (wrapper.getEntityId() != null) {
+            return wrapper.getEntityId();
+        }
+        if (wrapper.getLoanId() != null) {
+            return wrapper.getLoanId();
+        }
+        if (wrapper.getSavingsId() != null) {
+            return wrapper.getSavingsId();
+        }
+        if (wrapper.getClientId() != null) {
+            return wrapper.getClientId();
+        }
+        if (wrapper.getGroupId() != null) {
+            return wrapper.getGroupId();
+        }
+        return null;
     }
 
     @Override

--- a/fineract-core/src/test/java/org/apache/fineract/commands/service/PortfolioCommandSourceWritePlatformServiceImplTest.java
+++ b/fineract-core/src/test/java/org/apache/fineract/commands/service/PortfolioCommandSourceWritePlatformServiceImplTest.java
@@ -1,0 +1,135 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.commands.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.gson.JsonElement;
+import java.util.Collections;
+import java.util.List;
+import org.apache.fineract.commands.domain.CommandProcessingResultType;
+import org.apache.fineract.commands.domain.CommandSource;
+import org.apache.fineract.commands.domain.CommandSourceRepository;
+import org.apache.fineract.commands.domain.CommandWrapper;
+import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.apache.fineract.infrastructure.jobs.service.SchedulerJobRunnerReadService;
+import org.apache.fineract.infrastructure.security.exception.NoAuthorizationException;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.apache.fineract.useradministration.domain.AppUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class PortfolioCommandSourceWritePlatformServiceImplTest {
+
+    @Mock
+    private PlatformSecurityContext context;
+    @Mock
+    private CommandSourceRepository commandSourceRepository;
+    @Mock
+    private FromJsonHelper fromApiJsonHelper;
+    @Mock
+    private CommandProcessingService processAndLogCommandService;
+    @Mock
+    private SchedulerJobRunnerReadService schedulerJobRunnerReadService;
+    @Mock
+    private ConfigurationDomainService configurationService;
+    @Mock
+    private AppUser currentUser;
+
+    private PortfolioCommandSourceWritePlatformServiceImpl underTest;
+    private CommandWrapper wrapper;
+
+    @BeforeEach
+    public void setUp() {
+        underTest = new PortfolioCommandSourceWritePlatformServiceImpl(context, commandSourceRepository, fromApiJsonHelper,
+                processAndLogCommandService, schedulerJobRunnerReadService, configurationService, Collections.emptyList());
+
+        wrapper = CommandWrapper.wrap("ACTIVATE", "CLIENT", 1L, null);
+        when(context.authenticatedUser(any(CommandWrapper.class))).thenReturn(currentUser);
+        when(currentUser.getId()).thenReturn(100L);
+    }
+
+    private void stubApprovalOf(CommandSource pendingCommand) {
+        when(context.authenticatedUser()).thenReturn(currentUser);
+        when(commandSourceRepository.findById(pendingCommand.getId())).thenReturn(java.util.Optional.of(pendingCommand));
+        when(pendingCommand.isAwaitingApproval()).thenReturn(true);
+        when(configurationService.isSameMakerCheckerEnabled()).thenReturn(true);
+    }
+
+    private void stubSuccessfulExecution() {
+        when(fromApiJsonHelper.parse(any())).thenReturn(mock(JsonElement.class));
+        when(processAndLogCommandService.executeCommand(any(), any(), anyBoolean())).thenReturn(CommandProcessingResult.empty());
+    }
+
+    @Test
+    public void checkerOnlyUserWithPendingSubmissionAutoApprovesIt() {
+        when(currentUser.hasSpecificPermissionTo("ACTIVATE_CLIENT")).thenReturn(false);
+        when(currentUser.isCheckerSuperUser()).thenReturn(false);
+        when(currentUser.hasSpecificPermissionTo("ACTIVATE_CLIENT_CHECKER")).thenReturn(true);
+        CommandSource pendingCommand = mock(CommandSource.class);
+        when(pendingCommand.getId()).thenReturn(55L);
+        when(commandSourceRepository.findPendingByActionAndEntityAndResource("ACTIVATE", "CLIENT", 1L,
+                CommandProcessingResultType.AWAITING_APPROVAL.getValue())).thenReturn(List.of(pendingCommand));
+        stubApprovalOf(pendingCommand);
+        stubSuccessfulExecution();
+
+        underTest.logCommandSource(wrapper);
+
+        verify(processAndLogCommandService).executeCommand(any(), any(), eq(true));
+        verify(currentUser, never()).validateHasPermissionTo("ACTIVATE_CLIENT");
+    }
+
+    @Test
+    public void checkerOnlyUserWithNoPendingSubmissionGetsTheStandardAuthorizationFailure() {
+        when(currentUser.hasSpecificPermissionTo("ACTIVATE_CLIENT")).thenReturn(false);
+        when(currentUser.isCheckerSuperUser()).thenReturn(false);
+        when(currentUser.hasSpecificPermissionTo("ACTIVATE_CLIENT_CHECKER")).thenReturn(true);
+        when(commandSourceRepository.findPendingByActionAndEntityAndResource("ACTIVATE", "CLIENT", 1L,
+                CommandProcessingResultType.AWAITING_APPROVAL.getValue())).thenReturn(Collections.emptyList());
+        doThrow(new NoAuthorizationException("User has no authority to: ACTIVATE_CLIENT")).when(currentUser)
+                .validateHasPermissionTo("ACTIVATE_CLIENT");
+
+        assertThrows(NoAuthorizationException.class, () -> underTest.logCommandSource(wrapper));
+    }
+
+    @Test
+    public void userWithBasePermissionIsUnaffectedByTheCheckerOnlyLookup() {
+        when(currentUser.hasSpecificPermissionTo("ACTIVATE_CLIENT")).thenReturn(true);
+        stubSuccessfulExecution();
+
+        underTest.logCommandSource(wrapper);
+
+        verify(commandSourceRepository, never()).findPendingByActionAndEntityAndResource(any(), any(), any(), any());
+        verify(processAndLogCommandService).executeCommand(any(), any(), eq(false));
+    }
+}


### PR DESCRIPTION
For a maker-checker-enabled task, a user holding only the <TASK>_CHECKER permission (no base permission) was refused with a generic "not         
  authorized" response when calling the entity's normal action endpoint — even when a matching maker submission was already awaiting exactly this  
  user's approval. The only way such a user could act was through the separate checker-inbox approval endpoint (POST                               
  .../commands/{id}?command=approve); there was no fallback when a checker-only user instead called the same action endpoint a maker would use     
  (e.g. POST /clients/{clientId}?command=activate), which is the natural path from the entity's own screen.                                        
                                                                                                                                                   
  PortfolioCommandSourceWritePlatformServiceImpl#logCommandSource now checks, for a checker-only caller, whether a pending CommandSource exists for
  the same action/entity/resource, and approves it directly if found. If none exists, the call is refused with the existing permission-denied      
  response, unchanged. Maker flows and users holding both the base and checker permission are unaffected.      
  PR:(https://issues.apache.org/jira/browse/FINERACT-2762)