### PR TITLE
FINERACT-2782: Add UpdateEmailCommandHandler for /v1/email UPDATE endpoint

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/campaigns/email/handler/UpdateEmailCommandHandler.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/campaigns/email/handler/UpdateEmailCommandHandler.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.campaigns.email.handler;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.commands.annotation.CommandType;
+import org.apache.fineract.commands.handler.NewCommandSourceHandler;
+import org.apache.fineract.infrastructure.campaigns.email.service.EmailWritePlatformService;
+import org.apache.fineract.infrastructure.core.api.JsonCommand;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@CommandType(entity = "EMAIL", action = "UPDATE")
+@RequiredArgsConstructor
+public class UpdateEmailCommandHandler implements NewCommandSourceHandler {
+
+    private final EmailWritePlatformService writePlatformService;
+
+    @Transactional
+    @Override
+    public CommandProcessingResult processCommand(final JsonCommand command) {
+
+        return this.writePlatformService.update(command.entityId(), command);
+    }
+}


### PR DESCRIPTION
## Description

EmailApiResource exposes CREATE, RETRIEVE, UPDATE, DELETE endpoints for
/v1/email. CREATE and DELETE have working @CommandType handlers; UPDATE
does not, so calling the UPDATE endpoint throws UnsupportedCommandException
despite the endpoint existing and being documented.

Everything downstream of the handler already exists and is correct:
- EmailWritePlatformService.update(Long, JsonCommand) — interface method
  already declared
- EmailWritePlatformServiceJpaRepositoryImpl.update(...) — already
  implemented
- EmailApiResource.java — already calls
  CommandWrapperBuilder().updateEmail(resourceId)
- UPDATE_EMAIL permission — already exists in
  0002_initial_data.xml, same pattern as CREATE_EMAIL/DELETE_EMAIL

The only missing piece was the command handler itself, routing
@CommandType(entity="EMAIL", action="UPDATE") to the existing service
method. This PR adds that handler, matching the structural pattern of
CreateEmailCommandHandler and the sibling UpdateEmailCampaignCommandHandler.

Note: no test coverage exists for the /emails resource at any layer, and
a separate, pre-existing validator bug was found while investigating this
(EmailDataValidator validates against the wrong resource's constants,
ScheduledEmailConstants instead of EmailApiConstants). Both are tracked
and will be addressed in a separate ticket/PR, since they are independent
of this handler-wiring fix.

See https://issues.apache.org/jira/browse/FINERACT-2782