### PR TITLE
FINERACT-2767: Tax Component – Fields should be locked once linked to transactions

### DIFF
--- a/fineract-charge/src/main/java/org/apache/fineract/portfolio/charge/domain/ChargeRepository.java
+++ b/fineract-charge/src/main/java/org/apache/fineract/portfolio/charge/domain/ChargeRepository.java
@@ -28,4 +28,24 @@ public interface ChargeRepository extends JpaRepository<Charge, Long>, JpaSpecif
 
     @Query("select lc.id from WorkingCapitalLoanCharge lc where lc.charge.id = :chargeId and lc.active = true")
     Optional<Long> isAnyWorkingCapitalLoansAssociateWithThisCharge(@Param("chargeId") Long chargeId);
+
+    /**
+     * Checks if any Charge exists that references a TaxGroup containing the specified TaxComponent. This is used to
+     * determine if a TaxComponent is "in use" (linked to charges via tax groups).
+     *
+     * @param taxComponentId
+     *            the ID of the TaxComponent to check
+     * @return true if at least one Charge exists with a TaxGroup that contains this TaxComponent, false otherwise
+     */
+    @Query(value = """
+            SELECT EXISTS (
+                SELECT 1
+                FROM m_charge c
+                INNER JOIN m_tax_group_mappings tgm
+                    ON tgm.tax_group_id = c.tax_group_id
+                WHERE c.tax_group_id IS NOT NULL
+                AND tgm.tax_component_id = ?1
+            )
+            """, nativeQuery = true)
+    boolean existsByTaxGroupContainingTaxComponent(Long taxComponentId);
 }

