### PR TITLE
FINERACT-2804: Fix IndexOutOfBoundsException in SavingsAccountAssembler when no transactions exist after relaxed pivot date

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountAssembler.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountAssembler.java
@@ -357,8 +357,10 @@ public class SavingsAccountAssembler {
                     savingsAccountTransactions = this.savingsAccountRepository.findTransactionsAfterPivotDate(account,
                             interestPostedTillDate.minusDays(relaxingDaysForPivotDate));
 
-                    savingsAccountTransactions.get(0).getSavingsAccount()
-                            .setStartInterestCalculationDate(interestPostedTillDate.minusDays(relaxingDaysForPivotDate));
+                    if (savingsAccountTransactions != null && !savingsAccountTransactions.isEmpty()) {
+                        savingsAccountTransactions.get(0).getSavingsAccount()
+                                .setStartInterestCalculationDate(interestPostedTillDate.minusDays(relaxingDaysForPivotDate));
+                    }
                     List<SavingsAccountTransaction> pivotDateTransaction = this.savingsAccountRepository
                             .findTransactionRunningBalanceBeforePivotDate(account,
                                     interestPostedTillDate.minusDays(relaxingDaysForPivotDate + 1));

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountAssemblerTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/savings/domain/SavingsAccountAssemblerTest.java
@@ -1,0 +1,103 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.savings.domain;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
+import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.apache.fineract.infrastructure.core.service.ExternalIdFactory;
+import org.apache.fineract.organisation.staff.domain.StaffRepositoryWrapper;
+import org.apache.fineract.portfolio.account.service.AccountTransfersReadPlatformService;
+import org.apache.fineract.portfolio.client.domain.ClientRepositoryWrapper;
+import org.apache.fineract.portfolio.group.domain.GroupRepositoryWrapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class SavingsAccountAssemblerTest {
+
+    @Mock
+    private SavingsAccountTransactionSummaryWrapper savingsAccountTransactionSummaryWrapper;
+    @Mock
+    private SavingsAccountTransactionDataSummaryWrapper savingsAccountTransactionDataSummaryWrapper;
+    @Mock
+    private ClientRepositoryWrapper clientRepository;
+    @Mock
+    private GroupRepositoryWrapper groupRepository;
+    @Mock
+    private StaffRepositoryWrapper staffRepository;
+    @Mock
+    private SavingsProductRepository savingProductRepository;
+    @Mock
+    private SavingsAccountRepositoryWrapper savingsAccountRepository;
+    @Mock
+    private SavingsAccountChargeAssembler savingsAccountChargeAssembler;
+    @Mock
+    private FromJsonHelper fromApiJsonHelper;
+    @Mock
+    private AccountTransfersReadPlatformService accountTransfersReadPlatformService;
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+    @Mock
+    private ConfigurationDomainService configurationDomainService;
+    @Mock
+    private ExternalIdFactory externalIdFactory;
+    @Mock
+    private SavingsAccount account;
+
+    // Regression test for: SavingsAccountAssembler.loadTransactionsToSavingsAccount() called
+    // savingsAccountTransactions.get(0) unconditionally right after findTransactionsAfterPivotDate(), with no
+    // empty-list guard, when the relaxing-days pivot-date config is enabled. When an account has zero transactions
+    // after the relaxed pivot date (e.g. a dormant account, or one where all transactions fall before the pivot
+    // window), this threw IndexOutOfBoundsException on every write action that assembles the account (deposit,
+    // withdrawal, etc.). Fixed by guarding the access with the same null/empty check already used a few lines
+    // below for the transient-variable update.
+    @Test
+    void loadTransactionsToSavingsAccountWithNoTransactionsAfterPivotDateDoesNotThrow() {
+        SavingsAccountAssembler assembler = new SavingsAccountAssembler(savingsAccountTransactionSummaryWrapper,
+                savingsAccountTransactionDataSummaryWrapper, clientRepository, groupRepository, staffRepository, savingProductRepository,
+                savingsAccountRepository, savingsAccountChargeAssembler, fromApiJsonHelper, accountTransfersReadPlatformService,
+                jdbcTemplate, configurationDomainService, externalIdFactory);
+
+        SavingsAccountSummary summary = new SavingsAccountSummary();
+        summary.setInterestPostedTillDate(LocalDate.of(2026, 1, 1).minusDays(1));
+
+        when(account.getSummary()).thenReturn(summary);
+        when(configurationDomainService.isRelaxingDaysConfigForPivotDateEnabled()).thenReturn(true);
+        when(configurationDomainService.retrieveRelaxingDaysConfigForPivotDate()).thenReturn(5L);
+        // The scenario that triggers the bug: no transactions exist after the relaxed pivot date.
+        when(savingsAccountRepository.findTransactionsAfterPivotDate(any(SavingsAccount.class), any(LocalDate.class)))
+                .thenReturn(Collections.emptyList());
+        when(savingsAccountRepository.findTransactionRunningBalanceBeforePivotDate(any(SavingsAccount.class), any(LocalDate.class)))
+                .thenReturn(Collections.emptyList());
+
+        assertDoesNotThrow(() -> assembler.loadTransactionsToSavingsAccount(account, true));
+    }
+}


### PR DESCRIPTION
Description

SavingsAccountAssembler.loadTransactionsToSavingsAccount(), the method that loads a savings account's transactions before any write action (deposit, withdrawal, and so on), calls savingsAccountTransactions.get(0).getSavingsAccount().setStartInterestCalculationDate(...) with no check that the list returned by findTransactionsAfterPivotDate() is non-empty. This code path only runs when the relaxing days pivot date config (allow-backdated-transaction-before-interest-posting-date-for-days) is enabled. If an account has zero transactions after the relaxed pivot date window, for example a dormant account or one where every transaction falls before the window, this throws IndexOutOfBoundsException on every write action that assembles the account, including a plain deposit.

The running balance update logic in this method was refactored in 2022 to move the running balance calculation out of a block further down in the same method, one that was already properly guarded with savingsAccountTransactions != null && !savingsAccountTransactions.isEmpty(). That refactor introduced the new, unguarded get(0) access a few lines above the existing guarded block, and the guard was never carried over to the new access point.

Changes

Added SavingsAccountAssemblerTest.java to fineract-provider, covering:

loadTransactionsToSavingsAccountWithNoTransactionsAfterPivotDateDoesNotThrow(): confirms loadTransactionsToSavingsAccount() no longer throws when the relaxing days config is enabled and findTransactionsAfterPivotDate() returns no transactions after the pivot date.

SavingsAccountAssembler.loadTransactionsToSavingsAccount() now wraps the savingsAccountTransactions.get(0) access in the same null and empty check already used later in the method, so the method falls through safely when there are no transactions in the relaxed pivot window.

Verified locally end to end

See https://issues.apache.org/jira/browse/FINERACT-2804