### PR TITLE
FINERACT-2766: Tax Component - User should be able to edit a tax component

### DIFF
--- a/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/domain/TaxComponent.java
+++ b/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/domain/TaxComponent.java
@@ -72,8 +72,7 @@ public class TaxComponent extends AbstractAuditableCustom {
     @Column(name = "start_date", nullable = false)
     private LocalDate startDate;
 
-    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
-    @JoinColumn(name = "tax_component_id", referencedColumnName = "id", nullable = false)
+    @OneToMany(mappedBy = "taxComponent", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     private Set<TaxComponentHistory> taxComponentHistories = new HashSet<>();
 
     @OneToMany(cascade = CascadeType.DETACH, mappedBy = "taxComponent", orphanRemoval = false, fetch = FetchType.EAGER)
@@ -120,7 +119,7 @@ public class TaxComponent extends AbstractAuditableCustom {
             updateStartDate(command, changes, true);
             LocalDate newStartDate = this.startDate;
 
-            TaxComponentHistory history = TaxComponentHistory.createTaxComponentHistory(this.percentage, oldStartDate, newStartDate);
+            TaxComponentHistory history = TaxComponentHistory.createTaxComponentHistory(this, this.percentage, oldStartDate, newStartDate);
             this.taxComponentHistories.add(history);
             this.percentage = newValue;
 

--- a/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/domain/TaxComponentHistory.java
+++ b/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/domain/TaxComponentHistory.java
@@ -20,6 +20,8 @@ package org.apache.fineract.portfolio.tax.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -29,6 +31,10 @@ import org.apache.fineract.infrastructure.core.service.DateUtils;
 @Entity
 @Table(name = "m_tax_component_history")
 public class TaxComponentHistory extends AbstractAuditableCustom {
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "tax_component_id", referencedColumnName = "id", nullable = false)
+    private TaxComponent taxComponent;
 
     @Column(name = "percentage", scale = 6, precision = 19, nullable = false)
     private BigDecimal percentage;
@@ -43,15 +49,17 @@ public class TaxComponentHistory extends AbstractAuditableCustom {
 
     }
 
-    private TaxComponentHistory(final BigDecimal percentage, final LocalDate startDate, final LocalDate endDate) {
+    private TaxComponentHistory(final TaxComponent taxComponent, final BigDecimal percentage, final LocalDate startDate,
+            final LocalDate endDate) {
+        this.taxComponent = taxComponent;
         this.percentage = percentage;
         this.startDate = startDate;
         this.endDate = endDate;
     }
 
-    public static TaxComponentHistory createTaxComponentHistory(final BigDecimal percentage, final LocalDate startDate,
-            final LocalDate endDate) {
-        return new TaxComponentHistory(percentage, startDate, endDate);
+    public static TaxComponentHistory createTaxComponentHistory(final TaxComponent taxComponent, final BigDecimal percentage,
+            final LocalDate startDate, final LocalDate endDate) {
+        return new TaxComponentHistory(taxComponent, percentage, startDate, endDate);
     }
 
     public LocalDate startDate() {


### PR DESCRIPTION
  TaxComponent.taxComponentHistories was mapped as a unidirectional @OneToMany with a @JoinColumn(nullable = false) and no owning side (mappedBy)  
  declared on the child entity. This is a problematic pattern for a foreign-key-based one-to-many: since the parent's collection — not the child — 
  is left managing the relationship, adding a new TaxComponentHistory row to an already-persisted TaxComponent risks a flush-ordering issue against
  the NOT NULL foreign key column. This is exactly what happens whenever a tax component's percentage or start date is edited                      
  (TaxComponent.update() adds a new history entry to the collection).                                                                              
                                                                                                                                                   
  This PR makes the relationship properly bidirectional:                                                                                           
  - Adds a @ManyToOne(optional = false) back-reference (taxComponent) on TaxComponentHistory, owning the foreign key via @JoinColumn.              
  - Changes TaxComponent.taxComponentHistories to @OneToMany(mappedBy = "taxComponent", ...).                                                      
  - Updates TaxComponentHistory.createTaxComponentHistory(...) to accept and set the parent reference, and updates its single call site in         
    TaxComponent.update().                                                                                                                         
                                                                                                                                                   
  No API/behavior changes — this is purely a persistence-mapping correctness fix, functionally equivalent for read paths but avoids the            
  flush-ordering hazard on write.