### PR TITLE
FINERACT-2812: Github Actions memory optimization

### DIFF
--- a/.github/actions/gradle-memory-budget/action.yml
+++ b/.github/actions/gradle-memory-budget/action.yml
@@ -1,0 +1,27 @@
+name: Gradle Memory Budget
+description: >-
+  Cap the Gradle build JVM heap and worker concurrency for the current job, so jobs that run
+  several JVMs at once stay inside the runner's RAM. Run it after gradle/actions/setup-gradle
+  where that is used; otherwise it writes to Gradle's default ~/.gradle.
+
+inputs:
+  max-heap:
+    description: Value for -Xmx in the Gradle build JVM (org.gradle.jvmargs).
+    default: '4g'
+  workers-max:
+    description: Maximum concurrent Gradle workers (org.gradle.workers.max).
+    default: '2'
+  working-directory:
+    description: Directory containing the gradle.properties to derive org.gradle.jvmargs from.
+    default: '.'
+
+runs:
+  using: composite
+  steps:
+    - name: Apply Gradle memory budget
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        MAX_HEAP: ${{ inputs.max-heap }}
+        WORKERS_MAX: ${{ inputs.workers-max }}
+      run: "$GITHUB_ACTION_PATH/../../scripts/gradle-memory-budget.sh"

--- a/.github/actions/setup-and-build-fineract/action.yml
+++ b/.github/actions/setup-and-build-fineract/action.yml
@@ -8,6 +8,16 @@ inputs:
   working-directory:
     description: Directory containing the Fineract checkout to build.
     default: '.'
+  max-heap:
+    description: >-
+      Heap for the Gradle build JVM during this build. Must stay at or above 8g: the OpenAPI
+      generator runs through the worker API with classloader isolation, i.e. inside this JVM,
+      and ':fineract-client:buildJavaSdk' alone needs 7g (measured: 6g fails with Java heap
+      space, 7g passes). This build is sequential, so nothing else competes for the runner.
+    default: '8g'
+  workers-max:
+    description: Maximum concurrent Gradle workers during this build.
+    default: '2'
 
 runs:
   using: composite
@@ -23,6 +33,14 @@ runs:
       with:
         validate-wrappers: true
         cache-read-only: ${{ inputs.cache-read-only }}
+
+    - name: Apply Gradle memory budget
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        MAX_HEAP: ${{ inputs.max-heap }}
+        WORKERS_MAX: ${{ inputs.workers-max }}
+      run: "$GITHUB_ACTION_PATH/../../scripts/gradle-memory-budget.sh"
 
     - name: Build Avro Java SDK
       shell: bash
@@ -58,3 +76,12 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: ./gradlew build -x test -x cucumber -x doc -x javadoc -x javadocJar -x checkstyleMain -x checkstyleTest -x checkstyleJmh -x spotbugsMain -x spotbugsTest -x spotlessCheck -x spotlessApply -x rat
+
+    # The seven builds above share one daemon, which is why they do not use --no-daemon.
+    # Stop it here so an idle build JVM is never left alive alongside whatever the calling
+    # job runs next (org.gradle.daemon.idletimeout is 3h, so it would not expire on its own).
+    - name: Stop Gradle daemon
+      shell: bash
+      if: always()
+      working-directory: ${{ inputs.working-directory }}
+      run: ./gradlew --stop || true