--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/tax/data/TaxComponentData.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/tax/data/TaxComponentData.java
@@ -44,6 +44,9 @@ public final class TaxComponentData implements Serializable {
     private final LocalDate startDate;
     private final Collection<TaxComponentHistoryData> taxComponentHistories;
 
+    // editability indicator
+    private final Boolean accountsEditable;
+
     // template options
     private final Map<String, List<GLAccountData>> glAccountOptions;
     private final Collection<EnumOptionData> glAccountTypeOptions;
@@ -51,10 +54,20 @@ public final class TaxComponentData implements Serializable {
     public static TaxComponentData instance(final Long id, final String name, final BigDecimal percentage,
             final EnumOptionData debitAccountType, final GLAccountData debitAccount, final EnumOptionData creditAccountType,
             final GLAccountData creditAccount, final LocalDate startDate, final Collection<TaxComponentHistoryData> taxComponentHistories) {
+        final Boolean accountsEditable = null;
         final Map<String, List<GLAccountData>> glAccountOptions = null;
         final Collection<EnumOptionData> glAccountTypeOptions = null;
         return new TaxComponentData(id, name, percentage, debitAccountType, debitAccount, creditAccountType, creditAccount, startDate,
-                taxComponentHistories, glAccountOptions, glAccountTypeOptions);
+                taxComponentHistories, accountsEditable, glAccountOptions, glAccountTypeOptions);
+    }
+
+    public static TaxComponentData instance(final Long id, final String name, final BigDecimal percentage,
+            final EnumOptionData debitAccountType, final GLAccountData debitAccount, final EnumOptionData creditAccountType,
+            final GLAccountData creditAccount, final LocalDate startDate, final Collection<TaxComponentHistoryData> taxComponentHistories,
+            final Boolean accountsEditable, final Map<String, List<GLAccountData>> glAccountOptions,
+            final Collection<EnumOptionData> glAccountTypeOptions) {
+        return new TaxComponentData(id, name, percentage, debitAccountType, debitAccount, creditAccountType, creditAccount, startDate,
+                taxComponentHistories, accountsEditable, glAccountOptions, glAccountTypeOptions);
     }
 
     public static TaxComponentData lookup(final Long id, final String name) {
@@ -65,10 +78,11 @@ public final class TaxComponentData implements Serializable {
         final GLAccountData creditAccount = null;
         final LocalDate startDate = null;
         final Collection<TaxComponentHistoryData> taxComponentHistories = null;
+        final Boolean accountsEditable = null;
         final Map<String, List<GLAccountData>> glAccountOptions = null;
         final Collection<EnumOptionData> glAccountTypeOptions = null;
         return new TaxComponentData(id, name, percentage, debitAccountType, debitAccount, creditAccountType, creditAccount, startDate,
-                taxComponentHistories, glAccountOptions, glAccountTypeOptions);
+                taxComponentHistories, accountsEditable, glAccountOptions, glAccountTypeOptions);
     }
 
     public static TaxComponentData template(final Map<String, List<GLAccountData>> glAccountOptions,
@@ -82,8 +96,9 @@ public final class TaxComponentData implements Serializable {
         final GLAccountData creditAccount = null;
         final LocalDate startDate = null;
         final Collection<TaxComponentHistoryData> taxComponentHistories = null;
+        final Boolean accountsEditable = null;
         return new TaxComponentData(id, name, percentage, debitAccountType, debitAccount, creditAccountType, creditAccount, startDate,
-                taxComponentHistories, glAccountOptions, glAccountTypeOptions);
+                taxComponentHistories, accountsEditable, glAccountOptions, glAccountTypeOptions);
     }
 
     private TaxComponentData(final Long id, final BigDecimal percentage, final GLAccountData debitAccount,
@@ -97,6 +112,7 @@ public final class TaxComponentData implements Serializable {
         this.creditAccount = creditAccount;
         this.startDate = null;
         this.taxComponentHistories = null;
+        this.accountsEditable = null;
         this.glAccountOptions = null;
         this.glAccountTypeOptions = null;
     }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/tax/service/TaxReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/tax/service/TaxReadPlatformServiceImpl.java
@@ -20,10 +20,15 @@ package org.apache.fineract.portfolio.tax.service;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.apache.fineract.accounting.common.AccountingDropdownReadPlatformService;
+import org.apache.fineract.accounting.glaccount.data.GLAccountData;
+import org.apache.fineract.infrastructure.core.data.EnumOptionData;
+import org.apache.fineract.portfolio.charge.domain.ChargeRepository;
 import org.apache.fineract.portfolio.tax.data.TaxComponentData;
 import org.apache.fineract.portfolio.tax.data.TaxGroupData;
+import org.apache.fineract.portfolio.tax.domain.TaxComponent;
 import org.apache.fineract.portfolio.tax.domain.TaxComponentRepository;
 import org.apache.fineract.portfolio.tax.domain.TaxComponentRepositoryWrapper;
 import org.apache.fineract.portfolio.tax.domain.TaxGroupRepository;
@@ -41,6 +46,7 @@ public class TaxReadPlatformServiceImpl implements TaxReadPlatformService {
     private final TaxGroupRepository taxGroupRepository;
     private final TaxGroupRepositoryWrapper taxGroupRepositoryWrapper;
     private final TaxGroupMapper taxGroupMapper;
+    private final ChargeRepository chargeRepository;
 
     @Override
     public List<TaxComponentData> retrieveAllTaxComponents() {
@@ -49,7 +55,25 @@ public class TaxReadPlatformServiceImpl implements TaxReadPlatformService {
 
     @Override
     public TaxComponentData retrieveTaxComponentData(final Long id) {
-        return taxComponentMapper.map(taxComponentRepositoryWrapper.findOneWithNotFoundDetection(id));
+        final TaxComponent taxComponent = taxComponentRepositoryWrapper.findOneWithNotFoundDetection(id);
+        final TaxComponentData result = taxComponentMapper.map(taxComponent);
+
+        // Check if accounts are editable (component is not in use)
+        final boolean accountsEditable = !taxComponent
+                .isInUse(() -> chargeRepository.existsByTaxGroupContainingTaxComponent(taxComponent.getId()));
+
+        // Conditionally include account options if editable
+        Map<String, List<GLAccountData>> glAccountOptions = null;
+        Collection<EnumOptionData> glAccountTypeOptions = null;
+        if (accountsEditable) {
+            glAccountOptions = accountingDropdownReadPlatformService.retrieveAccountMappingOptions();
+            glAccountTypeOptions = accountingDropdownReadPlatformService.retrieveGLAccountTypeOptions();
+        }
+
+        // Return enhanced data with accountsEditable and conditional options
+        return TaxComponentData.instance(result.getId(), result.getName(), result.getPercentage(), result.getDebitAccountType(),
+                result.getDebitAccount(), result.getCreditAccountType(), result.getCreditAccount(), result.getStartDate(),
+                result.getTaxComponentHistories(), accountsEditable, glAccountOptions, glAccountTypeOptions);
     }
 
     @Override

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/tax/service/TaxWritePlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/tax/service/TaxWritePlatformServiceImpl.java
@@ -18,12 +18,22 @@
  */
 package org.apache.fineract.portfolio.tax.service;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.apache.fineract.accounting.glaccount.domain.GLAccount;
+import org.apache.fineract.accounting.glaccount.domain.GLAccountRepositoryWrapper;
+import org.apache.fineract.accounting.glaccount.domain.GLAccountType;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
+import org.apache.fineract.infrastructure.core.data.ApiParameterError;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResultBuilder;
+import org.apache.fineract.infrastructure.core.data.DataValidatorBuilder;
+import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
+import org.apache.fineract.portfolio.charge.domain.ChargeRepository;
+import org.apache.fineract.portfolio.tax.api.TaxApiConstants;
 import org.apache.fineract.portfolio.tax.domain.TaxComponent;
 import org.apache.fineract.portfolio.tax.domain.TaxComponentRepository;
 import org.apache.fineract.portfolio.tax.domain.TaxComponentRepositoryWrapper;
@@ -42,6 +52,8 @@ public class TaxWritePlatformServiceImpl implements TaxWritePlatformService {
     private final TaxComponentRepositoryWrapper taxComponentRepositoryWrapper;
     private final TaxGroupRepository taxGroupRepository;
     private final TaxGroupRepositoryWrapper taxGroupRepositoryWrapper;
+    private final ChargeRepository chargeRepository;
+    private final GLAccountRepositoryWrapper glAccountRepositoryWrapper;
 
     @Override
     public CommandProcessingResult createTaxComponent(final JsonCommand command) {
@@ -59,13 +71,112 @@ public class TaxWritePlatformServiceImpl implements TaxWritePlatformService {
         this.validator.validateForTaxComponentUpdate(command.json());
         final TaxComponent taxComponent = this.taxComponentRepositoryWrapper.findOneWithNotFoundDetection(id);
         this.validator.validateStartDate(taxComponent.startDate(), command);
-        Map<String, Object> changes = taxComponent.update(command);
+
+        // Enforce edit restrictions based on usage
+        // Check if tax component is in use (linked to charges via tax groups)
+        final boolean inUse = taxComponent.isInUse(() -> chargeRepository.existsByTaxGroupContainingTaxComponent(taxComponent.getId()));
+        if (inUse) {
+            validateRestrictedFieldsForInUseComponent(command);
+        }
+
+        // Load GLAccounts and convert account types if provided in the command
+        GLAccountType debitAccountType = null;
+        GLAccount debitAccount = null;
+        GLAccountType creditAccountType = null;
+        GLAccount creditAccount = null;
+
+        if (command.parameterExists(TaxApiConstants.debitAccountTypeParamName)) {
+            final Integer debitAccountTypeValue = command.integerValueSansLocaleOfParameterNamed(TaxApiConstants.debitAccountTypeParamName);
+            if (debitAccountTypeValue != null) {
+                debitAccountType = GLAccountType.fromInt(debitAccountTypeValue);
+            }
+        }
+
+        if (command.parameterExists(TaxApiConstants.debitAccountIdParamName)) {
+            final Long debitAccountId = command.longValueOfParameterNamed(TaxApiConstants.debitAccountIdParamName);
+            if (debitAccountId != null) {
+                debitAccount = this.glAccountRepositoryWrapper.findOneWithNotFoundDetection(debitAccountId);
+            }
+        }
+
+        if (command.parameterExists(TaxApiConstants.creditAccountTypeParamName)) {
+            final Integer creditAccountTypeValue = command
+                    .integerValueSansLocaleOfParameterNamed(TaxApiConstants.creditAccountTypeParamName);
+            if (creditAccountTypeValue != null) {
+                creditAccountType = GLAccountType.fromInt(creditAccountTypeValue);
+            }
+        }
+
+        if (command.parameterExists(TaxApiConstants.creditAccountIdParamName)) {
+            final Long creditAccountId = command.longValueOfParameterNamed(TaxApiConstants.creditAccountIdParamName);
+            if (creditAccountId != null) {
+                creditAccount = this.glAccountRepositoryWrapper.findOneWithNotFoundDetection(creditAccountId);
+            }
+        }
+
+        Map<String, Object> changes = taxComponent.update(command, debitAccountType, debitAccount, creditAccountType, creditAccount);
         this.validator.validateTaxComponentForUpdate(taxComponent);
         this.taxComponentRepository.saveAndFlush(taxComponent);
         return new CommandProcessingResultBuilder() //
                 .withEntityId(id) //
                 .with(changes) //
                 .build();
+    }
+
+    /**
+     * Validates that restricted fields are not being modified when tax component is in use. When a tax component is
+     * linked to tax groups (and potentially used in transactions), only the name field can be modified. All other
+     * fields (percentage, GL accounts, start date) must remain unchanged to maintain accounting integrity.
+     *
+     * @param command
+     *            the JSON command containing update parameters
+     * @throws PlatformApiDataValidationException
+     *             if any restricted field is present in the update request
+     */
+    private void validateRestrictedFieldsForInUseComponent(final JsonCommand command) {
+        final List<ApiParameterError> dataValidationErrors = new ArrayList<>();
+        final DataValidatorBuilder baseDataValidator = new DataValidatorBuilder(dataValidationErrors).resource("tax.component");
+
+        // Check if any restricted fields are being modified
+        if (command.parameterExists(TaxApiConstants.percentageParamName)) {
+            baseDataValidator.reset().parameter(TaxApiConstants.percentageParamName).failWithCode(
+                    "only.name.can.be.modified.once.tax.component.is.linked.or.used.in.transactions",
+                    "Only name can be modified once tax component is linked or used in transactions.");
+        }
+
+        if (command.parameterExists(TaxApiConstants.startDateParamName)) {
+            baseDataValidator.reset().parameter(TaxApiConstants.startDateParamName).failWithCode(
+                    "only.name.can.be.modified.once.tax.component.is.linked.or.used.in.transactions",
+                    "Only name can be modified once tax component is linked or used in transactions.");
+        }
+
+        if (command.parameterExists(TaxApiConstants.debitAccountTypeParamName)) {
+            baseDataValidator.reset().parameter(TaxApiConstants.debitAccountTypeParamName).failWithCode(
+                    "only.name.can.be.modified.once.tax.component.is.linked.or.used.in.transactions",
+                    "Only name can be modified once tax component is linked or used in transactions.");
+        }
+
+        if (command.parameterExists(TaxApiConstants.debitAccountIdParamName)) {
+            baseDataValidator.reset().parameter(TaxApiConstants.debitAccountIdParamName).failWithCode(
+                    "only.name.can.be.modified.once.tax.component.is.linked.or.used.in.transactions",
+                    "Only name can be modified once tax component is linked or used in transactions.");
+        }
+
+        if (command.parameterExists(TaxApiConstants.creditAccountTypeParamName)) {
+            baseDataValidator.reset().parameter(TaxApiConstants.creditAccountTypeParamName).failWithCode(
+                    "only.name.can.be.modified.once.tax.component.is.linked.or.used.in.transactions",
+                    "Only name can be modified once tax component is linked or used in transactions.");
+        }
+
+        if (command.parameterExists(TaxApiConstants.creditAccountIdParamName)) {
+            baseDataValidator.reset().parameter(TaxApiConstants.creditAccountIdParamName).failWithCode(
+                    "only.name.can.be.modified.once.tax.component.is.linked.or.used.in.transactions",
+                    "Only name can be modified once tax component is linked or used in transactions.");
+        }
+
+        if (!dataValidationErrors.isEmpty()) {
+            throw new PlatformApiDataValidationException(dataValidationErrors);
+        }
     }
 
     @Override

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/tax/starter/TaxConfiguration.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/tax/starter/TaxConfiguration.java
@@ -21,6 +21,7 @@ package org.apache.fineract.portfolio.tax.starter;
 import org.apache.fineract.accounting.common.AccountingDropdownReadPlatformService;
 import org.apache.fineract.accounting.glaccount.domain.GLAccountRepositoryWrapper;
 import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.apache.fineract.portfolio.charge.domain.ChargeRepository;
 import org.apache.fineract.portfolio.tax.domain.TaxComponentRepository;
 import org.apache.fineract.portfolio.tax.domain.TaxComponentRepositoryWrapper;
 import org.apache.fineract.portfolio.tax.domain.TaxGroupRepository;
@@ -52,17 +53,19 @@ public class TaxConfiguration {
     public TaxReadPlatformService taxReadPlatformService(final TaxComponentRepository taxComponentRepository,
             final TaxComponentRepositoryWrapper taxComponentRepositoryWrapper, final TaxComponentMapper taxComponentMapper,
             final TaxGroupRepository taxGroupRepository, final TaxGroupRepositoryWrapper taxGroupRepositoryWrapper,
-            final TaxGroupMapper taxGroupMapper, AccountingDropdownReadPlatformService accountingDropdownReadPlatformService) {
+            final TaxGroupMapper taxGroupMapper, AccountingDropdownReadPlatformService accountingDropdownReadPlatformService,
+            final ChargeRepository chargeRepository) {
         return new TaxReadPlatformServiceImpl(accountingDropdownReadPlatformService, taxComponentRepository, taxComponentRepositoryWrapper,
-                taxComponentMapper, taxGroupRepository, taxGroupRepositoryWrapper, taxGroupMapper);
+                taxComponentMapper, taxGroupRepository, taxGroupRepositoryWrapper, taxGroupMapper, chargeRepository);
     }
 
     @Bean
     @ConditionalOnMissingBean(TaxWritePlatformService.class)
     public TaxWritePlatformService taxWritePlatformService(TaxValidator validator, TaxAssembler taxAssembler,
             TaxComponentRepository taxComponentRepository, TaxGroupRepository taxGroupRepository,
-            TaxComponentRepositoryWrapper taxComponentRepositoryWrapper, TaxGroupRepositoryWrapper taxGroupRepositoryWrapper) {
+            TaxComponentRepositoryWrapper taxComponentRepositoryWrapper, TaxGroupRepositoryWrapper taxGroupRepositoryWrapper,
+            final ChargeRepository chargeRepository, final GLAccountRepositoryWrapper glAccountRepositoryWrapper) {
         return new TaxWritePlatformServiceImpl(validator, taxAssembler, taxComponentRepository, taxComponentRepositoryWrapper,
-                taxGroupRepository, taxGroupRepositoryWrapper);
+                taxGroupRepository, taxGroupRepositoryWrapper, chargeRepository, glAccountRepositoryWrapper);
     }
 }

--- a/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/domain/TaxComponent.java
+++ b/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/domain/TaxComponent.java
@@ -35,6 +35,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.fineract.accounting.glaccount.domain.GLAccount;
@@ -104,6 +105,11 @@ public class TaxComponent extends AbstractAuditableCustom {
     }
 
     public Map<String, Object> update(final JsonCommand command) {
+        return update(command, null, null, null, null);
+    }
+
+    public Map<String, Object> update(final JsonCommand command, final GLAccountType debitAccountType, final GLAccount debitAccount,
+            final GLAccountType creditAccountType, final GLAccount creditAccount) {
         final Map<String, Object> changes = new HashMap<>();
 
         if (command.isChangeInStringParameterNamed(TaxApiConstants.nameParamName, this.name)) {
@@ -112,11 +118,27 @@ public class TaxComponent extends AbstractAuditableCustom {
             this.name = StringUtils.defaultIfEmpty(newValue, null);
         }
 
+        // Track whether startDate was changed independently of percentage updates
+        LocalDate previousStartDate = this.startDate;
+
+        // Handle independent startDate update if provided and changed
+        if (command.parameterExists(TaxApiConstants.startDateParamName)) {
+            LocalDate requestedStartDate = command.localDateValueOfParameterNamed(TaxApiConstants.startDateParamName);
+            if ((requestedStartDate != null && !requestedStartDate.equals(this.startDate))
+                    || (requestedStartDate == null && this.startDate != null)) {
+                // Only update start date (no history here); history is handled for percentage changes below
+                updateStartDate(command, changes, false);
+            }
+        }
+
         if (command.isChangeInBigDecimalParameterNamed(TaxApiConstants.percentageParamName, this.percentage)) {
             final BigDecimal newValue = command.bigDecimalValueOfParameterNamed(TaxApiConstants.percentageParamName);
             changes.put(TaxApiConstants.percentageParamName, newValue);
 
-            LocalDate oldStartDate = this.startDate;
+            // For percentage change, history must capture old and new start dates. Use the
+            // start date as it was before any percentage-change-driven adjustment.
+            LocalDate oldStartDate = previousStartDate;
+            // Adjust start date for the new percentage; this may honor provided startDate
             updateStartDate(command, changes, true);
             LocalDate newStartDate = this.startDate;
 
@@ -124,6 +146,66 @@ public class TaxComponent extends AbstractAuditableCustom {
             this.taxComponentHistories.add(history);
             this.percentage = newValue;
 
+        }
+
+        // Handle debit account type
+        if (command.isChangeInIntegerParameterNamed(TaxApiConstants.debitAccountTypeParamName, this.debitAccountType)) {
+            final Integer newValue = command.integerValueSansLocaleOfParameterNamed(TaxApiConstants.debitAccountTypeParamName);
+            changes.put(TaxApiConstants.debitAccountTypeParamName, newValue);
+            if (debitAccountType != null) {
+                this.debitAccountType = debitAccountType.getValue();
+            } else if (newValue != null) {
+                final GLAccountType accountType = GLAccountType.fromInt(newValue);
+                this.debitAccountType = accountType != null ? accountType.getValue() : null;
+            } else {
+                this.debitAccountType = null;
+            }
+        }
+
+        // Handle debit account ID
+        final Long currentDebitAccountId = this.debitAccount != null ? this.debitAccount.getId() : null;
+        if (command.isChangeInLongParameterNamed(TaxApiConstants.debitAccountIdParamName, currentDebitAccountId)) {
+            final Long newValue = command.longValueOfParameterNamed(TaxApiConstants.debitAccountIdParamName);
+            changes.put(TaxApiConstants.debitAccountIdParamName, newValue);
+            // debitAccount is loaded in service layer if newValue is not null, otherwise it's null
+            this.debitAccount = debitAccount;
+            // If account ID is set to null, also clear account type
+            if (newValue == null && command.parameterExists(TaxApiConstants.debitAccountIdParamName)) {
+                this.debitAccountType = null;
+                if (!changes.containsKey(TaxApiConstants.debitAccountTypeParamName)) {
+                    changes.put(TaxApiConstants.debitAccountTypeParamName, null);
+                }
+            }
+        }
+
+        // Handle credit account type
+        if (command.isChangeInIntegerParameterNamed(TaxApiConstants.creditAccountTypeParamName, this.creditAccountType)) {
+            final Integer newValue = command.integerValueSansLocaleOfParameterNamed(TaxApiConstants.creditAccountTypeParamName);
+            changes.put(TaxApiConstants.creditAccountTypeParamName, newValue);
+            if (creditAccountType != null) {
+                this.creditAccountType = creditAccountType.getValue();
+            } else if (newValue != null) {
+                final GLAccountType accountType = GLAccountType.fromInt(newValue);
+                this.creditAccountType = accountType != null ? accountType.getValue() : null;
+            } else {
+                this.creditAccountType = null;
+            }
+        }
+
+        // Handle credit account ID
+        final Long currentCreditAccountId = this.creditAccount != null ? this.creditAccount.getId() : null;
+        if (command.isChangeInLongParameterNamed(TaxApiConstants.creditAccountIdParamName, currentCreditAccountId)) {
+            final Long newValue = command.longValueOfParameterNamed(TaxApiConstants.creditAccountIdParamName);
+            changes.put(TaxApiConstants.creditAccountIdParamName, newValue);
+            // creditAccount is loaded in service layer if newValue is not null, otherwise it's null
+            this.creditAccount = creditAccount;
+            // If account ID is set to null, also clear account type
+            if (newValue == null && command.parameterExists(TaxApiConstants.creditAccountIdParamName)) {
+                this.creditAccountType = null;
+                if (!changes.containsKey(TaxApiConstants.creditAccountTypeParamName)) {
+                    changes.put(TaxApiConstants.creditAccountTypeParamName, null);
+                }
+            }
         }
 
         return changes;
@@ -204,5 +286,25 @@ public class TaxComponent extends AbstractAuditableCustom {
 
     public GLAccount getCreditAccount() {
         return this.creditAccount;
+    }
+
+    /**
+     * Checks if this tax component is in use. A tax component is considered "in use" ONLY if: - It is linked to
+     * TaxGroupMappings (mapped to tax groups) - AND at least one Charge exists that references a TaxGroup containing
+     * this TaxComponent
+     *
+     * Being mapped to TaxGroup alone is NOT considered in use.
+     *
+     * @param chargeUsageChecker
+     *            a supplier that checks if any Charge exists using this tax component via tax groups
+     * @return true if the tax component is in use (linked to charges via tax groups), false otherwise
+     */
+    public boolean isInUse(final Supplier<Boolean> chargeUsageChecker) {
+        // First check if component is mapped to any tax groups
+        if (this.taxGroupMappings == null || this.taxGroupMappings.isEmpty()) {
+            return false;
+        }
+        // Then check if any charges exist using those tax groups
+        return chargeUsageChecker != null && Boolean.TRUE.equals(chargeUsageChecker.get());
     }
 }

--- a/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/mapper/TaxComponentMapper.java
+++ b/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/mapper/TaxComponentMapper.java
@@ -37,6 +37,7 @@ public interface TaxComponentMapper {
     @Mapping(target = "glAccountOptions", ignore = true)
     @Mapping(target = "glAccountTypeOptions", ignore = true)
     @Mapping(target = "taxComponentHistories", ignore = true)
+    @Mapping(target = "accountsEditable", ignore = true)
     TaxComponentData map(TaxComponent taxComponent);
 
     List<TaxComponentData> map(List<TaxComponent> taxComponents);

--- a/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/serialization/TaxValidator.java
+++ b/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/serialization/TaxValidator.java
@@ -65,8 +65,10 @@ public class TaxValidator {
             Arrays.asList(DATE_FORMAT, LOCALE, TaxApiConstants.nameParamName, TaxApiConstants.percentageParamName,
                     TaxApiConstants.startDateParamName, TaxApiConstants.debitAccountTypeParamName, TaxApiConstants.debitAccountIdParamName,
                     TaxApiConstants.creditAccountTypeParamName, TaxApiConstants.creditAccountIdParamName));
-    private static final Set<String> SUPPORTED_TAX_COMPONENT_UPDATE_PARAMETERS = new HashSet<>(Arrays.asList(DATE_FORMAT, LOCALE,
-            TaxApiConstants.nameParamName, TaxApiConstants.percentageParamName, TaxApiConstants.startDateParamName));
+    private static final Set<String> SUPPORTED_TAX_COMPONENT_UPDATE_PARAMETERS = new HashSet<>(
+            Arrays.asList(DATE_FORMAT, LOCALE, TaxApiConstants.nameParamName, TaxApiConstants.percentageParamName,
+                    TaxApiConstants.startDateParamName, TaxApiConstants.debitAccountTypeParamName, TaxApiConstants.debitAccountIdParamName,
+                    TaxApiConstants.creditAccountTypeParamName, TaxApiConstants.creditAccountIdParamName));
     private static final Set<String> SUPPORTED_TAX_GROUP_PARAMETERS = new HashSet<>(
             Arrays.asList(DATE_FORMAT, LOCALE, TaxApiConstants.nameParamName, TaxApiConstants.taxComponentsParamName));
     private static final Set<String> SUPPORTED_TAX_GROUP_TAX_COMPONENTS_CREATE_PARAMETERS = new HashSet<>(
@@ -328,7 +330,24 @@ public class TaxValidator {
 
     private void validateStartDate(final LocalDate existingStartDate, final LocalDate startDate,
             final DataValidatorBuilder baseDataValidator) {
-        baseDataValidator.reset().parameter(TaxApiConstants.startDateParamName).value(startDate).validateDateAfter(existingStartDate);
+        // New business rules for start date updates:
+        // 1. If existingStartDate is on or before today, the start date is locked and cannot be modified.
+        // In this case, any attempt to change the startDate should result in a validation error.
+        // 2. If existingStartDate is after today, startDate can be modified, but the new value
+        // must be strictly after today.
+        final LocalDate today = DateUtils.getBusinessLocalDate();
+
+        if (existingStartDate != null && !DateUtils.isAfter(existingStartDate, today)) {
+            // Start date is locked; any presence of startDate is considered an invalid modification.
+            if (startDate != null && !DateUtils.isEqual(startDate, existingStartDate)) {
+                baseDataValidator.reset().parameter(TaxApiConstants.startDateParamName)
+                        .failWithCode("start.date.cannot.be.modified.after.activation");
+            }
+            return;
+        }
+
+        // Existing start date is in the future; allow change, but new date must be strictly after today.
+        baseDataValidator.reset().parameter(TaxApiConstants.startDateParamName).value(startDate).validateDateAfter(today);
     }
 
     private void validateOverlappingComponents(final Set<TaxGroupMappings> taxMappings, final DataValidatorBuilder baseDataValidator) {


### PR DESCRIPTION
Currently, a Tax Component's percentage, GL accounts (debit/credit), and start date can be modified at any time via PUT /v1/taxes/component/{id},
  even after the component has been linked to transactions through a Tax Group. This risks inconsistencies in historical calculations and journal  
  entries, since past periods rely on the component's percentage and GL account mapping at the time they were recorded.                            
                                                                                                                                                   
  This PR enforces the following rules on tax component updates:                                                                                   
                                                                                                                                                   
  - If a Tax Component has not been linked to any Tax Group, all fields (name, percentage, GL accounts, start date) remain editable.               
  - If a Tax Component is linked to a Tax Group that is in turn referenced by at least one Charge (i.e. it is "in use"), only the name can still be
    edited. Attempting to change percentage, GL accounts, or start date returns a validation error.                                                
  - Start date specifically: if the existing start date is still in the future (not yet active), it can still be changed, but only to another date 
    strictly after today. Once the start date has passed (component active), it is locked regardless of usage.                                     
  - GL account (debit/credit type and account) updates are now supported through the update endpoint for components not yet in use — previously    
    this endpoint did not support changing GL accounts at all. 
     Changes                                                                                                                                          
                                                                                                                                                   
  - ChargeRepository: added existsByTaxGroupContainingTaxComponent(Long) to check whether any Charge references a Tax Group containing a given Tax 
    Component.                                                                                                                                     
  - TaxComponent: added isInUse(Supplier<Boolean>) (mapped-to-a-group AND charge-usage check), and extended update(...) to accept and apply GL     
    account changes.                                                                                                                               
  - TaxComponentData: added accountsEditable indicator, surfaced on GET /v1/taxes/component/{id}.                                                  
  - TaxReadPlatformServiceImpl: computes accountsEditable and conditionally includes GL account template options based on it.                      
  - TaxWritePlatformServiceImpl: enforces the restricted-fields validation when a component is in use, and resolves GL accounts from the update    
    command.                                                                                                                                       
  - TaxValidator: extends supported update parameters to include GL account fields; adds the two-tier start-date validation rule described above.  
  - TaxConfiguration: wires the new ChargeRepository/GLAccountRepositoryWrapper dependencies into the read/write service beans.   