### PR TITLE
FINERACT-405: Centralize mobile number validation for Client and Staff

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/config/FineractProperties.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/config/FineractProperties.java
@@ -90,6 +90,7 @@ public class FineractProperties {
 
     private FineractSqlValidationProperties sqlValidation;
     private FineractInputValidationProperties inputValidation;
+    private FineractPhoneProperties phone;
 
     private FineractCache cache;
 
@@ -735,6 +736,13 @@ public class FineractProperties {
 
         private String name;
         private String pattern;
+    }
+
+    @Getter
+    @Setter
+    public static class FineractPhoneProperties {
+
+        private String regex = "^\\+?[0-9]{7,15}$";
     }
 
     @Getter

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/validator/PhoneNumberValidationService.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/validator/PhoneNumberValidationService.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.core.validator;
+
+import java.util.regex.Pattern;
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.infrastructure.core.config.FineractProperties;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PhoneNumberValidationService {
+
+    private final FineractProperties fineractProperties;
+
+    public boolean isValid(final String phoneNumber) {
+        if (phoneNumber == null || phoneNumber.isEmpty()) {
+            return true;
+        }
+        return Pattern.compile(getRegex()).matcher(phoneNumber).matches();
+    }
+
+    public String getRegex() {
+        return fineractProperties.getPhone().getRegex();
+    }
+}

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/validator/PhoneNumberValidator.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/validator/PhoneNumberValidator.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.core.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PhoneNumberValidator implements ConstraintValidator<ValidPhoneNumber, String> {
+
+    private final PhoneNumberValidationService phoneNumberValidationService;
+
+    @Override
+    public boolean isValid(final String value, final ConstraintValidatorContext context) {
+        return phoneNumberValidationService.isValid(value);
+    }
+}

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/validator/ValidPhoneNumber.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/validator/ValidPhoneNumber.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.core.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = PhoneNumberValidator.class)
+public @interface ValidPhoneNumber {
+
+    String message() default "{org.apache.fineract.organisation.staff.mobile-no.invalid}";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/fineract-core/src/test/java/org/apache/fineract/infrastructure/core/validator/PhoneNumberValidationServiceTest.java
+++ b/fineract-core/src/test/java/org/apache/fineract/infrastructure/core/validator/PhoneNumberValidationServiceTest.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.core.validator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+
+import org.apache.fineract.infrastructure.core.config.FineractProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class PhoneNumberValidationServiceTest {
+
+    private static final String DEFAULT_REGEX = "^\\+?[0-9]{7,15}$";
+
+    @Mock
+    private FineractProperties fineractProperties;
+
+    private PhoneNumberValidationService underTest;
+
+    @BeforeEach
+    public void setUp() {
+        FineractProperties.FineractPhoneProperties phoneProperties = new FineractProperties.FineractPhoneProperties();
+        phoneProperties.setRegex(DEFAULT_REGEX);
+        lenient().when(fineractProperties.getPhone()).thenReturn(phoneProperties);
+        underTest = new PhoneNumberValidationService(fineractProperties);
+    }
+
+    @Test
+    public void getRegexReturnsConfiguredRegex() {
+        assertEquals(DEFAULT_REGEX, underTest.getRegex());
+    }
+
+    @Test
+    public void nullPhoneNumberIsConsideredValid() {
+        assertTrue(underTest.isValid(null));
+    }
+
+    @Test
+    public void emptyPhoneNumberIsConsideredValid() {
+        assertTrue(underTest.isValid(""));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "1234567", "+1234567", "123456789012345", "+123456789012345" })
+    public void validPhoneNumbersPassValidation(String phoneNumber) {
+        assertTrue(underTest.isValid(phoneNumber));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "123456", "abcdefg", "12345678901234567", "+", "123-456-7890" })
+    public void invalidPhoneNumbersFailValidation(String phoneNumber) {
+        assertFalse(underTest.isValid(phoneNumber));
+    }
+
+    @Test
+    public void isValidUsesRegexFromFineractProperties() {
+        FineractProperties.FineractPhoneProperties strictProperties = new FineractProperties.FineractPhoneProperties();
+        strictProperties.setRegex("^[0-9]{10}$");
+        lenient().when(fineractProperties.getPhone()).thenReturn(strictProperties);
+
+        assertTrue(underTest.isValid("1234567890"));
+        assertFalse(underTest.isValid("+1234567890"));
+    }
+}

