### PR TITLE
FINERACT-817: Provide values of entity property for Entity Data Table Checks

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/dataqueries/data/EntityDataTableChecksData.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/dataqueries/data/EntityDataTableChecksData.java
@@ -20,6 +20,7 @@ package org.apache.fineract.infrastructure.dataqueries.data;
 
 import java.io.Serializable;
 import org.apache.fineract.infrastructure.core.data.EnumOptionData;
+import org.apache.fineract.infrastructure.core.data.StringEnumOptionData;
 
 /**
  * Immutable data object for role data.
@@ -28,6 +29,7 @@ public class EntityDataTableChecksData implements Serializable {
 
     private final long id;
     private final String entity;
+    private final StringEnumOptionData entityData;
     private final EnumOptionData status;
     private final String datatableName;
     private final boolean systemDefined;
@@ -35,10 +37,11 @@ public class EntityDataTableChecksData implements Serializable {
     private final Long productId;
     private final String productName;
 
-    public EntityDataTableChecksData(final long id, final String entity, final EnumOptionData status, final String datatableName,
-            final boolean systemDefined, final Long loanProductId, final String productName) {
+    public EntityDataTableChecksData(final long id, final String entity, final StringEnumOptionData entityData, final EnumOptionData status,
+            final String datatableName, final boolean systemDefined, final Long loanProductId, final String productName) {
         this.id = id;
         this.entity = entity;
+        this.entityData = entityData;
         this.status = status;
         this.datatableName = datatableName;
         this.systemDefined = systemDefined;

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/dataqueries/data/EntityTables.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/dataqueries/data/EntityTables.java
@@ -34,21 +34,22 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import org.apache.fineract.infrastructure.core.data.StringEnumOptionData;
 
 public enum EntityTables {
 
-    CLIENT("m_client", "client_id", "id", CREATE, ACTIVATE, CLOSE), //
-    GROUP("m_group", "group_id", "id", CREATE, ACTIVATE, CLOSE), //
-    CENTER("m_center", "m_group", "center_id", "id"), //
-    OFFICE("m_office", "office_id", "id"), //
-    LOAN_PRODUCT("m_product_loan", "product_loan_id", "id"), //
-    LOAN("m_loan", "loan_id", "id", CREATE, APPROVE, DISBURSE, WITHDRAWN, REJECTED, WRITE_OFF), //
-    SAVINGS_PRODUCT("m_savings_product", "savings_product_id", "id"), //
-    SAVINGS("m_savings_account", "savings_account_id", "id", CREATE, APPROVE, ACTIVATE, WITHDRAWN, REJECTED, CLOSE), //
-    SAVINGS_TRANSACTION("m_savings_account_transaction", "savings_transaction_id", "id"), //
-    SHARE_PRODUCT("m_share_product", "share_product_id", "id"), //
-    WC_LOAN_PRODUCT("m_wc_loan_product", "wc_product_loan_id", "id"), //
-    WC_LOAN("m_wc_loan", "wc_loan_id", "id"), //
+    CLIENT("m_client", "Client", "client_id", "id", CREATE, ACTIVATE, CLOSE), //
+    GROUP("m_group", "Group", "group_id", "id", CREATE, ACTIVATE, CLOSE), //
+    CENTER("m_center", "Center", "m_group", "center_id", "id"), //
+    OFFICE("m_office", "Office", "office_id", "id"), //
+    LOAN_PRODUCT("m_product_loan", "Loan Product", "product_loan_id", "id"), //
+    LOAN("m_loan", "Loan", "loan_id", "id", CREATE, APPROVE, DISBURSE, WITHDRAWN, REJECTED, WRITE_OFF), //
+    SAVINGS_PRODUCT("m_savings_product", "Savings Product", "savings_product_id", "id"), //
+    SAVINGS("m_savings_account", "Savings Account", "savings_account_id", "id", CREATE, APPROVE, ACTIVATE, WITHDRAWN, REJECTED, CLOSE), //
+    SAVINGS_TRANSACTION("m_savings_account_transaction", "Savings Account Transaction", "savings_transaction_id", "id"), //
+    SHARE_PRODUCT("m_share_product", "Share Product", "share_product_id", "id"), //
+    WC_LOAN_PRODUCT("m_wc_loan_product", "Working Capital Loan Product", "wc_product_loan_id", "id"), //
+    WC_LOAN("m_wc_loan", "Working Capital Loan", "wc_loan_id", "id"), //
     ;
 
     static final EntityTables[] ENTITY_VALUES = values();
@@ -61,6 +62,8 @@ public enum EntityTables {
     @NotNull
     private final String name;
     @NotNull
+    private final String humanReadableName;
+    @NotNull
     private final String apptableName;
 
     @NotNull
@@ -70,22 +73,29 @@ public enum EntityTables {
 
     private final ImmutableList<StatusEnum> checkStatuses;
 
-    EntityTables(@NotNull String name, @NotNull String apptableName, @NotNull String foreignKeyColumnNameOnDatatable,
-            @NotNull String refColumn, StatusEnum... statuses) {
+    EntityTables(@NotNull String name, @NotNull String humanReadableName, @NotNull String apptableName,
+            @NotNull String foreignKeyColumnNameOnDatatable, @NotNull String refColumn, StatusEnum... statuses) {
         this.name = name;
+        this.humanReadableName = humanReadableName;
         this.apptableName = apptableName;
         this.foreignKeyColumnNameOnDatatable = foreignKeyColumnNameOnDatatable;
         this.refColumn = refColumn;
         this.checkStatuses = statuses == null ? ImmutableList.of() : ImmutableList.copyOf(statuses);
     }
 
-    EntityTables(@NotNull String name, @NotNull String foreignKeyColumnNameOnDatatable, @NotNull String refColumn, StatusEnum... statuses) {
-        this(name, name, foreignKeyColumnNameOnDatatable, refColumn, statuses);
+    EntityTables(@NotNull String name, @NotNull String humanReadableName, @NotNull String foreignKeyColumnNameOnDatatable,
+            @NotNull String refColumn, StatusEnum... statuses) {
+        this(name, humanReadableName, name, foreignKeyColumnNameOnDatatable, refColumn, statuses);
     }
 
     @NotNull
     public String getName() {
         return name;
+    }
+
+    @NotNull
+    public String getHumanReadableName() {
+        return humanReadableName;
     }
 
     @NotNull
@@ -138,5 +148,9 @@ public enum EntityTables {
     @NotNull
     public static List<EntityTables> getFiltered(Predicate<EntityTables> filter) {
         return Arrays.stream(ENTITY_VALUES).filter(filter).toList();
+    }
+
+    public StringEnumOptionData toEnumOptionData() {
+        return new StringEnumOptionData(name(), getName(), getHumanReadableName());
     }
 }

--- a/fineract-core/src/test/java/org/apache/fineract/infrastructure/dataqueries/data/EntityTablesTest.java
+++ b/fineract-core/src/test/java/org/apache/fineract/infrastructure/dataqueries/data/EntityTablesTest.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.dataqueries.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.apache.fineract.infrastructure.core.data.StringEnumOptionData;
+import org.junit.jupiter.api.Test;
+
+class EntityTablesTest {
+
+    @Test
+    void testEntityTablesEnumOptionData() {
+        StringEnumOptionData clientOption = EntityTables.CLIENT.toEnumOptionData();
+        assertNotNull(clientOption);
+        assertEquals("CLIENT", clientOption.getId());
+        assertEquals("m_client", clientOption.getCode());
+        assertEquals("Client", clientOption.getValue());
+
+        StringEnumOptionData loanOption = EntityTables.LOAN.toEnumOptionData();
+        assertNotNull(loanOption);
+        assertEquals("LOAN", loanOption.getId());
+        assertEquals("m_loan", loanOption.getCode());
+        assertEquals("Loan", loanOption.getValue());
+
+        StringEnumOptionData savingsOption = EntityTables.SAVINGS.toEnumOptionData();
+        assertNotNull(savingsOption);
+        assertEquals("SAVINGS", savingsOption.getId());
+        assertEquals("m_savings_account", savingsOption.getCode());
+        assertEquals("Savings Account", savingsOption.getValue());
+
+        StringEnumOptionData groupOption = EntityTables.GROUP.toEnumOptionData();
+        assertNotNull(groupOption);
+        assertEquals("GROUP", groupOption.getId());
+        assertEquals("m_group", groupOption.getCode());
+        assertEquals("Group", groupOption.getValue());
+
+        StringEnumOptionData wcLoanOption = EntityTables.WC_LOAN.toEnumOptionData();
+        assertNotNull(wcLoanOption);
+        assertEquals("WC_LOAN", wcLoanOption.getId());
+        assertEquals("m_wc_loan", wcLoanOption.getCode());
+        assertEquals("Working Capital Loan", wcLoanOption.getValue());
+
+        StringEnumOptionData wcProductOption = EntityTables.WC_LOAN_PRODUCT.toEnumOptionData();
+        assertNotNull(wcProductOption);
+        assertEquals("WC_LOAN_PRODUCT", wcProductOption.getId());
+        assertEquals("m_wc_loan_product", wcProductOption.getCode());
+        assertEquals("Working Capital Loan Product", wcProductOption.getValue());
+    }
+
+    @Test
+    void testFromEntityName() {
+        assertEquals(EntityTables.CLIENT, EntityTables.fromEntityName("m_client"));
+        assertEquals(EntityTables.LOAN, EntityTables.fromEntityName("m_loan"));
+        assertEquals(EntityTables.SAVINGS, EntityTables.fromEntityName("m_savings_account"));
+        assertEquals(EntityTables.GROUP, EntityTables.fromEntityName("m_group"));
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/api/EntityDatatableChecksApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/api/EntityDatatableChecksApiResourceSwagger.java
@@ -22,6 +22,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Collection;
 import java.util.List;
 import org.apache.fineract.infrastructure.core.data.EnumOptionData;
+import org.apache.fineract.infrastructure.core.data.StringEnumOptionData;
 import org.apache.fineract.infrastructure.dataqueries.data.DatatableCheckStatusData;
 import org.apache.fineract.infrastructure.dataqueries.data.DatatableChecksData;
 import org.apache.fineract.portfolio.loanproduct.data.LoanProductData;
@@ -42,7 +43,9 @@ final class EntityDatatableChecksApiResourceSwagger {
         private GetEntityDatatableChecksResponse() {}
 
         public long id;
+        @Schema(example = "m_loan")
         public String entity;
+        public StringEnumOptionData entityData;
         public EnumOptionData status;
         public String datatableName;
         public boolean systemDefined;

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/EntityDatatableChecksReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/EntityDatatableChecksReadPlatformServiceImpl.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import org.apache.fineract.infrastructure.core.data.EnumOptionData;
+import org.apache.fineract.infrastructure.core.data.StringEnumOptionData;
 import org.apache.fineract.infrastructure.core.domain.JdbcSupport;
 import org.apache.fineract.infrastructure.core.service.Page;
 import org.apache.fineract.infrastructure.core.service.PaginationHelper;
@@ -197,7 +198,11 @@ public class EntityDatatableChecksReadPlatformServiceImpl implements EntityDatat
             final Long productId = JdbcSupport.getLong(rs, "productId");
             final String productName = rs.getString("productName");
 
-            return new EntityDataTableChecksData(id, entity, statusEnum, datatableName, systemDefined, productId, productName);
+            final EntityTables entityTables = EntityTables.fromEntityName(entity);
+            final StringEnumOptionData entityData = entityTables != null ? entityTables.toEnumOptionData()
+                    : new StringEnumOptionData(entity, entity, entity);
+
+            return new EntityDataTableChecksData(id, entity, entityData, statusEnum, datatableName, systemDefined, productId, productName);
         }
 
         public String schema() {


### PR DESCRIPTION
## Description

Previously, the Entity Data Table Checks API (`/v1/entityDatatableChecks`) only returned the internal table name string for the `entity` field (e.g. `"m_client"`) instead of structured enum option data containing human-readable display values.

This PR addresses [FINERACT-817](https://issues.apache.org/jira/browse/FINERACT-817) by:
1. Enhancing the `EntityTables` enum with human-readable display labels (e.g., "Client", "Loan") and adding a `toEnumOptionData()` method that returns `StringEnumOptionData` (`id`, `code`, `value`).
2. Introducing a new `entityData` property to `EntityDataTableChecksData` using `StringEnumOptionData` to provide the structured values to modern clients, while preserving the legacy `entity` string property to maintain backward compatibility for existing deployments.
3. Updating `EntityDatatableChecksReadPlatformServiceImpl` to populate the new `entityData` field using `EntityTables.fromEntityName(entity).toEnumOptionData()`.
4. Updating the Swagger documentation in `EntityDatatableChecksApiResourceSwagger` to reflect the newly added `entityData` object.
5. Adding unit tests in `EntityTablesTest` to verify enum option mapping and reverse lookup.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).
- [x] If merging this PR resolves a JIRA issue, I will mark that issue as resolved and set "Fix Version/s" appropriately.