### PR TITLE
FINERACT-2771: Tax - User should be able to set end date for a tax group

### DIFF
--- a/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/serialization/TaxValidator.java
+++ b/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/serialization/TaxValidator.java
@@ -286,13 +286,8 @@ public class TaxValidator {
         for (TaxGroupMappings mapping : groupMappings) {
             if (mapping.getId() != null) {
                 TaxGroupMappings existing = taxGroup.findOneBy(mapping);
-                if (existing.endDate() != null && mapping.endDate() != null && !DateUtils.isEqual(existing.endDate(), mapping.endDate())) {
-                    baseDataValidator.reset().parameter(TaxApiConstants.endDateParamName)
-                            .failWithCode("can.not.modify.end.date.once.updated");
-                } else {
-                    baseDataValidator.reset().parameter(TaxApiConstants.endDateParamName).value(mapping.endDate()).ignoreIfNull()
-                            .validateDateAfter(existing.startDate());
-                }
+                baseDataValidator.reset().parameter(TaxApiConstants.endDateParamName).value(mapping.endDate()).ignoreIfNull()
+                        .validateDateAfter(existing.startDate());
                 if (mapping.getTaxComponent() != null && !existing.getTaxComponent().getId().equals(mapping.getTaxComponent().getId())) {
                     baseDataValidator.reset().parameter(TaxApiConstants.taxComponentIdParamName).failWithCode("update.not.supported");
                 }


### PR DESCRIPTION
 A tax group component's end date could only ever be set once: `TaxValidator.validateTaxGroupEndDateAndTaxComponent()`                            
  rejected any attempt to change an end date to a different value if it had                                                                        
  already been set before, even when the new value was a perfectly valid                                                                           
  future date after the component's start date. This made it impossible to                                                                         
  correct or extend an end date once entered.                                                                                                      
                                                                                                                                                   
  This PR removes that one-time restriction. An existing tax group                                                                                 
  component's end date can now be updated repeatedly, with the only remaining                                                                      
  constraint being that each new end date must fall after the component's                                                                          
  start date.
  PR:(https://issues.apache.org/jira/browse/FINERACT-2771)