### PR TITLE
FINERACT-2790: Fix NoSuchElementException on Merchant Issued Refund for re-aged progressive loans

### DIFF
--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/transactionprocessor/impl/AdvancedPaymentScheduleTransactionProcessor.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/transactionprocessor/impl/AdvancedPaymentScheduleTransactionProcessor.java
@@ -2894,7 +2894,8 @@ public class AdvancedPaymentScheduleTransactionProcessor extends AbstractLoanRep
         ProgressiveLoanInterestScheduleModel model = ctx.getModel();
         LocalDate payDate = loanTransaction.getTransactionDate();
 
-        if (installment.isDownPayment() || installment.getDueDate().isAfter(ctx.getModel().getMaturityDate())) {
+        if (installment.isDownPayment() || installment.isAdditional()
+                || installment.getDueDate().isAfter(ctx.getModel().getMaturityDate())) {
             // Skip interest and principal payment processing for down payment period or periods after loan maturity
             // date
             ctx.getSkipRepaymentScheduleInstallments().add(installment);

--- a/fineract-progressive-loan/src/test/java/org/apache/fineract/portfolio/loanaccount/domain/transactionprocessor/impl/AdvancedPaymentScheduleTransactionProcessorTest.java
+++ b/fineract-progressive-loan/src/test/java/org/apache/fineract/portfolio/loanaccount/domain/transactionprocessor/impl/AdvancedPaymentScheduleTransactionProcessorTest.java
@@ -29,10 +29,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.refEq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
@@ -787,4 +789,69 @@ class AdvancedPaymentScheduleTransactionProcessorTest {
         Assertions.assertEquals(originalTransaction, repayment2);
     }
 
+    @Test
+    public void updateRepaymentPeriodBalancesSkipsAdditionalInstallmentAndAppliesPaymentDirectly() {
+        // given
+        LocalDate disbursementDate = LocalDate.of(2024, 1, 1);
+        LocalDate additionalFromDate = LocalDate.of(2024, 2, 1);
+        LocalDate additionalDueDate = LocalDate.of(2024, 2, 15);
+        LocalDate mirTransactionDate = LocalDate.of(2024, 2, 10);
+
+        Loan loan = mock(Loan.class, RETURNS_DEEP_STUBS);
+        LoanProductRelatedDetail loanProductRelatedDetail = mock(LoanProductRelatedDetail.class);
+        LoanPaymentAllocationRule loanPaymentAllocationRule = mock(LoanPaymentAllocationRule.class);
+        when(loan.getLoanProductRelatedDetail()).thenReturn(loanProductRelatedDetail);
+        when(loanProductRelatedDetail.getLoanScheduleProcessingType()).thenReturn(LoanScheduleProcessingType.HORIZONTAL);
+        when(loan.isInterestBearingAndInterestRecalculationEnabled()).thenReturn(Boolean.TRUE);
+        when(loan.getCurrency()).thenReturn(MONETARY_CURRENCY);
+        when(loan.getPaymentAllocationRules()).thenReturn(List.of(loanPaymentAllocationRule));
+        LoanInterestRecalculationDetails loanInterestRecalculationDetails = mock(LoanInterestRecalculationDetails.class);
+        when(loanInterestRecalculationDetails.disallowInterestCalculationOnPastDue()).thenReturn(false);
+        when(loan.getLoanInterestRecalculationDetails()).thenReturn(loanInterestRecalculationDetails);
+
+        when(loanPaymentAllocationRule.getTransactionType()).thenReturn(PaymentAllocationTransactionType.DEFAULT);
+        when(loanPaymentAllocationRule.getAllocationTypes())
+                .thenReturn(List.of(PaymentAllocationType.PAST_DUE_PRINCIPAL, PaymentAllocationType.PAST_DUE_INTEREST));
+
+        // Real (not mocked) additional installment, so its own persisted balances are what actually change.
+        LoanRepaymentScheduleInstallment additionalInstallment = new LoanRepaymentScheduleInstallment(loan, 2, additionalFromDate,
+                additionalDueDate, BigDecimal.valueOf(50.00), BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO,
+                BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO, true, false, false);
+
+        List<LoanRepaymentScheduleInstallment> installments = List.of(additionalInstallment);
+
+        LoanTransaction loanTransaction = mock(LoanTransaction.class);
+        when(loanTransaction.getTypeOf()).thenReturn(LoanTransactionType.MERCHANT_ISSUED_REFUND);
+        when(loanTransaction.getLoan()).thenReturn(loan);
+        when(loanTransaction.getTransactionDate()).thenReturn(mirTransactionDate);
+        BigDecimal transactionAmount = BigDecimal.valueOf(20.00);
+        Money transactionAmountMoney = Money.of(MONETARY_CURRENCY, transactionAmount);
+        when(loanTransaction.getAmount(MONETARY_CURRENCY)).thenReturn(transactionAmountMoney);
+        lenient().when(loanTransaction.isBefore(any(LocalDate.class))).thenReturn(false);
+        lenient().when(loanTransaction.isAfter(additionalDueDate)).thenReturn(true);
+        lenient().when(loanTransaction.isOn(any(LocalDate.class))).thenReturn(false);
+        lenient().when(loanTransaction.isRepaymentLikeType()).thenReturn(false);
+        lenient().when(loanTransaction.isNotReversed()).thenReturn(true);
+
+        MoneyHolder overpaymentHolder = new MoneyHolder(Money.zero(MONETARY_CURRENCY));
+        ProgressiveLoanInterestScheduleModel model = mock(ProgressiveLoanInterestScheduleModel.class);
+        lenient().when(model.getMaturityDate()).thenReturn(LocalDate.of(2024, 12, 31));
+        ChangedTransactionDetail changedTransactionDetail = mock(ChangedTransactionDetail.class);
+
+        ProgressiveTransactionCtx ctx = new ProgressiveTransactionCtx(MONETARY_CURRENCY, installments, Set.of(), overpaymentHolder,
+                changedTransactionDetail, model, loan.getActiveLoanTermVariations());
+
+        // when
+        underTest.processLatestTransaction(loanTransaction, ctx);
+
+        // then
+        // FINERACT-2790: the model-based due-amount lookup that used to throw NoSuchElementException for an
+        // "additional" installment is never invoked for it.
+        Mockito.verify(emiCalculator, never()).getDueAmounts(any(), any(), any(), any());
+
+        // The money was not silently dropped -- it was applied straight to the installment's own persisted
+        // principal balance (paidPrincipal), the same mechanism already used for down-payment installments.
+        assertEquals(0, BigDecimal.valueOf(20.00).compareTo(additionalInstallment.getPrincipalCompleted(MONETARY_CURRENCY).getAmount()));
+        assertEquals(0, additionalInstallment.getPrincipalOutstanding(MONETARY_CURRENCY).getAmount().compareTo(BigDecimal.valueOf(30.00)));
+    }
 }

--- a/fineract-progressive-loan/src/test/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculatorTest.java
+++ b/fineract-progressive-loan/src/test/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculatorTest.java
@@ -24,6 +24,7 @@ import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.stream.IntStream;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.infrastructure.core.service.DateUtils;
@@ -5480,5 +5481,46 @@ class ProgressiveEMICalculatorTest {
                 "The fully paid last period must keep its EMI");
         Assertions.assertEquals(70.16, toDouble(interestSchedule.getTotalDuePrincipal()), 0.001,
                 "The amortized principal must stay equal to the disbursed amount");
+    }
+
+    @Test
+    public void getDueAmountsThrowsNoSuchElementExceptionForAdditionalInstallment() {
+        // given
+        Mockito.when(loanProductRelatedDetail.getAnnualNominalInterestRate()).thenReturn(BigDecimal.valueOf(12));
+        Mockito.when(loanProductRelatedDetail.getDaysInYearType()).thenReturn(DaysInYearType.DAYS_360.getValue());
+        Mockito.when(loanProductRelatedDetail.getDaysInMonthType()).thenReturn(DaysInMonthType.DAYS_30.getValue());
+        Mockito.when(loanProductRelatedDetail.getRepaymentPeriodFrequencyType()).thenReturn(PeriodFrequencyType.MONTHS);
+        Mockito.when(loanProductRelatedDetail.getRepayEvery()).thenReturn(1);
+        Mockito.when(loanProductRelatedDetail.isAllowFullTermForTranche()).thenReturn(false);
+
+        LocalDate start = LocalDate.of(2024, 1, 1);
+
+        // Normal installment 1: Jan 1 - Feb 1
+        RepaymentScheduleInstallmentData normal1 = RepaymentScheduleInstallmentData.of(start, start.plusMonths(1), false, false,
+                BigDecimal.ZERO, BigDecimal.ZERO);
+        // "Additional" installment inserted by a prior re-age: Feb 1 - Feb 15 (a stub period the model will NOT
+        // contain)
+        RepaymentScheduleInstallmentData additional = RepaymentScheduleInstallmentData.of(start.plusMonths(1),
+                start.plusMonths(1).plusDays(14), false, true, BigDecimal.ZERO, BigDecimal.ZERO);
+        // Normal installment 2 continues after the additional stub: Feb 15 - Mar 15
+        RepaymentScheduleInstallmentData normal2 = RepaymentScheduleInstallmentData.of(start.plusMonths(1).plusDays(14),
+                start.plusMonths(2).plusDays(14), false, false, BigDecimal.ZERO, BigDecimal.ZERO);
+
+        List<RepaymentScheduleInstallmentData> installments = List.of(normal1, additional, normal2);
+
+        // This mirrors generateInstallmentInterestScheduleModel(), which filters out isAdditional() installments
+        // when building the model's repaymentPeriods -- so "additional" never gets a RepaymentPeriod.
+        ProgressiveLoanInterestScheduleModel model = emiCalculator.generateInstallmentInterestScheduleModel(installments,
+                loanProductRelatedDetail, null, mc);
+
+        // then
+        // This mirrors updateRepaymentPeriodBalances() in AdvancedPaymentScheduleTransactionProcessor, which calls
+        // getDueAmounts() using the additional installment's own from/due dates when it is picked as the
+        // LAST_INSTALLMENT "in advance" target during a Merchant Issued Refund.
+        Assertions.assertThrows(NoSuchElementException.class,
+                () -> emiCalculator.getDueAmounts(model, additional.getFromDate(), additional.getDueDate(), additional.getDueDate()),
+                "Expected FINERACT-2790 to reproduce: getDueAmounts() should throw NoSuchElementException "
+                        + "when called with an 'additional' installment's dates, since such installments are excluded "
+                        + "from the model's repaymentPeriods.");
     }
 }


