### PR TITLE
FINERACT-2789: Balloon loan not working as expected

### DIFF
--- a/fineract-e2e-tests-runner/src/test/resources/features/LoanBulletBalloon.feature
+++ b/fineract-e2e-tests-runner/src/test/resources/features/LoanBulletBalloon.feature
@@ -1,0 +1,28 @@
+@Emi
+Feature: Progressive bullet / balloon loan schedule (grace on principal = N-1)
+
+  Scenario: BL01 - Progressive bullet schedule when grace on principal equals number of repayments minus 1 - N=8
+    When Admin sets the business date to "1 January 2024"
+    When Admin creates a client with random data
+    When Admin creates a fully customized loan with the following data:
+      | LoanProduct                             | submitted on date | with Principal | ANNUAL interest rate % | interest type     | interest calculation period | amortization type  | loanTermFrequency | loanTermFrequencyType | repaymentEvery | repaymentFrequencyType | numberOfRepayments | graceOnPrincipalPayment | graceOnInterestPayment | interest free period | Payment strategy            |
+      | LP2_ADV_PYMNT_INTEREST_DAILY_EMI_360_30 | 1 January 2024    | 100            | 30                     | DECLINING_BALANCE | DAILY                       | EQUAL_INSTALLMENTS | 8                 | MONTHS                | 1              | MONTHS                 | 8                  | 7                       | 0                      | 0                    | ADVANCED_PAYMENT_ALLOCATION |
+    And Admin successfully approves the loan on "1 January 2024" with "100" amount and expected disbursement date on "1 January 2024"
+    When Admin successfully disburse the loan on "1 January 2024" with "100" EUR transaction amount
+    Then Loan Repayment schedule has 8 periods, with the following data for periods:
+      | Nr | Days | Date               | Paid date | Balance of loan | Principal due | Interest | Fees | Penalties | Due   | Paid | In advance | Late | Outstanding |
+      |    |      | 01 January 2024    |           | 100.0           |               |          | 0.0  |           | 0.0   | 0.0  |            |      |             |
+      | 1  | 31   | 01 February 2024   |           | 100.0           | 0.0           | 2.5      | 0.0  | 0.0       | 2.5   | 0.0  | 0.0        | 0.0  | 2.5         |
+      | 2  | 29   | 01 March 2024      |           | 100.0           | 0.0           | 2.5      | 0.0  | 0.0       | 2.5   | 0.0  | 0.0        | 0.0  | 2.5         |
+      | 3  | 31   | 01 April 2024      |           | 100.0           | 0.0           | 2.5      | 0.0  | 0.0       | 2.5   | 0.0  | 0.0        | 0.0  | 2.5         |
+      | 4  | 30   | 01 May 2024        |           | 100.0           | 0.0           | 2.5      | 0.0  | 0.0       | 2.5   | 0.0  | 0.0        | 0.0  | 2.5         |
+      | 5  | 31   | 01 June 2024       |           | 100.0           | 0.0           | 2.5      | 0.0  | 0.0       | 2.5   | 0.0  | 0.0        | 0.0  | 2.5         |
+      | 6  | 30   | 01 July 2024       |           | 100.0           | 0.0           | 2.5      | 0.0  | 0.0       | 2.5   | 0.0  | 0.0        | 0.0  | 2.5         |
+      | 7  | 31   | 01 August 2024     |           | 100.0           | 0.0           | 2.5      | 0.0  | 0.0       | 2.5   | 0.0  | 0.0        | 0.0  | 2.5         |
+      | 8  | 31   | 01 September 2024  |           | 0.0             | 100.0         | 2.5      | 0.0  | 0.0       | 102.5 | 0.0  | 0.0        | 0.0  | 102.5       |
+    Then Loan Repayment schedule has the following data in Total row:
+      | Principal due | Interest | Fees | Penalties | Due   | Paid | In advance | Late | Outstanding |
+      | 100.0         | 20.0     | 0.0  | 0.0       | 120.0 | 0.0  | 0.0        | 0.0  | 120.0       |
+    Then Loan Transactions tab has the following data:
+      | Transaction date | Transaction Type | Amount | Principal | Interest | Fees | Penalties | Loan Balance |
+      | 01 January 2024  | Disbursement     | 100.0  | 0.0       | 0.0      | 0.0  | 0.0       | 100.0        |