--- a/.github/scripts/gradle-memory-budget.sh
+++ b/.github/scripts/gradle-memory-budget.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Cap the Gradle build JVM heap and worker concurrency for the current CI job.
+#
+# The override is appended to GRADLE_USER_HOME/gradle.properties, which outranks the
+# project's own gradle.properties, so it applies to every Gradle invocation in the job
+# without editing tracked files. Appending is safe even if the key is already present:
+# java.util.Properties keeps the last occurrence.
+#
+# gradle/actions/setup-gradle exports GRADLE_USER_HOME; jobs that do not use it fall back to
+# Gradle's own default of ~/.gradle.
+#
+# CAUTION on MAX_HEAP: the OpenAPI generator (org.openapi.generator GenerateTask) runs through
+# the worker API with classloader isolation, i.e. inside the build JVM, and
+# ':fineract-client:buildJavaSdk' alone needs 7g (6g fails with Java heap space). Serializing
+# the generators does not help -- see openApiGeneratorLock in build.gradle, which already does
+# that. So a job may only go below 8g if it never executes a GenerateTask, which in practice
+# means either it passes '-x buildJavaSdk' or the generated sources arrive already built in the
+# workspace artifact.
+#
+# Usage: MAX_HEAP=4g WORKERS_MAX=2 gradle-memory-budget.sh
+#        (run from the directory containing the gradle.properties to derive args from)
+
+set -euo pipefail
+
+MAX_HEAP="${MAX_HEAP:-4g}"
+WORKERS_MAX="${WORKERS_MAX:-2}"
+
+GUH="${GRADLE_USER_HOME:-$HOME/.gradle}"
+
+if [ ! -f gradle.properties ]; then
+  echo "::error::gradle.properties not found in $(pwd)"
+  exit 1
+fi
+
+GRADLE_JVMARGS=$(sed -n 's/^org\.gradle\.jvmargs=//p' gradle.properties)
+if [ -z "$GRADLE_JVMARGS" ]; then
+  echo "::error::org.gradle.jvmargs is missing from gradle.properties"
+  exit 1
+fi
+
+case "$GRADLE_JVMARGS" in
+  *-Xmx*) ;;
+  *)
+    echo "::error::org.gradle.jvmargs has no -Xmx to override — the budget would be a no-op."
+    exit 1
+    ;;
+esac
+
+GRADLE_JVMARGS=$(printf '%s' "$GRADLE_JVMARGS" | sed -E "s/-Xmx[^ ]+/-Xmx${MAX_HEAP}/")
+
+mkdir -p "$GUH"
+{
+  echo "org.gradle.jvmargs=$GRADLE_JVMARGS"
+  echo "org.gradle.workers.max=$WORKERS_MAX"
+} >> "$GUH/gradle.properties"
+
+echo "Gradle build JVM capped at -Xmx${MAX_HEAP}, org.gradle.workers.max=${WORKERS_MAX}"
+echo "(written to $GUH/gradle.properties)."

--- a/.github/workflows/build-cucumber.yml
+++ b/.github/workflows/build-cucumber.yml
@@ -62,6 +62,12 @@ jobs:
         with:
           validate-wrappers: true
 
+      - name: Apply Gradle memory budget
+        uses: ./.github/actions/gradle-memory-budget
+        with:
+          max-heap: '4g'
+          workers-max: '2'
+
       - name: Run Cucumber
         run: ./gradlew --no-daemon cucumber -x :fineract-e2e-tests-runner:cucumber -x checkstyleJmh -x checkstyleMain -x checkstyleTest -x spotlessCheck -x spotlessApply -x spotbugsMain -x spotbugsTest -x javadoc -x javadocJar -x modernizer -x buildJavaSdk
 

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -70,6 +70,12 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
 
+      - name: Apply Gradle memory budget
+        uses: ./.github/actions/gradle-memory-budget
+        with:
+          max-heap: '4g'
+          workers-max: '2'
+
       - name: Build the image
         run: ./gradlew --no-daemon --console=plain :fineract-provider:jibDockerBuild -Djib.to.image=$IMAGE_NAME -x test -x cucumber -x buildJavaSdk
 

--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -45,6 +45,13 @@ jobs:
           cache-read-only: false
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+
+      - name: Apply Gradle memory budget
+        uses: ./.github/actions/gradle-memory-budget
+        with:
+          max-heap: '4g'
+          workers-max: '2'
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: 22

--- a/.github/workflows/build-e2e-tests.yml
+++ b/.github/workflows/build-e2e-tests.yml
@@ -80,6 +80,12 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
 
+      - name: Apply Gradle memory budget
+        uses: ./.github/actions/gradle-memory-budget
+        with:
+          max-heap: '4g'
+          workers-max: '2'
+
       - name: Make scripts executable
         run: chmod +x scripts/split-features.sh
 

--- a/.github/workflows/build-mariadb.yml
+++ b/.github/workflows/build-mariadb.yml
@@ -80,6 +80,12 @@ jobs:
         with:
           validate-wrappers: true
 
+      - name: Apply Gradle memory budget
+        uses: ./.github/actions/gradle-memory-budget
+        with:
+          max-heap: '4g'
+          workers-max: '2'
+
       - name: Build the image
         run: ./gradlew --no-daemon --console=plain :fineract-provider:jibDockerBuild -Djib.to.image=$IMAGE_NAME -x test -x cucumber -x buildJavaSdk
 

--- a/.github/workflows/build-mysql.yml
+++ b/.github/workflows/build-mysql.yml
@@ -80,6 +80,12 @@ jobs:
         with:
           validate-wrappers: true
 
