### PR TITLE
FINERACT-2805: Correct parameter comparison in updatePostDatedChecks validation

### DIFF
--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/repaymentwithpostdatedchecks/domain/PostDatedChecks.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/repaymentwithpostdatedchecks/domain/PostDatedChecks.java
@@ -102,7 +102,7 @@ public class PostDatedChecks extends AbstractPersistableCustom<Long> {
             changes.put("accountNo", newAccountNo);
         }
 
-        if (command.isChangeInLongParameterNamed("checkNo", this.accountNo)) {
+        if (command.isChangeInLongParameterNamed("checkNo", this.checkNo)) {
             final Long newCheckNo = command.longValueOfParameterNamed("checkNo");
             this.checkNo = newCheckNo;
             changes.put("checkNo", newCheckNo);


### PR DESCRIPTION
## Description
This Pull Request corrects a copy-paste logic bug in the `updatePostDatedChecks` method inside `PostDatedChecks.java`. 

Previously, the condition for checking a change in the check number parameter was comparing the new input value against `this.accountNo` instead of `this.checkNo`:
`if (command.isChangeInLongParameterNamed("checkNo", this.accountNo))`

This error causes unexpected validation behaviors when updating check information. This fix switches the parameter reference to the correct field variable:
`if (command.isChangeInLongParameterNamed("checkNo", this.checkNo))`

## Impact
- Corrects data validation accuracy for updating post-dated checks.
- Prevents potential bugs where a check number matching the account number fails to update.
- No runtime breaking changes or structural updates.

## Verifications
- Code compiles cleanly locally using `./gradlew compileJava`.
