### PR TITLE
FINERACT-2455: WC - allow business step update by resolving the step family per COB job

### DIFF
--- a/fineract-cob/src/main/java/org/apache/fineract/cob/service/BusinessStepCategory.java
+++ b/fineract-cob/src/main/java/org/apache/fineract/cob/service/BusinessStepCategory.java
@@ -23,7 +23,8 @@ import java.util.Optional;
 
 public enum BusinessStepCategory {
 
-    LOAN("LOAN"); //
+    LOAN("LOAN"), //
+    WORKING_CAPITAL_LOAN("WORKING_CAPITAL_LOAN"); //
 
     private final String name;
 

--- a/fineract-cob/src/main/java/org/apache/fineract/cob/service/ConfigJobParameterServiceImpl.java
+++ b/fineract-cob/src/main/java/org/apache/fineract/cob/service/ConfigJobParameterServiceImpl.java
@@ -18,9 +18,9 @@
  */
 package org.apache.fineract.cob.service;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.apache.fineract.cob.COBBusinessStep;
 import org.apache.fineract.cob.data.BusinessStep;
@@ -34,25 +34,18 @@ import org.apache.fineract.cob.exceptions.BusinessStepNotBelongsToJobException;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResultBuilder;
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class ConfigJobParameterServiceImpl implements ConfigJobParameterService, InitializingBean {
+public class ConfigJobParameterServiceImpl implements ConfigJobParameterService {
 
     private final BatchBusinessStepRepository batchBusinessStepRepository;
     private final BusinessStepConfigDataParser dataParser;
-    private final BusinessStepCategoryService businessStepCategoryService;
+    private final List<BusinessStepCategoryService> businessStepCategoryServices;
     private final ApplicationContext applicationContext;
     private final BusinessStepMapper mapper;
-    private JobBusinessStepDetail availableBusinessStepsForLoan;
-
-    @Override
-    public void afterPropertiesSet() throws Exception {
-        availableBusinessStepsForLoan = getAvailableBusinessStepsByJobName(BusinessStepCategory.LOAN.name());
-    }
 
     @Override
     public JobBusinessStepConfigData getBusinessStepConfigByJobName(String jobName) {
@@ -64,56 +57,71 @@ public class ConfigJobParameterServiceImpl implements ConfigJobParameterService,
     }
 
     @Override
-    public CommandProcessingResult updateStepConfigByJobName(JsonCommand command, String jobName)
+    public CommandProcessingResult updateStepConfigByJobName(final JsonCommand command, final String jobName)
             throws BusinessStepNotBelongsToJobException {
-        List<BusinessStep> businessSteps = dataParser.parseUpdate(command);
+        final List<BusinessStep> businessSteps = dataParser.parseUpdate(command);
         if (businessSteps.isEmpty()) {
             throw new BusinessStepException("A job needs to have 1 business step at least.");
         }
-        List<String> availableBusinessStepNames = availableBusinessStepsForLoan.getAvailableBusinessSteps().stream()
+        final BusinessStepCategoryService categoryService = findByCobJobName(jobName)
+                .orElseThrow(() -> new BusinessStepException(jobName + " is not a configurable business step job."));
+        final List<String> availableBusinessStepNames = availableBusinessSteps(categoryService).stream()
                 .map(BusinessStepDetail::getStepName).toList();
-        List<String> notValidBusinessStepNames = businessSteps.stream().map(BusinessStep::getStepName)
+        final List<String> notValidBusinessStepNames = businessSteps.stream().map(BusinessStep::getStepName)
                 .filter(businessStepName -> !availableBusinessStepNames.contains(businessStepName)).toList();
-        if (notValidBusinessStepNames.isEmpty()) {
-            batchBusinessStepRepository.deleteAllByJobName(jobName);
-            businessSteps.forEach(newBusinessStepConfig -> {
-                BatchBusinessStep batchBusinessStep = new BatchBusinessStep();
-                batchBusinessStep.setJobName(jobName);
-                batchBusinessStep.setStepName(newBusinessStepConfig.getStepName());
-                batchBusinessStep.setStepOrder(newBusinessStepConfig.getOrder());
-                batchBusinessStepRepository.save(batchBusinessStep);
-            });
-        } else {
+        if (!notValidBusinessStepNames.isEmpty()) {
             throw new BusinessStepException(notValidBusinessStepNames + " Business steps are not configurable for this job.");
         }
+        batchBusinessStepRepository.deleteAllByJobName(jobName);
+        businessSteps.forEach(newBusinessStepConfig -> {
+            final BatchBusinessStep batchBusinessStep = new BatchBusinessStep();
+            batchBusinessStep.setJobName(jobName);
+            batchBusinessStep.setStepName(newBusinessStepConfig.getStepName());
+            batchBusinessStep.setStepOrder(newBusinessStepConfig.getOrder());
+            batchBusinessStepRepository.save(batchBusinessStep);
+        });
         return new CommandProcessingResultBuilder() //
                 .withCommandId(command.commandId()) //
                 .build();
     }
 
     @Override
-    public JobBusinessStepDetail getAvailableBusinessStepsByJobName(String jobName) {
-        Class<? extends COBBusinessStep> businessStepClass = businessStepCategoryService.getBusinessStepByCategory(jobName);
-        if (businessStepClass == null) {
-            return null;
-        }
-        List<String> businessStepBeanNames = Arrays.stream(applicationContext.getBeanNamesForType(businessStepClass)).toList();
-        JobBusinessStepDetail jobBusinessStepDetail = new JobBusinessStepDetail();
-        List<BusinessStepDetail> availableBusinessSteps = new ArrayList<>();
-        for (String businessStepBean : businessStepBeanNames) {
-            COBBusinessStep businessStep = (COBBusinessStep) applicationContext.getBean(businessStepBean);
-            BusinessStepDetail businessStepDetail = new BusinessStepDetail();
-            businessStepDetail.setStepName(businessStep.getEnumStyledName());
-            businessStepDetail.setStepDescription(businessStep.getHumanReadableName());
-            availableBusinessSteps.add(businessStepDetail);
-        }
-        jobBusinessStepDetail.setJobName(jobName);
-        jobBusinessStepDetail.setAvailableBusinessSteps(availableBusinessSteps);
-        return jobBusinessStepDetail;
+    public JobBusinessStepDetail getAvailableBusinessStepsByJobName(final String jobName) {
+        return findByCategoryOrCobJobName(jobName).map(categoryService -> {
+            final JobBusinessStepDetail jobBusinessStepDetail = new JobBusinessStepDetail();
+            jobBusinessStepDetail.setJobName(jobName);
+            jobBusinessStepDetail.setAvailableBusinessSteps(availableBusinessSteps(categoryService));
+            return jobBusinessStepDetail;
+        }).orElse(null);
     }
 
     @Override
     public List<String> getAllConfiguredJobNames() {
         return batchBusinessStepRepository.findConfiguredJobNames();
+    }
+
+    private Optional<BusinessStepCategoryService> findByCobJobName(final String jobName) {
+        return businessStepCategoryServices.stream() //
+                .filter(categoryService -> categoryService.getCobJobName().equals(jobName)) //
+                .findFirst();
+    }
+
+    private Optional<BusinessStepCategoryService> findByCategoryOrCobJobName(final String name) {
+        return businessStepCategoryServices.stream() //
+                .filter(categoryService -> categoryService.getCategory().name().equalsIgnoreCase(name)
+                        || categoryService.getCobJobName().equals(name)) //
+                .findFirst();
+    }
+
+    private List<BusinessStepDetail> availableBusinessSteps(final BusinessStepCategoryService categoryService) {
+        return Arrays.stream(applicationContext.getBeanNamesForType(categoryService.getBusinessStepClass())) //
+                .map(beanName -> (COBBusinessStep<?>) applicationContext.getBean(beanName)) //
+                .map(businessStep -> {
+                    final BusinessStepDetail businessStepDetail = new BusinessStepDetail();
+                    businessStepDetail.setStepName(businessStep.getEnumStyledName());
+                    businessStepDetail.setStepDescription(businessStep.getHumanReadableName());
+                    return businessStepDetail;
+                }) //
+                .toList();
     }
 }

--- a/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/common/BusinessStepConfigurationStepDef.java
+++ b/fineract-e2e-tests-core/src/test/java/org/apache/fineract/test/stepdef/common/BusinessStepConfigurationStepDef.java
@@ -21,11 +21,14 @@ package org.apache.fineract.test.stepdef.common;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.cucumber.datatable.DataTable;
+import io.cucumber.java.After;
+import io.cucumber.java.Before;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.client.feign.util.CallFailedRuntimeException;
 import org.apache.fineract.client.models.BusinessStep;
@@ -35,13 +38,27 @@ import org.apache.fineract.client.models.JobBusinessStepConfigData;
 import org.apache.fineract.client.models.JobBusinessStepDetail;
 import org.apache.fineract.test.helper.WorkFlowJobHelper;
 import org.apache.fineract.test.stepdef.AbstractStepDef;
-import org.springframework.beans.factory.annotation.Autowired;
 
 @Slf4j
+@RequiredArgsConstructor
 public class BusinessStepConfigurationStepDef extends AbstractStepDef {
 
-    @Autowired
-    private WorkFlowJobHelper workFlowJobHelper;
+    private static final String WORKFLOW_NAME_WORKING_CAPITAL_LOAN_CLOSE_OF_BUSINESS = "WORKING_CAPITAL_LOAN_CLOSE_OF_BUSINESS";
+
+    private final WorkFlowJobHelper workFlowJobHelper;
+
+    private List<BusinessStep> savedWorkingCapitalBusinessSteps;
+
+    @Before("@WCBusinessStepConfig")
+    public void saveWorkingCapitalBusinessSteps() {
+        savedWorkingCapitalBusinessSteps = workFlowJobHelper
+                .getConfiguredWorkflowSteps(WORKFLOW_NAME_WORKING_CAPITAL_LOAN_CLOSE_OF_BUSINESS).getBusinessSteps();
+    }
+
+    @After("@WCBusinessStepConfig")
+    public void restoreWorkingCapitalBusinessSteps() {
+        workFlowJobHelper.updateWorkflowSteps(WORKFLOW_NAME_WORKING_CAPITAL_LOAN_CLOSE_OF_BUSINESS, savedWorkingCapitalBusinessSteps);
+    }
 
     @Then("Admin checks that configured business jobs contain {string}")
     public void checkConfiguredBusinessJobsContain(String jobName) {

--- a/fineract-e2e-tests-runner/src/test/resources/features/WorkingCapital_COB.feature
+++ b/fineract-e2e-tests-runner/src/test/resources/features/WorkingCapital_COB.feature
@@ -22,6 +22,70 @@ Feature: Working Capital COB Job
     Then Admin verifies scheduler job "WC_COB" has display name "Working Capital Loan COB"
     Then Admin verifies scheduler job "WC_COB" has active status "false"
 
+  Scenario: Available business steps are exposed for the Working Capital COB job name
+    Then Admin verifies available business steps for "WORKING_CAPITAL_LOAN_CLOSE_OF_BUSINESS" contain:
+      | stepName                           |
+      | DUMMY_BUSINESS_STEP                |
+      | WC_MISSED_PAYMENT_ACKNOWLEDGEMENT  |
+      | WC_DELINQUENCY_RANGE_SCHEDULE      |
+      | WC_LOAN_DELINQUENCY_CLASSIFICATION |
+      | WC_BREACH_SCHEDULE                 |
+      | WC_NEAR_BREACH_EVALUATION          |
+      | WC_DISCOUNT_FEE_AMORTIZATION       |
+      | WC_CHARGE_ACCRUAL                  |
+
+  @WCBusinessStepConfig
+  Scenario: Working Capital COB job rejects a business step from the Loan COB family
+    Then Admin fails to update business steps for "WORKING_CAPITAL_LOAN_CLOSE_OF_BUSINESS" with invalid step "APPLY_CHARGE_TO_OVERDUE_LOANS"
+
+  Scenario: Loan COB job rejects a business step from the Working Capital family
+    Then Admin fails to update business steps for "LOAN_CLOSE_OF_BUSINESS" with invalid step "WC_CHARGE_ACCRUAL"
+
+  Scenario: Business step update is rejected for an unknown job name
+    Then Admin fails to update business steps for "NOT_A_COB_JOB" with invalid step "APPLY_CHARGE_TO_OVERDUE_LOANS"
+
+  @WCBusinessStepConfig
+  Scenario: Working Capital COB business step order is updated
+    When Admin updates business steps for "WORKING_CAPITAL_LOAN_CLOSE_OF_BUSINESS" with:
+      | stepName                           | order |
+      | DUMMY_BUSINESS_STEP                | 1     |
+      | WC_CHARGE_ACCRUAL                  | 2     |
+      | WC_MISSED_PAYMENT_ACKNOWLEDGEMENT  | 3     |
+      | WC_DELINQUENCY_RANGE_SCHEDULE      | 4     |
+      | WC_LOAN_DELINQUENCY_CLASSIFICATION | 5     |
+      | WC_BREACH_SCHEDULE                 | 6     |
+      | WC_NEAR_BREACH_EVALUATION          | 7     |
+      | WC_DISCOUNT_FEE_AMORTIZATION       | 8     |
+    Then Admin verifies configured business steps for "WORKING_CAPITAL_LOAN_CLOSE_OF_BUSINESS" match:
+      | stepName                           | order |
+      | DUMMY_BUSINESS_STEP                | 1     |
+      | WC_CHARGE_ACCRUAL                  | 2     |
+      | WC_MISSED_PAYMENT_ACKNOWLEDGEMENT  | 3     |
+      | WC_DELINQUENCY_RANGE_SCHEDULE      | 4     |
+      | WC_LOAN_DELINQUENCY_CLASSIFICATION | 5     |
+      | WC_BREACH_SCHEDULE                 | 6     |
+      | WC_NEAR_BREACH_EVALUATION          | 7     |
+      | WC_DISCOUNT_FEE_AMORTIZATION       | 8     |
+
+  @WCBusinessStepConfig
+  Scenario: Working Capital COB runs with a reordered business step configuration
+    When Admin updates business steps for "WORKING_CAPITAL_LOAN_CLOSE_OF_BUSINESS" with:
+      | stepName                           | order |
+      | WC_MISSED_PAYMENT_ACKNOWLEDGEMENT  | 1     |
+      | WC_DELINQUENCY_RANGE_SCHEDULE      | 2     |
+      | WC_LOAN_DELINQUENCY_CLASSIFICATION | 3     |
+      | WC_BREACH_SCHEDULE                 | 4     |
+      | WC_NEAR_BREACH_EVALUATION          | 5     |
+      | WC_DISCOUNT_FEE_AMORTIZATION       | 6     |
+      | WC_CHARGE_ACCRUAL                  | 7     |
+      | DUMMY_BUSINESS_STEP                | 8     |
+    When Admin sets the business date to "01 January 2024"
+    When Admin creates a client with random data
+    When Admin creates a new Working Capital Loan Product
+    Given Admin inserts an active WC loan into the database
+    When Admin runs WC COB job
+    Then Admin verifies all inserted WC loans have lastClosedBusinessDate "31 December 2023"
+
   @TestRailId:C4696
   Scenario: WC COB and Loan COB coexistence — both jobs listed and execute without interference
     Then Admin checks that configured business jobs contain "LOAN_CLOSE_OF_BUSINESS"

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/service/LoanBusinessStepCategoryServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/service/LoanBusinessStepCategoryServiceImpl.java
@@ -18,22 +18,26 @@
  */
 package org.apache.fineract.cob.service;
 
-import java.util.Locale;
-import java.util.Map;
 import org.apache.fineract.cob.COBBusinessStep;
 import org.apache.fineract.cob.loan.LoanCOBBusinessStep;
+import org.apache.fineract.cob.loan.LoanCOBConstant;
 import org.springframework.stereotype.Service;
 
 @Service
 public class LoanBusinessStepCategoryServiceImpl implements BusinessStepCategoryService {
 
-    private static final Map<BusinessStepCategory, Class<? extends COBBusinessStep>> businessSteps = Map.of(BusinessStepCategory.LOAN,
-            LoanCOBBusinessStep.class);
+    @Override
+    public BusinessStepCategory getCategory() {
+        return BusinessStepCategory.LOAN;
+    }
 
     @Override
-    public Class<? extends COBBusinessStep> getBusinessStepByCategory(String category) {
-        Map.Entry<BusinessStepCategory, Class<? extends COBBusinessStep>> businessStepCategoryClassEntry = businessSteps.entrySet().stream()
-                .filter(businessStep -> businessStep.getKey().name().equals(category.toUpperCase(Locale.ROOT))).findFirst().orElse(null);
-        return businessStepCategoryClassEntry != null ? businessStepCategoryClassEntry.getValue() : null;
+    public String getCobJobName() {
+        return LoanCOBConstant.LOAN_COB_JOB_NAME;
+    }
+
+    @Override
+    public Class<? extends COBBusinessStep<?>> getBusinessStepClass() {
+        return LoanCOBBusinessStep.class;
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/cob/service/WorkingCapitalLoanBusinessStepCategoryServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/cob/service/WorkingCapitalLoanBusinessStepCategoryServiceImpl.java
@@ -19,12 +19,25 @@
 package org.apache.fineract.cob.service;
 
 import org.apache.fineract.cob.COBBusinessStep;
+import org.apache.fineract.cob.workingcapitalloan.WorkingCapitalLoanCOBConstant;
+import org.apache.fineract.cob.workingcapitalloan.businessstep.WorkingCapitalLoanCOBBusinessStep;
+import org.springframework.stereotype.Service;
 
-public interface BusinessStepCategoryService {
+@Service
+public class WorkingCapitalLoanBusinessStepCategoryServiceImpl implements BusinessStepCategoryService {
 
-    BusinessStepCategory getCategory();
+    @Override
+    public BusinessStepCategory getCategory() {
+        return BusinessStepCategory.WORKING_CAPITAL_LOAN;
+    }
 
-    String getCobJobName();
+    @Override
+    public String getCobJobName() {
+        return WorkingCapitalLoanCOBConstant.WORKING_CAPITAL_LOAN_COB_JOB_NAME;
+    }
 
-    Class<? extends COBBusinessStep<?>> getBusinessStepClass();
+    @Override
+    public Class<? extends COBBusinessStep<?>> getBusinessStepClass() {
+        return WorkingCapitalLoanCOBBusinessStep.class;
+    }
 }


### PR DESCRIPTION
## Description

Working Capital COB business steps could not be configured.

ConfigJobParameterServiceImpl checked every update against one list of available steps, built once at startup for the Loan family (afterPropertiesSet() cached the result for LOAN). The job name from the request was not used to pick the step family, so any payload containing a Working Capital step was rejected with "... Business steps are not configurable for this job.", including every PUT to /jobs/WORKING_CAPITAL_LOAN_CLOSE_OF_BUSINESS/steps.

The fix resolves the step family per job. BusinessStepCategoryService now describes one family: its category, its COB job name and its business step base type. ConfigJobParameterServiceImpl injects all implementations and looks up the one whose job name matches the request. WorkingCapitalLoanBusinessStepCategoryServiceImpl registers the Working Capital family, LoanBusinessStepCategoryServiceImpl keeps the Loan one.

The same change closes two related defects.

Loan steps could be saved onto the Working Capital job, because they passed the check against the cached Loan list. The result was a configuration that never ran. The execution map is built by intersecting the configured step names with the beans of the job's own family, so it came out empty, the batch job stopped in the partitioner, and inline COB failed with "Execution map is empty!".

A request that carried valid Loan step names was accepted under any job name and wrote rows into m_batch_business_steps that no job would ever read. Unknown job names now return 400.

Removing the startup cache also removes an applicationContext.getBean() call during context refresh and a mutable field shared between requests. Available steps are resolved per request instead.

API behaviour

GET /jobs/{jobName}/available-steps now also accepts a COB job name such as WORKING_CAPITAL_LOAN_CLOSE_OF_BUSINESS. The old category name (loan, any case) still works, and the response still echoes back the value that was passed in.

PUT /jobs/{jobName}/steps returns 400 for a name that is not a configurable COB job. A category name like loan used to be accepted here together with valid Loan steps, and wrote rows under that name which no job ever executed.

Testing

Six scenarios were added to WorkingCapital_COB.feature: available steps for the WC job name, the WC job rejecting a Loan step, the Loan job rejecting a WC step, an unknown job name being rejected, a reorder of all eight WC steps read back through the API, and a WC COB run on a reordered configuration. Scenarios that touch the configuration save it before and restore it after, so a failure cannot leak into the rest of the suite.

BusinessConfigurationApiTest needed no changes. shouldReturnApplyChargeToOverdueLoanStepConfigByJobCategory still sends the category name loan and still gets it back as the response jobName.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [ ] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).
- [ ] If merging this PR resolves a JIRA issue, I will mark that issue as resolved and set "Fix Version/s" appropriately.
- [ ] I followed the [AI Policy](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#ai-policy).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
