### PR TITLE
FINERACT-2810: Add automatic retry for flaky tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,10 @@ Here's how to run the set of relatively fast and independent Fineract tests:
 This runs nearly 1,000 tests and completes in a few minutes on decent hardware.
 They shouldn't need any special servers/services running.
 
+On CI, individual test failures are automatically retried up to twice (see [Flaky tests](#flaky-tests) below).
+Retry is disabled locally by default; add `-PtestRetry=true` to opt in, or `-PtestRetry=false` to force it off (e.g. on a self-hosted CI-like environment).
+You can also exclude specific tests with `-PexcludeTests=<pattern>` (matched against the fully-qualified test name).
+
 #### Cucumber E2E tests
 
 The Cucumber E2E tests run against a live Fineract instance instead of starting one for you.
@@ -301,7 +305,18 @@ Our `ClasspathHellDuplicatesCheckRuleTest` detects classes that appear in more t
 Your PR title must include a JIRA issue and a one-liner that describes the changes.
 Start your one-liner after the JIRA issue id. Use an upper case present-tense imperative verb and a short but concise clear description. (E.g. "FINERACT-821: Add enforced HideUtilityClassConstructor checkstyle").
 
-If your PR is failing to pass our CI build due to a test failure, then:
+#### Flaky tests
+
+Our CI automatically retries an individual test up to twice if it fails, via the [Gradle Test Retry plugin](https://github.com/gradle/test-retry-gradle-plugin) (`build.gradle`, `retry { ... }` in the shared `test { }` block). If a test passes on retry, the build stays green - this is meant to absorb one-off environmental flakiness (timing, network, CI resource contention), not to replace fixing the underlying instability. Retry does not apply to the `cucumber` task (Cucumber E2E tests aren't `Test`-typed tasks).
+
+If 20 or more tests fail within the same round of execution, no retries are attempted for that round - that many simultaneous failures indicates a real regression, not flakiness, so it's treated as a hard failure straight away.
+
+To see whether (and which) tests were retried in a given CI run:
+
+- Open the run's **Develocity build scan** (linked from the GitHub Actions job output, or via `https://develocity.apache.org`) - its Tests tab explicitly tags retried/flaky tests.
+- Or download the job's `test-results-*` artifact and open `build/reports/tests/test/index.html` for the affected module - the retry plugin's report shows every attempt.
+
+If your PR is still failing to pass our CI build due to a test failure after the automatic retries, then:
 
 1. Understand if the failure is due to your PR or an unrelated unstable test.
 1. If you suspect it is because of a "flaky" test, and not due to a change in your PR, then please do not simply wait for an active maintainer to come and help you, but instead be a proactive contributor to the project - see next steps.  Do understand that we may not review PRs that are not green - it is the contributor's (that's you!) responsibility to get a proposed PR to pass the build, not primarily the maintainers.

--- a/build.gradle
+++ b/build.gradle
@@ -133,6 +133,7 @@ plugins {
     id 'org.cyclonedx.bom' version '3.4.1' apply false
     id 'com.docktape.swagger-brake' version '2.7.0' apply false
     id 'io.github.usekylis.java-architecture-metrics' version '0.1.1' apply false
+    id 'org.gradle.test-retry' version '1.6.5' apply false
 }
 
 apply from: "${rootDir}/buildSrc/src/main/groovy/org.apache.fineract.release.gradle"
@@ -448,6 +449,7 @@ configure(project.fineractJavaProjects) {
     apply plugin: 'com.github.spotbugs'
     apply plugin: 'com.github.andygoossens.modernizer'
     apply plugin: 'io.github.usekylis.java-architecture-metrics'
+    apply plugin: 'org.gradle.test-retry'
     apply from: "${rootDir}/buildSrc/src/main/groovy/org.apache.fineract.dependencies.gradle"
 
     group = 'org.apache.fineract'
@@ -742,6 +744,17 @@ configure(project.fineractJavaProjects) {
         // definitions that the 'cucumber' task or ':fineract-e2e-tests-runner' consumes, a JMH
         // benchmark -- so their own test task legitimately has nothing to run.
         failOnNoDiscoveredTests = false
+
+        // Retry flaky tests. Enabled only on CI (env var CI) to avoid masking flakiness
+        // during local development. Override locally with -PtestRetry=true / -PtestRetry=false.
+        def retryEnabled = project.hasProperty('testRetry')
+                ? Boolean.parseBoolean(project.property('testRetry').toString())
+                : (System.getenv('CI') != null)
+        retry {
+            failOnPassedAfterRetry = false // keep the build green if a test passes on retry
+            maxRetries = retryEnabled ? 2 : 0
+            maxFailures = 20 // safety cap: too many failures => real breakage, stop retrying
+        }
 
         if (project.hasProperty('excludeTests')) {
             filter {

--- a/fineract-doc/src/docs/en/chapters/development/gradle.adoc
+++ b/fineract-doc/src/docs/en/chapters/development/gradle.adoc
@@ -1,3 +1,25 @@
 = Gradle
 
 The https://docs.gradle.org/current/userguide/gradle_wrapper.html[Gradle Wrapper] included with Fineract will automatically run the correct version of Gradle.
+
+== Build properties
+
+A few `-P` properties (Gradle project properties) control test execution across all modules; they are configured in the shared `test { }` block in the root `build.gradle`:
+
+[cols="1,3", options="header"]
+|===
+| Property | Effect
+| `-PtestRetry=true` / `-PtestRetry=false` | Force-enable or force-disable automatic retry of failed tests. Retry is enabled by default on CI (detected via the `CI` environment variable) and disabled by default locally.
+| `-PexcludeTests=<pattern>` | Exclude tests matching the given pattern (matched against the fully-qualified test name) from the run.
+|===
+
+== Flaky test retry
+
+Failed tests are automatically retried up to twice via the https://github.com/gradle/test-retry-gradle-plugin[Gradle Test Retry plugin]. If a retry passes, the build is still considered successful (`failOnPassedAfterRetry = false`). This does not apply to the `cucumber` task, which isn't a `Test`-typed task.
+
+As a safety cap, if 20 or more tests fail within the same round of execution, no retries are attempted for that round: that many simultaneous failures is treated as a real regression rather than flakiness, so retrying would just waste CI time.
+
+=== Viewing retried tests
+
+- The **Develocity build scan** for a build (published to `https://develocity.apache.org` on CI, or generated locally with `--scan`) tags retried/flaky tests on its Tests tab.
+- The standard HTML test report, `<module>/build/reports/tests/test/index.html`, lists every attempt of a retried test.


### PR DESCRIPTION
## Description

We've been seeing intermittent test failures in CI that aren't caused by actual code defects, but by external or non-deterministic factors such as timing, network issues, resource contention, or test ordering. These "flaky" failures currently block PRs and require manual re-runs, wasting CI time and reviewer attention.

This PR introduces the official Gradle Test Retry Plugin, which automatically re-runs failed tests up to two times within the same Gradle test task before the build fails.

### What's configured

The configuration is added to the shared `test { }` block in `build.gradle`:

* **CI-only by default** — Retry is enabled only when the CI environment variable is set, which GitHub Actions provides automatically. It remains disabled locally by default, so flaky tests aren't silently masked during development. This can be overridden with `-PtestRetry=true` or `-PtestRetry=false`.
* **`maxRetries = 2`** — Each failed test gets up to two additional attempts.
* **`failOnPassedAfterRetry = false`** — If a test passes on any retry, the build succeeds.
* **`maxFailures = 20`** — A safety cap prevents retries when 20 or more tests fail in the same round. A large number of simultaneous failures is much more likely to indicate a real regression than isolated flakiness.
* **Scope** — Applies to all standard `Test`-typed tasks, including unit tests across all Java modules, as well as `integration-tests`, `oauth2-tests`, and `twofactor-tests`. It does not apply to the separate Cucumber tasks (`fineract-provider` and `fineract-e2e-tests-runner`), since those tasks are not `Test`-typed.

### Visibility

Retried tests remain fully visible and traceable. They can be identified through:

* **Develocity Build Scan** — retried tests are explicitly tagged in the Tests tab.
* **Standard HTML test reports** — available under `build/reports/tests/test/index.html`.

Therefore, this mechanism does not hide test instability. It only prevents transient failures from unnecessarily blocking CI.

The behavior and configuration are also documented in `CONTRIBUTING.md` and `fineract-doc/.../development/gradle.adoc`.

### Why this is safe

The retry mechanism operates entirely within a single Gradle test task, in the same CI job and on the same runner, using the same permissions and token as the rest of the build. This is fundamentally different from re-running an entire GitHub Actions job.

* **No additional executor, runner, or job is created.**
* **No new `GITHUB_TOKEN` or permission set is involved.** The build's permission scope remains unchanged.
* **The added dependency is the official Gradle Test Retry Plugin** (`org.gradle.test-retry`), licensed under Apache 2.0 and used as a standard build-time plugin dependency.
* **Retries do not replace fixing flaky tests.** Failed tests remain visible through Develocity and HTML reports, allowing chronically flaky tests to be identified and addressed.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).
- [ ] If merging this PR resolves a JIRA issue, I will mark that issue as resolved and set "Fix Version/s" appropriately.

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
