### PR TITLE
FINERACT-2776: Add entitySubType to GetDataTablesResponse schema

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/api/DatatablesApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/api/DatatablesApiResourceSwagger.java
@@ -45,6 +45,8 @@ final class DatatablesApiResourceSwagger {
         public String applicationTableName;
         @Schema(example = "extra_client_details")
         public String registeredTableName;
+        @Schema(example = "Person", description = "The entity sub type the datatable is registered against, when the application table supports one (for example Person or Entity on m_client). Null when the registration is not scoped to a sub type.")
+        public String entitySubType;
         public List<ResultsetColumnHeaderData> columnHeaderData;
     }
 

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/datatable/DatatableIntegrationTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/datatable/DatatableIntegrationTest.java
@@ -702,6 +702,7 @@ public class DatatableIntegrationTest extends IntegrationTest {
         assertEquals(datatableName, datatableUpdateResponse.getResourceIdentifier());
 
         GetDataTablesResponse dataTable = datatableHelper.getDataTableDetails(datatableName);
+        assertEquals(CLIENT_PERSON_SUBTYPE_NAME, dataTable.getEntitySubType());
         List<ResultsetColumnHeaderData> columnHeaders = dataTable.getColumnHeaderData();
         assertEquals(5, columnHeaders.size());
         ResultsetColumnHeaderData stringColumn = columnHeaders.get(1);


### PR DESCRIPTION
POST /datatables accepts an entitySubType and the platform stores it in x_registered_table.entity_subtype. Both GET routes return it: DatatableData carries the field, and DatatableReadServiceImpl selects entity_subtype and passes it to DatatableData.create on the list path and the single-table path alike.

The class both routes name as their @ApiResponse schema does not declare it. PostDataTablesRequest does; GetDataTablesResponse does not. So the published document describes a datatable as having only applicationTableName, registeredTableName and columnHeaderData, and a caller can set a property that the documented response does not contain.

Hand-written clients are unaffected, since the JSON has the field. Generated ones cannot read it at all. entitySubType scopes a datatable to a client legal form, so a client that renders custom fields on a customer needs it to tell whether a given table belongs on a person or on an entity.

DatatableIntegrationTest already sets entitySubType on eleven datatable creations and never asserts it comes back, because the generated model has no getter for it. validateCreateAndEditDatatable now asserts the sub type it created the table with. fineract-client is generated from this spec, so that assertion does not compile before this change and passes after it.

No runtime behaviour changes; the response was already correct.

## Description

Describe the changes made and why they were made. (Ignore if these details are present on the associated Apache Fineract JIRA ticket.)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [ ] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).
- [ ] If merging this PR resolves a JIRA issue, I will mark that issue as resolved and set "Fix Version/s" appropriately.

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