+      - name: Apply Gradle memory budget
+        uses: ./.github/actions/gradle-memory-budget
+        with:
+          max-heap: '4g'
+          workers-max: '2'
+
       - name: Build the image
         run: ./gradlew --no-daemon --console=plain :fineract-provider:jibDockerBuild -Djib.to.image=$IMAGE_NAME -x test -x cucumber -x buildJavaSdk
 

--- a/.github/workflows/build-postgresql.yml
+++ b/.github/workflows/build-postgresql.yml
@@ -80,6 +80,12 @@ jobs:
         with:
           validate-wrappers: true
 
+      - name: Apply Gradle memory budget
+        uses: ./.github/actions/gradle-memory-budget
+        with:
+          max-heap: '4g'
+          workers-max: '2'
+
       - name: Build the image
         run: ./gradlew --no-daemon --console=plain :fineract-provider:jibDockerBuild -Djib.to.image=$IMAGE_NAME -x test -x cucumber -x buildJavaSdk
 

--- a/.github/workflows/build-progressive-loan.yml
+++ b/.github/workflows/build-progressive-loan.yml
@@ -62,6 +62,12 @@ jobs:
         with:
           validate-wrappers: true
 
+      - name: Apply Gradle memory budget
+        uses: ./.github/actions/gradle-memory-budget
+        with:
+          max-heap: '4g'
+          workers-max: '2'
+
       - name: Build and Test Progressive Loan
         run: |
           # Build the JAR

--- a/.github/workflows/build-quality-checks.yml
+++ b/.github/workflows/build-quality-checks.yml
@@ -62,8 +62,14 @@ jobs:
         with:
           validate-wrappers: true
 
+      - name: Apply Gradle memory budget
+        uses: ./.github/actions/gradle-memory-budget
+        with:
+          max-heap: '4g'
+          workers-max: '2'
+
       - name: Generate Javadocs
-        run: ./gradlew javadoc
+        run: ./gradlew javadoc -x buildJavaSdk
 
       - name: Archive Javadoc reports
         if: ${{ failure() || inputs.upload_artifacts }}
@@ -121,8 +127,14 @@ jobs:
         with:
           validate-wrappers: true
 
+      - name: Apply Gradle memory budget
+        uses: ./.github/actions/gradle-memory-budget
+        with:
+          max-heap: '4g'
+          workers-max: '2'
+
       - name: Run Checkstyle
-        run: ./gradlew checkstyleMain checkstyleTest checkstyleJmh
+        run: ./gradlew checkstyleMain checkstyleTest checkstyleJmh -x buildJavaSdk
 
       - name: Archive Checkstyle reports
         if: ${{ failure() || inputs.upload_artifacts }}
@@ -180,8 +192,14 @@ jobs:
         with:
           validate-wrappers: true
 
+      - name: Apply Gradle memory budget
+        uses: ./.github/actions/gradle-memory-budget
+        with:
+          max-heap: '4g'
+          workers-max: '2'
+
       - name: Run RAT
-        run: ./gradlew rat
+        run: ./gradlew rat -x buildJavaSdk
 
       - name: Archive RAT reports
         if: ${{ failure() || inputs.upload_artifacts }}
@@ -239,8 +257,14 @@ jobs:
         with:
           validate-wrappers: true
 
+      - name: Apply Gradle memory budget
+        uses: ./.github/actions/gradle-memory-budget
+        with:
+          max-heap: '4g'
+          workers-max: '2'
+
       - name: Run SpotBugs
-        run: ./gradlew spotbugsMain spotbugsTest
+        run: ./gradlew spotbugsMain spotbugsTest -x buildJavaSdk
 
       - name: Archive SpotBugs reports
         if: ${{ failure() || inputs.upload_artifacts }}
@@ -298,5 +322,11 @@ jobs:
         with:
           validate-wrappers: true
 
+      - name: Apply Gradle memory budget
+        uses: ./.github/actions/gradle-memory-budget
+        with:
+          max-heap: '4g'
+          workers-max: '2'
+
       - name: Run Spotless
-        run: ./gradlew spotlessCheck
+        run: ./gradlew spotlessCheck -x buildJavaSdk

--- a/.github/workflows/liquibase-only-postgresql.yml
+++ b/.github/workflows/liquibase-only-postgresql.yml
@@ -66,6 +66,12 @@ jobs:
         with:
           validate-wrappers: true
 
+      - name: Apply Gradle memory budget
+        uses: ./.github/actions/gradle-memory-budget
+        with:
+          max-heap: '4g'
+          workers-max: '2'
+
       - name: Verify PostgreSQL connection
         run: |
           while ! pg_isready -d postgres -U root -h 127.0.0.1 -p 5432 ; do