--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculator.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculator.java
@@ -1279,7 +1279,7 @@ public final class ProgressiveEMICalculator implements EMICalculator {
             newScheduleModel.repaymentPeriods().forEach(period -> {
                 if (!period.getFromDate().isBefore(relatedPeriodsFirstFromDate) && !period.getDueDate().isBefore(relatedPeriodsFirstDueDate)
                         && !adjustedEqualMonthlyInstallmentValue.isLessThan(period.getTotalPaidAmount())
-                        && !period.isReAgedEarlyRepaymentHolder()) {
+                        && !period.isReAgedEarlyRepaymentHolder() && !period.isPrincipalPaymentGrace()) {
                     period.setEmi(adjustedEqualMonthlyInstallmentValue);
                     period.setOriginalEmi(adjustedEqualMonthlyInstallmentValue);
                 }
@@ -1292,10 +1292,14 @@ public final class ProgressiveEMICalculator implements EMICalculator {
 
             final Iterator<RepaymentPeriod> relatedPeriodFromNewModelIterator = newScheduleModel.repaymentPeriods().stream()//
                     .filter(period -> !period.getFromDate().isBefore(relatedPeriodsFirstFromDate)
-                            && !period.getDueDate().isBefore(relatedPeriodsFirstDueDate) && !period.isReAgedEarlyRepaymentHolder())//
+                            && !period.getDueDate().isBefore(relatedPeriodsFirstDueDate) && !period.isReAgedEarlyRepaymentHolder()
+                            && !period.isPrincipalPaymentGrace())//
                     .toList().iterator();//
 
             relatedRepaymentPeriods.forEach(relatedRepaymentPeriod -> {
+                if (relatedRepaymentPeriod.isPrincipalPaymentGrace()) {
+                    return;
+                }
                 if (!relatedPeriodFromNewModelIterator.hasNext()) {
                     return;
                 }
@@ -1687,6 +1691,7 @@ public final class ProgressiveEMICalculator implements EMICalculator {
         if (repaymentPeriods.isEmpty()) {
             return;
         }
+        repaymentPeriods.forEach(rp -> rp.setPrincipalPaymentGrace(false));
         Integer graceOnPrincipalPayment = scheduleModel.loanProductRelatedDetail().getGraceOnPrincipalPayment();
         if (graceOnPrincipalPayment == null || graceOnPrincipalPayment <= 0) {
             return;
@@ -1697,6 +1702,7 @@ public final class ProgressiveEMICalculator implements EMICalculator {
             Money interestOnlyEmi = period.getDueInterest();
             period.setEmi(interestOnlyEmi);
             period.setOriginalEmi(interestOnlyEmi);
+            period.setPrincipalPaymentGrace(true);
         });
         if (gracePeriods == repaymentPeriods.size()) {
             return;
@@ -1779,6 +1785,9 @@ public final class ProgressiveEMICalculator implements EMICalculator {
         for (int idx = repaymentPeriods.size() - 1; idx > 0; --idx) {
             RepaymentPeriod lastPeriod = repaymentPeriods.get(idx);
             RepaymentPeriod penultimatePeriod = repaymentPeriods.get(idx - 1);
+            if (lastPeriod.isPrincipalPaymentGrace() || penultimatePeriod.isPrincipalPaymentGrace()) {
+                continue;
+            }
             if (!lastPeriod.isFullyPaid() && !penultimatePeriod.isFullyPaid()) {
                 Money emiDifference = lastPeriod.getEmi().minus(penultimatePeriod.getEmi());
                 return new EmiAdjustment(penultimatePeriod.getEmi(), emiDifference, repaymentPeriods,

--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculator.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculator.java
@@ -754,6 +754,7 @@ public final class ProgressiveEMICalculator implements EMICalculator {
     public void updateModelRepaymentPeriodsDuringReAge(final ProgressiveLoanInterestScheduleModel scheduleModel,
             final LocalDate reAgePeriodStartDate, final LocalDate reAgeFirstDueDate, final LocalDate targetDate,
             final LoanApplicationTerms loanApplicationTerms, final MathContext mc) {
+        liftPrincipalPaymentGrace(scheduleModel.repaymentPeriods());
         final Money futureCreditedPrincipals = scheduleModel.repaymentPeriods().stream()
                 .filter(rp -> !rp.getFromDate().isBefore(targetDate)).filter(rp -> rp.getDueDate().isAfter(targetDate))
                 .map(RepaymentPeriod::getCreditedPrincipal).reduce(scheduleModel.zero(), Money::add);
@@ -871,6 +872,7 @@ public final class ProgressiveEMICalculator implements EMICalculator {
     @Override
     public void updateModelRepaymentPeriodsDuringReAmortization(final ProgressiveLoanInterestScheduleModel model,
             final LocalDate transactionDate) {
+        liftPrincipalPaymentGrace(model.repaymentPeriods());
         moveOutstandingAmountsFromPeriodsBeforeTransactionDate(model.repaymentPeriods(), transactionDate);
         final List<RepaymentPeriod> reAmortizedPeriods = model.repaymentPeriods().stream()
                 .filter(rp -> rp.getDueDate().isAfter(transactionDate)).toList();
@@ -883,6 +885,7 @@ public final class ProgressiveEMICalculator implements EMICalculator {
     @Override
     public void updateModelRepaymentPeriodsDuringReAmortizationWithEqualInterestSplit(final ProgressiveLoanInterestScheduleModel model,
             final LocalDate transactionDate) {
+        liftPrincipalPaymentGrace(model.repaymentPeriods());
         final MathContext mc = model.mc();
         final List<RepaymentPeriod> periodsBeforeTransactionDate = model.repaymentPeriods().stream()
                 .filter(rp -> !rp.getDueDate().isAfter(transactionDate) && !rp.isFullyPaid()).toList();
@@ -1684,6 +1687,10 @@ public final class ProgressiveEMICalculator implements EMICalculator {
             case DECLINING_BALANCE -> calculateEMIOnActualModelWithDecliningBalanceInterestMethod(repaymentPeriods, scheduleModel);
             default -> throw new UnsupportedOperationException("Unsupported interest method");
         }
+    }
+
+    private void liftPrincipalPaymentGrace(final List<RepaymentPeriod> repaymentPeriods) {
+        repaymentPeriods.forEach(rp -> rp.setPrincipalPaymentGrace(false));
     }
 
     private void applyPrincipalMoratoriumIfRequired(List<RepaymentPeriod> repaymentPeriods,

--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculator.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculator.java
@@ -1691,7 +1691,7 @@ public final class ProgressiveEMICalculator implements EMICalculator {
         if (repaymentPeriods.isEmpty()) {
             return;
         }
-        repaymentPeriods.forEach(rp -> rp.setPrincipalPaymentGrace(false));
+        scheduleModel.repaymentPeriods().forEach(rp -> rp.setPrincipalPaymentGrace(false));
         Integer graceOnPrincipalPayment = scheduleModel.loanProductRelatedDetail().getGraceOnPrincipalPayment();
         if (graceOnPrincipalPayment == null || graceOnPrincipalPayment <= 0) {
             return;

--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculator.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculator.java
@@ -2035,7 +2035,8 @@ public final class ProgressiveEMICalculator implements EMICalculator {
 
     private long getUncountablePeriods(final List<RepaymentPeriod> relatedRepaymentPeriods, final Money originalEmi) {
         return relatedRepaymentPeriods.stream() //
-                .filter(repaymentPeriod -> originalEmi.isLessThan(repaymentPeriod.getTotalPaidAmount())) //
+                .filter(repaymentPeriod -> repaymentPeriod.isPrincipalPaymentGrace()
+                        || originalEmi.isLessThan(repaymentPeriod.getTotalPaidAmount())) //
                 .count(); //
     }
 

--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/data/RepaymentPeriod.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/data/RepaymentPeriod.java
@@ -81,6 +81,9 @@ public class RepaymentPeriod {
     @Getter
     @Setter
     private boolean interestPaymentGrace = false;
+    @Getter
+    @Setter
+    private boolean principalPaymentGrace = false;
 
     @Setter
     private Money totalDisbursedAmount;
@@ -162,6 +165,7 @@ public class RepaymentPeriod {
         newRepaymentPeriod.setTotalCapitalizedIncomeAmount(repaymentPeriod.getTotalCapitalizedIncomeAmount());
         newRepaymentPeriod.setInterestMovedUpward(repaymentPeriod.isInterestMovedUpward());
         newRepaymentPeriod.setInterestPaymentGrace(repaymentPeriod.isInterestPaymentGrace());
+        newRepaymentPeriod.setPrincipalPaymentGrace(repaymentPeriod.isPrincipalPaymentGrace());
         newRepaymentPeriod.setCurrency(repaymentPeriod.getCurrency());
         // There is always at least 1 interest period, by default with same from-due date as repayment period
         for (InterestPeriod interestPeriod : repaymentPeriod.getInterestPeriods()) {
@@ -185,6 +189,7 @@ public class RepaymentPeriod {
         newRepaymentPeriod.setTotalCapitalizedIncomeAmount(repaymentPeriod.getTotalCapitalizedIncomeAmount());
         newRepaymentPeriod.setInterestMovedUpward(repaymentPeriod.isInterestMovedUpward());
         newRepaymentPeriod.setInterestPaymentGrace(repaymentPeriod.isInterestPaymentGrace());
+        newRepaymentPeriod.setPrincipalPaymentGrace(repaymentPeriod.isPrincipalPaymentGrace());
         newRepaymentPeriod.setCurrency(repaymentPeriod.getCurrency());
         // There is always at least 1 interest period, by default with same from-due date as repayment period
         for (InterestPeriod interestPeriod : repaymentPeriod.getInterestPeriods()) {

--- a/fineract-progressive-loan/src/test/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculatorTest.java
+++ b/fineract-progressive-loan/src/test/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculatorTest.java
@@ -5313,6 +5313,153 @@ class ProgressiveEMICalculatorTest {
         checkPeriod(interestSchedule, 5, 25.35, 0.15, 25.20, 0.0, false);
     }
 
+    /**
+     * Control case for the bullet-loan boundary defect.
+     *
+     * With N=8 repayments and graceOnPrincipalPayment = N-2 = 6, the schedule behaves correctly: installments 1..6 are
+     * interest-only and the principal is amortized across the final two installments (7 and 8). This test passes on the
+     * current engine and is here to demonstrate that the defect exercised by
+     * {@link #test_principalGrace_nMinus1_shouldProduceBulletLoan()} is specific to the grace = N-1 boundary.
+     */
+    @Test
+    public void test_principalGrace_nMinus2_deferralWorks() {
+        final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>();
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 7, 1), LocalDate.of(2024, 8, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 8, 1), LocalDate.of(2024, 9, 1)));
+
+        Mockito.when(loanProductRelatedDetail.getAnnualNominalInterestRate()).thenReturn(BigDecimal.valueOf(30.0));
+        Mockito.when(loanProductRelatedDetail.getDaysInYearType()).thenReturn(DaysInYearType.DAYS_360.getValue());
+        Mockito.when(loanProductRelatedDetail.getDaysInMonthType()).thenReturn(DaysInMonthType.DAYS_30.getValue());
+        Mockito.when(loanProductRelatedDetail.getRepaymentPeriodFrequencyType()).thenReturn(PeriodFrequencyType.MONTHS);
+        Mockito.when(loanProductRelatedDetail.getRepayEvery()).thenReturn(1);
+        Mockito.when(loanProductRelatedDetail.getNumberOfRepayments()).thenReturn(8);
+        Mockito.when(loanProductRelatedDetail.getGraceOnPrincipalPayment()).thenReturn(6);
+        Mockito.when(loanProductRelatedDetail.getGraceOnInterestPayment()).thenReturn(0);
+
+        final ProgressiveLoanInterestScheduleModel interestSchedule = emiCalculator
+                .generatePeriodInterestScheduleModel(expectedRepaymentPeriods, loanProductRelatedDetail, null, mc);
+
+        emiCalculator.addDisbursement(interestSchedule, LocalDate.of(2024, 1, 1), toMoney(100.0));
+
+        // Installments 1..6 (index 0..5) are interest-only: 100 * 30% / 12 = 2.50 each, balance stays at 100.
+        for (int idx = 0; idx <= 5; idx++) {
+            checkPeriod(interestSchedule, idx, 2.5, 2.5, 0.0, 100.0, false);
+        }
+
+        // Principal is deferred out of the grace periods and repaid over the final two installments.
+        final List<RepaymentPeriod> repaymentPeriods = interestSchedule.repaymentPeriods();
+        Assertions.assertEquals(0.0, toDouble(repaymentPeriods.get(0).getDuePrincipal()));
+        Assertions.assertTrue(toDouble(repaymentPeriods.get(6).getDuePrincipal()) > 0.0,
+                "Installment 7 should carry principal when grace = N-2");
+        Assertions.assertTrue(toDouble(repaymentPeriods.get(7).getDuePrincipal()) > 0.0,
+                "Installment 8 should carry principal when grace = N-2");
+        final double totalPrincipal = repaymentPeriods.stream().mapToDouble(rp -> toDouble(rp.getDuePrincipal())).sum();
+        Assertions.assertEquals(100.0, totalPrincipal, 0.01, "All principal must be scheduled");
+    }
+
+    /**
+     * Reproduces the bullet-loan defect at the grace = N-1 boundary (Fineract 1.15.0).
+     *
+     * <p>
+     * Setup: progressive schedule, advanced payment allocation, declining balance / equal installments, single
+     * disbursement, N = 8 repayments, graceOnPrincipalPayment = 7 (= N-1), interest recalculation disabled.
+     *
+     * <p>
+     * Expected (a true bullet loan): installments 1..7 are interest-only (principal 0, balance stays at 100) and
+     * installment 8 carries 100% of the principal.
+     *
+     * <p>
+     * Actual on the current engine: principal is fully amortized across installments 1..7 and the final installment (8)
+     * is left completely empty (0 principal / 0 interest). This assertion therefore FAILS on 1.15.0 and documents the
+     * defect. The neighbouring grace = N-2 case ({@link #test_principalGrace_nMinus2_deferralWorks()}) works correctly,
+     * showing the problem is confined to the single-remaining-period boundary.
+     */
+    @Test
+    public void test_principalGrace_nMinus1_shouldProduceBulletLoan() {
+        final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>();
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 7, 1), LocalDate.of(2024, 8, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 8, 1), LocalDate.of(2024, 9, 1)));
+
+        Mockito.when(loanProductRelatedDetail.getAnnualNominalInterestRate()).thenReturn(BigDecimal.valueOf(30.0));
+        Mockito.when(loanProductRelatedDetail.getDaysInYearType()).thenReturn(DaysInYearType.DAYS_360.getValue());
+        Mockito.when(loanProductRelatedDetail.getDaysInMonthType()).thenReturn(DaysInMonthType.DAYS_30.getValue());
+        Mockito.when(loanProductRelatedDetail.getRepaymentPeriodFrequencyType()).thenReturn(PeriodFrequencyType.MONTHS);
+        Mockito.when(loanProductRelatedDetail.getRepayEvery()).thenReturn(1);
+        Mockito.when(loanProductRelatedDetail.getNumberOfRepayments()).thenReturn(8);
+        Mockito.when(loanProductRelatedDetail.getGraceOnPrincipalPayment()).thenReturn(7);
+        Mockito.when(loanProductRelatedDetail.getGraceOnInterestPayment()).thenReturn(0);
+
+        final ProgressiveLoanInterestScheduleModel interestSchedule = emiCalculator
+                .generatePeriodInterestScheduleModel(expectedRepaymentPeriods, loanProductRelatedDetail, null, mc);
+
+        emiCalculator.addDisbursement(interestSchedule, LocalDate.of(2024, 1, 1), toMoney(100.0));
+
+        // Installments 1..7 (index 0..6) must be interest-only: 100 * 30% / 12 = 2.50 each, balance stays at 100.
+        checkPeriod(interestSchedule, 0, 2.5, 2.5, 0.0, 100.0, false);
+        checkPeriod(interestSchedule, 1, 2.5, 2.5, 0.0, 100.0, false);
+        checkPeriod(interestSchedule, 2, 2.5, 2.5, 0.0, 100.0, false);
+        checkPeriod(interestSchedule, 3, 2.5, 2.5, 0.0, 100.0, false);
+        checkPeriod(interestSchedule, 4, 2.5, 2.5, 0.0, 100.0, false);
+        checkPeriod(interestSchedule, 5, 2.5, 2.5, 0.0, 100.0, false);
+        checkPeriod(interestSchedule, 6, 2.5, 2.5, 0.0, 100.0, false);
+
+        // Installment 8 (index 7) must carry the full principal as a single balloon payment.
+        checkPeriod(interestSchedule, 7, 102.5, 2.5, 100.0, 0.0, false);
+    }
+
+    /**
+     * Generic guard for the grace = N-1 bullet boundary using a longer term (N = 12, graceOnPrincipalPayment = 11).
+     *
+     * <p>
+     * Installments 1..11 must be interest-only (100 * 30% / 12 = 2.50 each, balance stays at 100) and the final
+     * installment (12) must carry the full principal as a single balloon payment. This protects the boundary fix
+     * independently of the specific N = 8 reproduction.
+     */
+    @Test
+    public void test_principalGrace_nMinus1_longerTerm_shouldProduceBulletLoan() {
+        final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>();
+        LocalDate cursor = LocalDate.of(2024, 1, 1);
+        for (int i = 0; i < 12; i++) {
+            final LocalDate next = cursor.plusMonths(1);
+            expectedRepaymentPeriods.add(periodData(cursor, next));
+            cursor = next;
+        }
+
+        Mockito.when(loanProductRelatedDetail.getAnnualNominalInterestRate()).thenReturn(BigDecimal.valueOf(30.0));
+        Mockito.when(loanProductRelatedDetail.getDaysInYearType()).thenReturn(DaysInYearType.DAYS_360.getValue());
+        Mockito.when(loanProductRelatedDetail.getDaysInMonthType()).thenReturn(DaysInMonthType.DAYS_30.getValue());
+        Mockito.when(loanProductRelatedDetail.getRepaymentPeriodFrequencyType()).thenReturn(PeriodFrequencyType.MONTHS);
+        Mockito.when(loanProductRelatedDetail.getRepayEvery()).thenReturn(1);
+        Mockito.when(loanProductRelatedDetail.getNumberOfRepayments()).thenReturn(12);
+        Mockito.when(loanProductRelatedDetail.getGraceOnPrincipalPayment()).thenReturn(11);
+        Mockito.when(loanProductRelatedDetail.getGraceOnInterestPayment()).thenReturn(0);
+
+        final ProgressiveLoanInterestScheduleModel interestSchedule = emiCalculator
+                .generatePeriodInterestScheduleModel(expectedRepaymentPeriods, loanProductRelatedDetail, null, mc);
+
+        emiCalculator.addDisbursement(interestSchedule, LocalDate.of(2024, 1, 1), toMoney(100.0));
+
+        // Installments 1..11 (index 0..10) must be interest-only.
+        for (int idx = 0; idx <= 10; idx++) {
+            checkPeriod(interestSchedule, idx, 2.5, 2.5, 0.0, 100.0, false);
+        }
+
+        // Installment 12 (index 11) must carry the full principal as a single balloon payment.
+        checkPeriod(interestSchedule, 11, 102.5, 2.5, 100.0, 0.0, false);
+    }
+
     @Test
     public void test_interestGraceForProgressiveSchedule() {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>();

--- a/fineract-progressive-loan/src/test/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculatorTest.java
+++ b/fineract-progressive-loan/src/test/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculatorTest.java
@@ -5315,12 +5315,11 @@ class ProgressiveEMICalculatorTest {
     }
 
     /**
-     * Control case for the bullet-loan boundary defect.
+     * Progressive declining-balance loan with N = 8 repayments and graceOnPrincipalPayment = N-2 = 6.
      *
-     * With N=8 repayments and graceOnPrincipalPayment = N-2 = 6, the schedule behaves correctly: installments 1..6 are
-     * interest-only and the principal is amortized across the final two installments (7 and 8). This test passes on the
-     * current engine and is here to demonstrate that the defect exercised by
-     * {@link #test_principalGrace_nMinus1_shouldProduceBulletLoan()} is specific to the grace = N-1 boundary.
+     * <p>
+     * Installments 1..6 are interest-only and the principal is amortized across the final two installments (7 and 8).
+     * EMI equalization counts the grace periods as uncountable so the last two EMIs stay aligned.
      */
     @Test
     public void test_principalGrace_nMinus2_deferralWorks() {
@@ -5373,21 +5372,12 @@ class ProgressiveEMICalculatorTest {
     }
 
     /**
-     * Reproduces the bullet-loan defect at the grace = N-1 boundary (Fineract 1.15.0).
+     * Progressive declining-balance loan with N = 8 repayments and graceOnPrincipalPayment = N-1 = 7 produces a bullet /
+     * balloon schedule.
      *
      * <p>
-     * Setup: progressive schedule, advanced payment allocation, declining balance / equal installments, single
-     * disbursement, N = 8 repayments, graceOnPrincipalPayment = 7 (= N-1), interest recalculation disabled.
-     *
-     * <p>
-     * Expected (a true bullet loan): installments 1..7 are interest-only (principal 0, balance stays at 100) and
-     * installment 8 carries 100% of the principal.
-     *
-     * <p>
-     * Actual on the current engine: principal is fully amortized across installments 1..7 and the final installment (8)
-     * is left completely empty (0 principal / 0 interest). This assertion therefore FAILS on 1.15.0 and documents the
-     * defect. The neighbouring grace = N-2 case ({@link #test_principalGrace_nMinus2_deferralWorks()}) works correctly,
-     * showing the problem is confined to the single-remaining-period boundary.
+     * Installments 1..7 are interest-only (principal 0, balance stays at 100) and installment 8 carries the full
+     * principal.
      */
     @Test
     public void test_principalGrace_nMinus1_shouldProduceBulletLoan() {

--- a/fineract-progressive-loan/src/test/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculatorTest.java
+++ b/fineract-progressive-loan/src/test/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculatorTest.java
@@ -5506,6 +5506,78 @@ class ProgressiveEMICalculatorTest {
                 "Period 2 is outside the mid-loan suffix and must not keep a stale grace flag");
     }
 
+    /**
+     * Re-amortization overrides principal grace: flags are lifted and the remaining periods are equalized again.
+     */
+    @Test
+    public void test_principalGrace_reAmortization_liftsFlagAndEqualizesEmi() {
+        final ProgressiveLoanInterestScheduleModel interestSchedule = generatePrincipalGraceScheduleForReAmortProbe();
+        final List<RepaymentPeriod> before = interestSchedule.repaymentPeriods();
+        Assertions.assertTrue(before.get(0).isPrincipalPaymentGrace());
+        Assertions.assertTrue(before.get(1).isPrincipalPaymentGrace());
+        Assertions.assertTrue(before.get(2).isPrincipalPaymentGrace());
+
+        emiCalculator.updateModelRepaymentPeriodsDuringReAmortization(interestSchedule, LocalDate.of(2024, 2, 15));
+
+        assertPrincipalGraceLiftedAndFutureEmisEqualized(interestSchedule);
+    }
+
+    /**
+     * Equal-interest-split re-amortization also lifts principal grace so equalization is not skipped.
+     */
+    @Test
+    public void test_principalGrace_reAmortizationEqualInterestSplit_liftsFlagAndEqualizesEmi() {
+        final ProgressiveLoanInterestScheduleModel interestSchedule = generatePrincipalGraceScheduleForReAmortProbe();
+
+        emiCalculator.updateModelRepaymentPeriodsDuringReAmortizationWithEqualInterestSplit(interestSchedule, LocalDate.of(2024, 2, 15));
+
+        assertPrincipalGraceLiftedAndFutureEmisEqualized(interestSchedule);
+    }
+
+    private ProgressiveLoanInterestScheduleModel generatePrincipalGraceScheduleForReAmortProbe() {
+        final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>();
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 7, 1), LocalDate.of(2024, 8, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 8, 1), LocalDate.of(2024, 9, 1)));
+
+        Mockito.when(loanProductRelatedDetail.getAnnualNominalInterestRate()).thenReturn(BigDecimal.valueOf(30.0));
+        Mockito.when(loanProductRelatedDetail.getDaysInYearType()).thenReturn(DaysInYearType.DAYS_360.getValue());
+        Mockito.when(loanProductRelatedDetail.getDaysInMonthType()).thenReturn(DaysInMonthType.DAYS_30.getValue());
+        Mockito.when(loanProductRelatedDetail.getRepaymentPeriodFrequencyType()).thenReturn(PeriodFrequencyType.MONTHS);
+        Mockito.when(loanProductRelatedDetail.getRepayEvery()).thenReturn(1);
+        Mockito.when(loanProductRelatedDetail.getNumberOfRepayments()).thenReturn(8);
+        Mockito.when(loanProductRelatedDetail.getGraceOnPrincipalPayment()).thenReturn(3);
+        Mockito.when(loanProductRelatedDetail.getGraceOnInterestPayment()).thenReturn(0);
+
+        final ProgressiveLoanInterestScheduleModel interestSchedule = emiCalculator
+                .generatePeriodInterestScheduleModel(expectedRepaymentPeriods, loanProductRelatedDetail, null, mc);
+        emiCalculator.addDisbursement(interestSchedule, LocalDate.of(2024, 1, 1), toMoney(100.0));
+        return interestSchedule;
+    }
+
+    private static void assertPrincipalGraceLiftedAndFutureEmisEqualized(final ProgressiveLoanInterestScheduleModel interestSchedule) {
+        final LocalDate transactionDate = LocalDate.of(2024, 2, 15);
+        final List<RepaymentPeriod> repaymentPeriods = interestSchedule.repaymentPeriods();
+        Assertions.assertTrue(repaymentPeriods.stream().noneMatch(RepaymentPeriod::isPrincipalPaymentGrace),
+                "Re-amortization must lift principalPaymentGrace so equalization is not skipped");
+
+        final List<RepaymentPeriod> futurePeriods = repaymentPeriods.stream().filter(rp -> rp.getDueDate().isAfter(transactionDate))
+                .toList();
+        Assertions.assertFalse(futurePeriods.isEmpty());
+        final double firstFutureEmi = toDouble(futurePeriods.getFirst().getEmi());
+        for (final RepaymentPeriod futurePeriod : futurePeriods) {
+            Assertions.assertEquals(firstFutureEmi, toDouble(futurePeriod.getEmi()), 0.05,
+                    "Re-amortized remaining periods should be equal-installment after grace flags are lifted");
+        }
+        final double totalPrincipal = repaymentPeriods.stream().mapToDouble(rp -> toDouble(rp.getDuePrincipal())).sum();
+        Assertions.assertEquals(100.0, totalPrincipal, 0.01, "All principal must still be scheduled");
+    }
+
     @Test
     public void test_interestGraceForProgressiveSchedule() {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>();

--- a/fineract-progressive-loan/src/test/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculatorTest.java
+++ b/fineract-progressive-loan/src/test/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculatorTest.java
@@ -5459,6 +5459,53 @@ class ProgressiveEMICalculatorTest {
         checkPeriod(interestSchedule, 11, 102.5, 2.5, 100.0, 0.0, false);
     }
 
+    /**
+     * Mid-loan recalculation resets principalPaymentGrace on the full schedule model, not only the related suffix, so
+     * flags set on earlier periods during initial generation do not stay stuck.
+     */
+    @Test
+    public void test_principalGrace_midLoanRecalc_clearsFlagsOutsideRelatedSuffix() {
+        final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>();
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 2, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 4, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 4, 1), LocalDate.of(2024, 5, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 5, 1), LocalDate.of(2024, 6, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 7, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 7, 1), LocalDate.of(2024, 8, 1)));
+        expectedRepaymentPeriods.add(periodData(LocalDate.of(2024, 8, 1), LocalDate.of(2024, 9, 1)));
+
+        Mockito.when(loanProductRelatedDetail.getAnnualNominalInterestRate()).thenReturn(BigDecimal.valueOf(30.0));
+        Mockito.when(loanProductRelatedDetail.getDaysInYearType()).thenReturn(DaysInYearType.DAYS_360.getValue());
+        Mockito.when(loanProductRelatedDetail.getDaysInMonthType()).thenReturn(DaysInMonthType.DAYS_30.getValue());
+        Mockito.when(loanProductRelatedDetail.getRepaymentPeriodFrequencyType()).thenReturn(PeriodFrequencyType.MONTHS);
+        Mockito.when(loanProductRelatedDetail.getRepayEvery()).thenReturn(1);
+        Mockito.when(loanProductRelatedDetail.getNumberOfRepayments()).thenReturn(8);
+        Mockito.when(loanProductRelatedDetail.getGraceOnPrincipalPayment()).thenReturn(3);
+        Mockito.when(loanProductRelatedDetail.getGraceOnInterestPayment()).thenReturn(0);
+
+        final ProgressiveLoanInterestScheduleModel interestSchedule = emiCalculator
+                .generatePeriodInterestScheduleModel(expectedRepaymentPeriods, loanProductRelatedDetail, null, mc);
+
+        emiCalculator.addDisbursement(interestSchedule, LocalDate.of(2024, 1, 1), toMoney(100.0));
+
+        final List<RepaymentPeriod> afterFirst = interestSchedule.repaymentPeriods();
+        Assertions.assertTrue(afterFirst.get(0).isPrincipalPaymentGrace());
+        Assertions.assertTrue(afterFirst.get(1).isPrincipalPaymentGrace());
+        Assertions.assertTrue(afterFirst.get(2).isPrincipalPaymentGrace());
+        Assertions.assertFalse(afterFirst.get(3).isPrincipalPaymentGrace());
+
+        emiCalculator.addDisbursement(interestSchedule, LocalDate.of(2024, 4, 15), toMoney(50.0));
+
+        final List<RepaymentPeriod> afterSecond = interestSchedule.repaymentPeriods();
+        Assertions.assertFalse(afterSecond.get(0).isPrincipalPaymentGrace(),
+                "Period 0 is outside the mid-loan suffix and must not keep a stale grace flag");
+        Assertions.assertFalse(afterSecond.get(1).isPrincipalPaymentGrace(),
+                "Period 1 is outside the mid-loan suffix and must not keep a stale grace flag");
+        Assertions.assertFalse(afterSecond.get(2).isPrincipalPaymentGrace(),
+                "Period 2 is outside the mid-loan suffix and must not keep a stale grace flag");
+    }
+
     @Test
     public void test_interestGraceForProgressiveSchedule() {
         final List<LoanScheduleModelRepaymentPeriod> expectedRepaymentPeriods = new ArrayList<>();

--- a/fineract-progressive-loan/src/test/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculatorTest.java
+++ b/fineract-progressive-loan/src/test/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculatorTest.java
@@ -5372,8 +5372,8 @@ class ProgressiveEMICalculatorTest {
     }
 
     /**
-     * Progressive declining-balance loan with N = 8 repayments and graceOnPrincipalPayment = N-1 = 7 produces a bullet /
-     * balloon schedule.
+     * Progressive declining-balance loan with N = 8 repayments and graceOnPrincipalPayment = N-1 = 7 produces a balloon
+     * (bullet) schedule.
      *
      * <p>
      * Installments 1..7 are interest-only (principal 0, balance stays at 100) and installment 8 carries the full

--- a/fineract-progressive-loan/src/test/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculatorTest.java
+++ b/fineract-progressive-loan/src/test/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculatorTest.java
@@ -42,6 +42,7 @@ import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.DefaultSche
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanApplicationTerms;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleModelRepaymentPeriod;
 import org.apache.fineract.portfolio.loanaccount.service.ProgressiveLoanInterestScheduleModelParserServiceGsonImpl;
+import org.apache.fineract.portfolio.loanproduct.calc.data.EmiAdjustment;
 import org.apache.fineract.portfolio.loanproduct.calc.data.EqualAmortizationValues;
 import org.apache.fineract.portfolio.loanproduct.calc.data.InterestPeriod;
 import org.apache.fineract.portfolio.loanproduct.calc.data.LoanReAgeParameterData;
@@ -5361,6 +5362,14 @@ class ProgressiveEMICalculatorTest {
                 "Installment 8 should carry principal when grace = N-2");
         final double totalPrincipal = repaymentPeriods.stream().mapToDouble(rp -> toDouble(rp.getDuePrincipal())).sum();
         Assertions.assertEquals(100.0, totalPrincipal, 0.01, "All principal must be scheduled");
+
+        // Grace periods are skipped when EMI is rewritten, so they must also be uncountable in the
+        // adjustment divisor (N - uncountable = 2 amortizing periods, not 8).
+        final EmiAdjustment emiAdjustment = emiCalculator.getEmiAdjustment(repaymentPeriods);
+        Assertions.assertEquals(6, emiAdjustment.uncountablePeriods(),
+                "Principal-grace periods must be uncountable so adjustment() matches the update loop");
+        Assertions.assertEquals(toDouble(repaymentPeriods.get(6).getEmi()), toDouble(repaymentPeriods.get(7).getEmi()), 0.05,
+                "Last two EMIs should equalize when grace periods are excluded from the divisor");
     }
 
     /**


### PR DESCRIPTION
# Summary

When creating a loan product that uses progressive schedule, declining balance interest method and has a grace period on principal. The expected behavior is that during the grace period, no principal is applied to the grace period tranches. This currently works in the system for grace periods within the range `{1..N-2}`. Where N is the number of repayments.

When you setup `N-1` as the grace period, the system behaves with the bug, and all tranches have principal on them. The "Bullet/Balloon" loan concept (where the entire principal is repaid fully at the last repayment) is not possible to achieve.

# Root cause analysis

The code lives in `ProgressiveEMICalculator.java`. There's a method called `applyPrincipalMoratoriumIfRequired(...)` that does two things:

1. Marks the first N grace installments as interest-only (correct so far). 
2. Then it re-runs the amortization math on only the leftover installments — the ones that still owe principal. It does this by slicing the list: `subList(gracePeriods, size)`.

## Where it breaks

After the moratorium correctly parks the full principal onto that single last installment, a later normalization step kicks in (getEmiAdjustment, checkAndAdjustEmiIfNeededOnRelatedRepaymentPeriods, calculateLastUnpaidRepaymentPeriodEMI). This step's job is normally to fine-tune the last installment so the numbers reconcile perfectly (rounding, etc.).

But when there's only one non-grace period, this step re-does the amortization from scratch and undoes the moratorium's work. It ends up spreading the principal back across installments.

## Why N-2 works but N-1 doesn't?

When grace is N - 2, the leftover slice has two installments to work with. With two or more periods, the equal-installment solver has "room" to land on a valid split, and the moratorium survives the cleanup step. It's only the single-remaining-period edge case (N - 1) that trips the bug — which is precisely why the reproduction shows "N-2 works, N-1 breaks." The defect lives entirely at that one-period boundary.

# Steps to reproduce

Please see the jira issue at [FINERACT-2789](https://issues.apache.org/jira/browse/FINERACT-2789).

# Proposed solution

Adding a new `principalPaymentGrace` flag that sits next to the existing `interestPaymentGrace` to mark the entries as part of principal grace/moratorium. And avoiding the normalizations steps from breaking the 0 principal rule setup on the grace period setting.

# How is this change tested?

3 new unit tests have been added: a control one to verify N-2 works as it is today (grace period on principal), and 2 more to verify N-1 with two loan lengths. Also, the following command is passing running the whole suite of unit tests.

```bash
./gradlew test \
  -x :twofactor-tests:test \
  -x :oauth2-tests:test \
  -x :integration-tests:test \
  -x :fineract-client:test \
  -x :fineract-client-feign:test \
  -x :fineract-e2e-tests-core:test \
  -x :fineract-e2e-tests-runner:test \
  -x buildJavaSdk
```

It has also been manually tested seeing the same correct behavior between N-2 and N-1 grace on principal.

# Recommended reviewers

- adamsaghy@gmail.com
- airajena0@gmail.com
- janez@outlook.hu
- riaskay3@gmail.com
- soma.soros@dpc.hu
