### PR TITLE
FINERACT-2772: Tax group - User should be able to set end date if start date was in the past

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/tax/data/TaxGroupData.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/tax/data/TaxGroupData.java
@@ -19,6 +19,7 @@
 package org.apache.fineract.portfolio.tax.data;
 
 import java.io.Serializable;
+import java.time.LocalDate;
 import java.util.Collection;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -35,21 +36,28 @@ public final class TaxGroupData implements Serializable {
     @SuppressWarnings("unused")
     private final Collection<TaxComponentData> taxComponents;
 
+    // System business date, exposed so clients can validate a new tax component's start date client-side
+    private final LocalDate businessDate;
+
     public static TaxGroupData lookup(final Long id, final String name) {
         final Collection<TaxComponentData> taxComponents = null;
         final Collection<TaxGroupMappingsData> taxAssociations = null;
-        return new TaxGroupData(id, name, taxAssociations, taxComponents);
+        return new TaxGroupData(id, name, taxAssociations, taxComponents, null);
     }
 
     public static TaxGroupData template(final Collection<TaxComponentData> taxComponents) {
         final Long id = null;
         final String name = null;
         final Collection<TaxGroupMappingsData> taxAssociations = null;
-        return new TaxGroupData(id, name, taxAssociations, taxComponents);
+        return new TaxGroupData(id, name, taxAssociations, taxComponents, null);
     }
 
     public static TaxGroupData template(final TaxGroupData taxGroupData, final Collection<TaxComponentData> taxComponents) {
-        return new TaxGroupData(taxGroupData.id, taxGroupData.name, taxGroupData.taxAssociations, taxComponents);
+        return new TaxGroupData(taxGroupData.id, taxGroupData.name, taxGroupData.taxAssociations, taxComponents, taxGroupData.businessDate);
+    }
+
+    public static TaxGroupData withBusinessDate(final TaxGroupData taxGroupData, final LocalDate businessDate) {
+        return new TaxGroupData(taxGroupData.id, taxGroupData.name, taxGroupData.taxAssociations, taxGroupData.taxComponents, businessDate);
     }
 
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/tax/service/TaxReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/tax/service/TaxReadPlatformServiceImpl.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.apache.fineract.accounting.common.AccountingDropdownReadPlatformService;
+import org.apache.fineract.infrastructure.core.service.DateUtils;
 import org.apache.fineract.portfolio.tax.data.TaxComponentData;
 import org.apache.fineract.portfolio.tax.data.TaxGroupData;
 import org.apache.fineract.portfolio.tax.domain.TaxComponentRepository;
@@ -65,7 +66,8 @@ public class TaxReadPlatformServiceImpl implements TaxReadPlatformService {
 
     @Override
     public TaxGroupData retrieveTaxGroupData(final Long id) {
-        return taxGroupMapper.map(taxGroupRepositoryWrapper.findOneWithNotFoundDetection(id));
+        final TaxGroupData taxGroupData = taxGroupMapper.map(taxGroupRepositoryWrapper.findOneWithNotFoundDetection(id));
+        return TaxGroupData.withBusinessDate(taxGroupData, DateUtils.getBusinessLocalDate());
     }
 
     @Override

--- a/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/domain/TaxGroup.java
+++ b/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/domain/TaxGroup.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
@@ -93,15 +94,17 @@ public class TaxGroup extends AbstractAuditableCustom {
     }
 
     public TaxGroupMappings findOneBy(final TaxGroupMappings groupMapping) {
-        if (groupMapping.getId() != null) {
-            for (TaxGroupMappings groupMappings : this.taxGroupMappings) {
-                if (groupMappings.getId().equals(groupMapping.getId())) {
-                    return groupMappings;
-                }
-            }
-            throw new TaxMappingNotFoundException(groupMapping.getId());
+        if (groupMapping.getId() == null) {
+            return null;
         }
-        return null;
+
+        for (TaxGroupMappings existing : this.taxGroupMappings) {
+            if (Objects.equals(existing.getId(), groupMapping.getId())) {
+                return existing;
+            }
+        }
+
+        throw new TaxMappingNotFoundException(groupMapping.getId());
     }
 
     public Set<TaxGroupMappings> getTaxGroupMappings() {

--- a/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/mapper/TaxGroupMapper.java
+++ b/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/mapper/TaxGroupMapper.java
@@ -30,6 +30,7 @@ public interface TaxGroupMapper {
 
     @Mapping(target = "taxAssociations", source = "taxGroup.taxGroupMappings")
     @Mapping(target = "taxComponents", ignore = true)
+    @Mapping(target = "businessDate", ignore = true)
     TaxGroupData map(TaxGroup taxGroup);
 
     List<TaxGroupData> map(List<TaxGroup> taxGroups);


### PR DESCRIPTION

`TaxGroup.findOneBy(TaxGroupMappings)` threw `TaxMappingNotFoundException` as soon as the **first** existing mapping in the set didn't match the one being looked up, instead of checking the rest of the set. With a tax group that has more than one component mapping, this meant editing/adding a component could randomly fail with an Internal Server Error depending on iteration order, even though a matching mapping existed further down the set. The same method could also throw an NPE via `groupMappings.getId().equals(...)` when an existing mapping's id was itself `null`.

This PR:
- Fixes `findOneBy` to scan the full set of existing mappings and only throw `TaxMappingNotFoundException` if none of them match, using `Objects.equals` to avoid the NPE on a null id.
- Exposes a `businessDate` field on `TaxGroupData` (populated from `DateUtils.getBusinessLocalDate()` when fetching a single tax group), so a client can validate a new tax component's start date against the system business date before submitting, instead of relying on the server round-trip to reject it.
 ## Changes                                                                                                                                       
                                                                                                                                                   
  - `TaxGroup#findOneBy`: iterate over all mappings before giving up, `Objects.equals` instead of `.getId().equals(...)`                           
  - `TaxGroupData`: new `businessDate` field + `withBusinessDate(TaxGroupData, LocalDate)` factory (mirrors the existing `template(...)`           
  copy-factory pattern); existing `lookup()`/`template()` factories updated to carry the field through                                             
  - `TaxGroupMapper`: `businessDate` marked `ignore` in the MapStruct mapping (it's computed, not entity data)                                     
  - `TaxReadPlatformServiceImpl#retrieveTaxGroupData`: populates `businessDate` on the returned `TaxGroupData`   
  PR:(https://issues.apache.org/jira/browse/FINERACT-2772)