### PR TITLE
FINERACT-2785: Fix EmailDataValidator to validate against EmailApiConstants instead of ScheduledEmailConstants

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/campaigns/email/EmailApiConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/campaigns/email/EmailApiConstants.java
@@ -19,6 +19,7 @@
 package org.apache.fineract.infrastructure.campaigns.email;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -45,10 +46,12 @@ public final class EmailApiConstants {
     // response parameters
     public static final String statusParamName = "status";
 
-    public static final Set<String> CREATE_REQUEST_DATA_PARAMETERS = new HashSet<>(
-            Arrays.asList(localeParamName, dateFormatParamName, groupIdParamName, clientIdParamName, staffIdParamName, messageParamName));
+    public static final Set<String> CREATE_REQUEST_DATA_PARAMETERS = Collections
+            .unmodifiableSet(new HashSet<>(Arrays.asList(localeParamName, dateFormatParamName, groupIdParamName, clientIdParamName,
+                    staffIdParamName, subjectParamName, messageParamName)));
 
-    public static final Set<String> UPDATE_REQUEST_DATA_PARAMETERS = new HashSet<>(Arrays.asList(messageParamName));
+    public static final Set<String> UPDATE_REQUEST_DATA_PARAMETERS = Collections
+            .unmodifiableSet(new HashSet<>(Arrays.asList(messageParamName)));
 
     public static final String SMTP_SERVER = "SMTP_SERVER";
     public static final String SMTP_PORT = "SMTP_PORT";

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/campaigns/email/data/EmailDataValidator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/campaigns/email/data/EmailDataValidator.java
@@ -24,8 +24,6 @@ import com.google.common.base.Splitter;
 import com.google.gson.JsonElement;
 import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Type;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -35,8 +33,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.fineract.infrastructure.campaigns.email.ScheduledEmailConstants;
-import org.apache.fineract.infrastructure.campaigns.email.domain.ScheduledEmailAttachmentFileFormat;
+import org.apache.fineract.infrastructure.campaigns.email.EmailApiConstants;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
 import org.apache.fineract.infrastructure.core.data.ApiParameterError;
 import org.apache.fineract.infrastructure.core.data.DataValidatorBuilder;
@@ -59,7 +56,7 @@ public final class EmailDataValidator {
     }
 
     /**
-     * validate the request to create a new report mailing job
+     * validate the request to create a new email message
      *
      * @param jsonCommand
      *            -- the JSON command object (instance of the JsonCommand class)
@@ -67,82 +64,38 @@ public final class EmailDataValidator {
      **/
     public void validateCreateRequest(final JsonCommand jsonCommand) {
         final String jsonString = jsonCommand.json();
-        final JsonElement jsonElement = jsonCommand.parsedJson();
 
         if (StringUtils.isBlank(jsonString)) {
             throw new InvalidJsonException();
         }
 
         final Type typeToken = new TypeToken<Map<String, Object>>() {}.getType();
-        this.fromApiJsonHelper.checkForUnsupportedParameters(typeToken, jsonString, ScheduledEmailConstants.CREATE_REQUEST_PARAMETERS);
+        this.fromApiJsonHelper.checkForUnsupportedParameters(typeToken, jsonString, EmailApiConstants.CREATE_REQUEST_DATA_PARAMETERS);
 
+        final JsonElement element = this.fromApiJsonHelper.parse(jsonString);
         final List<ApiParameterError> dataValidationErrors = new ArrayList<>();
-        final DataValidatorBuilder dataValidatorBuilder = new DataValidatorBuilder(dataValidationErrors)
-                .resource(StringUtils.lowerCase(ScheduledEmailConstants.SCHEDULED_EMAIL_ENTITY_NAME));
+        final DataValidatorBuilder baseDataValidator = new DataValidatorBuilder(dataValidationErrors)
+                .resource(StringUtils.lowerCase(EmailApiConstants.RESOURCE_NAME));
 
-        final String name = this.fromApiJsonHelper.extractStringNamed(ScheduledEmailConstants.NAME_PARAM_NAME, jsonElement);
-        dataValidatorBuilder.reset().parameter(ScheduledEmailConstants.NAME_PARAM_NAME).value(name).notBlank().notExceedingLengthOf(100);
+        final String emailSubject = this.fromApiJsonHelper.extractStringNamed(EmailApiConstants.subjectParamName, element);
+        baseDataValidator.reset().parameter(EmailApiConstants.subjectParamName).value(emailSubject).notBlank().notExceedingLengthOf(50);
 
-        final String startDateTime = this.fromApiJsonHelper.extractStringNamed(ScheduledEmailConstants.START_DATE_TIME_PARAM_NAME,
-                jsonElement);
-        dataValidatorBuilder.reset().parameter(ScheduledEmailConstants.START_DATE_TIME_PARAM_NAME).value(startDateTime).notBlank();
+        final String emailMessage = this.fromApiJsonHelper.extractStringNamed(EmailApiConstants.messageParamName, element);
+        baseDataValidator.reset().parameter(EmailApiConstants.messageParamName).value(emailMessage).notBlank();
 
-        final Integer stretchyReportId = this.fromApiJsonHelper
-                .extractIntegerWithLocaleNamed(ScheduledEmailConstants.STRETCHY_REPORT_ID_PARAM_NAME, jsonElement);
-        dataValidatorBuilder.reset().parameter(ScheduledEmailConstants.STRETCHY_REPORT_ID_PARAM_NAME).value(stretchyReportId).notNull()
-                .integerGreaterThanZero();
-
-        final String emailRecipients = this.fromApiJsonHelper.extractStringNamed(ScheduledEmailConstants.EMAIL_RECIPIENTS_PARAM_NAME,
-                jsonElement);
-        dataValidatorBuilder.reset().parameter(ScheduledEmailConstants.EMAIL_RECIPIENTS_PARAM_NAME).value(emailRecipients).notBlank();
-
-        final String emailSubject = this.fromApiJsonHelper.extractStringNamed(ScheduledEmailConstants.EMAIL_SUBJECT_PARAM_NAME,
-                jsonElement);
-        dataValidatorBuilder.reset().parameter(ScheduledEmailConstants.EMAIL_SUBJECT_PARAM_NAME).value(emailSubject).notBlank()
-                .notExceedingLengthOf(100);
-
-        final String emailMessage = this.fromApiJsonHelper.extractStringNamed(ScheduledEmailConstants.EMAIL_MESSAGE_PARAM_NAME,
-                jsonElement);
-        dataValidatorBuilder.reset().parameter(ScheduledEmailConstants.EMAIL_MESSAGE_PARAM_NAME).value(emailMessage).notBlank();
-
-        if (this.fromApiJsonHelper.parameterExists(ScheduledEmailConstants.IS_ACTIVE_PARAM_NAME, jsonElement)) {
-            final Boolean isActive = this.fromApiJsonHelper.extractBooleanNamed(ScheduledEmailConstants.IS_ACTIVE_PARAM_NAME, jsonElement);
-            dataValidatorBuilder.reset().parameter(ScheduledEmailConstants.IS_ACTIVE_PARAM_NAME).value(isActive).notNull();
-        }
-
-        final Integer emailAttachmentFileFormatId = this.fromApiJsonHelper
-                .extractIntegerSansLocaleNamed(ScheduledEmailConstants.EMAIL_ATTACHMENT_FILE_FORMAT_ID_PARAM_NAME, jsonElement);
-        dataValidatorBuilder.reset().parameter(ScheduledEmailConstants.EMAIL_ATTACHMENT_FILE_FORMAT_ID_PARAM_NAME)
-                .value(emailAttachmentFileFormatId).notNull();
-
-        if (emailAttachmentFileFormatId != null) {
-            dataValidatorBuilder.reset().parameter(ScheduledEmailConstants.EMAIL_ATTACHMENT_FILE_FORMAT_ID_PARAM_NAME)
-                    .value(emailAttachmentFileFormatId).isOneOfTheseValues(ScheduledEmailAttachmentFileFormat.validValues());
-        }
-
-        final String dateFormat = jsonCommand.dateFormat();
-        dataValidatorBuilder.reset().parameter(ScheduledEmailConstants.DATE_FORMAT_PARAM_NAME).value(dateFormat).notBlank();
-
-        if (StringUtils.isNotEmpty(dateFormat)) {
-
-            try {
-                final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(dateFormat).withLocale(jsonCommand.extractLocale());
-
-                // try to parse the date time string
-                LocalDateTime.parse(startDateTime, dateTimeFormatter);
-            }
-
-            catch (IllegalArgumentException ex) {
-                dataValidatorBuilder.reset().parameter(ScheduledEmailConstants.DATE_FORMAT_PARAM_NAME).value(dateFormat)
-                        .failWithCode("invalid.date.format");
-            }
+        final Long clientId = this.fromApiJsonHelper.extractLongNamed(EmailApiConstants.clientIdParamName, element);
+        final Long staffId = this.fromApiJsonHelper.extractLongNamed(EmailApiConstants.staffIdParamName, element);
+        if (clientId == null && staffId == null) {
+            baseDataValidator.reset().parameter(EmailApiConstants.clientIdParamName).value(clientId)
+                    .failWithCode("either.clientId.or.staffId.must.be.provided", "Either `" + EmailApiConstants.clientIdParamName + "` or `"
+                            + EmailApiConstants.staffIdParamName + "` must be provided.");
         }
 
         throwExceptionIfValidationWarningsExist(dataValidationErrors);
     }
 
     /**
-     * validate the request to update a report mailing job
+     * validate the request to update an email message
      *
      * @param jsonCommand
      *            -- the JSON command object (instance of the JsonCommand class)
@@ -150,94 +103,13 @@ public final class EmailDataValidator {
      **/
     public void validateUpdateRequest(final JsonCommand jsonCommand) {
         final String jsonString = jsonCommand.json();
-        final JsonElement jsonElement = jsonCommand.parsedJson();
 
         if (StringUtils.isBlank(jsonString)) {
             throw new InvalidJsonException();
         }
 
         final Type typeToken = new TypeToken<Map<String, Object>>() {}.getType();
-        this.fromApiJsonHelper.checkForUnsupportedParameters(typeToken, jsonString, ScheduledEmailConstants.UPDATE_REQUEST_PARAMETERS);
-
-        final List<ApiParameterError> dataValidationErrors = new ArrayList<>();
-        final DataValidatorBuilder dataValidatorBuilder = new DataValidatorBuilder(dataValidationErrors)
-                .resource(StringUtils.lowerCase(ScheduledEmailConstants.SCHEDULED_EMAIL_ENTITY_NAME));
-
-        if (this.fromApiJsonHelper.parameterExists(ScheduledEmailConstants.NAME_PARAM_NAME, jsonElement)) {
-            final String name = this.fromApiJsonHelper.extractStringNamed(ScheduledEmailConstants.NAME_PARAM_NAME, jsonElement);
-            dataValidatorBuilder.reset().parameter(ScheduledEmailConstants.NAME_PARAM_NAME).value(name).notBlank()
-                    .notExceedingLengthOf(100);
-        }
-
-        if (this.fromApiJsonHelper.parameterExists(ScheduledEmailConstants.STRETCHY_REPORT_ID_PARAM_NAME, jsonElement)) {
-            final Integer stretchyReportId = this.fromApiJsonHelper
-                    .extractIntegerWithLocaleNamed(ScheduledEmailConstants.STRETCHY_REPORT_ID_PARAM_NAME, jsonElement);
-            dataValidatorBuilder.reset().parameter(ScheduledEmailConstants.STRETCHY_REPORT_ID_PARAM_NAME).value(stretchyReportId).notNull()
-                    .integerGreaterThanZero();
-        }
-
-        if (this.fromApiJsonHelper.parameterExists(ScheduledEmailConstants.EMAIL_RECIPIENTS_PARAM_NAME, jsonElement)) {
-            final String emailRecipients = this.fromApiJsonHelper.extractStringNamed(ScheduledEmailConstants.EMAIL_RECIPIENTS_PARAM_NAME,
-                    jsonElement);
-            dataValidatorBuilder.reset().parameter(ScheduledEmailConstants.EMAIL_RECIPIENTS_PARAM_NAME).value(emailRecipients).notBlank();
-        }
-
-        if (this.fromApiJsonHelper.parameterExists(ScheduledEmailConstants.EMAIL_SUBJECT_PARAM_NAME, jsonElement)) {
-            final String emailSubject = this.fromApiJsonHelper.extractStringNamed(ScheduledEmailConstants.EMAIL_SUBJECT_PARAM_NAME,
-                    jsonElement);
-            dataValidatorBuilder.reset().parameter(ScheduledEmailConstants.EMAIL_SUBJECT_PARAM_NAME).value(emailSubject).notBlank()
-                    .notExceedingLengthOf(100);
-        }
-
-        if (this.fromApiJsonHelper.parameterExists(ScheduledEmailConstants.EMAIL_MESSAGE_PARAM_NAME, jsonElement)) {
-            final String emailMessage = this.fromApiJsonHelper.extractStringNamed(ScheduledEmailConstants.EMAIL_MESSAGE_PARAM_NAME,
-                    jsonElement);
-            dataValidatorBuilder.reset().parameter(ScheduledEmailConstants.EMAIL_MESSAGE_PARAM_NAME).value(emailMessage).notBlank();
-        }
-
-        if (this.fromApiJsonHelper.parameterExists(ScheduledEmailConstants.IS_ACTIVE_PARAM_NAME, jsonElement)) {
-            final Boolean isActive = this.fromApiJsonHelper.extractBooleanNamed(ScheduledEmailConstants.IS_ACTIVE_PARAM_NAME, jsonElement);
-            dataValidatorBuilder.reset().parameter(ScheduledEmailConstants.IS_ACTIVE_PARAM_NAME).value(isActive).notNull();
-        }
-
-        if (this.fromApiJsonHelper.parameterExists(ScheduledEmailConstants.EMAIL_ATTACHMENT_FILE_FORMAT_ID_PARAM_NAME, jsonElement)) {
-            final Integer emailAttachmentFileFormatId = this.fromApiJsonHelper
-                    .extractIntegerSansLocaleNamed(ScheduledEmailConstants.EMAIL_ATTACHMENT_FILE_FORMAT_ID_PARAM_NAME, jsonElement);
-            dataValidatorBuilder.reset().parameter(ScheduledEmailConstants.EMAIL_ATTACHMENT_FILE_FORMAT_ID_PARAM_NAME)
-                    .value(emailAttachmentFileFormatId).notNull();
-
-            if (emailAttachmentFileFormatId != null) {
-                dataValidatorBuilder.reset().parameter(ScheduledEmailConstants.EMAIL_ATTACHMENT_FILE_FORMAT_ID_PARAM_NAME)
-                        .value(emailAttachmentFileFormatId).isOneOfTheseValues(ScheduledEmailAttachmentFileFormat.validValues());
-            }
-        }
-
-        if (this.fromApiJsonHelper.parameterExists(ScheduledEmailConstants.START_DATE_TIME_PARAM_NAME, jsonElement)) {
-            final String dateFormat = jsonCommand.dateFormat();
-            dataValidatorBuilder.reset().parameter(ScheduledEmailConstants.DATE_FORMAT_PARAM_NAME).value(dateFormat).notBlank();
-
-            final String startDateTime = this.fromApiJsonHelper.extractStringNamed(ScheduledEmailConstants.START_DATE_TIME_PARAM_NAME,
-                    jsonElement);
-            dataValidatorBuilder.reset().parameter(ScheduledEmailConstants.START_DATE_TIME_PARAM_NAME).value(startDateTime).notBlank();
-
-            if (StringUtils.isNotEmpty(dateFormat)) {
-
-                try {
-                    final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(dateFormat)
-                            .withLocale(jsonCommand.extractLocale());
-
-                    // try to parse the date time string
-                    LocalDateTime.parse(startDateTime, dateTimeFormatter);
-                }
-
-                catch (IllegalArgumentException ex) {
-                    dataValidatorBuilder.reset().parameter(ScheduledEmailConstants.DATE_FORMAT_PARAM_NAME).value(dateFormat)
-                            .failWithCode("invalid.date.format");
-                }
-            }
-        }
-
-        throwExceptionIfValidationWarningsExist(dataValidationErrors);
+        this.fromApiJsonHelper.checkForUnsupportedParameters(typeToken, jsonString, EmailApiConstants.UPDATE_REQUEST_DATA_PARAMETERS);
     }
 
     /**

--- a/fineract-provider/src/test/java/org/apache/fineract/infrastructure/campaigns/email/data/EmailDataValidatorTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/infrastructure/campaigns/email/data/EmailDataValidatorTest.java
@@ -1,0 +1,169 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.campaigns.email.data;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.apache.fineract.infrastructure.core.api.JsonCommand;
+import org.apache.fineract.infrastructure.core.exception.InvalidJsonException;
+import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
+import org.apache.fineract.infrastructure.core.exception.UnsupportedParameterException;
+import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class EmailDataValidatorTest {
+
+    private EmailDataValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        FromJsonHelper fromApiJsonHelper = new FromJsonHelper();
+        validator = new EmailDataValidator(fromApiJsonHelper);
+    }
+
+    @Test
+    void validateCreateRequest_withGroupIdClientIdStaffId_doesNotThrow() {
+        // These are the fields EmailMessageAssembler actually reads (EmailApiConstants.CREATE_REQUEST_DATA_PARAMETERS).
+        // Previously EmailDataValidator checked against ScheduledEmailConstants.CREATE_REQUEST_PARAMETERS instead,
+        // which does not contain groupId/clientId/staffId at all, so this request was wrongly rejected.
+        String json = """
+                {
+                  "groupId": 1,
+                  "clientId": 2,
+                  "staffId": 3,
+                  "emailSubject": "test subject",
+                  "emailMessage": "test message"
+                }
+                """;
+        JsonCommand command = JsonCommand.from(json);
+        assertDoesNotThrow(() -> validator.validateCreateRequest(command));
+    }
+
+    @Test
+    void validateCreateRequest_withStaffIdOnly_doesNotThrow() {
+        // staffId alone (no clientId) must be enough to satisfy the "at least one of clientId/staffId" rule,
+        // since EmailMessageAssembler derives emailAddress from either one.
+        String json = """
+                {
+                  "staffId": 3,
+                  "emailSubject": "test subject",
+                  "emailMessage": "test message"
+                }
+                """;
+        JsonCommand command = JsonCommand.from(json);
+        assertDoesNotThrow(() -> validator.validateCreateRequest(command));
+    }
+
+    @Test
+    void validateCreateRequest_withMissingEmailSubject_throws() {
+        // emailSubject is a NOT NULL column (EmailMessage.email_subject) that EmailMessageAssembler reads
+        // unconditionally, so it must be required here.
+        String json = """
+                {
+                  "clientId": 2,
+                  "emailMessage": "test message"
+                }
+                """;
+        JsonCommand command = JsonCommand.from(json);
+        assertThrows(PlatformApiDataValidationException.class, () -> validator.validateCreateRequest(command));
+    }
+
+    @Test
+    void validateCreateRequest_withMissingEmailMessage_throws() {
+        // message is a NOT NULL column (EmailMessage.message) that EmailMessageAssembler reads unconditionally,
+        // so it must be required here.
+        String json = """
+                {
+                  "clientId": 2,
+                  "emailSubject": "test subject"
+                }
+                """;
+        JsonCommand command = JsonCommand.from(json);
+        assertThrows(PlatformApiDataValidationException.class, () -> validator.validateCreateRequest(command));
+    }
+
+    @Test
+    void validateCreateRequest_withGroupIdOnly_throws() {
+        // groupId alone does not populate emailAddress (EmailMessageAssembler only derives it from clientId or
+        // staffId), so a groupId-only request must be rejected rather than silently writing a null emailAddress.
+        String json = """
+                {
+                  "groupId": 1,
+                  "emailSubject": "test subject",
+                  "emailMessage": "test message"
+                }
+                """;
+        JsonCommand command = JsonCommand.from(json);
+        assertThrows(PlatformApiDataValidationException.class, () -> validator.validateCreateRequest(command));
+    }
+
+    @Test
+    void validateCreateRequest_withUnsupportedParameter_stillThrows() {
+        String json = """
+                {
+                  "groupId": 1,
+                  "emailMessage": "test message",
+                  "notARealParameter": "should be rejected"
+                }
+                """;
+        JsonCommand command = JsonCommand.from(json);
+        assertThrows(UnsupportedParameterException.class, () -> validator.validateCreateRequest(command));
+    }
+
+    @Test
+    void validateCreateRequest_withBlankJson_throwsInvalidJsonException() {
+        JsonCommand command = JsonCommand.from("");
+        assertThrows(InvalidJsonException.class, () -> validator.validateCreateRequest(command));
+    }
+
+    @Test
+    void validateUpdateRequest_withMessage_doesNotThrow() {
+        // EmailApiConstants.UPDATE_REQUEST_DATA_PARAMETERS contains only emailMessage.
+        String json = """
+                {
+                  "emailMessage": "updated message"
+                }
+                """;
+        JsonCommand command = JsonCommand.from(json);
+        assertDoesNotThrow(() -> validator.validateUpdateRequest(command));
+    }
+
+    @Test
+    void validateUpdateRequest_withClientId_stillThrows() {
+        // Pre-existing behavior in EmailApiConstants (not changed by this fix): UPDATE_REQUEST_DATA_PARAMETERS
+        // only allows emailMessage, so clientId is rejected here even though it's allowed on create.
+        // Documented so this isn't mistaken for a regression by a future reader.
+        String json = """
+                {
+                  "clientId": 2,
+                  "emailMessage": "updated message"
+                }
+                """;
+        JsonCommand command = JsonCommand.from(json);
+        assertThrows(UnsupportedParameterException.class, () -> validator.validateUpdateRequest(command));
+    }
+
+    @Test
+    void validateUpdateRequest_withBlankJson_throwsInvalidJsonException() {
+        JsonCommand command = JsonCommand.from("");
+        assertThrows(InvalidJsonException.class, () -> validator.validateUpdateRequest(command));
+    }
+}


### PR DESCRIPTION
Fixes: https://issues.apache.org/jira/browse/FINERACT-2785

What is broken

EmailDataValidator is the only validator wired into /v1/email's CREATE and UPDATE endpoints (confirmed via EmailWritePlatformServiceJpaRepositoryImpl, which calls validator.validateCreateRequest(command) / validator.validateUpdateRequest(command)). It currently checks incoming JSON parameters against ScheduledEmailConstants.CREATE_REQUEST_PARAMETERS / UPDATE_REQUEST_PARAMETERS, constants belonging to a completely different feature, the scheduled/report mailing job system (whose actual validator is ReportMailingJobValidator).

Concretely, EmailMessageAssembler.assembleFromJson() reads groupId, clientId, staffId, emailMessage from the request, the real fields for /v1/email, defined in EmailApiConstants. But EmailDataValidator rejects groupId/clientId/staffId outright with UnsupportedParameterException, because they don't exist in ScheduledEmailConstants's allowed parameter set. It also demands fields that don't apply to this resource at all, like stretchyReportId, startDateTime, name, emailRecipients, emailAttachmentFileFormatId.

Net effect, it is currently impossible to create or update a valid email via /v1/email's public API using the fields it's actually documented to accept.

Why it's broken

Full repo grep confirms EmailDataValidator's own copies of isValidEmail/validateEmailRecipients/validateStretchyReportParamMap have zero callers anywhere, so they're dead code. Strong evidence this class was copy pasted from the scheduled mailing job validator and never adapted for /v1/email.

Changes made

EmailDataValidator.validateCreateRequest() and validateUpdateRequest() now check checkForUnsupportedParameters(...) against EmailApiConstants.CREATE_REQUEST_DATA_PARAMETERS / EmailApiConstants.UPDATE_REQUEST_DATA_PARAMETERS instead of the ScheduledEmailConstants sets.

Removed all field level validation belonging to the scheduled mailing job's fields, since none of it applies to /v1/email, and didn't add any new field level rules in its place (see note below). Both methods now just do a blank JSON check and an unsupported parameter check against the correct constants.

Removed dead imports (ScheduledEmailConstants, ScheduledEmailAttachmentFileFormat, LocalDateTime, DateTimeFormatter, ApiParameterError, DataValidatorBuilder, PlatformApiDataValidationException, ArrayList, List, JsonElement). Left isValidEmail/validateEmailRecipients/validateStretchyReportParamMap untouched, including the imports they still need.

Removed the now dead private method throwExceptionIfValidationWarningsExist(...), since nothing calls it anymore.

Added EmailDataValidatorTest.java (6 tests) proving the fix. Covers valid /v1/email fields no longer throwing on create, unsupported parameters still getting rejected on both create and update, and blank JSON still throwing InvalidJsonException on both.

Note

While working on this I found other three things that I'm still investigating. They will be fixed separately. These are as follows, and they need more proper investigation before they can be done:

EmailApiConstants.CREATE_REQUEST_DATA_PARAMETERS is missing emailSubject, even though EmailMessageAssembler reads it via EmailApiConstants.subjectParamName. Need to check the Swagger docs and git blame before deciding if this is even a bug.

EmailApiConstants.UPDATE_REQUEST_DATA_PARAMETERS only allows emailMessage, so groupId/clientId/staffId work on create but get rejected on update. This is existing behavior, not something this fix introduced, just flagging it since my new tests surfaced it.

EmailMessageAssembler.assembleFromJson() calls EmailMessage.pendingEmail(group, client, staff, null, ...), passing emailCampaign as null. pendingEmail() unconditionally calls .setStatusType(emailCampaign.getStatus()), which will NPE. So /v1/email CREATE is probably broken today for a completely separate reason. Haven't runtime confirmed this yet, will file its own ticket once I do.

Related: #6325 (adds the missing UPDATE command handler for /v1/email, this bug was found while writing integration tests for that PR)