### PR DESCRIPTION
JIRA
https://issues.apache.org/jira/browse/FINERACT-2790

Problem
A Merchant Issued Refund on a progressive loan schedule crashes with an unwrapped NoSuchElementException when the loan has an "additional" installment in its persisted schedule (inserted by a prior re-age), the product has down payments enabled, and the payment allocation rule is MERCHANT_ISSUED_REFUND with futureInstallmentAllocationRule = LAST_INSTALLMENT.

The crash happens because AdvancedPaymentScheduleTransactionProcessor.updateRepaymentPeriodBalances() did not exclude isAdditional() installments before calling ProgressiveEMICalculator.getDueAmounts(). Additional installments are filtered out of the EMI model's repaymentPeriods at build time, so a lookup using an additional installment's dates has nothing to find.

Grepped all call sites of isDownPayment() and isAdditional() in fineract-progressive-loan/src/main/java and found 17 places where both are already excluded together. This is an established convention in the module: down payment and additional installments are both "special installments" excluded from EMI-model-based lookups. The LAST_INSTALLMENT selection logic already excludes isAdditional() from candidacy, so this was a downstream consumer that hadn't caught up to that rule, not a missing design decision.

Fix
Excludes isAdditional() installments in updateRepaymentPeriodBalances() the same way isDownPayment() installments are already excluded.

Verification
Added test coverage to the existing AdvancedPaymentScheduleTransactionProcessorTest and ProgressiveEMICalculatorTest suites (no standalone ticket-numbered test classes, per the module's convention):
- updateRepaymentPeriodBalancesSkipsAdditionalInstallmentAndAppliesPaymentDirectly asserts getDueAmounts() is never called for an additional installment and that the payment is applied directly to its own persisted principal balance instead.
- getDueAmountsThrowsNoSuchElementExceptionForAdditionalInstallment reproduces the original crash mechanism directly against ProgressiveEMICalculator.