### PR TITLE
Fix/idempotency key storage width

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/commands/domain/CommandSource.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/domain/CommandSource.java
@@ -120,7 +120,7 @@ public class CommandSource extends AbstractPersistableCustom<Long> {
     @Column(name = "job_name")
     private String jobName;
 
-    @Column(name = "idempotency_key", length = 50)
+    @Column(name = "idempotency_key", length = 255)
     private String idempotencyKey;
 
     @Column(name = "resource_external_id")

--- a/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
@@ -273,4 +273,5 @@
     <include file="parts/0251_add_disallow_backdated_transactions_configuration.xml" relativeToChangelogFile="true" />
     <include file="parts/0252_trial_balance_summary_update_originator_external_ids.xml" relativeToChangelogFile="true" />
     <include file="parts/0253_remove_unused_entity_access.xml" relativeToChangelogFile="true" />
+    <include file="parts/0254_standardize_idempotency_key_length.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0254_standardize_idempotency_key_length.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0254_standardize_idempotency_key_length.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet author="fineract" id="1">
+        <modifyDataType tableName="m_portfolio_command_source" columnName="idempotency_key" newDataType="VARCHAR(255)"/>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
Fineract currently has inconsistent storage limits for idempotency keys across its command-processing paths.

The legacy m_portfolio_command_source.idempotency_key column and CommandSource JPA mapping are limited to 50 characters, while the newer JDBC command store uses VARCHAR(255).

The HTTP idempotency layer does not impose the legacy 50-character limit before command processing, so the effective storage constraint can differ depending on the command-storage path.

Proposed change:

* widen m_portfolio_command_source.idempotency_key to VARCHAR(255)
* update the CommandSource JPA mapping to match
* preserve existing idempotency behavior and existing keys

This is separate from FINERACT-2485 / PR #6231, which concerns idempotency semantics and concurrency behavior in the newer command-processing path.