### PR TITLE
FINERACT-2770: Tax - Unable to edit a tax group

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/tax/request/TaxGroupComponent.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/tax/request/TaxGroupComponent.java
@@ -32,6 +32,9 @@ public class TaxGroupComponent implements Serializable {
     @Serial
     private static final long serialVersionUID = 1L;
 
+    private Long id;
     private Long taxComponentId;
     private String startDate;
+    private String endDate;
+
 }


### PR DESCRIPTION
`TaxGroupComponent` (the request DTO used by `POST /v1/taxes/group` and                                                                          
  `PUT /v1/taxes/group/{taxGroupId}`) was missing the `id` and `endDate`                                                                           
  fields — it only declared `taxComponentId` and `startDate`. 
  `TaxGroupApiResource#createTaxGroup`/`#updateTaxGroup` deserialize the                                                                           
  incoming JSON request body into this DTO and then re-serialize it before                                                                         
  handing it off to the command handler. Because the DTO didn't declare                                                                            
  `id`/`endDate`, Jackson silently dropped those values during that                                                                                
  round-trip for any client that submitted them — before the tax group's                                                                           
  write-platform service or validators ever saw them. In practice this made                                                                        
  it impossible to correctly update an existing tax group's components (e.g.                                                                       
  resubmitting an existing component's `id`, or setting/keeping its                                                                                
  `endDate`). 
  This is a pre-existing mismatch between the DTO and its own documented                                                                           
  contract: `TaxGroupApiResource`'s Swagger docs already state                                                                                     
                                                                                                                                                   
  > Optional Fields in taxComponents: id, startDate and endDate                                                                                    
                                                                                                                                                   
  for tax group creation — the DTO just never actually had the `id`/`endDate`                                                                      
  fields to back that documentation.                                                                                                               
                                                                                                                                                   
  ## Fix                                                                                                                                           
                                                                                                                                                   
  Add the missing `id` and `endDate` fields to `TaxGroupComponent`, matching                                                                       
  what the API already documents and what `TaxGroupData`/response-side                                                                             
  mapping already expects.
  PR:(https://issues.apache.org/jira/browse/FINERACT-2770)