### PR TITLE
FINERACT-2778: Allow teller and vault financial activity mappings to be updated

### DIFF
--- a/fineract-accounting/src/main/java/org/apache/fineract/accounting/financialactivityaccount/serialization/FinancialActivityAccountDataValidator.java
+++ b/fineract-accounting/src/main/java/org/apache/fineract/accounting/financialactivityaccount/serialization/FinancialActivityAccountDataValidator.java
@@ -88,6 +88,7 @@ public final class FinancialActivityAccountDataValidator {
                     element);
             baseDataValidator.reset().parameter(paramNameForFinancialActivity).value(financialActivityId).ignoreIfNull().isOneOfTheseValues(
                     FinancialActivity.ASSET_TRANSFER.getValue(), FinancialActivity.LIABILITY_TRANSFER.getValue(),
+                    FinancialActivity.CASH_AT_MAINVAULT.getValue(), FinancialActivity.CASH_AT_TELLER.getValue(),
                     FinancialActivity.OPENING_BALANCES_TRANSFER_CONTRA.getValue(), FinancialActivity.ASSET_FUND_SOURCE.getValue(),
                     FinancialActivity.PAYABLE_DIVIDENDS.getValue());
         }

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/FinancialActivityAccountsTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/FinancialActivityAccountsTest.java
@@ -52,6 +52,7 @@ public class FinancialActivityAccountsTest {
     private FinancialActivityAccountHelper financialActivityAccountHelper;
     private final Integer assetTransferFinancialActivityId = FinancialActivity.ASSET_TRANSFER.getValue();
     public static final Integer LIABILITY_TRANSFER_FINANCIAL_ACTIVITY_ID = FinancialActivity.LIABILITY_TRANSFER.getValue();
+    public static final Integer CASH_AT_TELLER_FINANCIAL_ACTIVITY_ID = FinancialActivity.CASH_AT_TELLER.getValue();
 
     @BeforeEach
     public void setup() {
@@ -134,6 +135,26 @@ public class FinancialActivityAccountsTest {
 
         /*** Trying to fetch a Deleted Account Mapping should give me a 404 **/
         financialActivityAccountHelper.getFinancialActivityAccount(deletedFinancialActivityAccountId, responseSpecForResourceNotFoundError);
+    }
+
+    @Test
+    public void testTellerFinancialActivityAccountCanBeUpdated() {
+        Account tellerCashAccount = accountHelper.createAssetAccount();
+        Account replacementTellerCashAccount = accountHelper.createAssetAccount();
+        Assertions.assertNotNull(tellerCashAccount);
+        Assertions.assertNotNull(replacementTellerCashAccount);
+
+        Integer financialActivityAccountId = (Integer) financialActivityAccountHelper.createFinancialActivityAccount(
+                CASH_AT_TELLER_FINANCIAL_ACTIVITY_ID, tellerCashAccount.getAccountID(), responseSpec, CommonConstants.RESPONSE_RESOURCE_ID);
+        Assertions.assertNotNull(financialActivityAccountId);
+        assertFinancialActivityAccountCreation(financialActivityAccountId, CASH_AT_TELLER_FINANCIAL_ACTIVITY_ID, tellerCashAccount);
+
+        HashMap changes = (HashMap) financialActivityAccountHelper.updateFinancialActivityAccount(financialActivityAccountId,
+                CASH_AT_TELLER_FINANCIAL_ACTIVITY_ID, replacementTellerCashAccount.getAccountID(), responseSpec,
+                CommonConstants.RESPONSE_CHANGES);
+        Assertions.assertEquals(replacementTellerCashAccount.getAccountID(), changes.get("glAccountId"));
+        assertFinancialActivityAccountCreation(financialActivityAccountId, CASH_AT_TELLER_FINANCIAL_ACTIVITY_ID,
+                replacementTellerCashAccount);
     }
 
     private void assertFinancialActivityAccountCreation(Integer financialActivityAccountId, Integer financialActivityId,


### PR DESCRIPTION
FinancialActivityAccountDataValidator validates the same parameter against two
hand-written lists. validateForCreate accepts all seven FinancialActivity
constants; validateForUpdate accepted five, omitting CASH_AT_MAINVAULT (101)
and CASH_AT_TELLER (102). The platform will therefore create a teller or vault
mapping and then refuse every attempt to change it:

    PUT /financialactivityaccounts/{id} {"financialActivityId":102,...}
    400 validation.msg.financialactivityaccount.financialActivityId
        .is.not.one.of.expected.enumerations
        must be one of [ 100, 200, 300, 103, 201 ]

Both halves write the same column, and the teller module resolves the mapping
through findByFinancialActivityTypeWithNotFoundDetection whichever route
created it, so the two lists have no reason to differ.

These are the GL accounts the cashier module posts cash against. A deployment
that maps them wrongly, which is easy since they are set once at configuration
time, has every teller and vault movement landing on the wrong account and no
supported way to correct it. The remaining options are to delete the mapping
and create a replacement, discarding the row and its identity, or to update the
database directly, bypassing validation and the audit trail.

FinancialActivityAccountsTest exercised the update path only with
LIABILITY_TRANSFER, and its negative case used activity id 232, which is not in
the enum at all. A value that is in the enum, is accepted by create and is
refused by update fell between the two cases. The test now creates a
CASH_AT_TELLER mapping and updates it.

## Description

Describe the changes made and why they were made. (Ignore if these details are present on the associated Apache Fineract JIRA ticket.)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [ ] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).
- [ ] If merging this PR resolves a JIRA issue, I will mark that issue as resolved and set "Fix Version/s" appropriately.

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