--- a/.github/workflows/publish-dockerhub.yml
+++ b/.github/workflows/publish-dockerhub.yml
@@ -62,6 +62,12 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
 
+      - name: Apply Gradle memory budget
+        uses: ./.github/actions/gradle-memory-budget
+        with:
+          max-heap: '4g'
+          workers-max: '2'
+
       - name: Get Git Hashes
         run: |
           echo "short_hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT

--- a/.github/workflows/regression-safety-db-changes.yml
+++ b/.github/workflows/regression-safety-db-changes.yml
@@ -166,12 +166,30 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
 
+      # This job holds two Gradle build JVMs plus a backend and a test JVM at the same time.
+      # The build JVMs only configure the project and launch forked processes, so 2g is
+      # ample; every gradlew call here also uses --no-daemon so idle build JVMs cannot
+      # accumulate across the three instances (org.gradle.daemon.idletimeout is 3h).
+      - name: Apply Gradle memory budget
+        uses: ./.github/actions/gradle-memory-budget
+        with:
+          max-heap: '2g'
+          workers-max: '2'
+
       - name: Wait for PostgreSQL
         run: |
           until pg_isready -h localhost -U $DB_USER; do
             echo "Waiting for postgres..."
             sleep 2
           done
+
+      - name: Compile baseline backend
+        working-directory: baseline
+        env:
+          # The baseline checkout predates the compiler-daemon heap cap in build.gradle,
+          # so bound its forked javac processes here.
+          JAVA_TOOL_OPTIONS: -Xmx2g
+        run: ./gradlew --no-daemon :fineract-provider:classes
 
       - name: Print checked out revisions
         run: |
@@ -194,8 +212,10 @@ jobs:
 
       - name: "Instance #1: Start baseline backend"
         working-directory: baseline
+        env:
+          JAVA_TOOL_OPTIONS: -Xmx3g
         run: |
-          ./gradlew :fineract-provider:devRun --args="${DEVRUN_ARGS}" &
+          ./gradlew --no-daemon :fineract-provider:devRun --args="${DEVRUN_ARGS}" &
           BACKEND_PID=$!
           echo $BACKEND_PID > backend.pid
 
@@ -225,11 +245,14 @@ jobs:
       - name: "Instance #1: Run regression safety E2E test"
         id: instance1
         continue-on-error: true
+        env:
+          JAVA_TOOL_OPTIONS: -Xmx2g
         run: |
           ./gradlew --no-daemon --console=plain \
             :fineract-e2e-tests-runner:cucumber \
             -Pcucumber.tags="@RegressionSafety" \
-            -x spotlessCheck
+            -x spotlessCheck \
+            -x buildJavaSdk
 
       - name: "Instance #1: Stop backend"
         if: always()
@@ -257,6 +280,8 @@ jobs:
             -c "CREATE DATABASE $DB_NAME;"
 
       - name: "Instance #2: Apply PR Liquibase migrations (schema only)"
+        env:
+          JAVA_TOOL_OPTIONS: -Xmx3g
         run: |
           echo "Applying all Liquibase changesets (base + PR) using PR code..."
           # The liquibase-only profile sets web-application-type=none, so Spring Boot
@@ -285,9 +310,11 @@ jobs:
 
       - name: "Instance #2: Start baseline backend (old code, new schema)"
         working-directory: baseline
+        env:
+          JAVA_TOOL_OPTIONS: -Xmx3g
         run: |
           echo "Starting baseline code against DB with PR schema (Liquibase disabled)..."
-          ./gradlew :fineract-provider:devRun --args="\
+          ./gradlew --no-daemon :fineract-provider:devRun --args="\
           ${DEVRUN_ARGS} \
           --spring.liquibase.enabled=false" &
           BACKEND_PID=$!
@@ -320,11 +347,14 @@ jobs:
       - name: "Instance #2: Run regression safety E2E test"
         id: instance2
         continue-on-error: true
+        env:
+          JAVA_TOOL_OPTIONS: -Xmx2g
         run: |
           ./gradlew --no-daemon --console=plain \
             :fineract-e2e-tests-runner:cucumber \
             -Pcucumber.tags="@RegressionSafety" \
-            -x spotlessCheck
+            -x spotlessCheck \
+            -x buildJavaSdk
 
       - name: "Instance #2: Stop backend"
         if: always()
@@ -351,8 +381,10 @@ jobs:
             -c "CREATE DATABASE $DB_NAME;"
 
       - name: "Instance #3: Start PR backend"
+        env:
+          JAVA_TOOL_OPTIONS: -Xmx3g
         run: |