--- a/fineract-core/src/test/java/org/apache/fineract/infrastructure/core/validator/PhoneNumberValidatorTest.java
+++ b/fineract-core/src/test/java/org/apache/fineract/infrastructure/core/validator/PhoneNumberValidatorTest.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.core.validator;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class PhoneNumberValidatorTest {
+
+    @Mock
+    private PhoneNumberValidationService phoneNumberValidationService;
+
+    private PhoneNumberValidator underTest;
+
+    @BeforeEach
+    public void setUp() {
+        underTest = new PhoneNumberValidator(phoneNumberValidationService);
+    }
+
+    @Test
+    public void delegatesToServiceWhenValid() {
+        when(phoneNumberValidationService.isValid("1234567")).thenReturn(true);
+
+        assertTrue(underTest.isValid("1234567", null));
+    }
+
+    @Test
+    public void delegatesToServiceWhenInvalid() {
+        when(phoneNumberValidationService.isValid("abcdef")).thenReturn(false);
+
+        assertFalse(underTest.isValid("abcdef", null));
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/staff/data/StaffCreateRequest.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/staff/data/StaffCreateRequest.java
@@ -20,13 +20,13 @@ package org.apache.fineract.organisation.staff.data;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import java.io.Serial;
 import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.apache.fineract.infrastructure.core.validator.ValidPhoneNumber;
 import org.hibernate.validator.constraints.Length;
 
 @Builder
@@ -56,7 +56,7 @@ public class StaffCreateRequest implements Serializable {
     private String emailAddress;
     @Length(max = 50, message = "{org.apache.fineract.organisation.staff.mobile-no.max}")
     // @NotBlank(message = "{org.apache.fineract.organisation.staff.mobile-no.not-blank}")
-    @Pattern(regexp = "^\\+?[0-9]{7,15}$", message = "{org.apache.fineract.organisation.staff.mobile-no.invalid}")
+    @ValidPhoneNumber(message = "{org.apache.fineract.organisation.staff.mobile-no.invalid}")
     private String mobileNo;
     @Builder.Default
     @JsonProperty("isActive")

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/staff/data/StaffUpdateRequest.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/staff/data/StaffUpdateRequest.java
@@ -20,7 +20,6 @@ package org.apache.fineract.organisation.staff.data;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.Hidden;
-import jakarta.validation.constraints.Pattern;
 import java.io.Serial;
 import java.io.Serializable;
 import lombok.AllArgsConstructor;
@@ -28,6 +27,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldNameConstants;
+import org.apache.fineract.infrastructure.core.validator.ValidPhoneNumber;
 import org.apache.fineract.organisation.staff.validation.StaffForceStatus;
 import org.hibernate.validator.constraints.Length;
 
@@ -62,7 +62,7 @@ public class StaffUpdateRequest implements Serializable {
     private String emailAddress;
     @Length(max = 50, message = "{org.apache.fineract.organisation.staff.mobile-no.max}")
     // @NotBlank(message = "{org.apache.fineract.organisation.staff.mobile-no.not-blank}")
-    @Pattern(regexp = "^\\+?[0-9]{7,15}$", message = "{org.apache.fineract.organisation.staff.mobile-no.invalid}")
+    @ValidPhoneNumber(message = "{org.apache.fineract.organisation.staff.mobile-no.invalid}")
     private String mobileNo;
     @JsonProperty("isActive")
     private Boolean isActive;

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/data/ClientDataValidator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/data/ClientDataValidator.java
@@ -40,6 +40,7 @@ import org.apache.fineract.infrastructure.core.exception.InvalidJsonException;
 import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
 import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
 import org.apache.fineract.infrastructure.core.service.DateUtils;
+import org.apache.fineract.infrastructure.core.validator.PhoneNumberValidationService;
 import org.apache.fineract.infrastructure.dataqueries.data.EntityTables;
 import org.apache.fineract.infrastructure.dataqueries.data.StatusEnum;
 import org.apache.fineract.infrastructure.dataqueries.domain.EntityDatatableChecks;
@@ -56,15 +57,17 @@ public final class ClientDataValidator {
     private final FromJsonHelper fromApiJsonHelper;
     private final ConfigurationReadPlatformService configurationReadPlatformService;
     private final EntityDatatableChecksRepository entityDatatableChecksRepository;
-    private static final String MOBILE_NUMBER_REGEX = "^\\+?[0-9]{7,15}$";
+    private final PhoneNumberValidationService phoneNumberValidationService;
 
     @Autowired
     public ClientDataValidator(final FromJsonHelper fromApiJsonHelper,
             final ConfigurationReadPlatformService configurationReadPlatformService,
-            final EntityDatatableChecksRepository entityDatatableChecksRepository) {
+            final EntityDatatableChecksRepository entityDatatableChecksRepository,
+            final PhoneNumberValidationService phoneNumberValidationService) {
         this.fromApiJsonHelper = fromApiJsonHelper;
         this.configurationReadPlatformService = configurationReadPlatformService;
         this.entityDatatableChecksRepository = entityDatatableChecksRepository;
+        this.phoneNumberValidationService = phoneNumberValidationService;
     }
 
     public void validateForCreate(final String json) {
@@ -173,7 +176,7 @@ public final class ClientDataValidator {
         if (this.fromApiJsonHelper.parameterExists(ClientApiConstants.mobileNoParamName, element)) {
             final String mobileNo = this.fromApiJsonHelper.extractStringNamed(ClientApiConstants.mobileNoParamName, element);
             baseDataValidator.reset().parameter(ClientApiConstants.mobileNoParamName).value(mobileNo).ignoreIfNull()
-                    .matchesRegularExpression(MOBILE_NUMBER_REGEX).notExceedingLengthOf(50);
+                    .matchesRegularExpression(phoneNumberValidationService.getRegex()).notExceedingLengthOf(50);
         }
 
         final Boolean active = this.fromApiJsonHelper.extractBooleanNamed(ClientApiConstants.activeParamName, element);
@@ -461,7 +464,7 @@ public final class ClientDataValidator {
             atLeastOneParameterPassedForUpdate = true;
             final String mobileNo = this.fromApiJsonHelper.extractStringNamed(ClientApiConstants.mobileNoParamName, element);
             baseDataValidator.reset().parameter(ClientApiConstants.mobileNoParamName).value(mobileNo).ignoreIfNull()
-                    .matchesRegularExpression(MOBILE_NUMBER_REGEX).notExceedingLengthOf(50);
+                    .matchesRegularExpression(phoneNumberValidationService.getRegex()).notExceedingLengthOf(50);
         }
 
         final Boolean active = this.fromApiJsonHelper.extractBooleanNamed(ClientApiConstants.activeParamName, element);

--- a/fineract-provider/src/main/resources/application.properties
+++ b/fineract-provider/src/main/resources/application.properties
@@ -52,6 +52,7 @@ fineract.security.oidc-federation.post-logout-redirect-uri=${FINERACT_SECURITY_O
 # spring.security.oauth2.resourceserver.jwt.issuer-uri=https://your-idp.example.com/realm/your-realm
 # spring.security.oauth2.resourceserver.jwt.jwk-set-uri=https://your-idp.example.com/.../certs
 
+fineract.phone.regex=${FINERACT_PHONE_REGEX:^\\+?[0-9]{7,15}$}
 fineract.tenant.host=${FINERACT_DEFAULT_TENANTDB_HOSTNAME:localhost}
 fineract.tenant.port=${FINERACT_DEFAULT_TENANTDB_PORT:5432}
 fineract.tenant.username=${FINERACT_DEFAULT_TENANTDB_UID:root}

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/client/data/ClientDataValidatorTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/client/data/ClientDataValidatorTest.java
@@ -32,6 +32,7 @@ import org.apache.fineract.infrastructure.configuration.data.GlobalConfiguration
 import org.apache.fineract.infrastructure.configuration.service.ConfigurationReadPlatformService;
 import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
 import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.apache.fineract.infrastructure.core.validator.PhoneNumberValidationService;
 import org.apache.fineract.infrastructure.dataqueries.domain.EntityDatatableChecks;
 import org.apache.fineract.infrastructure.dataqueries.domain.EntityDatatableChecksRepository;
 import org.apache.fineract.portfolio.client.api.ClientApiConstants;
@@ -53,6 +54,9 @@ class ClientDataValidatorTest {
     @Mock
     private EntityDatatableChecksRepository entityDatatableChecksRepository;
 
+    @Mock
+    private PhoneNumberValidationService phoneNumberValidationService;
+
     private ClientDataValidator validator;
 
     @BeforeEach
@@ -60,7 +64,9 @@ class ClientDataValidatorTest {
         FromJsonHelper fromApiJsonHelper = new FromJsonHelper();
         when(configurationReadPlatformService.retrieveGlobalConfiguration(anyString()))
                 .thenReturn(new GlobalConfigurationPropertyData().setEnabled(false));
-        validator = new ClientDataValidator(fromApiJsonHelper, configurationReadPlatformService, entityDatatableChecksRepository);
+        when(phoneNumberValidationService.getRegex()).thenReturn("^\\+?[0-9]{7,15}$");
+        validator = new ClientDataValidator(fromApiJsonHelper, configurationReadPlatformService, entityDatatableChecksRepository,
+                phoneNumberValidationService);
     }
 
     private static String validMinimalCreateJson(String dateFormat) {

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/ClientTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/ClientTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import com.google.gson.Gson;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.builder.ResponseSpecBuilder;
@@ -56,6 +57,7 @@ public class ClientTest {
     private static final SecureRandom rand = new SecureRandom();
 
     private ResponseSpecification responseSpec;
+    private ResponseSpecification responseSpecForValidationError;
     private RequestSpecification requestSpec;
     private ClientHelper clientHelper;
     private GlobalConfigurationHelper globalConfigurationHelper;
@@ -66,6 +68,8 @@ public class ClientTest {
         requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
         requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
         responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
+        // TODO: figure out why Jakarta validation throws 403 instead of 400 (same note as StaffTest)
+        responseSpecForValidationError = new ResponseSpecBuilder().expectStatusCode(400).build();
         clientHelper = new ClientHelper(requestSpec, responseSpec);
         globalConfigurationHelper = new GlobalConfigurationHelper();
     }
@@ -74,6 +78,34 @@ public class ClientTest {
     public void tearDown() {
         globalConfigurationHelper.resetAllDefaultGlobalConfigurations();
         globalConfigurationHelper.verifyAllDefaultGlobalConfigurations();
+    }
+
+    @Test
+    public void testClientCreateWithInvalidMobileNoValidationError() {
+        // given
+        final HashMap<String, Object> map = ClientHelper.setInitialClientValues("1", ClientHelper.LEGALFORM_ID_PERSON);
+        map.put("active", "true");
+        map.put("activationDate", ClientHelper.DEFAULT_DATE);
+        map.put("mobileNo", "invalid-phone-###");
+
+        // when/then: expects 400 (validation error), not 500 (would indicate the
+        // FineractPhoneProperties NPE regression from FINERACT-405 has resurfaced)
+        Utils.performServerPost(requestSpec, responseSpecForValidationError, "/fineract-provider/api/v1/clients?" + Utils.TENANT_IDENTIFIER,
+                new Gson().toJson(map));
+    }
+
+    @Test
+    public void testClientUpdateWithInvalidMobileNoValidationError() {
+        // given
+        final Integer clientId = ClientHelper.createClient(requestSpec, responseSpec);
+        final HashMap<String, Object> map = new HashMap<>();
+        map.put("mobileNo", "invalid-phone-###");
+        map.put("locale", "en");
+
+        // when/then: expects 400 (validation error), not 500 (would indicate the
+        // FineractPhoneProperties NPE regression from FINERACT-405 has resurfaced)
+        final String updateClientUrl = "/fineract-provider/api/v1/clients/" + clientId + "?" + Utils.TENANT_IDENTIFIER;
+        Utils.performServerPut(requestSpec, responseSpecForValidationError, updateClientUrl, new Gson().toJson(map));
     }
 
     @Test


### PR DESCRIPTION
## Description

`ClientDataValidator` and the `@Pattern` annotations used by Staff create/update requests independently hardcoded the same mobile number regex:

`^+?[0-9]{7,15}$`

This duplicated the validation logic across multiple locations, creating multiple sources of truth and making future changes error-prone.

This PR centralizes the existing backend phone-number validation by introducing a configurable phone-number regex and a shared validation service used by both Client and Staff.

## Changes

- Added `fineract.phone.regex` under `FineractProperties` through `FineractPhoneProperties`, with the existing regex as the default.
- Added `PhoneNumberValidationService` as the single source of truth for phone-number regex validation.
- Added `@ValidPhoneNumber` and `PhoneNumberValidator` for Staff create/update requests.
- Updated `ClientDataValidator` to receive `PhoneNumberValidationService` through constructor injection.
- Removed the hardcoded `MOBILE_NUMBER_REGEX` from Client validation.
- Updated both Client create and update validation paths to use the shared service.
- Updated `ClientDataValidatorTest` for the new constructor dependency.
- Added `PhoneNumberValidationServiceTest`.
- Added `PhoneNumberValidatorTest`.
- Added Client integration tests covering invalid mobile numbers during create and update.


## Runtime Issue Identified During Verification

During end-to-end verification, a runtime issue was identified that was not covered by the existing unit tests.

Spring's `@ConfigurationProperties` binding does not instantiate the nested `FineractPhoneProperties` object when no matching `fineract.phone.*` property exists in the environment. As a result, when `fineract.phone.regex` was absent, `getPhone()` could return `null`, causing `getRegex()` to throw a `NullPointerException`.

This was not detected by the unit tests because they manually constructed `FineractProperties` rather than exercising the real Spring configuration-binding path.

The issue was reproduced against a Docker-built Fineract server, where the Staff integration test initially failed 3 of 17 tests with HTTP 500 responses.

The configuration was then corrected so that the default regex is available through the actual application configuration, and integration coverage was added to verify the real Spring binding path.


## Previous Attempts

### PR #5964

The first attempt introduced `PhoneNumberValidationService`, but it was not wired into `ClientDataValidator`.

`ClientDataValidator` continued to use `FineractProperties` directly, leaving the intended centralization incomplete.

The PR subsequently failed during `compileJava` after a force push.


### PR #6177

The second attempt correctly wired `PhoneNumberValidationService` into `ClientDataValidator`, but introduced several issues:

- A duplicate `FineractPhoneValidationProperties` class definition in `FineractProperties.java`.
- `@ValidPhoneNumber.message()` used the literal `"Invalid phone number"` instead of the existing i18n message key.
- CI checks failed.
- The branch also encountered merge conflicts.

Neither previous PR identified the Spring configuration-binding runtime issue because the necessary integration coverage was missing.


## Verification

The implementation was verified at multiple levels:

- `PhoneNumberValidationServiceTest`
- `PhoneNumberValidatorTest`
- Updated `ClientDataValidatorTest`
- Client create integration test with an invalid mobile number
- Client update integration test with an invalid mobile number
- Staff integration testing
- Real Spring `@ConfigurationProperties` binding
- Docker-built Fineract server
- End-to-end backend validation

The Client integration tests specifically verify that the configured regex is correctly bound through Spring rather than only testing manually constructed configuration objects.


## Scope

This PR covers the backend centralization of the existing phone-number regex validation.

FINERACT-405 also includes work outside the scope of this PR:

- UI-side phone-number validation
- A dedicated `PhoneNumber` value object


## Result

Client and Staff backend phone-number validation now use the same configurable validation mechanism instead of maintaining independent copies of the regex.

The resulting flow is:

`fineract.phone.regex` → `FineractPhoneProperties` → `PhoneNumberValidationService` → Client/Staff validation

This provides a single backend source of truth while preserving the existing validation behaviour and validation messages.


## Related Issue
https://issues.apache.org/jira/browse/FINERACT-405