### PR TITLE
FINERACT-2787: Remove ineffective GSIM application synchronization

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsApplicationProcessWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsApplicationProcessWritePlatformServiceJpaRepositoryImpl.java
@@ -122,14 +122,11 @@ public class SavingsApplicationProcessWritePlatformServiceJpaRepositoryImpl impl
 
         JsonArray gsimApplications = command.arrayOfParameterNamed("clientArray");
 
-        final Object lock = new Object();
-        synchronized (lock) {
-            for (JsonElement gsimApplication : gsimApplications) {
-                // result=submitApplication(JsonCommand.fromExistingCommand(command,
-                // gsimApplication));
-                result = submitApplication(JsonCommand.fromExistingCommand(command, gsimApplication,
-                        gsimApplication.getAsJsonObject().get("clientId").getAsLong()));
-            }
+        for (JsonElement gsimApplication : gsimApplications) {
+            // result=submitApplication(JsonCommand.fromExistingCommand(command,
+            // gsimApplication));
+            result = submitApplication(JsonCommand.fromExistingCommand(command, gsimApplication,
+                    gsimApplication.getAsJsonObject().get("clientId").getAsLong()));
         }
 
         return result;


### PR DESCRIPTION
## Description

Remove the ineffective method-local synchronization block from `submitGSIMApplication`.

Each invocation created its own lock object, so concurrent requests were never coordinated. The existing `for` loop remains sequential, with no API or behavior change.

Related issue: [FINERACT-2787](https://issues.apache.org/jira/browse/FINERACT-2787)

## Testing

- `:fineract-provider:compileJava`
- `spotlessCheck`
- `:fineract-provider:checkstyleMain`
- `GroupSavingsIntegrationTest.testGsimSavingsAccount_WithTwoClients_ChildCountTwo`
- Signed-commit verification

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build ("green") - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made. The existing GSIM integration test covers this behavior; no test code change is required.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation with details of any API changes. Not applicable; this change does not affect the API.
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). This PR changes one method in one file.
- [x] If merging this PR resolves a JIRA issue, I will mark that issue as resolved and set "Fix Version/s" appropriately.