### PR TITLE
FINERACT-2768: Tax Group cannot be edited once a linked Tax Component has ended

### DIFF
--- a/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/serialization/TaxValidator.java
+++ b/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/serialization/TaxValidator.java
@@ -247,8 +247,7 @@ public class TaxValidator {
                             SUPPORTED_TAX_GROUP_TAX_COMPONENTS_UPDATE_PARAMETERS);
                     final Long taxComponentId = this.fromApiJsonHelper.extractLongNamed(TaxApiConstants.taxComponentIdParamName,
                             taxComponent);
-                    final Long taxMappingId = this.fromApiJsonHelper.extractLongNamed(TaxApiConstants.taxComponentIdParamName,
-                            taxComponent);
+                    final Long taxMappingId = this.fromApiJsonHelper.extractLongNamed(TaxApiConstants.idParamName, taxComponent);
                     if (taxMappingId == null) {
                         baseDataValidator.reset().parameter(
                                 TaxApiConstants.taxComponentsParamName + DOT + TaxApiConstants.taxComponentIdParamName + AT_INDEX + i)
@@ -264,9 +263,14 @@ public class TaxValidator {
 
                     final LocalDate endDate = this.fromApiJsonHelper.extractLocalDateNamed(TaxApiConstants.endDateParamName, taxComponent,
                             dateFormat, locale);
-                    baseDataValidator.reset()
-                            .parameter(TaxApiConstants.taxComponentsParamName + DOT + TaxApiConstants.endDateParamName + AT_INDEX + i)
-                            .value(endDate).ignoreIfNull().validateDateAfter(DateUtils.getBusinessLocalDate());
+                    if (taxMappingId == null) {
+                        // Newly added component: its end date (if any) must be in the future.
+                        // Existing mappings are left to validateTaxGroupEndDateAndTaxComponent, which allows an
+                        // already-ended component to be resubmitted unchanged so the rest of the group can be edited.
+                        baseDataValidator.reset()
+                                .parameter(TaxApiConstants.taxComponentsParamName + DOT + TaxApiConstants.endDateParamName + AT_INDEX + i)
+                                .value(endDate).ignoreIfNull().validateDateAfter(DateUtils.getBusinessLocalDate());
+                    }
                     final LocalDate startDate = this.fromApiJsonHelper.extractLocalDateNamed(TaxApiConstants.startDateParamName,
                             taxComponent, dateFormat, locale);
                     if (endDate != null && startDate != null) {


### PR DESCRIPTION
What's the issue?                                                                                                                                
                                                                                                                                                   
  TaxValidator.validateForTaxGroupUpdate() required every taxComponents[].endDate submitted with a tax group update to be strictly in the future — 
  including for an existing, already-linked component that had already ended and was simply being resubmitted unchanged as part of editing         
  something else about the group (renaming it, adding a new component, etc.). Since clients typically resubmit the full taxComponents array on     
  update to avoid dropping existing mappings, this made a Tax Group permanently un-editable once any one of its linked components passed its end   
  date, even when that end date wasn't being changed.                                                                                              
                                                                                                                                                   
  What's the fix?                                                                                                                                  
                                                                                                                                                   
  The future-end-date check now only applies to newly added components (no existing mapping id yet). Existing mappings continue to be validated by 
  validateTaxGroupEndDateAndTaxComponent(), which already correctly allows an unchanged end date to pass through and only rejects an actual attempt
  to modify it. 
   Incidental fix                                                                                                                                   
                                                                                                                                                   
  While tracing the new-vs-existing distinction, found taxMappingId was being extracted using the taxComponentId JSON key instead of id — a        
  pre-existing bug (predates this change) that made the new/existing branch a no-op. Corrected the key so the distinction — and this fix — actually
  works.
  PR:(https://issues.apache.org/jira/browse/FINERACT-2768)