### PR TITLE
FINERACT-2765: Tax Component and Tax Group names should be unique

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/tax/service/TaxWritePlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/tax/service/TaxWritePlatformServiceImpl.java
@@ -18,12 +18,18 @@
  */
 package org.apache.fineract.portfolio.tax.service;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
+import org.apache.fineract.infrastructure.core.data.ApiParameterError;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResultBuilder;
+import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
+import org.apache.fineract.portfolio.tax.api.TaxApiConstants;
 import org.apache.fineract.portfolio.tax.domain.TaxComponent;
 import org.apache.fineract.portfolio.tax.domain.TaxComponentRepository;
 import org.apache.fineract.portfolio.tax.domain.TaxComponentRepositoryWrapper;
@@ -47,6 +53,21 @@ public class TaxWritePlatformServiceImpl implements TaxWritePlatformService {
     public CommandProcessingResult createTaxComponent(final JsonCommand command) {
         this.validator.validateForTaxComponentCreate(command.json());
         TaxComponent taxComponent = this.taxAssembler.assembleTaxComponentFrom(command);
+
+        // Enforce unique tax component name (case-sensitive, relying on DB collation for case handling)
+        if (taxComponent.getName() != null) {
+            Optional<TaxComponent> existing = this.taxComponentRepository.findByName(taxComponent.getName());
+            if (existing.isPresent()) {
+                final List<ApiParameterError> dataValidationErrors = new ArrayList<>();
+                String errorCode = "tax.component.name.must.be.unique";
+                String userMessage = "Tax component with name '" + taxComponent.getName() + "' already exists";
+                ApiParameterError error = ApiParameterError.parameterError(errorCode, userMessage, TaxApiConstants.nameParamName,
+                        taxComponent.getName());
+                dataValidationErrors.add(error);
+                throw new PlatformApiDataValidationException(errorCode, userMessage, dataValidationErrors);
+            }
+        }
+
         this.taxComponentRepository.saveAndFlush(taxComponent);
         return new CommandProcessingResultBuilder() //
                 .withCommandId(command.commandId()) //
@@ -56,9 +77,27 @@ public class TaxWritePlatformServiceImpl implements TaxWritePlatformService {
 
     @Override
     public CommandProcessingResult updateTaxComponent(final Long id, final JsonCommand command) {
-        this.validator.validateForTaxComponentUpdate(command.json());
+        this.validator.validateForTaxComponentUpdate(command.json(), id);
         final TaxComponent taxComponent = this.taxComponentRepositoryWrapper.findOneWithNotFoundDetection(id);
         this.validator.validateStartDate(taxComponent.startDate(), command);
+
+        // Enforce unique tax component name when name is being changed
+        if (command.parameterExists(TaxApiConstants.nameParamName)) {
+            final String newName = command.stringValueOfParameterNamed(TaxApiConstants.nameParamName);
+            if (newName != null && !newName.equalsIgnoreCase(taxComponent.getName())) {
+                Optional<TaxComponent> existing = this.taxComponentRepository.findByName(newName);
+                if (existing.isPresent() && !existing.get().getId().equals(taxComponent.getId())) {
+                    final List<ApiParameterError> dataValidationErrors = new ArrayList<>();
+                    String errorCode = "tax.component.name.must.be.unique";
+                    String userMessage = "Tax component with name '" + newName + "' already exists";
+                    ApiParameterError error = ApiParameterError.parameterError(errorCode, userMessage, TaxApiConstants.nameParamName,
+                            newName);
+                    dataValidationErrors.add(error);
+                    throw new PlatformApiDataValidationException(errorCode, userMessage, dataValidationErrors);
+                }
+            }
+        }
+
         Map<String, Object> changes = taxComponent.update(command);
         this.validator.validateTaxComponentForUpdate(taxComponent);
         this.taxComponentRepository.saveAndFlush(taxComponent);
@@ -72,6 +111,18 @@ public class TaxWritePlatformServiceImpl implements TaxWritePlatformService {
     public CommandProcessingResult createTaxGroup(final JsonCommand command) {
         this.validator.validateForTaxGroupCreate(command.json());
         final TaxGroup taxGroup = this.taxAssembler.assembleTaxGroupFrom(command);
+
+        // Enforce unique tax group name (case-insensitive)
+        if (taxGroup.getName() != null && this.taxGroupRepository.existsByNameIgnoreCase(taxGroup.getName())) {
+            final List<ApiParameterError> dataValidationErrors = new ArrayList<>();
+            String errorCode = "tax.group.name.must.be.unique";
+            String userMessage = "Tax group with name '" + taxGroup.getName() + "' already exists";
+            ApiParameterError error = ApiParameterError.parameterError(errorCode, userMessage, TaxApiConstants.nameParamName,
+                    taxGroup.getName());
+            dataValidationErrors.add(error);
+            throw new PlatformApiDataValidationException(errorCode, userMessage, dataValidationErrors);
+        }
+
         this.validator.validateTaxGroup(taxGroup);
         this.taxGroupRepository.saveAndFlush(taxGroup);
         return new CommandProcessingResultBuilder() //
@@ -84,6 +135,21 @@ public class TaxWritePlatformServiceImpl implements TaxWritePlatformService {
     public CommandProcessingResult updateTaxGroup(final Long id, final JsonCommand command) {
         this.validator.validateForTaxGroupUpdate(command.json());
         final TaxGroup taxGroup = this.taxGroupRepositoryWrapper.findOneWithNotFoundDetection(id);
+
+        // Validate unique tax group name (case-insensitive) BEFORE updating if name is being changed
+        if (command.parameterExists(TaxApiConstants.nameParamName)) {
+            final String newName = command.stringValueOfParameterNamed(TaxApiConstants.nameParamName);
+            if (newName != null && !newName.equalsIgnoreCase(taxGroup.getName())
+                    && this.taxGroupRepository.existsByNameIgnoreCaseAndIdNot(newName, id)) {
+                final List<ApiParameterError> dataValidationErrors = new ArrayList<>();
+                String errorCode = "tax.group.name.must.be.unique";
+                String userMessage = "Tax group with name '" + newName + "' already exists";
+                ApiParameterError error = ApiParameterError.parameterError(errorCode, userMessage, TaxApiConstants.nameParamName, newName);
+                dataValidationErrors.add(error);
+                throw new PlatformApiDataValidationException(errorCode, userMessage, dataValidationErrors);
+            }
+        }
+
         final boolean isUpdate = true;
         Set<TaxGroupMappings> groupMappings = this.taxAssembler.assembleTaxGroupMappingsFrom(command, isUpdate);
         this.validator.validateTaxGroupEndDateAndTaxComponent(taxGroup, groupMappings);

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/tax/starter/TaxConfiguration.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/tax/starter/TaxConfiguration.java
@@ -41,6 +41,12 @@ import org.springframework.context.annotation.Configuration;
 public class TaxConfiguration {
 
     @Bean
+    @ConditionalOnMissingBean(TaxValidator.class)
+    public TaxValidator taxValidator(FromJsonHelper fromApiJsonHelper, TaxComponentRepository taxComponentRepository) {
+        return new TaxValidator(fromApiJsonHelper, taxComponentRepository);
+    }
+
+    @Bean
     @ConditionalOnMissingBean(TaxAssembler.class)
     public TaxAssembler taxAssembler(FromJsonHelper fromApiJsonHelper, GLAccountRepositoryWrapper glAccountRepositoryWrapper,
             TaxComponentRepositoryWrapper taxComponentRepositoryWrapper) {

--- a/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/domain/TaxComponentRepository.java
+++ b/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/domain/TaxComponentRepository.java
@@ -18,9 +18,12 @@
  */
 package org.apache.fineract.portfolio.tax.domain;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 public interface TaxComponentRepository extends JpaRepository<TaxComponent, Long>, JpaSpecificationExecutor<TaxComponent> {
+
+    Optional<TaxComponent> findByName(String name);
 
 }

--- a/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/domain/TaxGroupRepository.java
+++ b/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/domain/TaxGroupRepository.java
@@ -23,4 +23,10 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 public interface TaxGroupRepository extends JpaRepository<TaxGroup, Long>, JpaSpecificationExecutor<TaxGroup> {
 
+    // Check if any TaxGroup exists with the given name
+    boolean existsByNameIgnoreCase(String name);
+
+    // Check if any other TaxGroup (excluding the given id) exists with the same name
+    boolean existsByNameIgnoreCaseAndIdNot(String name, Long id);
+
 }

--- a/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/serialization/TaxValidator.java
+++ b/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/serialization/TaxValidator.java
@@ -32,6 +32,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.fineract.accounting.glaccount.domain.GLAccountType;
@@ -44,6 +45,7 @@ import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
 import org.apache.fineract.infrastructure.core.service.DateUtils;
 import org.apache.fineract.portfolio.tax.api.TaxApiConstants;
 import org.apache.fineract.portfolio.tax.domain.TaxComponent;
+import org.apache.fineract.portfolio.tax.domain.TaxComponentRepository;
 import org.apache.fineract.portfolio.tax.domain.TaxGroup;
 import org.apache.fineract.portfolio.tax.domain.TaxGroupMappings;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -77,10 +79,12 @@ public class TaxValidator {
     public static final String DOT = ".";
     public static final String AT_INDEX = ".at.index.";
     private final FromJsonHelper fromApiJsonHelper;
+    private final TaxComponentRepository taxComponentRepository;
 
     @Autowired
-    public TaxValidator(final FromJsonHelper fromApiJsonHelper) {
+    public TaxValidator(final FromJsonHelper fromApiJsonHelper, final TaxComponentRepository taxComponentRepository) {
         this.fromApiJsonHelper = fromApiJsonHelper;
+        this.taxComponentRepository = taxComponentRepository;
     }
 
     public void validateForTaxComponentCreate(final String json) {
@@ -100,6 +104,14 @@ public class TaxValidator {
 
         final String name = this.fromApiJsonHelper.extractStringNamed(TaxApiConstants.nameParamName, element);
         baseDataValidator.reset().parameter(TaxApiConstants.nameParamName).value(name).notBlank();
+
+        // Check for duplicate name
+        if (name != null && this.taxComponentRepository.findByName(name).isPresent()) {
+            String errorCode = "tax.component.name.must.be.unique";
+            String userMessage = "Tax component with name '" + name + "' already exists";
+            ApiParameterError error = ApiParameterError.parameterError(errorCode, userMessage, TaxApiConstants.nameParamName, name);
+            dataValidationErrors.add(error);
+        }
 
         final BigDecimal percentage = this.fromApiJsonHelper.extractBigDecimalWithLocaleNamed(TaxApiConstants.percentageParamName, element);
         baseDataValidator.reset().parameter(TaxApiConstants.percentageParamName).value(percentage).notBlank().positiveAmount()
@@ -134,6 +146,10 @@ public class TaxValidator {
     }
 
     public void validateForTaxComponentUpdate(final String json) {
+        validateForTaxComponentUpdate(json, null);
+    }
+
+    public void validateForTaxComponentUpdate(final String json, final Long taxComponentId) {
         if (StringUtils.isBlank(json)) {
             throw new InvalidJsonException();
         }
@@ -151,6 +167,19 @@ public class TaxValidator {
         if (this.fromApiJsonHelper.parameterExists(TaxApiConstants.nameParamName, element)) {
             final String name = this.fromApiJsonHelper.extractStringNamed(TaxApiConstants.nameParamName, element);
             baseDataValidator.reset().parameter(TaxApiConstants.nameParamName).value(name).notBlank();
+
+            // Check for duplicate name (excluding current entity)
+            if (name != null && taxComponentId != null) {
+                this.taxComponentRepository.findByName(name).ifPresent(existingComponent -> {
+                    if (!Objects.equals(existingComponent.getId(), taxComponentId)) {
+                        String errorCode = "tax.component.name.must.be.unique";
+                        String userMessage = "Tax component with name '" + name + "' already exists";
+                        ApiParameterError error = ApiParameterError.parameterError(errorCode, userMessage, TaxApiConstants.nameParamName,
+                                name);
+                        dataValidationErrors.add(error);
+                    }
+                });
+            }
         }
 
         if (this.fromApiJsonHelper.parameterExists(TaxApiConstants.percentageParamName, element)) {
@@ -197,6 +226,10 @@ public class TaxValidator {
                         "Please add at least one Tax Component before submitting the Tax Group.", TaxApiConstants.taxComponentsParamName));
             }
             baseDataValidator.reset().parameter(TaxApiConstants.taxComponentsParamName).value(array.size()).integerGreaterThanZero();
+
+            // Ensure each taxComponentId appears at most once
+            Set<Long> seenComponentIds = new HashSet<>();
+
             for (int i = 1; i <= array.size(); i++) {
                 final JsonObject taxComponent = array.get(i - 1).getAsJsonObject();
                 final String arrayObjectJson = this.fromApiJsonHelper.toJson(taxComponent);
@@ -207,6 +240,11 @@ public class TaxValidator {
                         .parameterAtIndexArray(TaxApiConstants.taxComponentIdParamName, i).value(taxComponentId).notNull()
                         .longGreaterThanZero();
 
+                if (taxComponentId != null && !seenComponentIds.add(taxComponentId)) {
+                    dataValidationErrors.add(ApiParameterError.parameterError("validation.msg.tax.group.duplicate.component",
+                            "Each tax component can be included only once in a tax group.",
+                            TaxApiConstants.taxComponentsParamName + DOT + TaxApiConstants.taxComponentIdParamName + AT_INDEX + i));
+                }
             }
         }
         throwExceptionIfValidationWarningsExist(dataValidationErrors);
@@ -240,6 +278,10 @@ public class TaxValidator {
             final Locale locale = this.fromApiJsonHelper.extractLocaleParameter(topLevelJsonElement);
             if (topLevelJsonElement.get(TaxApiConstants.taxComponentsParamName).isJsonArray()) {
                 final JsonArray array = topLevelJsonElement.get(TaxApiConstants.taxComponentsParamName).getAsJsonArray();
+
+                // Ensure each taxComponentId appears at most once in update payload
+                Set<Long> seenComponentIds = new HashSet<>();
+
                 for (int i = 1; i <= array.size(); i++) {
                     final JsonObject taxComponent = array.get(i - 1).getAsJsonObject();
                     final String arrayObjectJson = this.fromApiJsonHelper.toJson(taxComponent);
@@ -260,6 +302,12 @@ public class TaxValidator {
                         baseDataValidator.reset()
                                 .parameter(TaxApiConstants.taxComponentsParamName + DOT + TaxApiConstants.idParamName + AT_INDEX + i)
                                 .value(taxMappingId).longGreaterThanZero();
+                    }
+
+                    if (taxComponentId != null && !seenComponentIds.add(taxComponentId)) {
+                        dataValidationErrors.add(ApiParameterError.parameterError("validation.msg.tax.group.duplicate.component",
+                                "Each tax component can be included only once in a tax group.",
+                                TaxApiConstants.taxComponentsParamName + DOT + TaxApiConstants.taxComponentIdParamName + AT_INDEX + i));
                     }
 
                     final LocalDate endDate = this.fromApiJsonHelper.extractLocalDateNamed(TaxApiConstants.endDateParamName, taxComponent,


### PR DESCRIPTION
 Currently nothing prevents creating a `TaxComponent` or `TaxGroup` with a                                                                        
  name that's already in use, or renaming one to collide with another. This                                                                        
  also allowed submitting a `TaxGroup` with the same tax component listed                                                                          
  more than once in its `taxComponents` array.
  This PR adds:                                                                                                                                    
                                                                                                                                                   
  - On tax component create/update: reject the request if another tax                                                                              
    component already has the given `name` (case-sensitive match against                                                                           
    `TaxComponentRepository.findByName`, relying on DB collation for exact                                                                         
    matching), returning `tax.component.name.must.be.unique`.                                                                                      
  - On tax group create/update: reject the request if another tax group                                                                            
    already has the given `name` (case-insensitive, via                                                                                            
    `TaxGroupRepository.existsByNameIgnoreCase` /                                                                                                  
    `existsByNameIgnoreCaseAndIdNot`), returning                                                                                                   
    `tax.group.name.must.be.unique`.                                                                                                               
  - On tax group create/update: reject a `taxComponents` payload that                                                                              
    references the same `taxComponentId` more than once, returning                                                                                 
    `validation.msg.tax.group.duplicate.component`. 
                                                                                                                                                       
  Update checks only trigger when the `name` (or, for groups, a component                                                                          
  list) is actually being changed, so updates that leave the name untouched                                                                        
  are unaffected.
 PR (https://issues.apache.org/jira/browse/FINERACT-2765).    