-          ./gradlew :fineract-provider:devRun --args="${DEVRUN_ARGS}" &
+          ./gradlew --no-daemon :fineract-provider:devRun --args="${DEVRUN_ARGS}" &
           BACKEND_PID=$!
           echo $BACKEND_PID > backend.pid
 
@@ -382,11 +414,14 @@ jobs:
       - name: "Instance #3: Run regression safety E2E test"
         id: instance3
         continue-on-error: true
+        env:
+          JAVA_TOOL_OPTIONS: -Xmx2g
         run: |
           ./gradlew --no-daemon --console=plain \
             :fineract-e2e-tests-runner:cucumber \
             -Pcucumber.tags="@RegressionSafety" \
-            -x spotlessCheck
+            -x spotlessCheck \
+            -x buildJavaSdk
 
       - name: "Instance #3: Stop backend"
         if: always()

--- a/.github/workflows/run-integration-test-sequentially-postgresql.yml
+++ b/.github/workflows/run-integration-test-sequentially-postgresql.yml
@@ -82,6 +82,13 @@ jobs:
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
         with:
           validate-wrappers: true
+
+      - name: Apply Gradle memory budget
+        uses: ./.github/actions/gradle-memory-budget
+        with:
+          max-heap: '4g'
+          workers-max: '2'
+
       - name: Verify PostgreSQL connection
         run: |
           while ! pg_isready -d postgres -U root -h 127.0.0.1 -p 5432 ; do

--- a/.github/workflows/smoke-messaging.yml
+++ b/.github/workflows/smoke-messaging.yml
@@ -70,6 +70,12 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
 
+      - name: Apply Gradle memory budget
+        uses: ./.github/actions/gradle-memory-budget
+        with:
+          max-heap: '4g'
+          workers-max: '2'
+
       - name: Build the image
         run: ./gradlew --no-daemon --console=plain :fineract-provider:jibDockerBuild -Djib.to.image=$IMAGE_NAME -x test -x cucumber -x buildJavaSdk
 

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -72,6 +72,15 @@ jobs:
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
         with:
           validate-wrappers: true
+
+      # The sonar task resolves every subproject's compileClasspath inside one build JVM, so
+      # it needs more headroom than the other jobs. It runs alone, with nothing to share with.
+      - name: Apply Gradle memory budget
+        uses: ./.github/actions/gradle-memory-budget
+        with:
+          max-heap: '6g'
+          workers-max: '2'
+
       - name: Sonar
         # --no-parallel is required: the sonar task resolves every subproject's
         # compileClasspath, and Gradle 9 rejects that cross-project resolution

--- a/.github/workflows/verify-liquibase-backward-compatibility.yml
+++ b/.github/workflows/verify-liquibase-backward-compatibility.yml
@@ -84,11 +84,29 @@ jobs:
             sleep 2
           done
 
+      # This job runs a Gradle build JVM alongside a backend started by devRun. The build JVM
+      # only configures the project and forks that backend, so 2g is ample.
+      - name: Apply Gradle memory budget
+        uses: ./.github/actions/gradle-memory-budget
+        with:
+          max-heap: '2g'
+          workers-max: '2'
+
       - name: Init base schema
         working-directory: baseline
         run: |
           ./gradlew --no-daemon createPGDB -PdbName=fineract_tenants
           ./gradlew --no-daemon createPGDB -PdbName=$DB_NAME
+
+      # Compile the baseline up front. Otherwise devRun compiles it inside its own build
+      # session and Gradle keeps those forked compiler daemons alive for the whole time the
+      # backend runs. The baseline checkout also predates the compiler heap cap in
+      # build.gradle, so bound its javac processes here.
+      - name: Compile baseline backend
+        working-directory: baseline
+        env:
+          JAVA_TOOL_OPTIONS: -Xmx2g
+        run: ./gradlew --no-daemon :fineract-provider:classes
 
       - name: Print checked out revisions
         env:
@@ -113,6 +131,8 @@ jobs:
 
       - name: Start backend on base commit
         working-directory: baseline
+        env:
+          JAVA_TOOL_OPTIONS: -Xmx3g
         run: |
           ./gradlew --no-daemon :fineract-provider:devRun --args="\
           --spring.datasource.hikari.driverClassName=org.postgresql.Driver \
@@ -162,6 +182,8 @@ jobs:
           sleep 10
 
       - name: Start backend on merged PR commit
+        env:
+          JAVA_TOOL_OPTIONS: -Xmx3g
         run: |
           ./gradlew --no-daemon :fineract-provider:devRun --args="\
           --spring.datasource.hikari.driverClassName=org.postgresql.Driver \

