### PR TITLE
FINERACT-2802: Progressive Loan charge-off crashes with NoSuchElementException for loans with an "additional" installment

### DIFF
--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/transactionprocessor/impl/AdvancedPaymentScheduleTransactionProcessor.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/transactionprocessor/impl/AdvancedPaymentScheduleTransactionProcessor.java
@@ -2150,7 +2150,8 @@ public class AdvancedPaymentScheduleTransactionProcessor extends AbstractLoanRep
         final LoanRepaymentScheduleInstallment currentInstallment = loan.getRelatedRepaymentScheduleInstallment(transactionDate);
 
         if (!installments.isEmpty() && transactionDate.isBefore(loan.getMaturityDate()) && currentInstallment != null) {
-            if (currentInstallment.isNotFullyPaidOff() || currentInstallment.isReAged()) {
+            // Additional installments are excluded from repaymentPeriods(), so skip them here.
+            if ((currentInstallment.isNotFullyPaidOff() || currentInstallment.isReAged()) && !currentInstallment.isAdditional()) {
                 if (transactionCtx instanceof ProgressiveTransactionCtx progressiveTransactionCtx
                         && loan.isInterestBearingAndInterestRecalculationEnabled()) {
                     final BigDecimal interestOutstanding = currentInstallment.getInterestOutstanding(loan.getCurrency()).getAmount();
@@ -2270,8 +2271,11 @@ public class AdvancedPaymentScheduleTransactionProcessor extends AbstractLoanRep
         if (!installments.isEmpty()) {
             if (transactionCtx instanceof ProgressiveTransactionCtx progressiveTransactionCtx
                     && loanTransaction.getLoan().isInterestBearingAndInterestRecalculationEnabled()) {
-                installments.stream().filter(installment -> !installment.getFromDate().isAfter(transactionDate)
-                        && installment.getDueDate().isAfter(transactionDate)).forEach(installment -> {
+                // Additional installments are excluded from repaymentPeriods(), so exclude them here.
+                installments.stream()
+                        .filter(installment -> !installment.getFromDate().isAfter(transactionDate)
+                                && installment.getDueDate().isAfter(transactionDate) && !installment.isAdditional())
+                        .forEach(installment -> {
                             final BigDecimal interestOutstanding = installment.getInterestOutstanding(currency).getAmount();
 
                             final BigDecimal newInterest = emiCalculator.getPeriodInterestTillDate(progressiveTransactionCtx.getModel(),

--- a/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculator.java
+++ b/fineract-progressive-loan/src/main/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculator.java
@@ -51,6 +51,7 @@ import org.apache.fineract.portfolio.common.domain.DaysInYearCustomStrategyType;
 import org.apache.fineract.portfolio.common.domain.DaysInYearType;
 import org.apache.fineract.portfolio.common.domain.PeriodFrequencyType;
 import org.apache.fineract.portfolio.loanaccount.domain.reaging.LoanReAgeInterestHandlingType;
+import org.apache.fineract.portfolio.loanaccount.exception.LoanTransactionProcessingException;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanApplicationTerms;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleModelRepaymentPeriod;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleProcessingType;
@@ -645,8 +646,14 @@ public final class ProgressiveEMICalculator implements EMICalculator {
         final ProgressiveLoanInterestScheduleModel recalculatedScheduleModelTillDate = recalculateScheduleModelTillDate(scheduleModel,
                 targetDate);
         final MathContext mc = recalculatedScheduleModelTillDate.mc();
+        // Additional installments have no matching repayment period in the model,
+        // so throw a descriptive exception instead of a bare NoSuchElementException.
         final RepaymentPeriod repaymentPeriod = recalculatedScheduleModelTillDate
-                .findRepaymentPeriodByFromAndDueDate(periodFromDate, periodDueDate).orElseThrow();
+                .findRepaymentPeriodByFromAndDueDate(periodFromDate, periodDueDate)
+                .orElseThrow(() -> new LoanTransactionProcessingException(
+                        String.format("No repayment period found in the interest schedule model for the period from %s to %s",
+                                periodFromDate, periodDueDate),
+                        periodFromDate, periodDueDate));
         Money calculatedDueInterest = repaymentPeriod.getCalculatedDueInterest();
         if (fixedInterestTillDate) {
             calculatedDueInterest = MathUtil.negativeToZero(
@@ -712,7 +719,12 @@ public final class ProgressiveEMICalculator implements EMICalculator {
         } else if (isAfterMaturityDate) {
             return scheduleModelCopy;
         } else {
-            RepaymentPeriod repaymentPeriod = scheduleModelCopy.findRepaymentPeriod(targetDate).orElseThrow();
+            // targetDate can fall inside an additional installment's range, which has no repayment period,
+            // so throw a descriptive exception instead of a bare NoSuchElementException.
+            RepaymentPeriod repaymentPeriod = scheduleModelCopy.findRepaymentPeriod(targetDate)
+                    .orElseThrow(() -> new LoanTransactionProcessingException(
+                            String.format("No repayment period found in the interest schedule model containing the date %s", targetDate),
+                            targetDate));
 
             scheduleModelCopy.repaymentPeriods().forEach(rp -> {
                 if (rp.getDueDate().isAfter(targetDate)) {

--- a/fineract-progressive-loan/src/test/java/org/apache/fineract/portfolio/loanaccount/domain/transactionprocessor/impl/AdvancedPaymentScheduleTransactionProcessorTest.java
+++ b/fineract-progressive-loan/src/test/java/org/apache/fineract/portfolio/loanaccount/domain/transactionprocessor/impl/AdvancedPaymentScheduleTransactionProcessorTest.java
@@ -60,6 +60,7 @@ import org.apache.fineract.portfolio.loanaccount.data.TransactionChangeData;
 import org.apache.fineract.portfolio.loanaccount.domain.ChangedTransactionDetail;
 import org.apache.fineract.portfolio.loanaccount.domain.Loan;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanCharge;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanChargeOffBehaviour;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanChargePaidBy;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanCreditAllocationRule;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanInterestRecalculationDetails;
@@ -787,4 +788,44 @@ class AdvancedPaymentScheduleTransactionProcessorTest {
         Assertions.assertEquals(originalTransaction, repayment2);
     }
 
+    @Test
+    public void handleZeroInterestChargeOffSkipsAdditionalInstallmentStraddlingChargeOffDate() {
+        // given
+        final LocalDate chargeOffDate = LocalDate.of(2024, 2, 10);
+        final LocalDate additionalFromDate = LocalDate.of(2024, 2, 1);
+        final LocalDate additionalDueDate = LocalDate.of(2024, 2, 15);
+
+        final Loan loan = mock(Loan.class);
+        final LoanProductRelatedDetail loanProductRelatedDetail = mock(LoanProductRelatedDetail.class);
+        when(loan.getLoanProductRelatedDetail()).thenReturn(loanProductRelatedDetail);
+        when(loanProductRelatedDetail.getChargeOffBehaviour()).thenReturn(LoanChargeOffBehaviour.ZERO_INTEREST);
+        when(loan.isInterestBearingAndInterestRecalculationEnabled()).thenReturn(true);
+        when(loan.isNpa()).thenReturn(true);
+        when(loan.getCurrency()).thenReturn(MONETARY_CURRENCY);
+        // Money.of() reads the statically mocked MoneyHelper, so it must not be evaluated inside a when() call
+        final Money loanPrincipal = Money.of(MONETARY_CURRENCY, BigDecimal.valueOf(1000.00));
+        when(loan.getPrincipal()).thenReturn(loanPrincipal);
+
+        final LoanRepaymentScheduleInstallment additionalInstallment = new LoanRepaymentScheduleInstallment(loan, 3, additionalFromDate,
+                additionalDueDate, BigDecimal.valueOf(50.00), BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO,
+                BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO, true, false, false);
+        final List<LoanRepaymentScheduleInstallment> installments = List.of(additionalInstallment);
+
+        final LoanTransaction chargeOffTransaction = mock(LoanTransaction.class);
+        when(chargeOffTransaction.getTypeOf()).thenReturn(LoanTransactionType.CHARGE_OFF);
+        when(chargeOffTransaction.getLoan()).thenReturn(loan);
+        when(chargeOffTransaction.getTransactionDate()).thenReturn(chargeOffDate);
+        lenient().when(chargeOffTransaction.isRepaymentLikeType()).thenReturn(false);
+        lenient().when(chargeOffTransaction.isNotReversed()).thenReturn(true);
+
+        final ProgressiveLoanInterestScheduleModel model = mock(ProgressiveLoanInterestScheduleModel.class);
+
+        final MoneyHolder overpaymentHolder = new MoneyHolder(Money.zero(MONETARY_CURRENCY));
+        final ChangedTransactionDetail changedTransactionDetail = mock(ChangedTransactionDetail.class);
+        final ProgressiveTransactionCtx ctx = new ProgressiveTransactionCtx(MONETARY_CURRENCY, installments, Set.of(), overpaymentHolder,
+                changedTransactionDetail, model, loan.getActiveLoanTermVariations());
+
+        // then
+        Assertions.assertDoesNotThrow(() -> underTest.processLatestTransaction(chargeOffTransaction, ctx));
+    }
 }

--- a/fineract-progressive-loan/src/test/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculatorTest.java
+++ b/fineract-progressive-loan/src/test/java/org/apache/fineract/portfolio/loanproduct/calc/ProgressiveEMICalculatorTest.java
@@ -38,6 +38,7 @@ import org.apache.fineract.portfolio.common.domain.DaysInYearType;
 import org.apache.fineract.portfolio.common.domain.PeriodFrequencyType;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentScheduleInstallment;
 import org.apache.fineract.portfolio.loanaccount.domain.reaging.LoanReAgeInterestHandlingType;
+import org.apache.fineract.portfolio.loanaccount.exception.LoanTransactionProcessingException;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.DefaultScheduledDateGenerator;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanApplicationTerms;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleModelRepaymentPeriod;
@@ -5480,5 +5481,43 @@ class ProgressiveEMICalculatorTest {
                 "The fully paid last period must keep its EMI");
         Assertions.assertEquals(70.16, toDouble(interestSchedule.getTotalDuePrincipal()), 0.001,
                 "The amortized principal must stay equal to the disbursed amount");
+    }
+
+    @Test
+    public void getPeriodInterestTillDateThrowsLoanTransactionProcessingExceptionForAdditionalInstallment() {
+        // given
+        Mockito.when(loanProductRelatedDetail.getAnnualNominalInterestRate()).thenReturn(BigDecimal.valueOf(12));
+        Mockito.when(loanProductRelatedDetail.getDaysInYearType()).thenReturn(DaysInYearType.DAYS_360.getValue());
+        Mockito.when(loanProductRelatedDetail.getDaysInMonthType()).thenReturn(DaysInMonthType.DAYS_30.getValue());
+        Mockito.when(loanProductRelatedDetail.getRepaymentPeriodFrequencyType()).thenReturn(PeriodFrequencyType.MONTHS);
+        Mockito.when(loanProductRelatedDetail.getRepayEvery()).thenReturn(1);
+        Mockito.when(loanProductRelatedDetail.isAllowFullTermForTranche()).thenReturn(false);
+
+        LocalDate start = LocalDate.of(2024, 1, 1);
+        // Normal installment 1: Jan 1 - Feb 1
+        RepaymentScheduleInstallmentData normal1 = RepaymentScheduleInstallmentData.of(start, start.plusMonths(1), false, false,
+                BigDecimal.ZERO, BigDecimal.ZERO);
+        // "Additional" installment left over from a prior re-age: Feb 1 - Feb 15 (never gets a RepaymentPeriod)
+        RepaymentScheduleInstallmentData additional = RepaymentScheduleInstallmentData.of(start.plusMonths(1),
+                start.plusMonths(1).plusDays(14), false, true, BigDecimal.ZERO, BigDecimal.ZERO);
+        // Normal installment 2 continues after the additional stub: Feb 15 - Mar 15
+        RepaymentScheduleInstallmentData normal2 = RepaymentScheduleInstallmentData.of(start.plusMonths(1).plusDays(14),
+                start.plusMonths(2).plusDays(14), false, false, BigDecimal.ZERO, BigDecimal.ZERO);
+
+        List<RepaymentScheduleInstallmentData> installments = List.of(normal1, additional, normal2);
+
+        // No mocking of the calculator itself -- this builds the real model the same way production code does,
+        // which filters out isAdditional() installments when constructing repaymentPeriods.
+        ProgressiveLoanInterestScheduleModel model = emiCalculator.generateInstallmentInterestScheduleModel(installments,
+                loanProductRelatedDetail, null, mc);
+
+        // then
+        // Additional installments are excluded from repaymentPeriods(), so resolving
+        // their raw dates through the interest schedule model has no matching period.
+        Assertions.assertThrows(LoanTransactionProcessingException.class,
+                () -> emiCalculator.getPeriodInterestTillDate(model, additional.getFromDate(), additional.getDueDate(),
+                        additional.getDueDate(), true, false),
+                "Expected LoanTransactionProcessingException when getPeriodInterestTillDate is "
+                        + "called with an 'additional' installment's dates");
     }
 }


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/FINERACT-2802

Additional installments (isAdditional()==true) are excluded from ProgressiveLoanInterestScheduleModel.repaymentPeriods() and therefore cannot be looked up by raw from/due dates. Two call sites in AdvancedPaymentScheduleTransactionProcessor were passing additional installments' dates directly to getPeriodInterestTillDate(), which called findRepaymentPeriodByFromAndDueDate().orElseThrow() and crashed with NoSuchElementException.

A second, previously-unguarded lookup was found one level deeper in ProgressiveEMICalculator#recalculateScheduleModelTillDate(): a target date falling inside an additional installment's range is neither before the first disbursement nor after the maturity date, so findRepaymentPeriod(targetDate).orElseThrow() also threw an unwrapped NoSuchElementException, even after the two call-site guards below were added, since this method runs earlier in the call chain.

Fix:
- handleAccelerateMaturityDate(): add !currentInstallment.isAdditional() guard before the getPeriodInterestTillDate() call.
- handleZeroInterestChargeOff(): add !installment.isAdditional() to the stream filter before the getPeriodInterestTillDate() call.
- ProgressiveEMICalculator.getPeriodInterestTillDate(): harden the bare orElseThrow() to throw LoanTransactionProcessingException with a descriptive message.
- ProgressiveEMICalculator.recalculateScheduleModelTillDate(): harden a second, previously-unguarded orElseThrow() the same way.

Reproducer: unit tests in AdvancedPaymentScheduleTransactionProcessorTest and ProgressiveEMICalculatorTest.

Related: https://issues.apache.org/jira/browse/FINERACT-2790