### PR TITLE
FINERACT-2684: Fix typo 'occured' -> 'occurred' in accounting, core and rates modules

### DIFF
--- a/fineract-accounting/src/main/java/org/apache/fineract/accounting/closure/service/GLClosureWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-accounting/src/main/java/org/apache/fineract/accounting/closure/service/GLClosureWritePlatformServiceJpaRepositoryImpl.java
@@ -151,7 +151,7 @@ public class GLClosureWritePlatformServiceJpaRepositoryImpl implements GLClosure
                     command.localDateValueOfParameterNamed(GLClosureJsonInputParams.CLOSING_DATE.getValue()));
         }
 
-        log.error("Error occured.", dve);
+        log.error("Error occurred.", dve);
         throw ErrorHandler.getMappable(dve, "error.msg.glClosure.unknown.data.integrity.issue",
                 "Unknown data integrity issue with resource GL Closure: " + realCause.getMessage());
     }

--- a/fineract-accounting/src/main/java/org/apache/fineract/accounting/financialactivityaccount/service/FinancialActivityAccountWritePlatformServiceImpl.java
+++ b/fineract-accounting/src/main/java/org/apache/fineract/accounting/financialactivityaccount/service/FinancialActivityAccountWritePlatformServiceImpl.java
@@ -147,7 +147,7 @@ public class FinancialActivityAccountWritePlatformServiceImpl implements Financi
             throw new DuplicateFinancialActivityAccountFoundException(financialActivityId);
         }
 
-        log.error("Error occured.", dve);
+        log.error("Error occurred.", dve);
         throw ErrorHandler.getMappable(dve, "error.msg.glAccount.unknown.data.integrity.issue",
                 "Unknown data integrity issue with resource GL Account: " + realCause.getMessage());
     }

--- a/fineract-accounting/src/main/java/org/apache/fineract/accounting/glaccount/service/GLAccountWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-accounting/src/main/java/org/apache/fineract/accounting/glaccount/service/GLAccountWritePlatformServiceJpaRepositoryImpl.java
@@ -244,7 +244,7 @@ public class GLAccountWritePlatformServiceJpaRepositoryImpl implements GLAccount
             throw new GLAccountDuplicateException(glCode);
         }
 
-        LOG.error("Error occured.", dve);
+        LOG.error("Error occurred.", dve);
         throw ErrorHandler.getMappable(dve, "error.msg.glAccount.unknown.data.integrity.issue",
                 "Unknown data integrity issue with resource GL Account: " + realCause.getMessage());
     }

--- a/fineract-accounting/src/main/java/org/apache/fineract/accounting/rule/service/AccountingRuleWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-accounting/src/main/java/org/apache/fineract/accounting/rule/service/AccountingRuleWritePlatformServiceJpaRepositoryImpl.java
@@ -77,7 +77,7 @@ public class AccountingRuleWritePlatformServiceJpaRepositoryImpl implements Acco
             throw new AccountingRuleDuplicateException();
         }
 
-        log.error("Error occured.", dve);
+        log.error("Error occurred.", dve);
         throw ErrorHandler.getMappable(dve, "error.msg.accounting.rule.unknown.data.integrity.issue",
                 "Unknown data integrity issue with resource Accounting Rule: " + realCause.getMessage());
     }

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/DataIntegrityErrorHandler.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/DataIntegrityErrorHandler.java
@@ -35,7 +35,7 @@ public class DataIntegrityErrorHandler {
             throw new PlatformDataIntegrityException("error.msg." + msgType + ".duplicate.externalId",
                     msgDescription + ": externalId `" + externalId + "` already exists", "externalId", externalId);
         }
-        log.error("Error occured.", dve);
+        log.error("Error occurred.", dve);
         throw ErrorHandler.getMappable(dve, "error.msg." + msgType + ".unknown.data.integrity.issue",
                 "Unknown data integrity issue with resource: " + msgDescription);
     }

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/data/ApiGlobalErrorResponse.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/data/ApiGlobalErrorResponse.java
@@ -185,7 +185,7 @@ public class ApiGlobalErrorResponse {
 
     public static ApiGlobalErrorResponse serverSideError(final String globalisationMessageCode, final String defaultUserMessage,
             final Object... defaultUserMessageArgs) {
-        String msg = "An unexpected error occured on the platform server.";
+        String msg = "An unexpected error occurred on the platform server.";
         final List<ApiParameterError> errors = new ArrayList<>();
         errors.add(ApiParameterError.generalError(globalisationMessageCode, defaultUserMessage, defaultUserMessageArgs));
 

--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/savings/DepositsApiConstants.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/savings/DepositsApiConstants.java
@@ -125,7 +125,7 @@ public final class DepositsApiConstants {
     public static final String interestFreePeriodFrequencyType = "interestFreePeriodFrequencyType";
     public static final String preClosurePenalInterestOnType = "preClosurePenalInterestOnType";
 
-    // term paramters
+    // term parameters
     public static final String minDepositTermParamName = "minDepositTerm";
     public static final String maxDepositTermParamName = "maxDepositTerm";
     public static final String minDepositTermTypeIdParamName = "minDepositTermTypeId";

--- a/fineract-rates/src/main/java/org/apache/fineract/portfolio/floatingrates/service/FloatingRateWriteServiceImpl.java
+++ b/fineract-rates/src/main/java/org/apache/fineract/portfolio/floatingrates/service/FloatingRateWriteServiceImpl.java
@@ -152,7 +152,7 @@ public class FloatingRateWriteServiceImpl implements FloatingRateWriteService {
             throw new PlatformDataIntegrityException("error.msg.floatingrates.duplicate.active.fromdate",
                     "Attempt to add multiple floating rate periods with same fromdate", "fromdate", "");
         }
-        log.error("Error occured.", dve);
+        log.error("Error occurred.", dve);
         throw ErrorHandler.getMappable(dve, "error.msg.floatingrates.unknown.data.integrity.issue",
                 "Unknown data integrity issue with resource: " + realCause.getMessage());
     }


### PR DESCRIPTION
Pure typo fix in log messages and comments across fineract-accounting, fineract-core and fineract-rates modules. No behavioral change.