--- a/build.gradle
+++ b/build.gradle
@@ -425,6 +425,10 @@ configure(project.fineractJavaProjects) {
     tasks.withType(JavaCompile).configureEach {
         options.incremental = true
         options.fork = true
+        // Forked compiler daemons get no explicit -Xmx, so each one defaults to 25% of the
+        // container's RAM. With parallel builds that tail is unbounded and can outgrow the
+        // build JVM itself, so give the compiler processes an explicit budget.
+        options.forkOptions.memoryMaximumSize = '2g'
         outputs.cacheIf { true }
         options.compilerArgs << '-parameters'
         options.encoding = 'UTF-8'
@@ -737,6 +741,12 @@ configure(project.fineractJavaProjects) {
     test {
         useJUnitPlatform()
 
+        // Forked test JVMs get no explicit -Xmx otherwise, so each one would default to 25%
+        // of the container's RAM -- 4g on a 16 GB CI runner, but 16g on a 64 GB workstation.
+        // Pin it so the figure is the same everywhere. ':fineract-provider' holds its own
+        // suite to 2g and adds a metaspace cap.
+        maxHeapSize = '4g'
+
         // Gradle 9 fails a Test task that has test sources but discovers no tests. Several modules
         // carry test *support* code only -- Spring @TestConfiguration classes, Cucumber step
         // definitions that the 'cucumber' task or ':fineract-e2e-tests-runner' consumes, a JMH
@@ -763,6 +773,8 @@ configure(project.fineractJavaProjects) {
         // reportLevel = com.github.spotbugs.snom.Confidence.DEFAULT
         showProgress = false
         excludeFilter = file("$rootDir/config/spotbugs/exclude.xml")
+        // Without this the SpotBugs worker inherits the JVM default (25% of container RAM).
+        maxHeapSize = '2g'
     }
     // https://github.com/spotbugs/spotbugs-gradle-plugin/issues/242
     spotbugsMain {

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,13 +16,14 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-org.gradle.jvmargs=-Xmx12g --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.management/javax.management=ALL-UNNAMED --add-opens=java.naming/javax.naming=ALL-UNNAMED --add-opens=java.rmi/sun.rmi.transport=null
+org.gradle.jvmargs=-Xmx8g --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.management/javax.management=ALL-UNNAMED --add-opens=java.naming/javax.naming=ALL-UNNAMED --add-opens=java.rmi/sun.rmi.transport=null
 buildType=BUILD
 org.gradle.caching=true
 org.gradle.parallel=true
-# Keep worker concurrency below CPU count to avoid heap spikes from parallel project tasks
-# and forked Java compilation running alongside Avro code generation.
-#org.gradle.workers.max=4
+# Worker concurrency is deliberately NOT pinned here: local machines should use all their
+# cores. Per-worker heap is bounded instead (see options.forkOptions.memoryMaximumSize and
+# spotbugs.maxHeapSize in build.gradle), and CI additionally caps org.gradle.workers.max via
+# .github/actions/gradle-memory-budget so the total fits a 16 GB runner.
 org.gradle.daemon.idletimeout=10800000
 # Temporarily disabled until we fix configuration cache compatibility
 #org.gradle.configuration-cache=true

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -64,7 +64,7 @@ cargo {
         containerProperties {
             def jvmArgs = '--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.management/javax.management=ALL-UNNAMED --add-opens=java.naming/javax.naming=ALL-UNNAMED '
             if (project.hasProperty('localDebug')) {
-                jvmArgs += ' -agentlib:jdwp=transport=dt_socket,server=y,address=*:9000,suspend=n -Xmx2G -Duser.timezone=Asia/Kolkata '
+                jvmArgs += ' -agentlib:jdwp=transport=dt_socket,server=y,address=*:9000,suspend=n -Duser.timezone=Asia/Kolkata '
             }
             if (project.hasProperty('dbType')) {
                 if ('postgresql'.equalsIgnoreCase(dbType)) {
@@ -78,6 +78,10 @@ cargo {
                 jvmArgs += '-Dspring.datasource.hikari.driverClassName=org.mariadb.jdbc.Driver -Dspring.datasource.hikari.jdbcUrl=jdbc:mariadb://localhost:3306/fineract_tenants -Dspring.datasource.hikari.username=root -Dspring.datasource.hikari.password=mysql -Dfineract.tenant.host=localhost -Dfineract.tenant.port=3306 -Dfineract.tenant.username=root -Dfineract.tenant.password=mysql'
             }
             jvmArgs += ' -Dspring.profiles.active=test -Dfineract.events.external.enabled=true'
+            // The cargo-launched Tomcat inherits no -Xmx of its own, so it would default to
+            // 25% of the container's RAM -- next to the Gradle build JVM and the forked test
+            // JVM that is enough to overrun a 16 GB CI runner.
+            jvmArgs += ' -Xmx2G'
             property 'cargo.start.jvmargs', jvmArgs
             property 'cargo.tomcat.connector.keystoreFile', file("$rootDir/fineract-provider/src/main/resources/keystore.jks")
             property 'cargo.tomcat.connector.keystorePass', 'openmf'

--- a/oauth2-tests/build.gradle
+++ b/oauth2-tests/build.gradle
@@ -74,6 +74,10 @@ cargo {
                 jvmArgs += '-Dspring.datasource.hikari.driverClassName=org.mariadb.jdbc.Driver -Dspring.datasource.hikari.jdbcUrl=jdbc:mariadb://localhost:3306/fineract_tenants -Dspring.datasource.hikari.username=root -Dspring.datasource.hikari.password=mysql -Dfineract.tenant.host=localhost -Dfineract.tenant.port=3306 -Dfineract.tenant.username=root -Dfineract.tenant.password=mysql'
             }
             jvmArgs += ' -Dspring.profiles.active=test -Dfineract.events.external.enabled=true'
+            // The cargo-launched Tomcat inherits no -Xmx of its own, so it would default to
+            // 25% of the container's RAM -- next to the Gradle build JVM and the forked test
+            // JVM that is enough to overrun a 16 GB CI runner.
+            jvmArgs += ' -Xmx2G'
             property 'cargo.start.jvmargs', jvmArgs
             property 'cargo.tomcat.connector.keystoreFile', file("$rootDir/fineract-provider/src/main/resources/keystore.jks")
             property 'cargo.tomcat.connector.keystorePass', 'openmf'

--- a/twofactor-tests/build.gradle
+++ b/twofactor-tests/build.gradle
@@ -71,6 +71,10 @@ cargo {
                 jvmArgs += '-Dspring.datasource.hikari.driverClassName=org.mariadb.jdbc.Driver -Dspring.datasource.hikari.jdbcUrl=jdbc:mariadb://localhost:3306/fineract_tenants -Dspring.datasource.hikari.username=root -Dspring.datasource.hikari.password=mysql -Dfineract.tenant.host=localhost -Dfineract.tenant.port=3306 -Dfineract.tenant.username=root -Dfineract.tenant.password=mysql'
             }
             jvmArgs += ' -Dspring.profiles.active=test -Dfineract.events.external.enabled=true'
+            // The cargo-launched Tomcat inherits no -Xmx of its own, so it would default to
+            // 25% of the container's RAM -- next to the Gradle build JVM and the forked test
+            // JVM that is enough to overrun a 16 GB CI runner.
+            jvmArgs += ' -Xmx2G'
             property 'cargo.start.jvmargs', jvmArgs
             property 'cargo.tomcat.connector.keystoreFile', file("$rootDir/fineract-provider/src/main/resources/keystore.jks")
             property 'cargo.tomcat.connector.keystorePass', 'openmf'


### PR DESCRIPTION
## 2. Fixes applied

### 2.1 Bounded the unbounded consumers (`build.gradle`)

Deterministic, and applies in CI *and* locally — replacing "25% of whatever machine this is"
with a fixed number.

| Cap | Location | Previous |
|---|---|---|
| `options.forkOptions.memoryMaximumSize = '2g'` | `build.gradle:431` | JVM default ≈ 4g **per** compiler daemon |
| `maxHeapSize = '4g'` on all `Test` tasks | `build.gradle:748` | JVM default ≈ 4g on CI, ≈ 16g on a 64 GB workstation |
| `maxHeapSize = '2g'` on SpotBugs | `build.gradle:777` | JVM default ≈ 4g |

`:fineract-provider` keeps its own explicit `maxHeapSize = '2g'` plus
`-XX:MaxMetaspaceSize=1g` — it is the largest suite and was already pinned there.

`org.gradle.workers.max` was deliberately left **out** of `gradle.properties`: pinning it
would cap developer machines. The comment now says so instead of naming a value it did not
set. CI applies the cap instead (§2.2).

### 2.2 A CI-side memory budget

- `.github/scripts/gradle-memory-budget.sh` — rewrites `-Xmx` in `org.gradle.jvmargs` and
  sets `org.gradle.workers.max`, appending both to `GRADLE_USER_HOME/gradle.properties`
  (which outranks the project file), falling back to Gradle's own `~/.gradle` for jobs that
  do not run `setup-gradle`. Hard-fails if `-Xmx` or the property is missing, rather than
  silently no-opping.
- `.github/actions/gradle-memory-budget/action.yml` — thin wrapper around the script.
- `setup-and-build-fineract` calls the script directly (via `$GITHUB_ACTION_PATH`) rather
  than nesting a local action, since composite-to-composite local `uses:` resolution is
  undocumented.

Applied at **4g / 2 workers** to every Gradle job, with two exceptions: **6g** for `sonar`
(the task resolves every subproject's `compileClasspath` in one build JVM and runs alone) and
**2g** for the three `devRun`-based jobs (their build JVMs only configure the project and fork
a process).

### 2.3 Cargo-launched Tomcat capped at 2g

`-Xmx2G` previously appeared only on the `localDebug` path in `integration-tests`, and not at
all in `oauth2-tests` / `twofactor-tests` — so in CI those servers inherited ≈ 4g. Now capped
in all three; the duplicate on the `localDebug` line was removed, leaving local debug
behaviour unchanged.

### 2.4 `regression-safety-db-changes.yml`

- `JAVA_TOOL_OPTIONS` moved off the job `env:` onto the seven steps that actually launch
  app/test JVMs — **3g** for the backend/migration JVMs, **2g** for the cucumber JVMs.
- New **`Compile baseline backend`** step. Otherwise the first `devRun` compiles baseline code
  inside its own build session, and Gradle holds those forked compiler daemons alive for the
  whole time the backend runs, next to the E2E JVMs. The baseline checkout also predates the
  compiler cap in `build.gradle`, so its `javac` processes are bounded via the step's own
  `JAVA_TOOL_OPTIONS`.
- `--no-daemon` **kept** — this is the one workflow where it is the actual fix.

The same treatment was applied to `verify-liquibase-backward-compatibility.yml`, which has the
identical two-`devRun` shape and had no budget at all.

### 2.5 `--no-daemon` rationalized

Reverted in `setup-and-build-fineract` (7 sequential builds now share one daemon again) and in
the 5 `build-quality-checks` jobs (one command each). The composite action now ends with
`./gradlew --stop` so it never leaves an idle build JVM alive for the calling job. Kept
everywhere it already existed on `develop`.

---

## 3. Resulting budget

| Component | Cap | Set in |
|---|---|---|
| Gradle build JVM — local | 8g | `gradle.properties` |
| Gradle build JVM — CI | 4g (6g sonar, 2g the three `devRun` jobs) | `gradle-memory-budget` |
| `org.gradle.workers.max` — CI | 2 | `gradle-memory-budget` |
| Forked `javac` | 2g each | `build.gradle` |
| SpotBugs worker | 2g | `build.gradle` |
| Forked test JVM | 4g (`:fineract-provider` 2g) | `build.gradle` |
| Cargo Tomcat | 2g | `integration-tests`, `oauth2-tests`, `twofactor-tests` |
| Dockerised backend | 1g | `config/docker/env/fineract-common.env` (pre-existing) |
| `devRun` / `bootRun` backend | 3g | per-step `JAVA_TOOL_OPTIONS` |
| E2E cucumber JVM | 2g | per-step `JAVA_TOOL_OPTIONS` |

### Peaks on a 16 GB runner

| Job | Arithmetic | Peak | Before |
|---|---|---|---|
| `run-integration-test-sequentially-postgresql` | 4g build + 2 × 4g test + 2g cargo | **14g** | 20g ceiling, uncapped |
| `regression-safety-db-changes` | 2g + 3g + 2g + 2g, ~2g overhead | **~11g** | ~14–15g |
| `build-postgresql` / `mysql` / `mariadb` | 4g build + 4g test + 1g Docker + containers | **~11g** | ~16g+ |
| `build-quality-checks` (incl. spotbugs) | 4g build + 2 × 2g worker | **8g** | up to 24g ceiling |
| `sonarqube` | 6g build, runs alone | **~8g** | ~16g+ |

`run-integration-test-sequentially` is the only job without comfortable headroom. It is also
the only job that runs a bare `./gradlew test` (so two `Test` tasks can fork concurrently at
`workers.max=2`) *and* the only one without `-PcargoDisabled`. It runs only on pushes to
`develop`/`release`, with a 180-minute timeout. If it is ever OOM-killed, the fix is
`workers-max: '1'` in that job's budget step → 10g; left at 2 rather than fully serializing
the longest suite in the pipeline.