### PR TITLE
FINERACT-848: Add ability to define custom interest rate in fixed and recurring deposit accounts

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/savings/DepositsApiConstants.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/savings/DepositsApiConstants.java
@@ -141,6 +141,7 @@ public final class DepositsApiConstants {
     public static final String depositMaxAmountParamName = "maxDepositAmount";
     public static final String depositPeriodParamName = "depositPeriod";
     public static final String depositPeriodFrequencyIdParamName = "depositPeriodFrequencyId";
+    public static final String isRateChartOverriddenParamName = "isRateChartOverridden";
 
     // recurring parameters
     public static final String mandatoryRecommendedDepositAmountParamName = "mandatoryRecommendedDepositAmount";
@@ -304,14 +305,14 @@ public final class DepositsApiConstants {
      * Depost Account parameters
      */
 
-    private static final Set<String> DEPOSIT_ACCOUNT_REQUEST_DATA_PARAMETERS = new HashSet<>(
-            Arrays.asList(localeParamName, dateFormatParamName, monthDayFormatParamName, accountNoParamName, externalIdParamName,
-                    clientIdParamName, groupIdParamName, productIdParamName, fieldOfficerIdParamName, submittedOnDateParamName,
-                    nominalAnnualInterestRateParamName, interestCompoundingPeriodTypeParamName, interestPostingPeriodTypeParamName,
-                    interestCalculationTypeParamName, interestCalculationDaysInYearTypeParamName, lockinPeriodFrequencyParamName,
-                    lockinPeriodFrequencyTypeParamName, chargesParamName, chartsParamName, depositAmountParamName, depositPeriodParamName,
-                    depositPeriodFrequencyIdParamName, savingsAccounts, expectedFirstDepositOnDateParamName,
-                    SavingsApiConstants.withHoldTaxParamName, maturityInstructionIdParamName, transferToSavingsIdParamName));
+    private static final Set<String> DEPOSIT_ACCOUNT_REQUEST_DATA_PARAMETERS = new HashSet<>(Arrays.asList(localeParamName,
+            dateFormatParamName, monthDayFormatParamName, accountNoParamName, externalIdParamName, clientIdParamName, groupIdParamName,
+            productIdParamName, fieldOfficerIdParamName, submittedOnDateParamName, nominalAnnualInterestRateParamName,
+            interestCompoundingPeriodTypeParamName, interestPostingPeriodTypeParamName, interestCalculationTypeParamName,
+            interestCalculationDaysInYearTypeParamName, lockinPeriodFrequencyParamName, lockinPeriodFrequencyTypeParamName,
+            chargesParamName, chartsParamName, depositAmountParamName, depositPeriodParamName, depositPeriodFrequencyIdParamName,
+            savingsAccounts, expectedFirstDepositOnDateParamName, SavingsApiConstants.withHoldTaxParamName, maturityInstructionIdParamName,
+            transferToSavingsIdParamName, isRateChartOverriddenParamName));
 
     public static final Set<String> FIXED_DEPOSIT_ACCOUNT_REQUEST_DATA_PARAMETERS = fixedDepositAccountRequestData();
     public static final Set<String> FIXED_DEPOSIT_ACCOUNT_RESPONSE_DATA_PARAMETERS = fixedDepositAccountResponseData();

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/api/FixedDepositAccountsApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/api/FixedDepositAccountsApiResourceSwagger.java
@@ -308,6 +308,8 @@ final class FixedDepositAccountsApiResourceSwagger {
         public Integer depositPeriod;
         @Schema(example = "2")
         public Long depositPeriodFrequencyId;
+        @Schema(example = "false", description = "Determines whether product level interest rate chart is overridden by custom nominal annual interest rate")
+        public Boolean isRateChartOverridden;
     }
 
     @Schema(description = "PostFixedDepositAccountsResponse")
@@ -474,6 +476,8 @@ final class FixedDepositAccountsApiResourceSwagger {
         public LocalDate maturityDate;
         @Schema(example = "6")
         public Integer depositPeriod;
+        @Schema(example = "false", description = "Determines whether product level interest rate chart is overridden by custom nominal annual interest rate")
+        public Boolean isRateChartOverridden;
         public GetFixedDepositAccountsResponse.GetFixedDepositAccountsDepositPeriodFrequency depositPeriodFrequency;
         public GetFixedDepositAccountsAccountIdSummary summary;
         public GetFixedDepositAccountsAccountChart accountChart;

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/api/RecurringDepositAccountsApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/api/RecurringDepositAccountsApiResourceSwagger.java
@@ -300,6 +300,8 @@ final class RecurringDepositAccountsApiResourceSwagger {
         public Integer recurringFrequencyType;
         @Schema(example = "2000")
         public Long mandatoryRecommendedDepositAmount;
+        @Schema(example = "false", description = "Determines whether product level interest rate chart is overridden by custom nominal annual interest rate")
+        public Boolean isRateChartOverridden;
     }
 
     @Schema(description = "PostRecurringDepositAccountsResponse")
@@ -436,6 +438,8 @@ final class RecurringDepositAccountsApiResourceSwagger {
         public GetRecurringDepositAccountsResponse.GetRecurringDepositAccountsRecurringDepositFrequencyType recurringDepositFrequencyType;
         @Schema(example = "6")
         public Integer depositPeriod;
+        @Schema(example = "false", description = "Determines whether product level interest rate chart is overridden by custom nominal annual interest rate")
+        public Boolean isRateChartOverridden;
         public GetRecurringDepositAccountsResponse.GetRecurringDepositAccountsDepositPeriodFrequency depositPeriodFrequency;
         public GetRecurringDepositAccountsResponse.GetRecurringDepositAccountsSummary summary;
         public GetRecurringDepositAccountsAccountChart accountChart;

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/data/DepositAccountDataValidator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/data/DepositAccountDataValidator.java
@@ -30,6 +30,7 @@ import static org.apache.fineract.portfolio.savings.DepositsApiConstants.interes
 import static org.apache.fineract.portfolio.savings.DepositsApiConstants.interestPostingPeriodInMonthsParamName;
 import static org.apache.fineract.portfolio.savings.DepositsApiConstants.isCalendarInheritedParamName;
 import static org.apache.fineract.portfolio.savings.DepositsApiConstants.isMandatoryDepositParamName;
+import static org.apache.fineract.portfolio.savings.DepositsApiConstants.isRateChartOverriddenParamName;
 import static org.apache.fineract.portfolio.savings.DepositsApiConstants.linkedAccountParamName;
 import static org.apache.fineract.portfolio.savings.DepositsApiConstants.mandatoryRecommendedDepositAmountParamName;
 import static org.apache.fineract.portfolio.savings.DepositsApiConstants.maturityInstructionIdParamName;
@@ -576,6 +577,20 @@ public class DepositAccountDataValidator {
                 element);
         baseDataValidator.reset().parameter(depositPeriodFrequencyIdParamName).value(depositPeriodFrequencyId)
                 .isOneOfTheseValues(SavingsPeriodFrequencyType.integerValues());
+
+        if (fromApiJsonHelper.parameterExists(isRateChartOverriddenParamName, element)) {
+            final Boolean isRateChartOverridden = this.fromApiJsonHelper.extractBooleanNamed(isRateChartOverriddenParamName, element);
+
+            baseDataValidator.reset().parameter(isRateChartOverriddenParamName).value(isRateChartOverridden).notNull();
+
+            if (Boolean.TRUE.equals(isRateChartOverridden)) {
+                final BigDecimal nominalAnnualInterestRate = this.fromApiJsonHelper
+                        .extractBigDecimalWithLocaleNamed(nominalAnnualInterestRateParamName, element);
+
+                baseDataValidator.reset().parameter(nominalAnnualInterestRateParamName).value(nominalAnnualInterestRate).notNull()
+                        .zeroOrPositiveAmount();
+            }
+        }
     }
 
     private void validateDepositTermDeatilForUpdate(final JsonElement element, final DataValidatorBuilder baseDataValidator,
@@ -601,6 +616,18 @@ public class DepositAccountDataValidator {
                     element);
             baseDataValidator.reset().parameter(depositPeriodFrequencyIdParamName).value(depositPeriodFrequencyId)
                     .isOneOfTheseValues(SavingsPeriodFrequencyType.integerValues());
+        }
+
+        if (fromApiJsonHelper.parameterExists(isRateChartOverriddenParamName, element)) {
+            final Boolean isRateChartOverridden = this.fromApiJsonHelper.extractBooleanNamed(isRateChartOverriddenParamName, element);
+            baseDataValidator.reset().parameter(isRateChartOverriddenParamName).value(isRateChartOverridden).notNull();
+
+            if (Boolean.TRUE.equals(isRateChartOverridden)) {
+                final BigDecimal nominalAnnualInterestRate = this.fromApiJsonHelper
+                        .extractBigDecimalWithLocaleNamed(nominalAnnualInterestRateParamName, element);
+                baseDataValidator.reset().parameter(nominalAnnualInterestRateParamName).value(nominalAnnualInterestRate).notNull()
+                        .zeroOrPositiveAmount();
+            }
         }
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/DepositAccountAssembler.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/DepositAccountAssembler.java
@@ -31,6 +31,7 @@ import static org.apache.fineract.portfolio.savings.DepositsApiConstants.deposit
 import static org.apache.fineract.portfolio.savings.DepositsApiConstants.expectedFirstDepositOnDateParamName;
 import static org.apache.fineract.portfolio.savings.DepositsApiConstants.isCalendarInheritedParamName;
 import static org.apache.fineract.portfolio.savings.DepositsApiConstants.isMandatoryDepositParamName;
+import static org.apache.fineract.portfolio.savings.DepositsApiConstants.isRateChartOverriddenParamName;
 import static org.apache.fineract.portfolio.savings.DepositsApiConstants.mandatoryRecommendedDepositAmountParamName;
 import static org.apache.fineract.portfolio.savings.DepositsApiConstants.maturityInstructionIdParamName;
 import static org.apache.fineract.portfolio.savings.DepositsApiConstants.transferInterestToSavingsParamName;
@@ -404,9 +405,13 @@ public class DepositAccountAssembler {
                 ? DepositAccountOnClosureType.fromInt(accountOnClosureTypeId)
                 : null;
         final Long transferToSavingsId = command.longValueOfParameterNamed(transferToSavingsIdParamName);
+        Boolean isRateChartOverridden = false;
+        if (command.parameterExists(isRateChartOverriddenParamName)) {
+            isRateChartOverridden = command.booleanObjectValueOfParameterNamed(isRateChartOverriddenParamName);
+        }
         return DepositAccountTermAndPreClosure.createNew(updatedProductPreClosure, updatedProductTerm, account, depositAmount,
                 maturityAmount, maturityDate, depositPeriod, depositPeriodFrequency, expectedFirstDepositOnDate, accountOnClosureType,
-                trasferInterest, transferToSavingsId);
+                trasferInterest, transferToSavingsId, isRateChartOverridden);
     }
 
     public DepositAccountRecurringDetail assembleAccountRecurringDetail(final JsonCommand command,

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/FixedDepositAccount.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/FixedDepositAccount.java
@@ -158,35 +158,36 @@ public class FixedDepositAccount extends SavingsAccount {
     protected BigDecimal getEffectiveInterestRateAsFraction(final MathContext mc, final LocalDate interestPostingUpToDate,
             final boolean isPreMatureClosure) {
 
-        // default it to nominalAnnualInterst rate. interest chart overrrides
-        // this value.
         BigDecimal applicableInterestRate = this.nominalAnnualInterestRate;
-        if (this.chart != null) {
-            boolean applyPreMaturePenalty = false;
-            BigDecimal penalInterest = BigDecimal.ZERO;
-            LocalDate depositCloseDate = calculateMaturityDate();
-            if (isPreMatureClosure) {
-                if (this.accountTermAndPreClosure.isPreClosurePenalApplicable()) {
-                    applyPreMaturePenalty = true;
-                    penalInterest = this.accountTermAndPreClosure.depositPreClosureDetail().preClosurePenalInterest();
-                    final PreClosurePenalInterestOnType preClosurePenalInterestOnType = this.accountTermAndPreClosure
-                            .depositPreClosureDetail().preClosurePenalInterestOnType();
-                    if (preClosurePenalInterestOnType == PreClosurePenalInterestOnType.WHOLE_TERM) {
-                        depositCloseDate = interestCalculatedUpto();
-                    } else if (preClosurePenalInterestOnType == PreClosurePenalInterestOnType.TILL_PREMATURE_WITHDRAWAL) {
-                        depositCloseDate = interestPostingUpToDate;
-                    }
+        boolean applyPreMaturePenalty = false;
+        BigDecimal penalInterest = BigDecimal.ZERO;
+        LocalDate depositCloseDate = calculateMaturityDate();
+
+        if (isPreMatureClosure) {
+            if (this.accountTermAndPreClosure.isPreClosurePenalApplicable()) {
+                applyPreMaturePenalty = true;
+                penalInterest = this.accountTermAndPreClosure.depositPreClosureDetail().preClosurePenalInterest();
+
+                final PreClosurePenalInterestOnType preClosurePenalInterestOnType = this.accountTermAndPreClosure.depositPreClosureDetail()
+                        .preClosurePenalInterestOnType();
+                if (preClosurePenalInterestOnType == PreClosurePenalInterestOnType.WHOLE_TERM) {
+                    depositCloseDate = interestCalculatedUpto();
+                } else if (preClosurePenalInterestOnType == PreClosurePenalInterestOnType.TILL_PREMATURE_WITHDRAWAL) {
+                    depositCloseDate = interestPostingUpToDate;
                 }
             }
+        }
 
+        if (this.chart != null && !this.accountTermAndPreClosure.isRateChartOverridden()) {
             final BigDecimal depositAmount = accountTermAndPreClosure.depositAmount();
             applicableInterestRate = this.chart.getApplicableInterestRate(depositAmount, depositStartDate(), depositCloseDate, this.client);
-
-            if (applyPreMaturePenalty) {
-                applicableInterestRate = applicableInterestRate.subtract(penalInterest);
-                applicableInterestRate = applicableInterestRate.compareTo(BigDecimal.ZERO) < 0 ? BigDecimal.ZERO : applicableInterestRate;
-            }
         }
+
+        if (applyPreMaturePenalty) {
+            applicableInterestRate = applicableInterestRate.subtract(penalInterest);
+            applicableInterestRate = applicableInterestRate.compareTo(BigDecimal.ZERO) < 0 ? BigDecimal.ZERO : applicableInterestRate;
+        }
+
         this.nominalAnnualInterestRate = applicableInterestRate;
 
         return applicableInterestRate.divide(BigDecimal.valueOf(100L), mc);
@@ -747,7 +748,7 @@ public class FixedDepositAccount extends SavingsAccount {
             }
         }
 
-        if (this.chart != null) {
+        if (this.chart != null && !this.accountTermAndPreClosure.isRateChartOverridden()) {
             final LocalDate chartFromDate = this.chart.getFromDate();
             LocalDate chartEndDate = this.chart.getEndDate();
             chartEndDate = chartEndDate == null ? DateUtils.getBusinessLocalDate() : chartEndDate;

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/RecurringDepositAccount.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/domain/RecurringDepositAccount.java
@@ -208,9 +208,11 @@ public class RecurringDepositAccount extends SavingsAccount {
     protected BigDecimal getEffectiveInterestRateAsFraction(final MathContext mc, final LocalDate interestPostingUpToDate,
             final boolean isPreMatureClosure) {
 
+        BigDecimal applicableInterestRate = this.nominalAnnualInterestRate;
         boolean applyPreMaturePenalty = false;
         BigDecimal penalInterest = BigDecimal.ZERO;
         LocalDate depositCloseDate = calculateMaturityDate();
+
         if (isPreMatureClosure) {
             if (this.accountTermAndPreClosure.isPreClosurePenalApplicable()) {
                 applyPreMaturePenalty = true;
@@ -225,13 +227,14 @@ public class RecurringDepositAccount extends SavingsAccount {
             }
         }
 
-        if (depositCloseDate == null) {
-            depositCloseDate = DateUtils.getBusinessLocalDate();
-        }
+        if (this.chart != null && !this.accountTermAndPreClosure.isRateChartOverridden()) {
+            if (depositCloseDate == null) {
+                depositCloseDate = DateUtils.getBusinessLocalDate();
+            }
 
-        final BigDecimal depositAmount = accountTermAndPreClosure.depositAmount();
-        BigDecimal applicableInterestRate = this.chart.getApplicableInterestRate(depositAmount, depositStartDate(), depositCloseDate,
-                this.client);
+            final BigDecimal depositAmount = accountTermAndPreClosure.depositAmount();
+            applicableInterestRate = this.chart.getApplicableInterestRate(depositAmount, depositStartDate(), depositCloseDate, this.client);
+        }
 
         if (applyPreMaturePenalty) {
             applicableInterestRate = applicableInterestRate.subtract(penalInterest);
@@ -1039,7 +1042,7 @@ public class RecurringDepositAccount extends SavingsAccount {
         final DataValidatorBuilder baseDataValidator = new DataValidatorBuilder(dataValidationErrors)
                 .resource(RECURRING_DEPOSIT_ACCOUNT_RESOURCE_NAME);
         LocalDate maturityDate = calculateMaturityDate();
-        if (this.chart != null) {
+        if (this.chart != null && !this.accountTermAndPreClosure.isRateChartOverridden()) {
             final LocalDate chartFromDate = this.chart.getFromDate();
             LocalDate chartEndDate = this.chart.getEndDate();
             chartEndDate = chartEndDate == null ? DateUtils.getBusinessLocalDate() : chartEndDate;

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/DepositAccountReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/DepositAccountReadPlatformServiceImpl.java
@@ -844,6 +844,7 @@ public class DepositAccountReadPlatformServiceImpl implements DepositAccountRead
         public static final String ON_ACCOUNT_CLOSURE_ID = "onAccountClosureId";
         public static final String TRANSFER_INTEREST_TO_SAVINGS = "transferInterestToSavings";
         public static final String TRANSFER_TO_SAVINGS_ID = "transferToSavingsId";
+        public static final String IS_RATE_CHART_OVERRIDDEN = "isRateChartOverridden";
         private final String schemaSql;
 
         FixedDepositAccountMapper() {
@@ -866,7 +867,8 @@ public class DepositAccountReadPlatformServiceImpl implements DepositAccountRead
             sqlBuilder.append("datp.deposit_period_frequency_enum as depositPeriodFrequencyTypeId, ");
             sqlBuilder.append("datp.on_account_closure_enum as onAccountClosureId, ");
             sqlBuilder.append("datp.transfer_interest_to_linked_account as transferInterestToSavings, ");
-            sqlBuilder.append("datp.transfer_to_savings_account_id as transferToSavingsId ");
+            sqlBuilder.append("datp.transfer_to_savings_account_id as transferToSavingsId, ");
+            sqlBuilder.append("datp.is_rate_chart_overridden as isRateChartOverridden ");
 
             sqlBuilder.append(super.selectTablesSql());
 
@@ -916,10 +918,13 @@ public class DepositAccountReadPlatformServiceImpl implements DepositAccountRead
 
             final Long transferToSavingsId = JdbcSupport.getLong(rs, TRANSFER_TO_SAVINGS_ID);
 
+            final boolean isRateChartOverridden = rs.getBoolean(IS_RATE_CHART_OVERRIDDEN);
+
             return FixedDepositAccountData.instance(depositAccountData, preClosurePenalApplicable, preClosurePenalInterest,
                     preClosurePenalInterestOnType, minDepositTerm, maxDepositTerm, minDepositTermType, maxDepositTermType,
                     inMultiplesOfDepositTerm, inMultiplesOfDepositTermType, depositAmount, maturityAmount, maturityDate, depositPeriod,
-                    depositPeriodFrequencyType, onAccountClosureType, transferInterestToSavings, transferToSavingsId);
+                    depositPeriodFrequencyType, onAccountClosureType, transferInterestToSavings, transferToSavingsId,
+                    isRateChartOverridden);
         }
     }
 
@@ -948,6 +953,7 @@ public class DepositAccountReadPlatformServiceImpl implements DepositAccountRead
         public static final String IS_CALENDAR_INHERITED = "isCalendarInherited";
         public static final String ON_ACCOUNT_CLOSURE_ID = "onAccountClosureId";
         public static final String EXPECTED_FIRST_DEPOSIT_ON_DATE = "expectedFirstDepositOnDate";
+        public static final String IS_RATE_CHART_OVERRIDDEN = "isRateChartOverridden";
         private final String schemaSql;
 
         RecurringDepositAccountMapper() {
@@ -976,7 +982,8 @@ public class DepositAccountReadPlatformServiceImpl implements DepositAccountRead
             sqlBuilder.append("datp.maturity_date as maturityDate, ");
             sqlBuilder.append("datp.deposit_period as depositPeriod, ");
             sqlBuilder.append("datp.deposit_period_frequency_enum as depositPeriodFrequencyTypeId, ");
-            sqlBuilder.append("datp.on_account_closure_enum as onAccountClosureId ");
+            sqlBuilder.append("datp.on_account_closure_enum as onAccountClosureId, ");
+            sqlBuilder.append("datp.is_rate_chart_overridden as isRateChartOverridden ");
 
             sqlBuilder.append(this.selectTablesSql());
             sqlBuilder.append("left join m_deposit_account_recurring_detail dard on sa.id = dard.savings_account_id ");
@@ -1033,12 +1040,14 @@ public class DepositAccountReadPlatformServiceImpl implements DepositAccountRead
                     : SavingsEnumerations.depositAccountOnClosureType(onAccountClosureId);
             final LocalDate expectedFirstDepositOnDate = JdbcSupport.getLocalDate(rs, EXPECTED_FIRST_DEPOSIT_ON_DATE);
 
+            final boolean isRateChartOverridden = rs.getBoolean(IS_RATE_CHART_OVERRIDDEN);
+
             return RecurringDepositAccountData.instance(depositAccountData, preClosurePenalApplicable, preClosurePenalInterest,
                     preClosurePenalInterestOnType, minDepositTerm, maxDepositTerm, minDepositTermType, maxDepositTermType,
                     inMultiplesOfDepositTerm, inMultiplesOfDepositTermType, depositAmount, maturityAmount, maturityDate, depositPeriod,
                     depositPeriodFrequencyType, mandatoryRecommendedDepositAmount, onAccountClosureType, expectedFirstDepositOnDate,
                     totalOverdueAmount, noOfOverdueInstallments, isMandatoryDeposit, allowWithdrawal, adjustAdvanceTowardsFuturePayments,
-                    isCalendarInherited);
+                    isCalendarInherited, isRateChartOverridden);
 
         }
     }
@@ -1433,11 +1442,12 @@ public class DepositAccountReadPlatformServiceImpl implements DepositAccountRead
             final EnumOptionData depositPeriodFrequencyType = null;
             final EnumOptionData onAccountClosureType = null;
             final Boolean transferInterestToSavings = false;
+            final boolean isRateChartOverridden = false;
 
             return FixedDepositAccountData.instance(depositAccountData, preClosurePenalApplicable, preClosurePenalInterest,
                     preClosurePenalInterestOnType, minDepositTerm, maxDepositTerm, minDepositTermType, maxDepositTermType,
                     inMultiplesOfDepositTerm, inMultiplesOfDepositTermType, depositAmount, maturityAmount, maturityDate, depositPeriod,
-                    depositPeriodFrequencyType, onAccountClosureType, transferInterestToSavings, null);
+                    depositPeriodFrequencyType, onAccountClosureType, transferInterestToSavings, null, isRateChartOverridden);
         }
     }
 
@@ -1513,6 +1523,7 @@ public class DepositAccountReadPlatformServiceImpl implements DepositAccountRead
             final boolean allowWithdrawal = rs.getBoolean(ALLOW_WITHDRAWAL);
             final boolean adjustAdvanceTowardsFuturePayments = rs.getBoolean(ADJUST_ADVANCE_TOWARDS_FUTURE_PAYMENTS);
             final boolean isCalendarInherited = false;
+            final boolean isRateChartOverridden = false;
 
             final BigDecimal depositAmount = null;
             final BigDecimal maturityAmount = null;
@@ -1530,7 +1541,7 @@ public class DepositAccountReadPlatformServiceImpl implements DepositAccountRead
                     inMultiplesOfDepositTerm, inMultiplesOfDepositTermType, depositAmount, maturityAmount, maturityDate, depositPeriod,
                     depositPeriodFrequencyType, mandatoryRecommendedDepositAmount, onAccountClosureType, expectedFirstDepositOnDate,
                     totalOverdueAmount, noOfOverdueInstallments, isMandatoryDeposit, allowWithdrawal, adjustAdvanceTowardsFuturePayments,
-                    isCalendarInherited);
+                    isCalendarInherited, isRateChartOverridden);
         }
     }
 

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/savings/domain/DepositAccountRateChartOverriddenTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/savings/domain/DepositAccountRateChartOverriddenTest.java
@@ -1,0 +1,394 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.savings.domain;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
+import org.apache.fineract.infrastructure.core.domain.ActionContext;
+import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
+import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
+import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.apache.fineract.infrastructure.core.service.DateUtils;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import org.apache.fineract.portfolio.savings.PreClosurePenalInterestOnType;
+import org.apache.fineract.portfolio.savings.SavingsCompoundingInterestPeriodType;
+import org.apache.fineract.portfolio.savings.SavingsPeriodFrequencyType;
+import org.apache.fineract.portfolio.savings.SavingsPostingInterestPeriodType;
+import org.apache.fineract.portfolio.savings.data.DepositAccountDataValidator;
+import org.apache.fineract.portfolio.savings.data.DepositProductDataValidator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class DepositAccountRateChartOverriddenTest {
+
+    @BeforeEach
+    public void setUp() {
+        ThreadLocalContextUtil.setTenant(new FineractPlatformTenant(1L, "default", "Default", "Asia/Kolkata", null));
+        ThreadLocalContextUtil.setActionContext(ActionContext.DEFAULT);
+        ThreadLocalContextUtil.setBusinessDates(new HashMap<>(
+                Map.of(BusinessDateType.BUSINESS_DATE, LocalDate.of(2024, 6, 1), BusinessDateType.COB_DATE, LocalDate.of(2024, 5, 31))));
+    }
+
+    @AfterEach
+    public void tearDown() {
+        ThreadLocalContextUtil.reset();
+    }
+
+    @Test
+    void testDepositAccountTermAndPreClosureHoldsOverriddenFlag() {
+        DepositTermDetail termDetails = DepositTermDetail.createFrom(1, 12, SavingsPeriodFrequencyType.MONTHS,
+                SavingsPeriodFrequencyType.MONTHS, 1, SavingsPeriodFrequencyType.MONTHS);
+        DepositPreClosureDetail preClosureDetail = DepositPreClosureDetail.createFrom(true, BigDecimal.valueOf(1.0),
+                PreClosurePenalInterestOnType.WHOLE_TERM);
+
+        DepositAccountTermAndPreClosure term = DepositAccountTermAndPreClosure.createNew(preClosureDetail, termDetails, null,
+                BigDecimal.valueOf(1000), BigDecimal.valueOf(1000), null, 12, SavingsPeriodFrequencyType.MONTHS, null, null, false, null,
+                true);
+
+        assertTrue(term.isRateChartOverridden());
+
+        DepositAccountTermAndPreClosure copiedTerm = term.copy(BigDecimal.valueOf(2000));
+        assertTrue(copiedTerm.isRateChartOverridden());
+    }
+
+    @Test
+    void testDepositAccountTermAndPreClosureDefaultFalseFlag() {
+        DepositTermDetail termDetails = DepositTermDetail.createFrom(1, 12, SavingsPeriodFrequencyType.MONTHS,
+                SavingsPeriodFrequencyType.MONTHS, 1, SavingsPeriodFrequencyType.MONTHS);
+        DepositPreClosureDetail preClosureDetail = DepositPreClosureDetail.createFrom(false, null, null);
+
+        DepositAccountTermAndPreClosure term = DepositAccountTermAndPreClosure.createNew(preClosureDetail, termDetails, null,
+                BigDecimal.valueOf(1000), BigDecimal.valueOf(1000), null, 12, SavingsPeriodFrequencyType.MONTHS, null, null, false, null,
+                false);
+
+        assertFalse(term.isRateChartOverridden());
+
+        DepositAccountTermAndPreClosure copiedTerm = term.copy(BigDecimal.valueOf(2000));
+        assertFalse(copiedTerm.isRateChartOverridden());
+    }
+
+    @Test
+    void testFixedDepositEffectiveInterestRateUsesOverriddenRateInsteadOfChart() {
+        FixedDepositAccount account = new FixedDepositAccount();
+        ReflectionTestUtils.setField(account, "nominalAnnualInterestRate", new BigDecimal("7.50"));
+        ReflectionTestUtils.setField(account, "submittedOnDate", LocalDate.of(2024, 1, 1));
+
+        DepositTermDetail termDetails = DepositTermDetail.createFrom(1, 12, SavingsPeriodFrequencyType.MONTHS,
+                SavingsPeriodFrequencyType.MONTHS, 1, SavingsPeriodFrequencyType.MONTHS);
+        DepositPreClosureDetail preClosureDetail = DepositPreClosureDetail.createFrom(false, null, null);
+
+        DepositAccountTermAndPreClosure term = DepositAccountTermAndPreClosure.createNew(preClosureDetail, termDetails, account,
+                BigDecimal.valueOf(10000), BigDecimal.valueOf(10000), null, 6, SavingsPeriodFrequencyType.MONTHS, null, null, false, null,
+                true);
+        ReflectionTestUtils.setField(account, "accountTermAndPreClosure", term);
+
+        DepositAccountInterestRateChart chart = mock(DepositAccountInterestRateChart.class);
+        when(chart.getApplicableInterestRate(any(), any(), any(), any())).thenReturn(new BigDecimal("5.00"));
+        ReflectionTestUtils.setField(account, "chart", chart);
+
+        // When isRateChartOverridden is true, effective rate should be customNominalRate / 100 = 0.075
+        BigDecimal effectiveRate = account.getEffectiveInterestRateAsFraction(MathContext.DECIMAL64, DateUtils.getBusinessLocalDate(),
+                false);
+        assertEquals(0, new BigDecimal("0.075").compareTo(effectiveRate));
+    }
+
+    @Test
+    void testFixedDepositEffectiveInterestRateUsesChartWhenNotOverridden() {
+        FixedDepositAccount account = new FixedDepositAccount();
+        ReflectionTestUtils.setField(account, "nominalAnnualInterestRate", new BigDecimal("7.50"));
+        ReflectionTestUtils.setField(account, "submittedOnDate", LocalDate.of(2024, 1, 1));
+
+        DepositTermDetail termDetails = DepositTermDetail.createFrom(1, 12, SavingsPeriodFrequencyType.MONTHS,
+                SavingsPeriodFrequencyType.MONTHS, 1, SavingsPeriodFrequencyType.MONTHS);
+        DepositPreClosureDetail preClosureDetail = DepositPreClosureDetail.createFrom(false, null, null);
+
+        // isRateChartOverridden = false
+        DepositAccountTermAndPreClosure term = DepositAccountTermAndPreClosure.createNew(preClosureDetail, termDetails, account,
+                BigDecimal.valueOf(10000), BigDecimal.valueOf(10000), null, 6, SavingsPeriodFrequencyType.MONTHS, null, null, false, null,
+                false);
+        ReflectionTestUtils.setField(account, "accountTermAndPreClosure", term);
+
+        DepositAccountInterestRateChart chart = mock(DepositAccountInterestRateChart.class);
+        when(chart.getApplicableInterestRate(any(), any(), any(), any())).thenReturn(new BigDecimal("5.00"));
+        ReflectionTestUtils.setField(account, "chart", chart);
+
+        // When isRateChartOverridden is false, effective rate comes from chart (5.00 / 100 = 0.05)
+        BigDecimal effectiveRate = account.getEffectiveInterestRateAsFraction(MathContext.DECIMAL64, DateUtils.getBusinessLocalDate(),
+                false);
+        assertEquals(0, new BigDecimal("0.05").compareTo(effectiveRate));
+    }
+
+    @Test
+    void testFixedDepositEffectiveInterestRateWithOverriddenRateAndPrematureClosurePenalty() {
+        FixedDepositAccount account = new FixedDepositAccount();
+        ReflectionTestUtils.setField(account, "nominalAnnualInterestRate", new BigDecimal("7.50"));
+        ReflectionTestUtils.setField(account, "submittedOnDate", LocalDate.of(2024, 1, 1));
+
+        DepositTermDetail termDetails = DepositTermDetail.createFrom(1, 12, SavingsPeriodFrequencyType.MONTHS,
+                SavingsPeriodFrequencyType.MONTHS, 1, SavingsPeriodFrequencyType.MONTHS);
+        // Pre-closure penalty of 1.0%
+        DepositPreClosureDetail preClosureDetail = DepositPreClosureDetail.createFrom(true, new BigDecimal("1.00"),
+                PreClosurePenalInterestOnType.WHOLE_TERM);
+
+        DepositAccountTermAndPreClosure term = DepositAccountTermAndPreClosure.createNew(preClosureDetail, termDetails, account,
+                BigDecimal.valueOf(10000), BigDecimal.valueOf(10000), null, 6, SavingsPeriodFrequencyType.MONTHS, null, null, false, null,
+                true);
+        ReflectionTestUtils.setField(account, "accountTermAndPreClosure", term);
+
+        DepositAccountInterestRateChart chart = mock(DepositAccountInterestRateChart.class);
+        ReflectionTestUtils.setField(account, "chart", chart);
+
+        // Premature close: effective rate is (7.50 - 1.00) / 100 = 0.065
+        LocalDate prematureCloseDate = DateUtils.getBusinessLocalDate().minusMonths(1);
+        BigDecimal effectiveRate = account.getEffectiveInterestRateAsFraction(MathContext.DECIMAL64, prematureCloseDate, true);
+        assertEquals(0, new BigDecimal("0.065").compareTo(effectiveRate));
+    }
+
+    @Test
+    void testRecurringDepositEffectiveInterestRateUsesOverriddenRateInsteadOfChart() {
+        RecurringDepositAccount account = new RecurringDepositAccount();
+        ReflectionTestUtils.setField(account, "nominalAnnualInterestRate", new BigDecimal("8.00"));
+        ReflectionTestUtils.setField(account, "submittedOnDate", LocalDate.of(2024, 1, 1));
+
+        DepositTermDetail termDetails = DepositTermDetail.createFrom(1, 12, SavingsPeriodFrequencyType.MONTHS,
+                SavingsPeriodFrequencyType.MONTHS, 1, SavingsPeriodFrequencyType.MONTHS);
+        DepositPreClosureDetail preClosureDetail = DepositPreClosureDetail.createFrom(false, null, null);
+
+        DepositAccountTermAndPreClosure term = DepositAccountTermAndPreClosure.createNew(preClosureDetail, termDetails, account,
+                BigDecimal.valueOf(10000), BigDecimal.valueOf(10000), null, 6, SavingsPeriodFrequencyType.MONTHS, null, null, false, null,
+                true);
+        ReflectionTestUtils.setField(account, "accountTermAndPreClosure", term);
+
+        DepositAccountInterestRateChart chart = mock(DepositAccountInterestRateChart.class);
+        when(chart.getApplicableInterestRate(any(), any(), any(), any())).thenReturn(new BigDecimal("6.00"));
+        ReflectionTestUtils.setField(account, "chart", chart);
+
+        // When isRateChartOverridden is true, effective rate should be customNominalRate / 100 = 0.08
+        BigDecimal effectiveRate = account.getEffectiveInterestRateAsFraction(MathContext.DECIMAL64, DateUtils.getBusinessLocalDate(),
+                false);
+        assertEquals(0, new BigDecimal("0.08").compareTo(effectiveRate));
+    }
+
+    @Test
+    void testRecurringDepositEffectiveInterestRateWithOverriddenRateAndPrematureClosurePenalty() {
+        RecurringDepositAccount account = new RecurringDepositAccount();
+        ReflectionTestUtils.setField(account, "nominalAnnualInterestRate", new BigDecimal("8.00"));
+        ReflectionTestUtils.setField(account, "submittedOnDate", LocalDate.of(2024, 1, 1));
+
+        DepositTermDetail termDetails = DepositTermDetail.createFrom(1, 12, SavingsPeriodFrequencyType.MONTHS,
+                SavingsPeriodFrequencyType.MONTHS, 1, SavingsPeriodFrequencyType.MONTHS);
+        // Pre-closure penalty of 1.5%
+        DepositPreClosureDetail preClosureDetail = DepositPreClosureDetail.createFrom(true, new BigDecimal("1.50"),
+                PreClosurePenalInterestOnType.WHOLE_TERM);
+
+        DepositAccountTermAndPreClosure term = DepositAccountTermAndPreClosure.createNew(preClosureDetail, termDetails, account,
+                BigDecimal.valueOf(10000), BigDecimal.valueOf(10000), null, 6, SavingsPeriodFrequencyType.MONTHS, null, null, false, null,
+                true);
+        ReflectionTestUtils.setField(account, "accountTermAndPreClosure", term);
+
+        DepositAccountInterestRateChart chart = mock(DepositAccountInterestRateChart.class);
+        ReflectionTestUtils.setField(account, "chart", chart);
+
+        // Premature close: effective rate is (8.00 - 1.50) / 100 = 0.065
+        LocalDate prematureCloseDate = DateUtils.getBusinessLocalDate().minusMonths(1);
+        BigDecimal effectiveRate = account.getEffectiveInterestRateAsFraction(MathContext.DECIMAL64, prematureCloseDate, true);
+        assertEquals(0, new BigDecimal("0.065").compareTo(effectiveRate));
+    }
+
+    @Test
+    void testValidationFailsWhenRateChartOverriddenTrueWithoutNominalAnnualInterestRate() {
+        FromJsonHelper fromJsonHelper = new FromJsonHelper();
+        DepositProductDataValidator productValidator = mock(DepositProductDataValidator.class);
+        DepositAccountDataValidator validator = new DepositAccountDataValidator(fromJsonHelper, productValidator);
+
+        // JSON payload with isRateChartOverridden = true but no nominalAnnualInterestRate
+        String invalidJson = """
+                {
+                    "clientId": 1,
+                    "productId": 1,
+                    "submittedOnDate": "01 January 2024",
+                    "dateFormat": "dd MMMM yyyy",
+                    "locale": "en",
+                    "depositAmount": 1000,
+                    "depositPeriod": 6,
+                    "depositPeriodFrequencyId": 2,
+                    "isRateChartOverridden": true
+                }
+                """;
+
+        assertThrows(PlatformApiDataValidationException.class, () -> validator.validateFixedDepositForSubmit(invalidJson));
+    }
+
+    @Test
+    void testValidationPassesWhenRateChartOverriddenTrueWithNominalAnnualInterestRate() {
+        FromJsonHelper fromJsonHelper = new FromJsonHelper();
+        DepositProductDataValidator productValidator = mock(DepositProductDataValidator.class);
+        DepositAccountDataValidator validator = new DepositAccountDataValidator(fromJsonHelper, productValidator);
+
+        String validJson = """
+                {
+                    "clientId": 1,
+                    "productId": 1,
+                    "submittedOnDate": "01 January 2024",
+                    "dateFormat": "dd MMMM yyyy",
+                    "locale": "en",
+                    "depositAmount": 1000,
+                    "depositPeriod": 6,
+                    "depositPeriodFrequencyId": 2,
+                    "isRateChartOverridden": true,
+                    "nominalAnnualInterestRate": 7.5
+                }
+                """;
+
+        // Should not throw validation exception
+        validator.validateFixedDepositForSubmit(validJson);
+    }
+
+    @Test
+    void testValidationFailsWhenRateChartOverriddenTrueWithoutNominalAnnualInterestRateOnUpdate() {
+        FromJsonHelper fromJsonHelper = new FromJsonHelper();
+        DepositProductDataValidator productValidator = mock(DepositProductDataValidator.class);
+        DepositAccountDataValidator validator = new DepositAccountDataValidator(fromJsonHelper, productValidator);
+
+        String invalidUpdateJson = """
+                {
+                    "isRateChartOverridden": true
+                }
+                """;
+
+        assertThrows(PlatformApiDataValidationException.class, () -> validator.validateFixedDepositForUpdate(invalidUpdateJson));
+    }
+
+    @Test
+    void testFixedDepositValidateDomainRulesSucceedsWhenRateChartOverriddenEvenIfNoMatchingSlab() {
+        FixedDepositAccount account = new FixedDepositAccount();
+        ReflectionTestUtils.setField(account, "nominalAnnualInterestRate", new BigDecimal("7.50"));
+        ReflectionTestUtils.setField(account, "submittedOnDate", LocalDate.of(2024, 1, 1));
+        ReflectionTestUtils.setField(account, "interestPostingPeriodType", SavingsPostingInterestPeriodType.MONTHLY.getValue());
+        ReflectionTestUtils.setField(account, "interestCompoundingPeriodType", SavingsCompoundingInterestPeriodType.MONTHLY.getValue());
+
+        DepositTermDetail termDetails = DepositTermDetail.createFrom(1, 12, SavingsPeriodFrequencyType.MONTHS,
+                SavingsPeriodFrequencyType.MONTHS, 1, SavingsPeriodFrequencyType.MONTHS);
+        DepositPreClosureDetail preClosureDetail = DepositPreClosureDetail.createFrom(false, null, null);
+
+        DepositAccountTermAndPreClosure term = DepositAccountTermAndPreClosure.createNew(preClosureDetail, termDetails, account,
+                BigDecimal.valueOf(10000), BigDecimal.valueOf(10000), null, 6, SavingsPeriodFrequencyType.MONTHS, null, null, false, null,
+                true);
+        ReflectionTestUtils.setField(account, "accountTermAndPreClosure", term);
+
+        DepositAccountInterestRateChart chart = mock(DepositAccountInterestRateChart.class);
+        when(chart.getFromDate()).thenReturn(LocalDate.of(2024, 1, 1));
+        when(chart.getApplicableInterestRate(any(), any(), any(), any())).thenReturn(BigDecimal.ZERO);
+        ReflectionTestUtils.setField(account, "chart", chart);
+
+        // Even though chart returns ZERO (no slab matched), domain rules should succeed because chart is overridden
+        assertDoesNotThrow(account::validateDomainRules);
+    }
+
+    @Test
+    void testFixedDepositValidateDomainRulesFailsWhenRateChartNotOverriddenAndNoMatchingSlab() {
+        FixedDepositAccount account = new FixedDepositAccount();
+        ReflectionTestUtils.setField(account, "nominalAnnualInterestRate", new BigDecimal("7.50"));
+        ReflectionTestUtils.setField(account, "submittedOnDate", LocalDate.of(2024, 1, 1));
+        ReflectionTestUtils.setField(account, "interestPostingPeriodType", SavingsPostingInterestPeriodType.MONTHLY.getValue());
+        ReflectionTestUtils.setField(account, "interestCompoundingPeriodType", SavingsCompoundingInterestPeriodType.MONTHLY.getValue());
+
+        DepositTermDetail termDetails = DepositTermDetail.createFrom(1, 12, SavingsPeriodFrequencyType.MONTHS,
+                SavingsPeriodFrequencyType.MONTHS, 1, SavingsPeriodFrequencyType.MONTHS);
+        DepositPreClosureDetail preClosureDetail = DepositPreClosureDetail.createFrom(false, null, null);
+
+        // isRateChartOverridden = false
+        DepositAccountTermAndPreClosure term = DepositAccountTermAndPreClosure.createNew(preClosureDetail, termDetails, account,
+                BigDecimal.valueOf(10000), BigDecimal.valueOf(10000), null, 6, SavingsPeriodFrequencyType.MONTHS, null, null, false, null,
+                false);
+        ReflectionTestUtils.setField(account, "accountTermAndPreClosure", term);
+
+        DepositAccountInterestRateChart chart = mock(DepositAccountInterestRateChart.class);
+        when(chart.getFromDate()).thenReturn(LocalDate.of(2024, 1, 1));
+        when(chart.getApplicableInterestRate(any(), any(), any(), any())).thenReturn(BigDecimal.ZERO);
+        ReflectionTestUtils.setField(account, "chart", chart);
+
+        // When not overridden and no slab matches (returns ZERO), validation must fail
+        assertThrows(PlatformApiDataValidationException.class, account::validateDomainRules);
+    }
+
+    @Test
+    void testRecurringDepositValidateApplicableInterestRateSucceedsWhenRateChartOverriddenEvenIfNoMatchingSlab() {
+        RecurringDepositAccount account = new RecurringDepositAccount();
+        ReflectionTestUtils.setField(account, "nominalAnnualInterestRate", new BigDecimal("8.00"));
+        ReflectionTestUtils.setField(account, "submittedOnDate", LocalDate.of(2024, 1, 1));
+
+        DepositTermDetail termDetails = DepositTermDetail.createFrom(1, 12, SavingsPeriodFrequencyType.MONTHS,
+                SavingsPeriodFrequencyType.MONTHS, 1, SavingsPeriodFrequencyType.MONTHS);
+        DepositPreClosureDetail preClosureDetail = DepositPreClosureDetail.createFrom(false, null, null);
+
+        DepositAccountTermAndPreClosure term = DepositAccountTermAndPreClosure.createNew(preClosureDetail, termDetails, account,
+                BigDecimal.valueOf(10000), BigDecimal.valueOf(10000), null, 6, SavingsPeriodFrequencyType.MONTHS, null, null, false, null,
+                true);
+        ReflectionTestUtils.setField(account, "accountTermAndPreClosure", term);
+
+        DepositAccountInterestRateChart chart = mock(DepositAccountInterestRateChart.class);
+        when(chart.getFromDate()).thenReturn(LocalDate.of(2024, 1, 1));
+        when(chart.getApplicableInterestRate(any(), any(), any(), any())).thenReturn(BigDecimal.ZERO);
+        ReflectionTestUtils.setField(account, "chart", chart);
+
+        // Even though chart returns ZERO, validation should succeed because chart is overridden
+        assertDoesNotThrow(account::validateApplicableInterestRate);
+    }
+
+    @Test
+    void testRecurringDepositValidateApplicableInterestRateFailsWhenRateChartNotOverriddenAndNoMatchingSlab() {
+        RecurringDepositAccount account = new RecurringDepositAccount();
+        ReflectionTestUtils.setField(account, "nominalAnnualInterestRate", new BigDecimal("8.00"));
+        ReflectionTestUtils.setField(account, "submittedOnDate", LocalDate.of(2024, 1, 1));
+
+        DepositTermDetail termDetails = DepositTermDetail.createFrom(1, 12, SavingsPeriodFrequencyType.MONTHS,
+                SavingsPeriodFrequencyType.MONTHS, 1, SavingsPeriodFrequencyType.MONTHS);
+        DepositPreClosureDetail preClosureDetail = DepositPreClosureDetail.createFrom(false, null, null);
+
+        // isRateChartOverridden = false
+        DepositAccountTermAndPreClosure term = DepositAccountTermAndPreClosure.createNew(preClosureDetail, termDetails, account,
+                BigDecimal.valueOf(10000), BigDecimal.valueOf(10000), null, 6, SavingsPeriodFrequencyType.MONTHS, null, null, false, null,
+                false);
+        ReflectionTestUtils.setField(account, "accountTermAndPreClosure", term);
+
+        DepositAccountInterestRateChart chart = mock(DepositAccountInterestRateChart.class);
+        when(chart.getFromDate()).thenReturn(LocalDate.of(2024, 1, 1));
+        when(chart.getApplicableInterestRate(any(), any(), any(), any())).thenReturn(BigDecimal.ZERO);
+        ReflectionTestUtils.setField(account, "chart", chart);
+
+        // When not overridden and no slab matches (returns ZERO), validation must fail
+        assertThrows(PlatformApiDataValidationException.class, account::validateApplicableInterestRate);
+    }
+}

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/data/FixedDepositAccountData.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/data/FixedDepositAccountData.java
@@ -56,6 +56,7 @@ public final class FixedDepositAccountData extends DepositAccountData {
     private EnumOptionData depositPeriodFrequency;
     private BigDecimal activationCharge;
     private Long transferToSavingsId;
+    private boolean isRateChartOverridden;
 
     // used for account close
     private EnumOptionData onAccountClosure;
@@ -129,6 +130,7 @@ public final class FixedDepositAccountData extends DepositAccountData {
         this.submittedOnDate = submittedOnDate;
         this.depositPeriodFrequencyId = depositPeriodFrequencyId;
         this.maturityInstructionOptions = null;
+        this.isRateChartOverridden = false;
     }
 
     public static FixedDepositAccountData instance(final DepositAccountData depositAccountData, final boolean preClosurePenalApplicable,
@@ -137,7 +139,7 @@ public final class FixedDepositAccountData extends DepositAccountData {
             final Integer inMultiplesOfDepositTerm, final EnumOptionData inMultiplesOfDepositTermType, final BigDecimal depositAmount,
             final BigDecimal maturityAmount, final LocalDate maturityDate, final Integer depositPeriod,
             final EnumOptionData depositPeriodFrequency, final EnumOptionData onAccountClosure, final Boolean transferInterestToSavings,
-            final Long transferToSavingsId) {
+            final Long transferToSavingsId, final boolean isRateChartOverridden) {
 
         final PortfolioAccountData linkedAccount = null;
         final PortfolioAccountData transferToSavingsAccount = null;
@@ -169,7 +171,8 @@ public final class FixedDepositAccountData extends DepositAccountData {
                 maxDepositTermType, inMultiplesOfDepositTerm, inMultiplesOfDepositTermType, depositAmount, maturityAmount, maturityDate,
                 depositPeriod, depositPeriodFrequency, periodFrequencyTypeOptions, depositType, onAccountClosure, onAccountClosureOptions,
                 paymentTypeOptions, savingsAccountDatas, linkedAccount, transferInterestToSavings, depositAccountData.withHoldTax,
-                depositAccountData.taxGroup, maturityInstructionOptions, transferToSavingsId, transferToSavingsAccount);
+                depositAccountData.taxGroup, maturityInstructionOptions, transferToSavingsId, transferToSavingsAccount,
+                isRateChartOverridden);
     }
 
     public static FixedDepositAccountData withInterestChart(final FixedDepositAccountData account,
@@ -191,7 +194,8 @@ public final class FixedDepositAccountData extends DepositAccountData {
                 account.depositPeriod, account.depositPeriodFrequency, account.periodFrequencyTypeOptions, account.depositType,
                 account.onAccountClosure, account.onAccountClosureOptions, account.paymentTypeOptions, account.savingsAccounts,
                 account.linkedAccount, account.transferInterestToSavings, account.withHoldTax, account.taxGroup,
-                account.maturityInstructionOptions, account.transferToSavingsId, account.transferToSavingsAccount);
+                account.maturityInstructionOptions, account.transferToSavingsId, account.transferToSavingsAccount,
+                account.isRateChartOverridden);
     }
 
     public static FixedDepositAccountData associationsAndTemplate(final FixedDepositAccountData account, FixedDepositAccountData template,
@@ -219,7 +223,7 @@ public final class FixedDepositAccountData extends DepositAccountData {
                 account.depositPeriod, account.depositPeriodFrequency, template.periodFrequencyTypeOptions, account.depositType,
                 account.onAccountClosure, account.onAccountClosureOptions, account.paymentTypeOptions, template.savingsAccounts,
                 linkedAccount, account.transferInterestToSavings, account.withHoldTax, account.taxGroup, account.maturityInstructionOptions,
-                account.transferToSavingsId, transferToSavingsAccount);
+                account.transferToSavingsId, transferToSavingsAccount, account.isRateChartOverridden);
     }
 
     public static FixedDepositAccountData withTemplateOptions(final FixedDepositAccountData account,
@@ -250,7 +254,7 @@ public final class FixedDepositAccountData extends DepositAccountData {
                 account.depositPeriod, account.depositPeriodFrequency, periodFrequencyTypeOptions, account.depositType,
                 account.onAccountClosure, account.onAccountClosureOptions, account.paymentTypeOptions, savingsAccounts,
                 account.linkedAccount, account.transferInterestToSavings, account.withHoldTax, account.taxGroup, maturityInstructionOptions,
-                account.transferToSavingsId, account.transferToSavingsAccount);
+                account.transferToSavingsId, account.transferToSavingsAccount, account.isRateChartOverridden);
     }
 
     public static FixedDepositAccountData withClientTemplate(final Long clientId, final String clientName, final Long groupId,
@@ -322,6 +326,7 @@ public final class FixedDepositAccountData extends DepositAccountData {
         final Collection<SavingsAccountData> savingsAccountDatas = null;
         final Collection<EnumOptionData> maturityInstructionOptions = null;
         final Long transferToSavingsId = null;
+        final boolean isRateChartOverridden = false;
 
         return new FixedDepositAccountData(id, accountNo, externalId, groupId, groupName, clientId, clientName, productId, productName,
                 fieldOfficerId, fieldOfficerName, status, timeline, currency, nominalAnnualInterestRate, interestPeriodType,
@@ -334,8 +339,8 @@ public final class FixedDepositAccountData extends DepositAccountData {
                 maxDepositTerm, minDepositTermType, maxDepositTermType, inMultiplesOfDepositTerm, inMultiplesOfDepositTermType,
                 depositAmount, maturityAmount, maturityDate, depositPeriod, depositPeriodFrequency, periodFrequencyTypeOptions, depositType,
                 onAccountClosure, onAccountClosureOptions, paymentTypeOptions, savingsAccountDatas, linkedAccount,
-                transferInterestToSavings, withHoldTax, taxGroup, maturityInstructionOptions, transferToSavingsId,
-                transferToSavingsAccount);
+                transferInterestToSavings, withHoldTax, taxGroup, maturityInstructionOptions, transferToSavingsId, transferToSavingsAccount,
+                isRateChartOverridden);
     }
 
     public static FixedDepositAccountData preClosureDetails(final Long accountId, BigDecimal maturityAmount,
@@ -407,6 +412,7 @@ public final class FixedDepositAccountData extends DepositAccountData {
         final Collection<EnumOptionData> maturityInstructionOptions = null;
         final Long transferToSavingsId = null;
         final PortfolioAccountData transferToSavingsAccount = null;
+        final boolean isRateChartOverridden = false;
 
         return new FixedDepositAccountData(accountId, accountNo, externalId, groupId, groupName, clientId, clientName, productId,
                 productName, fieldOfficerId, fieldOfficerName, status, timeline, currency, nominalAnnualInterestRate, interestPeriodType,
@@ -419,8 +425,8 @@ public final class FixedDepositAccountData extends DepositAccountData {
                 maxDepositTerm, minDepositTermType, maxDepositTermType, inMultiplesOfDepositTerm, inMultiplesOfDepositTermType,
                 depositAmount, maturityAmount, maturityDate, depositPeriod, depositPeriodFrequency, periodFrequencyTypeOptions, depositType,
                 onAccountClosure, onAccountClosureOptions, paymentTypeOptions, savingsAccountDatas, linkedAccount,
-                transferInterestToSavings, withHoldTax, taxGroup, maturityInstructionOptions, transferToSavingsId,
-                transferToSavingsAccount);
+                transferInterestToSavings, withHoldTax, taxGroup, maturityInstructionOptions, transferToSavingsId, transferToSavingsAccount,
+                isRateChartOverridden);
     }
 
     public static FixedDepositAccountData withClosureTemplateDetails(final FixedDepositAccountData account,
@@ -444,7 +450,7 @@ public final class FixedDepositAccountData extends DepositAccountData {
                 account.depositPeriod, account.depositPeriodFrequency, account.periodFrequencyTypeOptions, account.depositType,
                 account.onAccountClosure, onAccountClosureOptions, paymentTypeOptions, savingsAccountDatas, account.linkedAccount,
                 account.transferInterestToSavings, account.withHoldTax, account.taxGroup, account.maturityInstructionOptions,
-                account.transferToSavingsId, account.transferToSavingsAccount);
+                account.transferToSavingsId, account.transferToSavingsAccount, account.isRateChartOverridden);
 
     }
 
@@ -476,7 +482,7 @@ public final class FixedDepositAccountData extends DepositAccountData {
             final Collection<PaymentTypeData> paymentTypeOptions, final Collection<SavingsAccountData> savingsAccountDatas,
             final PortfolioAccountData linkedAccount, final Boolean transferInterestToSavings, final boolean withHoldTax,
             final TaxGroupData taxGroup, final Collection<EnumOptionData> maturityInstructionOptions, final Long transferToSavingsId,
-            final PortfolioAccountData transferToSavingsAccount) {
+            final PortfolioAccountData transferToSavingsAccount, final boolean isRateChartOverridden) {
 
         super(id, accountNo, externalId, groupId, groupName, clientId, clientName, productId, productName, fieldofficerId, fieldofficerName,
                 status, timeline, currency, nominalAnnualInterestRate, interestPeriodType, interestPostingPeriodType,
@@ -515,6 +521,7 @@ public final class FixedDepositAccountData extends DepositAccountData {
         this.savingsAccounts = savingsAccountDatas;
         this.maturityInstructionOptions = maturityInstructionOptions;
         this.transferToSavingsId = transferToSavingsId;
+        this.isRateChartOverridden = isRateChartOverridden;
     }
 
     @Override

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/data/RecurringDepositAccountData.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/data/RecurringDepositAccountData.java
@@ -64,6 +64,7 @@ public final class RecurringDepositAccountData extends DepositAccountData {
     private final boolean isCalendarInherited;
     private final Integer recurringFrequency;
     private final EnumOptionData recurringFrequencyType;
+    private final boolean isRateChartOverridden;
 
     // used for account close
     private final EnumOptionData onAccountClosure;
@@ -143,6 +144,7 @@ public final class RecurringDepositAccountData extends DepositAccountData {
         this.locale = locale;
         this.submittedOnDate = submittedOnDate;
         this.depositPeriodFrequencyId = depositPeriodFrequencyId;
+        this.isRateChartOverridden = false;
     }
 
     public Integer getRowIndex() {
@@ -157,7 +159,7 @@ public final class RecurringDepositAccountData extends DepositAccountData {
             final EnumOptionData depositPeriodFrequency, final BigDecimal mandatoryRecommendedDepositAmount,
             final EnumOptionData onAccountClosure, final LocalDate expectedFirstDepositOnDate, final BigDecimal totalOverdueAmount,
             final Integer noOfOverdueInstallments, final boolean isMandatoryDeposit, final boolean allowWithdrawal,
-            final boolean adjustAdvanceTowardsFuturePayments, final boolean isCalendarInherited) {
+            final boolean adjustAdvanceTowardsFuturePayments, final boolean isCalendarInherited, final boolean isRateChartOverridden) {
 
         final Collection<EnumOptionData> preClosurePenalInterestOnTypeOptions = null;
         final Collection<EnumOptionData> periodFrequencyTypeOptions = null;
@@ -190,7 +192,7 @@ public final class RecurringDepositAccountData extends DepositAccountData {
                 onAccountClosure, onAccountClosureOptions, paymentTypeOptions, savingsAccountDatas, expectedFirstDepositOnDate,
                 totalOverdueAmount, noOfOverdueInstallments, isMandatoryDeposit, allowWithdrawal, adjustAdvanceTowardsFuturePayments,
                 isCalendarInherited, recurringFrequency, recurringFrequencyType, depositAccountData.withHoldTax,
-                depositAccountData.taxGroup);
+                depositAccountData.taxGroup, isRateChartOverridden);
     }
 
     public static RecurringDepositAccountData withInterestChartAndRecurringDetails(final RecurringDepositAccountData account,
@@ -215,7 +217,7 @@ public final class RecurringDepositAccountData extends DepositAccountData {
                 account.paymentTypeOptions, account.savingsAccounts, account.expectedFirstDepositOnDate, account.totalOverdueAmount,
                 account.noOfOverdueInstallments, account.isMandatoryDeposit, account.allowWithdrawal,
                 account.adjustAdvanceTowardsFuturePayments, account.isCalendarInherited, recurringFrequency, recurringFrequencyType,
-                account.withHoldTax, account.taxGroup);
+                account.withHoldTax, account.taxGroup, account.isRateChartOverridden);
     }
 
     public static RecurringDepositAccountData withTemplateOptions(final RecurringDepositAccountData account,
@@ -261,7 +263,7 @@ public final class RecurringDepositAccountData extends DepositAccountData {
                 account.paymentTypeOptions, account.savingsAccounts, account.expectedFirstDepositOnDate, account.totalOverdueAmount,
                 account.noOfOverdueInstallments, account.isMandatoryDeposit, account.allowWithdrawal,
                 account.adjustAdvanceTowardsFuturePayments, account.isCalendarInherited, account.recurringFrequency,
-                account.recurringFrequencyType, account.withHoldTax, account.taxGroup);
+                account.recurringFrequencyType, account.withHoldTax, account.taxGroup, account.isRateChartOverridden);
 
     }
 
@@ -294,7 +296,7 @@ public final class RecurringDepositAccountData extends DepositAccountData {
                 account.paymentTypeOptions, account.savingsAccounts, account.expectedFirstDepositOnDate, account.totalOverdueAmount,
                 account.noOfOverdueInstallments, account.isMandatoryDeposit, account.allowWithdrawal,
                 account.adjustAdvanceTowardsFuturePayments, account.isCalendarInherited, account.recurringFrequency,
-                account.recurringFrequencyType, account.withHoldTax, account.taxGroup);
+                account.recurringFrequencyType, account.withHoldTax, account.taxGroup, account.isRateChartOverridden);
     }
 
     public static RecurringDepositAccountData withClientTemplate(final Long clientId, final String clientName, final Long groupId,
@@ -374,6 +376,7 @@ public final class RecurringDepositAccountData extends DepositAccountData {
         final EnumOptionData recurringFrequencyType = null;
         final boolean withHoldTax = false;
         final TaxGroupData taxGroup = null;
+        final boolean isRateChartOverridden = false;
 
         return new RecurringDepositAccountData(id, accountNo, externalId, groupId, groupName, clientId, clientName, productId, productName,
                 fieldOfficerId, fieldOfficerName, status, timeline, currency, nominalAnnualInterestRate, interestPeriodType,
@@ -387,7 +390,8 @@ public final class RecurringDepositAccountData extends DepositAccountData {
                 depositAmount, maturityAmount, maturityDate, depositPeriod, depositPeriodFrequency, mandatoryRecommendedDepositAmount,
                 periodFrequencyTypeOptions, depositType, onAccountClosure, onAccountClosureOptions, paymentTypeOptions, savingsAccountDatas,
                 expectedFirstDepositOnDate, totalOverdueAmount, noOfOverdueInstallments, isMandatoryDeposit, allowWithdrawal,
-                adjustAdvanceTowardsFuturePayments, isCalendarInherited, recurringFrequency, recurringFrequencyType, withHoldTax, taxGroup);
+                adjustAdvanceTowardsFuturePayments, isCalendarInherited, recurringFrequency, recurringFrequencyType, withHoldTax, taxGroup,
+                isRateChartOverridden);
     }
 
     public static RecurringDepositAccountData preClosureDetails(final Long accountId, final BigDecimal maturityAmount,
@@ -465,6 +469,7 @@ public final class RecurringDepositAccountData extends DepositAccountData {
         final EnumOptionData recurringFrequencyType = null;
         final boolean withHoldTax = false;
         final TaxGroupData taxGroup = null;
+        final boolean isRateChartOverridden = false;
 
         return new RecurringDepositAccountData(accountId, accountNo, externalId, groupId, groupName, clientId, clientName, productId,
                 productName, fieldOfficerId, fieldOfficerName, status, timeline, currency, nominalAnnualInterestRate, interestPeriodType,
@@ -478,7 +483,8 @@ public final class RecurringDepositAccountData extends DepositAccountData {
                 depositAmount, maturityAmount, maturityDate, depositPeriod, depositPeriodFrequency, mandatoryRecommendedDepositAmount,
                 periodFrequencyTypeOptions, depositType, onAccountClosure, onAccountClosureOptions, paymentTypeOptions, savingsAccountDatas,
                 expectedFirstDepositOnDate, totalOverdueAmount, noOfOverdueInstallments, isMandatoryDeposit, allowWithdrawal,
-                adjustAdvanceTowardsFuturePayments, isCalendarInherited, recurringFrequency, recurringFrequencyType, withHoldTax, taxGroup);
+                adjustAdvanceTowardsFuturePayments, isCalendarInherited, recurringFrequency, recurringFrequencyType, withHoldTax, taxGroup,
+                isRateChartOverridden);
     }
 
     public static RecurringDepositAccountData withClosureTemplateDetails(final RecurringDepositAccountData account,
@@ -504,7 +510,7 @@ public final class RecurringDepositAccountData extends DepositAccountData {
                 paymentTypeOptions, savingsAccountDatas, account.expectedFirstDepositOnDate, account.totalOverdueAmount,
                 account.noOfOverdueInstallments, account.isMandatoryDeposit, account.allowWithdrawal,
                 account.adjustAdvanceTowardsFuturePayments, account.isCalendarInherited, account.recurringFrequency,
-                account.recurringFrequencyType, account.withHoldTax, account.taxGroup);
+                account.recurringFrequencyType, account.withHoldTax, account.taxGroup, account.isRateChartOverridden);
     }
 
     private RecurringDepositAccountData(final Long id, final String accountNo, final String externalId, final Long groupId,
@@ -537,7 +543,7 @@ public final class RecurringDepositAccountData extends DepositAccountData {
             final BigDecimal totalOverdueAmount, final Integer noOfOverdueInstallments, final boolean isMandatoryDeposit,
             final boolean allowWithdrawal, final boolean adjustAdvanceTowardsFuturePayments, final boolean isCalendarInherited,
             final Integer recurringFrequency, final EnumOptionData recurringFrequencyType, final boolean withHoldTax,
-            final TaxGroupData taxGroup) {
+            final TaxGroupData taxGroup, final boolean isRateChartOverridden) {
 
         super(id, accountNo, externalId, groupId, groupName, clientId, clientName, productId, productName, fieldofficerId, fieldofficerName,
                 status, timeline, currency, nominalAnnualInterestRate, interestPeriodType, interestPostingPeriodType,
@@ -581,6 +587,8 @@ public final class RecurringDepositAccountData extends DepositAccountData {
         // account close template options
         this.onAccountClosureOptions = onAccountClosureOptions;
         this.paymentTypeOptions = paymentTypeOptions;
+
+        this.isRateChartOverridden = isRateChartOverridden;
     }
 
     @Override

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/DepositAccountTermAndPreClosure.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/domain/DepositAccountTermAndPreClosure.java
@@ -23,6 +23,7 @@ import static org.apache.fineract.portfolio.savings.DepositsApiConstants.deposit
 import static org.apache.fineract.portfolio.savings.DepositsApiConstants.depositPeriodFrequencyIdParamName;
 import static org.apache.fineract.portfolio.savings.DepositsApiConstants.depositPeriodParamName;
 import static org.apache.fineract.portfolio.savings.DepositsApiConstants.expectedFirstDepositOnDateParamName;
+import static org.apache.fineract.portfolio.savings.DepositsApiConstants.isRateChartOverriddenParamName;
 import static org.apache.fineract.portfolio.savings.DepositsApiConstants.localeParamName;
 import static org.apache.fineract.portfolio.savings.DepositsApiConstants.maturityInstructionIdParamName;
 import static org.apache.fineract.portfolio.savings.DepositsApiConstants.transferInterestToSavingsParamName;
@@ -85,6 +86,9 @@ public class DepositAccountTermAndPreClosure extends AbstractPersistableCustom<L
     @Column(name = "transfer_interest_to_linked_account", nullable = false)
     private boolean transferInterestToLinkedAccount;
 
+    @Column(name = "is_rate_chart_overridden", nullable = false)
+    private boolean isRateChartOverridden;
+
     @Column(name = "transfer_to_savings_account_id")
     private Long transferToSavingsAccountId;
 
@@ -95,17 +99,19 @@ public class DepositAccountTermAndPreClosure extends AbstractPersistableCustom<L
     public static DepositAccountTermAndPreClosure createNew(DepositPreClosureDetail preClosureDetail, DepositTermDetail depositTermDetail,
             SavingsAccount account, BigDecimal depositAmount, BigDecimal maturityAmount, final LocalDate maturityDate,
             Integer depositPeriod, final SavingsPeriodFrequencyType depositPeriodFrequency, final LocalDate expectedFirstDepositOnDate,
-            final DepositAccountOnClosureType accountOnClosureType, Boolean trasferInterest, Long transferToSavingsId) {
+            final DepositAccountOnClosureType accountOnClosureType, Boolean trasferInterest, Long transferToSavingsId,
+            Boolean isRateChartOverridden) {
 
         return new DepositAccountTermAndPreClosure(preClosureDetail, depositTermDetail, account, depositAmount, maturityAmount,
                 maturityDate, depositPeriod, depositPeriodFrequency, expectedFirstDepositOnDate, accountOnClosureType, trasferInterest,
-                transferToSavingsId);
+                transferToSavingsId, isRateChartOverridden);
     }
 
     private DepositAccountTermAndPreClosure(DepositPreClosureDetail preClosureDetail, DepositTermDetail depositTermDetail,
             SavingsAccount account, BigDecimal depositAmount, BigDecimal maturityAmount, final LocalDate maturityDate,
             Integer depositPeriod, final SavingsPeriodFrequencyType depositPeriodFrequency, final LocalDate expectedFirstDepositOnDate,
-            final DepositAccountOnClosureType accountOnClosureType, Boolean transferInterest, Long transferToSavingsId) {
+            final DepositAccountOnClosureType accountOnClosureType, Boolean transferInterest, Long transferToSavingsId,
+            Boolean isRateChartOverridden) {
         this.depositAmount = depositAmount;
         this.maturityAmount = maturityAmount;
         this.maturityDate = maturityDate;
@@ -118,6 +124,7 @@ public class DepositAccountTermAndPreClosure extends AbstractPersistableCustom<L
         this.onAccountClosureType = (accountOnClosureType == null) ? null : accountOnClosureType.getValue();
         this.transferInterestToLinkedAccount = transferInterest;
         this.transferToSavingsAccountId = transferToSavingsId;
+        this.isRateChartOverridden = isRateChartOverridden != null ? isRateChartOverridden : false;
     }
 
     public Map<String, Object> update(final JsonCommand command, final DataValidatorBuilder baseDataValidator) {
@@ -178,6 +185,13 @@ public class DepositAccountTermAndPreClosure extends AbstractPersistableCustom<L
         if (this.depositTermDetail != null) {
             actualChanges.putAll(this.depositTermDetail.update(command, baseDataValidator));
         }
+
+        if (command.isChangeInBooleanParameterNamed(isRateChartOverriddenParamName, this.isRateChartOverridden)) {
+            final Boolean newValue = command.booleanPrimitiveValueOfParameterNamed(isRateChartOverriddenParamName);
+            actualChanges.put(isRateChartOverriddenParamName, newValue);
+            this.isRateChartOverridden = newValue;
+        }
+
         return actualChanges;
     }
 
@@ -301,12 +315,13 @@ public class DepositAccountTermAndPreClosure extends AbstractPersistableCustom<L
         final DepositTermDetail depositTermDetail = this.depositTermDetail.copy();
         final LocalDate expectedFirstDepositOnDate = null;
         final Boolean transferInterestToLinkedAccount = false;
+        final boolean isRateChartOverridden = this.isRateChartOverridden;
 
         final DepositAccountOnClosureType accountOnClosureType = null;
         final Long transferToSavingsId = null;
         return DepositAccountTermAndPreClosure.createNew(preClosureDetail, depositTermDetail, account, actualDepositAmount, maturityAmount,
                 maturityDate, depositPeriod, depositPeriodFrequency, expectedFirstDepositOnDate, accountOnClosureType,
-                transferInterestToLinkedAccount, transferToSavingsId);
+                transferInterestToLinkedAccount, transferToSavingsId, isRateChartOverridden);
     }
 
     public void updateExpectedFirstDepositDate(final LocalDate expectedFirstDepositOnDate) {
@@ -327,5 +342,9 @@ public class DepositAccountTermAndPreClosure extends AbstractPersistableCustom<L
 
     public Long getTransferToSavingsAccountId() {
         return transferToSavingsAccountId;
+    }
+
+    public boolean isRateChartOverridden() {
+        return isRateChartOverridden;
     }
 }

--- a/fineract-savings/src/main/resources/db/changelog/tenant/module/savings/parts/parts/2006_add_is_rate_chart_overridden_to_deposit_term.xml
+++ b/fineract-savings/src/main/resources/db/changelog/tenant/module/savings/parts/parts/2006_add_is_rate_chart_overridden_to_deposit_term.xml
@@ -20,13 +20,13 @@
 
 -->
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
-  <!-- Sequence is starting from 2000 to make it easier to move existing liquibase changesets here -->
-  <include file="parts/2001_add_savings_accrual_job.xml" relativeToChangelogFile="true" />
-  <include file="parts/2002_add_savings_accrual_permission.xml" relativeToChangelogFile="true" />
-  <include file="parts/2003_add_accrued_till_date_to_savings_account.xml" relativeToChangelogFile="true" />
-  <include file="parts/2004_add_savings_account_cob_infrastructure.xml" relativeToChangelogFile="true" />
-  <include file="parts/2005_add_external_id_to_savings_transaction.xml" relativeToChangelogFile="true" />
-  <include file="parts/2006_add_is_rate_chart_overridden_to_deposit_term.xml" relativeToChangelogFile="true" />
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+    <changeSet author="fineract" id="1">
+        <addColumn tableName="m_deposit_account_term_and_preclosure">
+            <column name="is_rate_chart_overridden" type="BOOLEAN" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
## Description
Resolves [FINERACT-848](https://issues.apache.org/jira/browse/FINERACT-848).

Adds the ability to override product-level interest rate charts with a custom nominal annual interest rate for Fixed Deposit (FD) and Recurring Deposit (RD) accounts:
- Added `isRateChartOverridden` boolean flag to deposit account terms and data models.
- Updated domain interest calculation and validation in `FixedDepositAccount` and `RecurringDepositAccount` so that when `isRateChartOverridden` is enabled, custom nominal annual interest rate takes precedence and bypasses product chart slab lookups.
- Added API request/response parameters, Swagger documentation annotations, and Liquibase database migration.
- Added comprehensive unit tests in `DepositAccountRateChartOverriddenTest`.

## Checklist
- [x] Write the commit message as per our guidelines
- [x] Acknowledge that we will not review PRs that are not passing the build ("green")
- [x] Create/update unit or integration tests for verifying the changes made
- [x] Follow our coding conventions
- [x] Add required Swagger annotation and update API documentation
- [x] This PR must not be a "code dump"
- [x] If merging this PR resolves a JIRA issue, I will mark that issue as resolved and set "Fix Version/s" appropriately