### PR TITLE
FINERACT-2767: Tax Component – Fields should be locked once linked to transactions

### DIFF
--- a/fineract-charge/src/main/java/org/apache/fineract/portfolio/charge/domain/ChargeRepository.java
+++ b/fineract-charge/src/main/java/org/apache/fineract/portfolio/charge/domain/ChargeRepository.java
@@ -28,4 +28,16 @@ public interface ChargeRepository extends JpaRepository<Charge, Long>, JpaSpecif
 
     @Query("select lc.id from WorkingCapitalLoanCharge lc where lc.charge.id = :chargeId and lc.active = true")
     Optional<Long> isAnyWorkingCapitalLoansAssociateWithThisCharge(@Param("chargeId") Long chargeId);
+
+    @Query(value = """
+            SELECT EXISTS (
+                SELECT 1
+                FROM m_charge c
+                INNER JOIN m_tax_group_mappings tgm
+                    ON tgm.tax_group_id = c.tax_group_id
+                WHERE c.tax_group_id IS NOT NULL
+                AND tgm.tax_component_id = ?1
+            )
+            """, nativeQuery = true)
+    boolean existsByTaxGroupContainingTaxComponent(Long taxComponentId);
 }

--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/tax/data/TaxComponentData.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/tax/data/TaxComponentData.java
@@ -44,6 +44,9 @@ public final class TaxComponentData implements Serializable {
     private final LocalDate startDate;
     private final Collection<TaxComponentHistoryData> taxComponentHistories;
 
+    // editability indicator
+    private final Boolean accountsEditable;
+
     // template options
     private final Map<String, List<GLAccountData>> glAccountOptions;
     private final Collection<EnumOptionData> glAccountTypeOptions;
@@ -51,10 +54,20 @@ public final class TaxComponentData implements Serializable {
     public static TaxComponentData instance(final Long id, final String name, final BigDecimal percentage,
             final EnumOptionData debitAccountType, final GLAccountData debitAccount, final EnumOptionData creditAccountType,
             final GLAccountData creditAccount, final LocalDate startDate, final Collection<TaxComponentHistoryData> taxComponentHistories) {
+        final Boolean accountsEditable = null;
         final Map<String, List<GLAccountData>> glAccountOptions = null;
         final Collection<EnumOptionData> glAccountTypeOptions = null;
         return new TaxComponentData(id, name, percentage, debitAccountType, debitAccount, creditAccountType, creditAccount, startDate,
-                taxComponentHistories, glAccountOptions, glAccountTypeOptions);
+                taxComponentHistories, accountsEditable, glAccountOptions, glAccountTypeOptions);
+    }
+
+    public static TaxComponentData instance(final Long id, final String name, final BigDecimal percentage,
+            final EnumOptionData debitAccountType, final GLAccountData debitAccount, final EnumOptionData creditAccountType,
+            final GLAccountData creditAccount, final LocalDate startDate, final Collection<TaxComponentHistoryData> taxComponentHistories,
+            final Boolean accountsEditable, final Map<String, List<GLAccountData>> glAccountOptions,
+            final Collection<EnumOptionData> glAccountTypeOptions) {
+        return new TaxComponentData(id, name, percentage, debitAccountType, debitAccount, creditAccountType, creditAccount, startDate,
+                taxComponentHistories, accountsEditable, glAccountOptions, glAccountTypeOptions);
     }
 
     public static TaxComponentData lookup(final Long id, final String name) {
@@ -65,10 +78,11 @@ public final class TaxComponentData implements Serializable {
         final GLAccountData creditAccount = null;
         final LocalDate startDate = null;
         final Collection<TaxComponentHistoryData> taxComponentHistories = null;
+        final Boolean accountsEditable = null;
         final Map<String, List<GLAccountData>> glAccountOptions = null;
         final Collection<EnumOptionData> glAccountTypeOptions = null;
         return new TaxComponentData(id, name, percentage, debitAccountType, debitAccount, creditAccountType, creditAccount, startDate,
-                taxComponentHistories, glAccountOptions, glAccountTypeOptions);
+                taxComponentHistories, accountsEditable, glAccountOptions, glAccountTypeOptions);
     }
 
     public static TaxComponentData template(final Map<String, List<GLAccountData>> glAccountOptions,
@@ -82,8 +96,9 @@ public final class TaxComponentData implements Serializable {
         final GLAccountData creditAccount = null;
         final LocalDate startDate = null;
         final Collection<TaxComponentHistoryData> taxComponentHistories = null;
+        final Boolean accountsEditable = null;
         return new TaxComponentData(id, name, percentage, debitAccountType, debitAccount, creditAccountType, creditAccount, startDate,
-                taxComponentHistories, glAccountOptions, glAccountTypeOptions);
+                taxComponentHistories, accountsEditable, glAccountOptions, glAccountTypeOptions);
     }
 
     private TaxComponentData(final Long id, final BigDecimal percentage, final GLAccountData debitAccount,
@@ -97,6 +112,7 @@ public final class TaxComponentData implements Serializable {
         this.creditAccount = creditAccount;
         this.startDate = null;
         this.taxComponentHistories = null;
+        this.accountsEditable = null;
         this.glAccountOptions = null;
         this.glAccountTypeOptions = null;
     }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/tax/service/TaxReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/tax/service/TaxReadPlatformServiceImpl.java
@@ -20,10 +20,15 @@ package org.apache.fineract.portfolio.tax.service;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.apache.fineract.accounting.common.AccountingDropdownReadPlatformService;
+import org.apache.fineract.accounting.glaccount.data.GLAccountData;
+import org.apache.fineract.infrastructure.core.data.EnumOptionData;
+import org.apache.fineract.portfolio.charge.domain.ChargeRepository;
 import org.apache.fineract.portfolio.tax.data.TaxComponentData;
 import org.apache.fineract.portfolio.tax.data.TaxGroupData;
+import org.apache.fineract.portfolio.tax.domain.TaxComponent;
 import org.apache.fineract.portfolio.tax.domain.TaxComponentRepository;
 import org.apache.fineract.portfolio.tax.domain.TaxComponentRepositoryWrapper;
 import org.apache.fineract.portfolio.tax.domain.TaxGroupRepository;
@@ -41,6 +46,7 @@ public class TaxReadPlatformServiceImpl implements TaxReadPlatformService {
     private final TaxGroupRepository taxGroupRepository;
     private final TaxGroupRepositoryWrapper taxGroupRepositoryWrapper;
     private final TaxGroupMapper taxGroupMapper;
+    private final ChargeRepository chargeRepository;
 
     @Override
     public List<TaxComponentData> retrieveAllTaxComponents() {
@@ -49,7 +55,21 @@ public class TaxReadPlatformServiceImpl implements TaxReadPlatformService {
 
     @Override
     public TaxComponentData retrieveTaxComponentData(final Long id) {
-        return taxComponentMapper.map(taxComponentRepositoryWrapper.findOneWithNotFoundDetection(id));
+        final TaxComponent taxComponent = taxComponentRepositoryWrapper.findOneWithNotFoundDetection(id);
+        final TaxComponentData result = taxComponentMapper.map(taxComponent);
+
+        final boolean accountsEditable = !this.chargeRepository.existsByTaxGroupContainingTaxComponent(taxComponent.getId());
+
+        Map<String, List<GLAccountData>> glAccountOptions = null;
+        Collection<EnumOptionData> glAccountTypeOptions = null;
+        if (accountsEditable) {
+            glAccountOptions = accountingDropdownReadPlatformService.retrieveAccountMappingOptions();
+            glAccountTypeOptions = accountingDropdownReadPlatformService.retrieveGLAccountTypeOptions();
+        }
+
+        return TaxComponentData.instance(result.getId(), result.getName(), result.getPercentage(), result.getDebitAccountType(),
+                result.getDebitAccount(), result.getCreditAccountType(), result.getCreditAccount(), result.getStartDate(),
+                result.getTaxComponentHistories(), accountsEditable, glAccountOptions, glAccountTypeOptions);
     }
 
     @Override

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/tax/service/TaxWritePlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/tax/service/TaxWritePlatformServiceImpl.java
@@ -18,12 +18,22 @@
  */
 package org.apache.fineract.portfolio.tax.service;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.apache.fineract.accounting.glaccount.domain.GLAccount;
+import org.apache.fineract.accounting.glaccount.domain.GLAccountRepositoryWrapper;
+import org.apache.fineract.accounting.glaccount.domain.GLAccountType;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
+import org.apache.fineract.infrastructure.core.data.ApiParameterError;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResultBuilder;
+import org.apache.fineract.infrastructure.core.data.DataValidatorBuilder;
+import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
+import org.apache.fineract.portfolio.charge.domain.ChargeRepository;
+import org.apache.fineract.portfolio.tax.api.TaxApiConstants;
 import org.apache.fineract.portfolio.tax.domain.TaxComponent;
 import org.apache.fineract.portfolio.tax.domain.TaxComponentRepository;
 import org.apache.fineract.portfolio.tax.domain.TaxComponentRepositoryWrapper;
@@ -42,6 +52,8 @@ public class TaxWritePlatformServiceImpl implements TaxWritePlatformService {
     private final TaxComponentRepositoryWrapper taxComponentRepositoryWrapper;
     private final TaxGroupRepository taxGroupRepository;
     private final TaxGroupRepositoryWrapper taxGroupRepositoryWrapper;
+    private final ChargeRepository chargeRepository;
+    private final GLAccountRepositoryWrapper glAccountRepositoryWrapper;
 
     @Override
     public CommandProcessingResult createTaxComponent(final JsonCommand command) {
@@ -59,13 +71,99 @@ public class TaxWritePlatformServiceImpl implements TaxWritePlatformService {
         this.validator.validateForTaxComponentUpdate(command.json());
         final TaxComponent taxComponent = this.taxComponentRepositoryWrapper.findOneWithNotFoundDetection(id);
         this.validator.validateStartDate(taxComponent.startDate(), command);
-        Map<String, Object> changes = taxComponent.update(command);
+
+        final boolean inUse = this.chargeRepository.existsByTaxGroupContainingTaxComponent(taxComponent.getId());
+        if (inUse) {
+            validateRestrictedFieldsForInUseComponent(taxComponent, command);
+        }
+
+        GLAccountType debitAccountType = null;
+        GLAccount debitAccount = null;
+        GLAccountType creditAccountType = null;
+        GLAccount creditAccount = null;
+
+        if (!inUse) {
+            if (command.parameterExists(TaxApiConstants.debitAccountTypeParamName)) {
+                final Integer debitAccountTypeValue = command
+                        .integerValueSansLocaleOfParameterNamed(TaxApiConstants.debitAccountTypeParamName);
+                if (debitAccountTypeValue != null) {
+                    debitAccountType = GLAccountType.fromInt(debitAccountTypeValue);
+                }
+            }
+
+            if (command.parameterExists(TaxApiConstants.debitAccountIdParamName)) {
+                final Long debitAccountId = command.longValueOfParameterNamed(TaxApiConstants.debitAccountIdParamName);
+                if (debitAccountId != null) {
+                    debitAccount = this.glAccountRepositoryWrapper.findOneWithNotFoundDetection(debitAccountId);
+                }
+            }
+
+            if (command.parameterExists(TaxApiConstants.creditAccountTypeParamName)) {
+                final Integer creditAccountTypeValue = command
+                        .integerValueSansLocaleOfParameterNamed(TaxApiConstants.creditAccountTypeParamName);
+                if (creditAccountTypeValue != null) {
+                    creditAccountType = GLAccountType.fromInt(creditAccountTypeValue);
+                }
+            }
+
+            if (command.parameterExists(TaxApiConstants.creditAccountIdParamName)) {
+                final Long creditAccountId = command.longValueOfParameterNamed(TaxApiConstants.creditAccountIdParamName);
+                if (creditAccountId != null) {
+                    creditAccount = this.glAccountRepositoryWrapper.findOneWithNotFoundDetection(creditAccountId);
+                }
+            }
+        }
+
+        Map<String, Object> changes = taxComponent.update(command, debitAccountType, debitAccount, creditAccountType, creditAccount);
         this.validator.validateTaxComponentForUpdate(taxComponent);
         this.taxComponentRepository.saveAndFlush(taxComponent);
         return new CommandProcessingResultBuilder() //
                 .withEntityId(id) //
                 .with(changes) //
                 .build();
+    }
+
+    private void validateRestrictedFieldsForInUseComponent(final TaxComponent taxComponent, final JsonCommand command) {
+        final List<ApiParameterError> dataValidationErrors = new ArrayList<>();
+        final DataValidatorBuilder baseDataValidator = new DataValidatorBuilder(dataValidationErrors).resource("tax.component");
+
+        if (command.isChangeInBigDecimalParameterNamed(TaxApiConstants.percentageParamName, taxComponent.getPercentage())) {
+            baseDataValidator.reset().parameter(TaxApiConstants.percentageParamName).failWithCode(
+                    "only.name.can.be.modified.once.tax.component.is.linked.or.used.in.transactions",
+                    "Only name can be modified once tax component is linked or used in transactions.");
+        }
+
+        if (command.isChangeInIntegerSansLocaleParameterNamed(TaxApiConstants.debitAccountTypeParamName,
+                taxComponent.getDebitAccountType())) {
+            baseDataValidator.reset().parameter(TaxApiConstants.debitAccountTypeParamName).failWithCode(
+                    "only.name.can.be.modified.once.tax.component.is.linked.or.used.in.transactions",
+                    "Only name can be modified once tax component is linked or used in transactions.");
+        }
+
+        final Long currentDebitAccountId = taxComponent.getDebitAccount() != null ? taxComponent.getDebitAccount().getId() : null;
+        if (command.isChangeInLongParameterNamed(TaxApiConstants.debitAccountIdParamName, currentDebitAccountId)) {
+            baseDataValidator.reset().parameter(TaxApiConstants.debitAccountIdParamName).failWithCode(
+                    "only.name.can.be.modified.once.tax.component.is.linked.or.used.in.transactions",
+                    "Only name can be modified once tax component is linked or used in transactions.");
+        }
+
+        if (command.isChangeInIntegerSansLocaleParameterNamed(TaxApiConstants.creditAccountTypeParamName,
+                taxComponent.getCreditAccountType())) {
+            baseDataValidator.reset().parameter(TaxApiConstants.creditAccountTypeParamName).failWithCode(
+                    "only.name.can.be.modified.once.tax.component.is.linked.or.used.in.transactions",
+                    "Only name can be modified once tax component is linked or used in transactions.");
+        }
+
+        final Long currentCreditAccountId = taxComponent.getCreditAccount() != null ? taxComponent.getCreditAccount().getId() : null;
+        if (command.isChangeInLongParameterNamed(TaxApiConstants.creditAccountIdParamName, currentCreditAccountId)) {
+            baseDataValidator.reset().parameter(TaxApiConstants.creditAccountIdParamName).failWithCode(
+                    "only.name.can.be.modified.once.tax.component.is.linked.or.used.in.transactions",
+                    "Only name can be modified once tax component is linked or used in transactions.");
+        }
+
+        if (!dataValidationErrors.isEmpty()) {
+            throw new PlatformApiDataValidationException(dataValidationErrors);
+        }
     }
 
     @Override

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/tax/starter/TaxConfiguration.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/tax/starter/TaxConfiguration.java
@@ -21,6 +21,7 @@ package org.apache.fineract.portfolio.tax.starter;
 import org.apache.fineract.accounting.common.AccountingDropdownReadPlatformService;
 import org.apache.fineract.accounting.glaccount.domain.GLAccountRepositoryWrapper;
 import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.apache.fineract.portfolio.charge.domain.ChargeRepository;
 import org.apache.fineract.portfolio.tax.domain.TaxComponentRepository;
 import org.apache.fineract.portfolio.tax.domain.TaxComponentRepositoryWrapper;
 import org.apache.fineract.portfolio.tax.domain.TaxGroupRepository;
@@ -52,17 +53,19 @@ public class TaxConfiguration {
     public TaxReadPlatformService taxReadPlatformService(final TaxComponentRepository taxComponentRepository,
             final TaxComponentRepositoryWrapper taxComponentRepositoryWrapper, final TaxComponentMapper taxComponentMapper,
             final TaxGroupRepository taxGroupRepository, final TaxGroupRepositoryWrapper taxGroupRepositoryWrapper,
-            final TaxGroupMapper taxGroupMapper, AccountingDropdownReadPlatformService accountingDropdownReadPlatformService) {
+            final TaxGroupMapper taxGroupMapper, AccountingDropdownReadPlatformService accountingDropdownReadPlatformService,
+            final ChargeRepository chargeRepository) {
         return new TaxReadPlatformServiceImpl(accountingDropdownReadPlatformService, taxComponentRepository, taxComponentRepositoryWrapper,
-                taxComponentMapper, taxGroupRepository, taxGroupRepositoryWrapper, taxGroupMapper);
+                taxComponentMapper, taxGroupRepository, taxGroupRepositoryWrapper, taxGroupMapper, chargeRepository);
     }
 
     @Bean
     @ConditionalOnMissingBean(TaxWritePlatformService.class)
     public TaxWritePlatformService taxWritePlatformService(TaxValidator validator, TaxAssembler taxAssembler,
             TaxComponentRepository taxComponentRepository, TaxGroupRepository taxGroupRepository,
-            TaxComponentRepositoryWrapper taxComponentRepositoryWrapper, TaxGroupRepositoryWrapper taxGroupRepositoryWrapper) {
+            TaxComponentRepositoryWrapper taxComponentRepositoryWrapper, TaxGroupRepositoryWrapper taxGroupRepositoryWrapper,
+            ChargeRepository chargeRepository, GLAccountRepositoryWrapper glAccountRepositoryWrapper) {
         return new TaxWritePlatformServiceImpl(validator, taxAssembler, taxComponentRepository, taxComponentRepositoryWrapper,
-                taxGroupRepository, taxGroupRepositoryWrapper);
+                taxGroupRepository, taxGroupRepositoryWrapper, chargeRepository, glAccountRepositoryWrapper);
     }
 }

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/tax/service/TaxReadPlatformServiceImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/tax/service/TaxReadPlatformServiceImplTest.java
@@ -1,0 +1,127 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.tax.service;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.apache.fineract.accounting.common.AccountingDropdownReadPlatformService;
+import org.apache.fineract.accounting.glaccount.data.GLAccountData;
+import org.apache.fineract.accounting.glaccount.domain.GLAccountType;
+import org.apache.fineract.infrastructure.core.data.EnumOptionData;
+import org.apache.fineract.portfolio.charge.domain.ChargeRepository;
+import org.apache.fineract.portfolio.tax.data.TaxComponentData;
+import org.apache.fineract.portfolio.tax.domain.TaxComponent;
+import org.apache.fineract.portfolio.tax.domain.TaxComponentRepositoryWrapper;
+import org.apache.fineract.portfolio.tax.domain.TaxGroupMappings;
+import org.apache.fineract.portfolio.tax.domain.TaxGroupRepository;
+import org.apache.fineract.portfolio.tax.domain.TaxGroupRepositoryWrapper;
+import org.apache.fineract.portfolio.tax.mapper.TaxComponentMapper;
+import org.apache.fineract.portfolio.tax.mapper.TaxGroupMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class TaxReadPlatformServiceImplTest {
+
+    @Mock
+    private TaxComponentRepositoryWrapper taxComponentRepositoryWrapper;
+    @Mock
+    private TaxGroupRepositoryWrapper taxGroupRepositoryWrapper;
+    @Mock
+    private TaxGroupRepository taxGroupRepository;
+    @Mock
+    private AccountingDropdownReadPlatformService accountingDropdownReadPlatformService;
+    @Mock
+    private TaxComponentMapper taxComponentMapper;
+    @Mock
+    private TaxGroupMapper taxGroupMapper;
+    @Mock
+    private ChargeRepository chargeRepository;
+
+    @InjectMocks
+    private TaxReadPlatformServiceImpl underTest;
+
+    private static final LocalDate TODAY = LocalDate.of(2026, 9, 10);
+    private TaxComponent taxComponent;
+    private static final Long COMPONENT_ID = 1L;
+
+    @BeforeEach
+    void setUp() {
+        taxComponent = TaxComponent.createTaxComponent("TC1", BigDecimal.TEN, GLAccountType.ASSET, null, GLAccountType.LIABILITY, null,
+                TODAY);
+        ReflectionTestUtils.setField(taxComponent, "id", COMPONENT_ID);
+    }
+
+    @Test
+    void testRetrieveTaxComponentWhenNotInUse() {
+        TaxComponentData baseData = TaxComponentData.lookup(COMPONENT_ID, "TC1");
+        when(taxComponentRepositoryWrapper.findOneWithNotFoundDetection(COMPONENT_ID)).thenReturn(taxComponent);
+        when(taxComponentMapper.map(taxComponent)).thenReturn(baseData);
+
+        Map<String, List<GLAccountData>> accountOptions = Collections.emptyMap();
+        List<EnumOptionData> glAccountTypeOptions = Collections.emptyList();
+        when(accountingDropdownReadPlatformService.retrieveAccountMappingOptions()).thenReturn(accountOptions);
+        when(accountingDropdownReadPlatformService.retrieveGLAccountTypeOptions()).thenReturn(glAccountTypeOptions);
+
+        TaxComponentData result = underTest.retrieveTaxComponentData(COMPONENT_ID);
+
+        assertNotNull(result);
+        assertTrue(result.getAccountsEditable());
+        assertNotNull(result.getGlAccountOptions());
+        assertNotNull(result.getGlAccountTypeOptions());
+        verify(accountingDropdownReadPlatformService).retrieveAccountMappingOptions();
+        verify(accountingDropdownReadPlatformService).retrieveGLAccountTypeOptions();
+    }
+
+    @Test
+    void testRetrieveTaxComponentWhenInUse() {
+        TaxGroupMappings mapping = TaxGroupMappings.createTaxGroupMappings(taxComponent, TODAY);
+        taxComponent.getTaxGroupMappings().add(mapping);
+
+        TaxComponentData baseData = TaxComponentData.lookup(COMPONENT_ID, "TC1");
+        when(taxComponentRepositoryWrapper.findOneWithNotFoundDetection(COMPONENT_ID)).thenReturn(taxComponent);
+        when(taxComponentMapper.map(taxComponent)).thenReturn(baseData);
+        when(chargeRepository.existsByTaxGroupContainingTaxComponent(COMPONENT_ID)).thenReturn(true);
+
+        TaxComponentData result = underTest.retrieveTaxComponentData(COMPONENT_ID);
+
+        assertNotNull(result);
+        assertFalse(result.getAccountsEditable());
+        assertNull(result.getGlAccountOptions());
+        assertNull(result.getGlAccountTypeOptions());
+        verify(accountingDropdownReadPlatformService, never()).retrieveAccountMappingOptions();
+        verify(accountingDropdownReadPlatformService, never()).retrieveGLAccountTypeOptions();
+    }
+}

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/tax/service/TaxWritePlatformServiceImplTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/tax/service/TaxWritePlatformServiceImplTest.java
@@ -1,0 +1,334 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.tax.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.fineract.accounting.glaccount.domain.GLAccount;
+import org.apache.fineract.accounting.glaccount.domain.GLAccountRepositoryWrapper;
+import org.apache.fineract.accounting.glaccount.domain.GLAccountType;
+import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
+import org.apache.fineract.infrastructure.core.api.JsonCommand;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import org.apache.fineract.portfolio.charge.domain.ChargeRepository;
+import org.apache.fineract.portfolio.tax.api.TaxApiConstants;
+import org.apache.fineract.portfolio.tax.domain.TaxComponent;
+import org.apache.fineract.portfolio.tax.domain.TaxComponentRepository;
+import org.apache.fineract.portfolio.tax.domain.TaxComponentRepositoryWrapper;
+import org.apache.fineract.portfolio.tax.domain.TaxGroupRepository;
+import org.apache.fineract.portfolio.tax.domain.TaxGroupRepositoryWrapper;
+import org.apache.fineract.portfolio.tax.serialization.TaxValidator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TaxWritePlatformServiceImplTest {
+
+    @Mock
+    private TaxValidator validator;
+    @Mock
+    private TaxAssembler taxAssembler;
+    @Mock
+    private TaxComponentRepository taxComponentRepository;
+    @Mock
+    private TaxComponentRepositoryWrapper taxComponentRepositoryWrapper;
+    @Mock
+    private TaxGroupRepository taxGroupRepository;
+    @Mock
+    private TaxGroupRepositoryWrapper taxGroupRepositoryWrapper;
+    @Mock
+    private ChargeRepository chargeRepository;
+    @Mock
+    private GLAccountRepositoryWrapper glAccountRepositoryWrapper;
+
+    @InjectMocks
+    private TaxWritePlatformServiceImpl underTest;
+
+    private static final LocalDate TODAY = LocalDate.of(2026, 9, 10);
+    private TaxComponent taxComponent;
+    private static final Long COMPONENT_ID = 1L;
+
+    @BeforeEach
+    void setUp() {
+        ThreadLocalContextUtil.setBusinessDates(new HashMap<>(Map.of(BusinessDateType.BUSINESS_DATE, TODAY)));
+        taxComponent = TaxComponent.createTaxComponent("TC1", BigDecimal.TEN, GLAccountType.ASSET, null, GLAccountType.LIABILITY, null,
+                TODAY);
+        ReflectionTestUtils.setField(taxComponent, "id", COMPONENT_ID);
+    }
+
+    @AfterEach
+    void tearDown() {
+        ThreadLocalContextUtil.reset();
+    }
+
+    @Test
+    void testUpdateTaxComponentWhenNotInUseAllowsGLAccountsAndPercentage() {
+        when(taxComponentRepositoryWrapper.findOneWithNotFoundDetection(COMPONENT_ID)).thenReturn(taxComponent);
+
+        GLAccount newDebitAccount = mock(GLAccount.class);
+        GLAccount newCreditAccount = mock(GLAccount.class);
+        when(glAccountRepositoryWrapper.findOneWithNotFoundDetection(10L)).thenReturn(newDebitAccount);
+        when(glAccountRepositoryWrapper.findOneWithNotFoundDetection(20L)).thenReturn(newCreditAccount);
+
+        JsonCommand command = mock(JsonCommand.class);
+        when(command.parameterExists(TaxApiConstants.debitAccountTypeParamName)).thenReturn(true);
+        when(command.integerValueSansLocaleOfParameterNamed(TaxApiConstants.debitAccountTypeParamName))
+                .thenReturn(GLAccountType.EXPENSE.getValue());
+        when(command.parameterExists(TaxApiConstants.debitAccountIdParamName)).thenReturn(true);
+        when(command.longValueOfParameterNamed(TaxApiConstants.debitAccountIdParamName)).thenReturn(10L);
+
+        when(command.parameterExists(TaxApiConstants.creditAccountTypeParamName)).thenReturn(true);
+        when(command.integerValueSansLocaleOfParameterNamed(TaxApiConstants.creditAccountTypeParamName))
+                .thenReturn(GLAccountType.INCOME.getValue());
+        when(command.parameterExists(TaxApiConstants.creditAccountIdParamName)).thenReturn(true);
+        when(command.longValueOfParameterNamed(TaxApiConstants.creditAccountIdParamName)).thenReturn(20L);
+
+        when(command.isChangeInStringParameterNamed(TaxApiConstants.nameParamName, "TC1")).thenReturn(false);
+        when(command.parameterExists(TaxApiConstants.startDateParamName)).thenReturn(false);
+        when(command.isChangeInBigDecimalParameterNamed(TaxApiConstants.percentageParamName, BigDecimal.TEN)).thenReturn(false);
+
+        when(command.isChangeInIntegerParameterNamed(TaxApiConstants.debitAccountTypeParamName, GLAccountType.ASSET.getValue()))
+                .thenReturn(true);
+        when(command.isChangeInLongParameterNamed(TaxApiConstants.debitAccountIdParamName, null)).thenReturn(true);
+        when(command.isChangeInIntegerParameterNamed(TaxApiConstants.creditAccountTypeParamName, GLAccountType.LIABILITY.getValue()))
+                .thenReturn(true);
+        when(command.isChangeInLongParameterNamed(TaxApiConstants.creditAccountIdParamName, null)).thenReturn(true);
+
+        CommandProcessingResult result = underTest.updateTaxComponent(COMPONENT_ID, command);
+
+        assertEquals(COMPONENT_ID, result.getResourceId());
+        verify(taxComponentRepository).saveAndFlush(taxComponent);
+        assertEquals(GLAccountType.EXPENSE.getValue(), taxComponent.getDebitAccountType());
+        assertEquals(newDebitAccount, taxComponent.getDebitAccount());
+        assertEquals(GLAccountType.INCOME.getValue(), taxComponent.getCreditAccountType());
+        assertEquals(newCreditAccount, taxComponent.getCreditAccount());
+    }
+
+    @Test
+    void testUpdateTaxComponentInUseThrowsWhenPercentageChanged() {
+        when(taxComponentRepositoryWrapper.findOneWithNotFoundDetection(COMPONENT_ID)).thenReturn(taxComponent);
+        when(chargeRepository.existsByTaxGroupContainingTaxComponent(COMPONENT_ID)).thenReturn(true);
+
+        JsonCommand command = mock(JsonCommand.class);
+        when(command.isChangeInBigDecimalParameterNamed(TaxApiConstants.percentageParamName, BigDecimal.TEN)).thenReturn(true);
+
+        PlatformApiDataValidationException exception = assertThrows(PlatformApiDataValidationException.class,
+                () -> underTest.updateTaxComponent(COMPONENT_ID, command));
+
+        assertTrue(exception.getErrors().get(0).getUserMessageGlobalisationCode()
+                .contains("only.name.can.be.modified.once.tax.component.is.linked.or.used.in.transactions"));
+    }
+
+    @Test
+    void testUpdateTaxComponentInUseThrowsWhenDebitAccountTypeChanged() {
+        when(taxComponentRepositoryWrapper.findOneWithNotFoundDetection(COMPONENT_ID)).thenReturn(taxComponent);
+        when(chargeRepository.existsByTaxGroupContainingTaxComponent(COMPONENT_ID)).thenReturn(true);
+
+        JsonCommand command = mock(JsonCommand.class);
+        when(command.isChangeInIntegerSansLocaleParameterNamed(TaxApiConstants.debitAccountTypeParamName,
+                GLAccountType.ASSET.getValue())).thenReturn(true);
+
+        PlatformApiDataValidationException exception = assertThrows(PlatformApiDataValidationException.class,
+                () -> underTest.updateTaxComponent(COMPONENT_ID, command));
+
+        assertTrue(exception.getErrors().get(0).getUserMessageGlobalisationCode()
+                .contains("only.name.can.be.modified.once.tax.component.is.linked.or.used.in.transactions"));
+    }
+
+    @Test
+    void testUpdateTaxComponentInUseThrowsWhenDebitAccountIdChanged() {
+        when(taxComponentRepositoryWrapper.findOneWithNotFoundDetection(COMPONENT_ID)).thenReturn(taxComponent);
+        when(chargeRepository.existsByTaxGroupContainingTaxComponent(COMPONENT_ID)).thenReturn(true);
+
+        JsonCommand command = mock(JsonCommand.class);
+        when(command.isChangeInLongParameterNamed(TaxApiConstants.debitAccountIdParamName, null)).thenReturn(true);
+
+        PlatformApiDataValidationException exception = assertThrows(PlatformApiDataValidationException.class,
+                () -> underTest.updateTaxComponent(COMPONENT_ID, command));
+
+        assertTrue(exception.getErrors().get(0).getUserMessageGlobalisationCode()
+                .contains("only.name.can.be.modified.once.tax.component.is.linked.or.used.in.transactions"));
+    }
+
+    @Test
+    void testUpdateTaxComponentInUseThrowsWhenCreditAccountTypeChanged() {
+        when(taxComponentRepositoryWrapper.findOneWithNotFoundDetection(COMPONENT_ID)).thenReturn(taxComponent);
+        when(chargeRepository.existsByTaxGroupContainingTaxComponent(COMPONENT_ID)).thenReturn(true);
+
+        JsonCommand command = mock(JsonCommand.class);
+        when(command.isChangeInIntegerSansLocaleParameterNamed(TaxApiConstants.creditAccountTypeParamName,
+                GLAccountType.LIABILITY.getValue())).thenReturn(true);
+
+        PlatformApiDataValidationException exception = assertThrows(PlatformApiDataValidationException.class,
+                () -> underTest.updateTaxComponent(COMPONENT_ID, command));
+
+        assertTrue(exception.getErrors().get(0).getUserMessageGlobalisationCode()
+                .contains("only.name.can.be.modified.once.tax.component.is.linked.or.used.in.transactions"));
+    }
+
+    @Test
+    void testUpdateTaxComponentInUseThrowsWhenCreditAccountIdChanged() {
+        when(taxComponentRepositoryWrapper.findOneWithNotFoundDetection(COMPONENT_ID)).thenReturn(taxComponent);
+        when(chargeRepository.existsByTaxGroupContainingTaxComponent(COMPONENT_ID)).thenReturn(true);
+
+        JsonCommand command = mock(JsonCommand.class);
+        when(command.isChangeInLongParameterNamed(TaxApiConstants.creditAccountIdParamName, null)).thenReturn(true);
+
+        PlatformApiDataValidationException exception = assertThrows(PlatformApiDataValidationException.class,
+                () -> underTest.updateTaxComponent(COMPONENT_ID, command));
+
+        assertTrue(exception.getErrors().get(0).getUserMessageGlobalisationCode()
+                .contains("only.name.can.be.modified.once.tax.component.is.linked.or.used.in.transactions"));
+    }
+
+    @Test
+    void testUpdateTaxComponentInUseAllowsNameChange() {
+        when(taxComponentRepositoryWrapper.findOneWithNotFoundDetection(COMPONENT_ID)).thenReturn(taxComponent);
+        when(chargeRepository.existsByTaxGroupContainingTaxComponent(COMPONENT_ID)).thenReturn(true);
+
+        JsonCommand command = mock(JsonCommand.class);
+        when(command.isChangeInBigDecimalParameterNamed(TaxApiConstants.percentageParamName, BigDecimal.TEN)).thenReturn(false);
+        when(command.isChangeInIntegerSansLocaleParameterNamed(TaxApiConstants.debitAccountTypeParamName,
+                GLAccountType.ASSET.getValue())).thenReturn(false);
+        when(command.isChangeInLongParameterNamed(TaxApiConstants.debitAccountIdParamName, null)).thenReturn(false);
+        when(command.isChangeInIntegerSansLocaleParameterNamed(TaxApiConstants.creditAccountTypeParamName,
+                GLAccountType.LIABILITY.getValue())).thenReturn(false);
+        when(command.isChangeInLongParameterNamed(TaxApiConstants.creditAccountIdParamName, null)).thenReturn(false);
+
+        when(command.parameterExists(TaxApiConstants.debitAccountTypeParamName)).thenReturn(false);
+        when(command.parameterExists(TaxApiConstants.debitAccountIdParamName)).thenReturn(false);
+        when(command.parameterExists(TaxApiConstants.creditAccountTypeParamName)).thenReturn(false);
+        when(command.parameterExists(TaxApiConstants.creditAccountIdParamName)).thenReturn(false);
+        when(command.parameterExists(TaxApiConstants.startDateParamName)).thenReturn(false);
+
+        when(command.isChangeInStringParameterNamed(TaxApiConstants.nameParamName, "TC1")).thenReturn(true);
+        when(command.stringValueOfParameterNamed(TaxApiConstants.nameParamName)).thenReturn("TC1-Renamed");
+
+        CommandProcessingResult result = underTest.updateTaxComponent(COMPONENT_ID, command);
+
+        assertEquals(COMPONENT_ID, result.getResourceId());
+        verify(taxComponentRepository).saveAndFlush(taxComponent);
+        assertEquals("TC1-Renamed", taxComponent.getName());
+    }
+
+    @Test
+    void testUpdateTaxComponentInUseThrowsWhenNameAndRestrictedFieldChangedTogether() {
+        when(taxComponentRepositoryWrapper.findOneWithNotFoundDetection(COMPONENT_ID)).thenReturn(taxComponent);
+        when(chargeRepository.existsByTaxGroupContainingTaxComponent(COMPONENT_ID)).thenReturn(true);
+
+        JsonCommand command = mock(JsonCommand.class);
+        when(command.isChangeInBigDecimalParameterNamed(TaxApiConstants.percentageParamName, BigDecimal.TEN)).thenReturn(true);
+
+        PlatformApiDataValidationException exception = assertThrows(PlatformApiDataValidationException.class,
+                () -> underTest.updateTaxComponent(COMPONENT_ID, command));
+
+        assertTrue(exception.getErrors().get(0).getUserMessageGlobalisationCode()
+                .contains("only.name.can.be.modified.once.tax.component.is.linked.or.used.in.transactions"));
+        assertEquals("TC1", taxComponent.getName());
+    }
+
+    @Test
+    void testUpdateTaxComponentInUseAllowsFutureStartDateChange() {
+        LocalDate futureDate = TODAY.plusDays(10);
+        LocalDate newFutureDate = TODAY.plusDays(20);
+
+        TaxComponent futureComponent = TaxComponent.createTaxComponent("TC_Future", BigDecimal.TEN, GLAccountType.ASSET, null,
+                GLAccountType.LIABILITY, null, futureDate);
+        ReflectionTestUtils.setField(futureComponent, "id", COMPONENT_ID);
+
+        when(taxComponentRepositoryWrapper.findOneWithNotFoundDetection(COMPONENT_ID)).thenReturn(futureComponent);
+        when(chargeRepository.existsByTaxGroupContainingTaxComponent(COMPONENT_ID)).thenReturn(true);
+
+        JsonCommand command = mock(JsonCommand.class);
+        when(command.isChangeInBigDecimalParameterNamed(TaxApiConstants.percentageParamName, BigDecimal.TEN)).thenReturn(false);
+        when(command.isChangeInIntegerSansLocaleParameterNamed(TaxApiConstants.debitAccountTypeParamName, GLAccountType.ASSET.getValue()))
+                .thenReturn(false);
+        when(command.isChangeInLongParameterNamed(TaxApiConstants.debitAccountIdParamName, null)).thenReturn(false);
+        when(command.isChangeInIntegerSansLocaleParameterNamed(TaxApiConstants.creditAccountTypeParamName,
+                GLAccountType.LIABILITY.getValue())).thenReturn(false);
+        when(command.isChangeInLongParameterNamed(TaxApiConstants.creditAccountIdParamName, null)).thenReturn(false);
+
+        when(command.parameterExists(TaxApiConstants.debitAccountTypeParamName)).thenReturn(false);
+        when(command.parameterExists(TaxApiConstants.debitAccountIdParamName)).thenReturn(false);
+        when(command.parameterExists(TaxApiConstants.creditAccountTypeParamName)).thenReturn(false);
+        when(command.parameterExists(TaxApiConstants.creditAccountIdParamName)).thenReturn(false);
+
+        when(command.parameterExists(TaxApiConstants.startDateParamName)).thenReturn(true);
+        when(command.localDateValueOfParameterNamed(TaxApiConstants.startDateParamName)).thenReturn(newFutureDate);
+
+        when(command.isChangeInStringParameterNamed(TaxApiConstants.nameParamName, "TC_Future")).thenReturn(false);
+
+        assertDoesNotThrow(() -> underTest.updateTaxComponent(COMPONENT_ID, command));
+        verify(taxComponentRepository).saveAndFlush(futureComponent);
+        assertEquals(newFutureDate, futureComponent.startDate());
+    }
+
+    @Test
+    void testUpdateTaxComponentInUseDoesNotLookupGLAccountsWhenLocked() {
+        GLAccount debitAccount = mock(GLAccount.class);
+        when(debitAccount.getId()).thenReturn(10L);
+        ReflectionTestUtils.setField(taxComponent, "debitAccount", debitAccount);
+        ReflectionTestUtils.setField(taxComponent, "debitAccountType", GLAccountType.ASSET.getValue());
+
+        when(taxComponentRepositoryWrapper.findOneWithNotFoundDetection(COMPONENT_ID)).thenReturn(taxComponent);
+        when(chargeRepository.existsByTaxGroupContainingTaxComponent(COMPONENT_ID)).thenReturn(true);
+
+        JsonCommand command = mock(JsonCommand.class);
+        when(command.isChangeInBigDecimalParameterNamed(TaxApiConstants.percentageParamName, BigDecimal.TEN)).thenReturn(false);
+        when(command.isChangeInIntegerSansLocaleParameterNamed(TaxApiConstants.debitAccountTypeParamName, GLAccountType.ASSET.getValue()))
+                .thenReturn(false);
+        when(command.isChangeInLongParameterNamed(TaxApiConstants.debitAccountIdParamName, 10L)).thenReturn(false);
+        when(command.isChangeInIntegerSansLocaleParameterNamed(TaxApiConstants.creditAccountTypeParamName,
+                GLAccountType.LIABILITY.getValue())).thenReturn(false);
+        when(command.isChangeInLongParameterNamed(TaxApiConstants.creditAccountIdParamName, null)).thenReturn(false);
+
+        when(command.parameterExists(TaxApiConstants.debitAccountIdParamName)).thenReturn(true);
+        when(command.longValueOfParameterNamed(TaxApiConstants.debitAccountIdParamName)).thenReturn(10L);
+        when(command.parameterExists(TaxApiConstants.startDateParamName)).thenReturn(false);
+
+        when(command.isChangeInStringParameterNamed(TaxApiConstants.nameParamName, "TC1")).thenReturn(true);
+        when(command.stringValueOfParameterNamed(TaxApiConstants.nameParamName)).thenReturn("TC1-Updated");
+
+        assertDoesNotThrow(() -> underTest.updateTaxComponent(COMPONENT_ID, command));
+        verify(glAccountRepositoryWrapper, never()).findOneWithNotFoundDetection(any());
+    }
+}

--- a/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/api/TaxComponentApiResourceSwagger.java
+++ b/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/api/TaxComponentApiResourceSwagger.java
@@ -74,6 +74,8 @@ final class TaxComponentApiResourceSwagger {
         @Schema(example = "[2016, 4, 11]")
         public LocalDate startDate;
         public Set<GetTaxesComponentsHistories> taxComponentsHistories;
+        @Schema(example = "true")
+        public Boolean accountsEditable;
     }
 
     @Schema(description = "PostTaxesComponentsRequest")
@@ -119,6 +121,14 @@ final class TaxComponentApiResourceSwagger {
         public String name;
         @Schema(example = "15")
         public Float percentage;
+        @Schema(example = "2")
+        public Integer debitAccountType;
+        @Schema(example = "4")
+        public Long debitAccountId;
+        @Schema(example = "4")
+        public Integer creditAccountType;
+        @Schema(example = "4")
+        public Long creditAccountId;
         @Schema(example = "en")
         public String locale;
         @Schema(example = "dd MMMM yyyy")
@@ -142,6 +152,14 @@ final class TaxComponentApiResourceSwagger {
             public String name;
             @Schema(example = "[2016, 4, 15]")
             public LocalDate startDate;
+            @Schema(example = "2")
+            public Integer debitAccountType;
+            @Schema(example = "4")
+            public Long debitAccountId;
+            @Schema(example = "4")
+            public Integer creditAccountType;
+            @Schema(example = "4")
+            public Long creditAccountId;
         }
 
         @Schema(example = "1")

--- a/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/domain/TaxComponent.java
+++ b/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/domain/TaxComponent.java
@@ -103,6 +103,11 @@ public class TaxComponent extends AbstractAuditableCustom {
     }
 
     public Map<String, Object> update(final JsonCommand command) {
+        return update(command, null, null, null, null);
+    }
+
+    public Map<String, Object> update(final JsonCommand command, final GLAccountType debitAccountType, final GLAccount debitAccount,
+            final GLAccountType creditAccountType, final GLAccount creditAccount) {
         final Map<String, Object> changes = new HashMap<>();
 
         if (command.isChangeInStringParameterNamed(TaxApiConstants.nameParamName, this.name)) {
@@ -122,7 +127,64 @@ public class TaxComponent extends AbstractAuditableCustom {
             TaxComponentHistory history = TaxComponentHistory.createTaxComponentHistory(this, this.percentage, oldStartDate, newStartDate);
             this.taxComponentHistories.add(history);
             this.percentage = newValue;
+        } else {
+            updateStartDate(command, changes, false);
+        }
 
+        // Handle debit account type
+        if (command.isChangeInIntegerParameterNamed(TaxApiConstants.debitAccountTypeParamName, this.debitAccountType)) {
+            final Integer newValue = command.integerValueSansLocaleOfParameterNamed(TaxApiConstants.debitAccountTypeParamName);
+            changes.put(TaxApiConstants.debitAccountTypeParamName, newValue);
+            if (debitAccountType != null) {
+                this.debitAccountType = debitAccountType.getValue();
+            } else if (newValue != null) {
+                final GLAccountType accountType = GLAccountType.fromInt(newValue);
+                this.debitAccountType = accountType != null ? accountType.getValue() : null;
+            } else {
+                this.debitAccountType = null;
+            }
+        }
+
+        // Handle debit account ID
+        final Long currentDebitAccountId = this.debitAccount != null ? this.debitAccount.getId() : null;
+        if (command.isChangeInLongParameterNamed(TaxApiConstants.debitAccountIdParamName, currentDebitAccountId)) {
+            final Long newValue = command.longValueOfParameterNamed(TaxApiConstants.debitAccountIdParamName);
+            changes.put(TaxApiConstants.debitAccountIdParamName, newValue);
+            this.debitAccount = debitAccount;
+            if (newValue == null && command.parameterExists(TaxApiConstants.debitAccountIdParamName)) {
+                this.debitAccountType = null;
+                if (!changes.containsKey(TaxApiConstants.debitAccountTypeParamName)) {
+                    changes.put(TaxApiConstants.debitAccountTypeParamName, null);
+                }
+            }
+        }
+
+        // Handle credit account type
+        if (command.isChangeInIntegerParameterNamed(TaxApiConstants.creditAccountTypeParamName, this.creditAccountType)) {
+            final Integer newValue = command.integerValueSansLocaleOfParameterNamed(TaxApiConstants.creditAccountTypeParamName);
+            changes.put(TaxApiConstants.creditAccountTypeParamName, newValue);
+            if (creditAccountType != null) {
+                this.creditAccountType = creditAccountType.getValue();
+            } else if (newValue != null) {
+                final GLAccountType accountType = GLAccountType.fromInt(newValue);
+                this.creditAccountType = accountType != null ? accountType.getValue() : null;
+            } else {
+                this.creditAccountType = null;
+            }
+        }
+
+        // Handle credit account ID
+        final Long currentCreditAccountId = this.creditAccount != null ? this.creditAccount.getId() : null;
+        if (command.isChangeInLongParameterNamed(TaxApiConstants.creditAccountIdParamName, currentCreditAccountId)) {
+            final Long newValue = command.longValueOfParameterNamed(TaxApiConstants.creditAccountIdParamName);
+            changes.put(TaxApiConstants.creditAccountIdParamName, newValue);
+            this.creditAccount = creditAccount;
+            if (newValue == null && command.parameterExists(TaxApiConstants.creditAccountIdParamName)) {
+                this.creditAccountType = null;
+                if (!changes.containsKey(TaxApiConstants.creditAccountTypeParamName)) {
+                    changes.put(TaxApiConstants.creditAccountTypeParamName, null);
+                }
+            }
         }
 
         return changes;
@@ -135,13 +197,14 @@ public class TaxComponent extends AbstractAuditableCustom {
             if (startDateFromUI != null) {
                 startDate = startDateFromUI;
             }
-            this.startDate = startDate;
-            changes.put(TaxApiConstants.startDateParamName, startDate);
+            if (setAsCurrentDate || !DateUtils.isEqual(this.startDate, startDate)) {
+                this.startDate = startDate;
+                changes.put(TaxApiConstants.startDateParamName, startDate);
+            }
         } else if (setAsCurrentDate) {
             changes.put(TaxApiConstants.startDateParamName, startDate);
             this.startDate = startDate;
         }
-
     }
 
     public BigDecimal getPercentage() {

--- a/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/mapper/TaxComponentMapper.java
+++ b/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/mapper/TaxComponentMapper.java
@@ -37,6 +37,7 @@ public interface TaxComponentMapper {
     @Mapping(target = "glAccountOptions", ignore = true)
     @Mapping(target = "glAccountTypeOptions", ignore = true)
     @Mapping(target = "taxComponentHistories", ignore = true)
+    @Mapping(target = "accountsEditable", ignore = true)
     TaxComponentData map(TaxComponent taxComponent);
 
     List<TaxComponentData> map(List<TaxComponent> taxComponents);

--- a/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/serialization/TaxValidator.java
+++ b/fineract-tax/src/main/java/org/apache/fineract/portfolio/tax/serialization/TaxValidator.java
@@ -65,8 +65,10 @@ public class TaxValidator {
             Arrays.asList(DATE_FORMAT, LOCALE, TaxApiConstants.nameParamName, TaxApiConstants.percentageParamName,
                     TaxApiConstants.startDateParamName, TaxApiConstants.debitAccountTypeParamName, TaxApiConstants.debitAccountIdParamName,
                     TaxApiConstants.creditAccountTypeParamName, TaxApiConstants.creditAccountIdParamName));
-    private static final Set<String> SUPPORTED_TAX_COMPONENT_UPDATE_PARAMETERS = new HashSet<>(Arrays.asList(DATE_FORMAT, LOCALE,
-            TaxApiConstants.nameParamName, TaxApiConstants.percentageParamName, TaxApiConstants.startDateParamName));
+    private static final Set<String> SUPPORTED_TAX_COMPONENT_UPDATE_PARAMETERS = new HashSet<>(
+            Arrays.asList(DATE_FORMAT, LOCALE, TaxApiConstants.nameParamName, TaxApiConstants.percentageParamName,
+                    TaxApiConstants.startDateParamName, TaxApiConstants.debitAccountTypeParamName, TaxApiConstants.debitAccountIdParamName,
+                    TaxApiConstants.creditAccountTypeParamName, TaxApiConstants.creditAccountIdParamName));
     private static final Set<String> SUPPORTED_TAX_GROUP_PARAMETERS = new HashSet<>(
             Arrays.asList(DATE_FORMAT, LOCALE, TaxApiConstants.nameParamName, TaxApiConstants.taxComponentsParamName));
     private static final Set<String> SUPPORTED_TAX_GROUP_TAX_COMPONENTS_CREATE_PARAMETERS = new HashSet<>(
@@ -158,12 +160,6 @@ public class TaxValidator {
                     element);
             baseDataValidator.reset().parameter(TaxApiConstants.percentageParamName).value(percentage).notBlank().positiveAmount()
                     .notGreaterThanMax(BigDecimal.valueOf(100));
-        }
-
-        if (this.fromApiJsonHelper.parameterExists(TaxApiConstants.startDateParamName, element)) {
-            final LocalDate startDate = this.fromApiJsonHelper.extractLocalDateNamed(TaxApiConstants.startDateParamName, element);
-            baseDataValidator.reset().parameter(TaxApiConstants.startDateParamName).value(startDate)
-                    .validateDateAfter(DateUtils.getBusinessLocalDate());
         }
         throwExceptionIfValidationWarningsExist(dataValidationErrors);
     }
@@ -320,15 +316,33 @@ public class TaxValidator {
     }
 
     public void validateStartDate(final LocalDate existingStartDate, final JsonCommand command) {
-        final List<ApiParameterError> dataValidationErrors = new ArrayList<>();
-        final DataValidatorBuilder baseDataValidator = new DataValidatorBuilder(dataValidationErrors).resource(TAX_COMPONENT);
-        validateStartDate(existingStartDate, command.localDateValueOfParameterNamed(TaxApiConstants.startDateParamName), baseDataValidator);
-        throwExceptionIfValidationWarningsExist(dataValidationErrors);
+        if (command.parameterExists(TaxApiConstants.startDateParamName)) {
+            final List<ApiParameterError> dataValidationErrors = new ArrayList<>();
+            final DataValidatorBuilder baseDataValidator = new DataValidatorBuilder(dataValidationErrors).resource(TAX_COMPONENT);
+            validateStartDate(existingStartDate, command.localDateValueOfParameterNamed(TaxApiConstants.startDateParamName),
+                    baseDataValidator);
+            throwExceptionIfValidationWarningsExist(dataValidationErrors);
+        }
     }
 
     private void validateStartDate(final LocalDate existingStartDate, final LocalDate startDate,
             final DataValidatorBuilder baseDataValidator) {
-        baseDataValidator.reset().parameter(TaxApiConstants.startDateParamName).value(startDate).validateDateAfter(existingStartDate);
+        final LocalDate today = DateUtils.getBusinessLocalDate();
+
+        if (existingStartDate != null && !DateUtils.isAfter(existingStartDate, today)) {
+            if (startDate == null || !DateUtils.isEqual(startDate, existingStartDate)) {
+                baseDataValidator.reset().parameter(TaxApiConstants.startDateParamName)
+                        .failWithCode("start.date.cannot.be.modified.after.activation", "Start date cannot be modified after activation.");
+            }
+            return;
+        }
+
+        if (startDate == null) {
+            baseDataValidator.reset().parameter(TaxApiConstants.startDateParamName).value(startDate).notNull();
+        } else if (!DateUtils.isAfter(startDate, today)) {
+            baseDataValidator.reset().parameter(TaxApiConstants.startDateParamName).value(startDate).failWithCode("is.less.than.date",
+                    today);
+        }
     }
 
     private void validateOverlappingComponents(final Set<TaxGroupMappings> taxMappings, final DataValidatorBuilder baseDataValidator) {

--- a/fineract-tax/src/test/java/org/apache/fineract/portfolio/tax/domain/TaxComponentTest.java
+++ b/fineract-tax/src/test/java/org/apache/fineract/portfolio/tax/domain/TaxComponentTest.java
@@ -1,0 +1,251 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.tax.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.fineract.accounting.glaccount.domain.GLAccount;
+import org.apache.fineract.accounting.glaccount.domain.GLAccountType;
+import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
+import org.apache.fineract.infrastructure.core.api.JsonCommand;
+import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import org.apache.fineract.portfolio.tax.api.TaxApiConstants;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TaxComponentTest {
+
+    private static final LocalDate TODAY = LocalDate.of(2026, 9, 10);
+
+    @BeforeEach
+    void setUp() {
+        ThreadLocalContextUtil.setTenant(new FineractPlatformTenant(1L, "default", "Default", "Asia/Kolkata", null));
+        ThreadLocalContextUtil.setBusinessDates(new HashMap<>(Map.of(BusinessDateType.BUSINESS_DATE, TODAY)));
+    }
+
+    @AfterEach
+    void tearDown() {
+        ThreadLocalContextUtil.reset();
+    }
+
+    @Test
+    void testUpdateNameAlone() {
+        TaxComponent component = TaxComponent.createTaxComponent("TC_OLD", BigDecimal.TEN, GLAccountType.ASSET, null,
+                GLAccountType.LIABILITY, null, TODAY);
+
+        JsonCommand command = mock(JsonCommand.class);
+        when(command.isChangeInStringParameterNamed(TaxApiConstants.nameParamName, "TC_OLD")).thenReturn(true);
+        when(command.stringValueOfParameterNamed(TaxApiConstants.nameParamName)).thenReturn("TC_NEW");
+        when(command.isChangeInBigDecimalParameterNamed(TaxApiConstants.percentageParamName, BigDecimal.TEN)).thenReturn(false);
+        when(command.parameterExists(TaxApiConstants.startDateParamName)).thenReturn(false);
+
+        Map<String, Object> changes = component.update(command);
+
+        assertEquals("TC_NEW", component.getName());
+        assertEquals("TC_NEW", changes.get(TaxApiConstants.nameParamName));
+        assertTrue(component.getTaxComponentHistories().isEmpty());
+    }
+
+    @Test
+    void testUpdatePercentageCreatesHistoryAndUpdatesStartDate() {
+        LocalDate initialStartDate = TODAY.minusMonths(1);
+        TaxComponent component = TaxComponent.createTaxComponent("TC1", BigDecimal.TEN, GLAccountType.ASSET, null, GLAccountType.LIABILITY,
+                null, initialStartDate);
+
+        JsonCommand command = mock(JsonCommand.class);
+        when(command.isChangeInStringParameterNamed(TaxApiConstants.nameParamName, "TC1")).thenReturn(false);
+        when(command.isChangeInBigDecimalParameterNamed(TaxApiConstants.percentageParamName, BigDecimal.TEN)).thenReturn(true);
+        when(command.bigDecimalValueOfParameterNamed(TaxApiConstants.percentageParamName)).thenReturn(BigDecimal.valueOf(15));
+        when(command.parameterExists(TaxApiConstants.startDateParamName)).thenReturn(false);
+
+        Map<String, Object> changes = component.update(command);
+
+        assertEquals(BigDecimal.valueOf(15), component.getPercentage());
+        assertEquals(TODAY, component.startDate());
+        assertEquals(BigDecimal.valueOf(15), changes.get(TaxApiConstants.percentageParamName));
+        assertEquals(TODAY, changes.get(TaxApiConstants.startDateParamName));
+
+        assertEquals(1, component.getTaxComponentHistories().size());
+        TaxComponentHistory history = component.getTaxComponentHistories().iterator().next();
+        assertEquals(BigDecimal.TEN, history.getPercentage());
+        assertEquals(initialStartDate, history.startDate());
+        assertEquals(TODAY, history.endDate());
+    }
+
+    @Test
+    void testUpdatePercentageWithProvidedStartDateCreatesHistoryWithNewStartDate() {
+        LocalDate initialStartDate = TODAY.minusMonths(1);
+        LocalDate futureStartDate = TODAY.plusDays(10);
+        TaxComponent component = TaxComponent.createTaxComponent("TC1", BigDecimal.TEN, GLAccountType.ASSET, null, GLAccountType.LIABILITY,
+                null, initialStartDate);
+
+        JsonCommand command = mock(JsonCommand.class);
+        when(command.isChangeInStringParameterNamed(TaxApiConstants.nameParamName, "TC1")).thenReturn(false);
+        when(command.isChangeInBigDecimalParameterNamed(TaxApiConstants.percentageParamName, BigDecimal.TEN)).thenReturn(true);
+        when(command.bigDecimalValueOfParameterNamed(TaxApiConstants.percentageParamName)).thenReturn(BigDecimal.valueOf(18));
+        when(command.parameterExists(TaxApiConstants.startDateParamName)).thenReturn(true);
+        when(command.localDateValueOfParameterNamed(TaxApiConstants.startDateParamName)).thenReturn(futureStartDate);
+
+        Map<String, Object> changes = component.update(command);
+
+        assertEquals(BigDecimal.valueOf(18), component.getPercentage());
+        assertEquals(futureStartDate, component.startDate());
+        assertEquals(BigDecimal.valueOf(18), changes.get(TaxApiConstants.percentageParamName));
+        assertEquals(futureStartDate, changes.get(TaxApiConstants.startDateParamName));
+
+        assertEquals(1, component.getTaxComponentHistories().size());
+        TaxComponentHistory history = component.getTaxComponentHistories().iterator().next();
+        assertEquals(BigDecimal.TEN, history.getPercentage());
+        assertEquals(initialStartDate, history.startDate());
+        assertEquals(futureStartDate, history.endDate());
+    }
+
+    @Test
+    void testUpdateStartDateAloneUpdatesDateWithoutCreatingHistory() {
+        LocalDate initialStartDate = TODAY.plusDays(5);
+        LocalDate newFutureStartDate = TODAY.plusDays(15);
+        TaxComponent component = TaxComponent.createTaxComponent("TC1", BigDecimal.TEN, GLAccountType.ASSET, null, GLAccountType.LIABILITY,
+                null, initialStartDate);
+
+        JsonCommand command = mock(JsonCommand.class);
+        when(command.isChangeInStringParameterNamed(TaxApiConstants.nameParamName, "TC1")).thenReturn(false);
+        when(command.isChangeInBigDecimalParameterNamed(TaxApiConstants.percentageParamName, BigDecimal.TEN)).thenReturn(false);
+        when(command.parameterExists(TaxApiConstants.startDateParamName)).thenReturn(true);
+        when(command.localDateValueOfParameterNamed(TaxApiConstants.startDateParamName)).thenReturn(newFutureStartDate);
+
+        Map<String, Object> changes = component.update(command);
+
+        assertEquals(newFutureStartDate, component.startDate());
+        assertEquals(newFutureStartDate, changes.get(TaxApiConstants.startDateParamName));
+        assertTrue(component.getTaxComponentHistories().isEmpty());
+    }
+
+    @Test
+    void testUpdateStartDateAloneSameDateIsNoOp() {
+        LocalDate initialStartDate = TODAY.plusDays(5);
+        TaxComponent component = TaxComponent.createTaxComponent("TC1", BigDecimal.TEN, GLAccountType.ASSET, null, GLAccountType.LIABILITY,
+                null, initialStartDate);
+
+        JsonCommand command = mock(JsonCommand.class);
+        when(command.isChangeInStringParameterNamed(TaxApiConstants.nameParamName, "TC1")).thenReturn(false);
+        when(command.isChangeInBigDecimalParameterNamed(TaxApiConstants.percentageParamName, BigDecimal.TEN)).thenReturn(false);
+        when(command.parameterExists(TaxApiConstants.startDateParamName)).thenReturn(true);
+        when(command.localDateValueOfParameterNamed(TaxApiConstants.startDateParamName)).thenReturn(initialStartDate);
+
+        Map<String, Object> changes = component.update(command);
+
+        assertEquals(initialStartDate, component.startDate());
+        assertFalse(changes.containsKey(TaxApiConstants.startDateParamName));
+        assertTrue(component.getTaxComponentHistories().isEmpty());
+    }
+
+    @Test
+    void testUpdateGLAccountsWhenNotLocked() {
+        GLAccount oldDebitAccount = mock(GLAccount.class);
+        when(oldDebitAccount.getId()).thenReturn(1L);
+
+        GLAccount oldCreditAccount = mock(GLAccount.class);
+        when(oldCreditAccount.getId()).thenReturn(2L);
+
+        TaxComponent component = TaxComponent.createTaxComponent("TC1", BigDecimal.TEN, GLAccountType.ASSET, oldDebitAccount,
+                GLAccountType.LIABILITY, oldCreditAccount, TODAY);
+
+        GLAccount newDebitAccount = mock(GLAccount.class);
+        when(newDebitAccount.getId()).thenReturn(10L);
+
+        GLAccount newCreditAccount = mock(GLAccount.class);
+        when(newCreditAccount.getId()).thenReturn(20L);
+
+        JsonCommand command = mock(JsonCommand.class);
+        when(command.isChangeInStringParameterNamed(TaxApiConstants.nameParamName, "TC1")).thenReturn(false);
+        when(command.parameterExists(TaxApiConstants.startDateParamName)).thenReturn(false);
+        when(command.isChangeInBigDecimalParameterNamed(TaxApiConstants.percentageParamName, BigDecimal.TEN)).thenReturn(false);
+
+        when(command.isChangeInIntegerParameterNamed(TaxApiConstants.debitAccountTypeParamName, GLAccountType.ASSET.getValue()))
+                .thenReturn(true);
+        when(command.integerValueSansLocaleOfParameterNamed(TaxApiConstants.debitAccountTypeParamName))
+                .thenReturn(GLAccountType.EXPENSE.getValue());
+
+        when(command.isChangeInLongParameterNamed(TaxApiConstants.debitAccountIdParamName, 1L)).thenReturn(true);
+        when(command.longValueOfParameterNamed(TaxApiConstants.debitAccountIdParamName)).thenReturn(10L);
+
+        when(command.isChangeInIntegerParameterNamed(TaxApiConstants.creditAccountTypeParamName, GLAccountType.LIABILITY.getValue()))
+                .thenReturn(true);
+        when(command.integerValueSansLocaleOfParameterNamed(TaxApiConstants.creditAccountTypeParamName))
+                .thenReturn(GLAccountType.INCOME.getValue());
+
+        when(command.isChangeInLongParameterNamed(TaxApiConstants.creditAccountIdParamName, 2L)).thenReturn(true);
+        when(command.longValueOfParameterNamed(TaxApiConstants.creditAccountIdParamName)).thenReturn(20L);
+
+        Map<String, Object> changes = component.update(command, GLAccountType.EXPENSE, newDebitAccount, GLAccountType.INCOME,
+                newCreditAccount);
+
+        assertEquals(GLAccountType.EXPENSE.getValue(), component.getDebitAccountType());
+        assertEquals(newDebitAccount, component.getDebitAccount());
+        assertEquals(GLAccountType.INCOME.getValue(), component.getCreditAccountType());
+        assertEquals(newCreditAccount, component.getCreditAccount());
+
+        assertEquals(GLAccountType.EXPENSE.getValue(), changes.get(TaxApiConstants.debitAccountTypeParamName));
+        assertEquals(10L, changes.get(TaxApiConstants.debitAccountIdParamName));
+        assertEquals(GLAccountType.INCOME.getValue(), changes.get(TaxApiConstants.creditAccountTypeParamName));
+        assertEquals(20L, changes.get(TaxApiConstants.creditAccountIdParamName));
+    }
+
+    @Test
+    void testUpdateGLAccountsClearWhenNull() {
+        GLAccount oldDebitAccount = mock(GLAccount.class);
+        when(oldDebitAccount.getId()).thenReturn(1L);
+
+        TaxComponent component = TaxComponent.createTaxComponent("TC1", BigDecimal.TEN, GLAccountType.ASSET, oldDebitAccount,
+                GLAccountType.LIABILITY, null, TODAY);
+
+        JsonCommand command = mock(JsonCommand.class);
+        when(command.isChangeInStringParameterNamed(TaxApiConstants.nameParamName, "TC1")).thenReturn(false);
+        when(command.parameterExists(TaxApiConstants.startDateParamName)).thenReturn(false);
+        when(command.isChangeInBigDecimalParameterNamed(TaxApiConstants.percentageParamName, BigDecimal.TEN)).thenReturn(false);
+
+        when(command.isChangeInLongParameterNamed(TaxApiConstants.debitAccountIdParamName, 1L)).thenReturn(true);
+        when(command.longValueOfParameterNamed(TaxApiConstants.debitAccountIdParamName)).thenReturn(null);
+        when(command.parameterExists(TaxApiConstants.debitAccountIdParamName)).thenReturn(true);
+
+        when(command.isChangeInIntegerParameterNamed(TaxApiConstants.debitAccountTypeParamName, GLAccountType.ASSET.getValue()))
+                .thenReturn(false);
+        when(command.isChangeInIntegerParameterNamed(TaxApiConstants.creditAccountTypeParamName, GLAccountType.LIABILITY.getValue()))
+                .thenReturn(false);
+        when(command.isChangeInLongParameterNamed(TaxApiConstants.creditAccountIdParamName, null)).thenReturn(false);
+
+        Map<String, Object> changes = component.update(command, null, null, null, null);
+
+        assertNull(component.getDebitAccount());
+        assertNull(component.getDebitAccountType());
+        assertNull(changes.get(TaxApiConstants.debitAccountIdParamName));
+        assertNull(changes.get(TaxApiConstants.debitAccountTypeParamName));
+    }
+}

--- a/fineract-tax/src/test/java/org/apache/fineract/portfolio/tax/serialization/TaxValidatorTest.java
+++ b/fineract-tax/src/test/java/org/apache/fineract/portfolio/tax/serialization/TaxValidatorTest.java
@@ -1,0 +1,213 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.tax.serialization;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
+import org.apache.fineract.infrastructure.core.api.JsonCommand;
+import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
+import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
+import org.apache.fineract.infrastructure.core.exception.UnsupportedParameterException;
+import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import org.apache.fineract.portfolio.tax.api.TaxApiConstants;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TaxValidatorTest {
+
+    private final FromJsonHelper fromJsonHelper = new FromJsonHelper();
+    private TaxValidator taxValidator;
+
+    private static final LocalDate TODAY = LocalDate.of(2026, 9, 10);
+
+    @BeforeEach
+    void setUp() {
+        taxValidator = new TaxValidator(fromJsonHelper);
+        ThreadLocalContextUtil.setTenant(new FineractPlatformTenant(1L, "default", "Default", "Asia/Kolkata", null));
+        ThreadLocalContextUtil.setBusinessDates(new HashMap<>(Map.of(BusinessDateType.BUSINESS_DATE, TODAY)));
+    }
+
+    @AfterEach
+    void tearDown() {
+        ThreadLocalContextUtil.reset();
+    }
+
+    @Test
+    void testValidateStartDateBoundary1ExistingPastNewFutureRejected() {
+        LocalDate existingStartDate = TODAY.minusDays(5);
+        LocalDate newStartDate = TODAY.plusDays(5);
+
+        JsonCommand command = mock(JsonCommand.class);
+        when(command.parameterExists(TaxApiConstants.startDateParamName)).thenReturn(true);
+        when(command.localDateValueOfParameterNamed(TaxApiConstants.startDateParamName)).thenReturn(newStartDate);
+
+        PlatformApiDataValidationException exception = assertThrows(PlatformApiDataValidationException.class,
+                () -> taxValidator.validateStartDate(existingStartDate, command));
+
+        assertEquals("validation.msg.tax.component.startDate.start.date.cannot.be.modified.after.activation",
+                exception.getErrors().get(0).getUserMessageGlobalisationCode());
+    }
+
+    @Test
+    void testValidateStartDateBoundary2ExistingPastSamePastDateAllowed() {
+        LocalDate existingStartDate = TODAY.minusDays(5);
+
+        JsonCommand command = mock(JsonCommand.class);
+        when(command.parameterExists(TaxApiConstants.startDateParamName)).thenReturn(true);
+        when(command.localDateValueOfParameterNamed(TaxApiConstants.startDateParamName)).thenReturn(existingStartDate);
+
+        assertDoesNotThrow(() -> taxValidator.validateStartDate(existingStartDate, command));
+    }
+
+    @Test
+    void testValidateStartDateBoundary3ExistingTodayNewFutureRejected() {
+        LocalDate existingStartDate = TODAY;
+        LocalDate newStartDate = TODAY.plusDays(5);
+
+        JsonCommand command = mock(JsonCommand.class);
+        when(command.parameterExists(TaxApiConstants.startDateParamName)).thenReturn(true);
+        when(command.localDateValueOfParameterNamed(TaxApiConstants.startDateParamName)).thenReturn(newStartDate);
+
+        PlatformApiDataValidationException exception = assertThrows(PlatformApiDataValidationException.class,
+                () -> taxValidator.validateStartDate(existingStartDate, command));
+
+        assertEquals("validation.msg.tax.component.startDate.start.date.cannot.be.modified.after.activation",
+                exception.getErrors().get(0).getUserMessageGlobalisationCode());
+    }
+
+    @Test
+    void testValidateStartDateBoundary4ExistingTodaySameTodayAllowed() {
+        LocalDate existingStartDate = TODAY;
+
+        JsonCommand command = mock(JsonCommand.class);
+        when(command.parameterExists(TaxApiConstants.startDateParamName)).thenReturn(true);
+        when(command.localDateValueOfParameterNamed(TaxApiConstants.startDateParamName)).thenReturn(TODAY);
+
+        assertDoesNotThrow(() -> taxValidator.validateStartDate(existingStartDate, command));
+    }
+
+    @Test
+    void testValidateStartDateBoundary5ExistingFutureAnotherFutureDateAllowed() {
+        LocalDate existingStartDate = TODAY.plusDays(5);
+        LocalDate newStartDate = TODAY.plusDays(10);
+
+        JsonCommand command = mock(JsonCommand.class);
+        when(command.parameterExists(TaxApiConstants.startDateParamName)).thenReturn(true);
+        when(command.localDateValueOfParameterNamed(TaxApiConstants.startDateParamName)).thenReturn(newStartDate);
+
+        assertDoesNotThrow(() -> taxValidator.validateStartDate(existingStartDate, command));
+    }
+
+    @Test
+    void testValidateStartDateBoundary6ExistingFutureSameFutureDateAllowed() {
+        LocalDate existingStartDate = TODAY.plusDays(5);
+
+        JsonCommand command = mock(JsonCommand.class);
+        when(command.parameterExists(TaxApiConstants.startDateParamName)).thenReturn(true);
+        when(command.localDateValueOfParameterNamed(TaxApiConstants.startDateParamName)).thenReturn(existingStartDate);
+
+        assertDoesNotThrow(() -> taxValidator.validateStartDate(existingStartDate, command));
+    }
+
+    @Test
+    void testValidateStartDateBoundary7ExistingFutureTodayRejected() {
+        LocalDate existingStartDate = TODAY.plusDays(5);
+
+        JsonCommand command = mock(JsonCommand.class);
+        when(command.parameterExists(TaxApiConstants.startDateParamName)).thenReturn(true);
+        when(command.localDateValueOfParameterNamed(TaxApiConstants.startDateParamName)).thenReturn(TODAY);
+
+        assertThrows(PlatformApiDataValidationException.class, () -> taxValidator.validateStartDate(existingStartDate, command));
+    }
+
+    @Test
+    void testValidateStartDateBoundary8ExistingFuturePastRejected() {
+        LocalDate existingStartDate = TODAY.plusDays(5);
+
+        JsonCommand command = mock(JsonCommand.class);
+        when(command.parameterExists(TaxApiConstants.startDateParamName)).thenReturn(true);
+        when(command.localDateValueOfParameterNamed(TaxApiConstants.startDateParamName)).thenReturn(TODAY.minusDays(1));
+
+        assertThrows(PlatformApiDataValidationException.class, () -> taxValidator.validateStartDate(existingStartDate, command));
+    }
+
+    @Test
+    void testValidateStartDateBoundary9ExistingPastOrTodayNullRejected() {
+        LocalDate existingPastDate = TODAY.minusDays(5);
+        JsonCommand command = mock(JsonCommand.class);
+        when(command.parameterExists(TaxApiConstants.startDateParamName)).thenReturn(true);
+        when(command.localDateValueOfParameterNamed(TaxApiConstants.startDateParamName)).thenReturn(null);
+
+        PlatformApiDataValidationException exceptionPast = assertThrows(PlatformApiDataValidationException.class,
+                () -> taxValidator.validateStartDate(existingPastDate, command));
+        assertEquals("validation.msg.tax.component.startDate.start.date.cannot.be.modified.after.activation",
+                exceptionPast.getErrors().get(0).getUserMessageGlobalisationCode());
+
+        LocalDate existingTodayDate = TODAY;
+        PlatformApiDataValidationException exceptionToday = assertThrows(PlatformApiDataValidationException.class,
+                () -> taxValidator.validateStartDate(existingTodayDate, command));
+        assertEquals("validation.msg.tax.component.startDate.start.date.cannot.be.modified.after.activation",
+                exceptionToday.getErrors().get(0).getUserMessageGlobalisationCode());
+    }
+
+    @Test
+    void testValidateStartDateBoundary10ExistingFutureNullRejected() {
+        LocalDate existingFutureDate = TODAY.plusDays(5);
+        JsonCommand command = mock(JsonCommand.class);
+        when(command.parameterExists(TaxApiConstants.startDateParamName)).thenReturn(true);
+        when(command.localDateValueOfParameterNamed(TaxApiConstants.startDateParamName)).thenReturn(null);
+
+        assertThrows(PlatformApiDataValidationException.class, () -> taxValidator.validateStartDate(existingFutureDate, command));
+    }
+
+    @Test
+    void testValidateForTaxComponentUpdateWithSupportedGLParameters() {
+        String json = """
+                {
+                    "debitAccountType": 1,
+                    "debitAccountId": 10,
+                    "creditAccountType": 4,
+                    "creditAccountId": 20
+                }
+                """;
+
+        assertDoesNotThrow(() -> taxValidator.validateForTaxComponentUpdate(json));
+    }
+
+    @Test
+    void testValidateForTaxComponentUpdateWithUnsupportedParameterThrows() {
+        String json = """
+                {
+                    "unsupportedParam": "value"
+                }
+                """;
+
+        assertThrows(UnsupportedParameterException.class, () -> taxValidator.validateForTaxComponentUpdate(json));
+    }
+}


### PR DESCRIPTION
## Description

Jira: https://issues.apache.org/jira/browse/FINERACT-2767

### Problem
Previously, `PUT /v1/taxes/component/{id}` allowed updating any field of a Tax Component, including its percentage, debit/credit GL account mappings, and start date. If a tax component was already linked to active transactions (via a Tax Group referenced by one or more Charges), modifying its percentage or GL accounts would compromise historical audit trails and cause accounting inconsistencies.

### Solution
This PR implements field locking on `TaxComponent` based on usage status:
1. **Usage Check**: A tax component is considered in use if it belongs to a `TaxGroup` that is referenced by at least one `Charge` (via `ChargeRepository.existsByTaxGroupContainingTaxComponent(taxComponentId)`).
2. **Field Locking When In Use**:
   - `percentage`, `debitAccountType`, `debitAccountId`, `creditAccountType`, and `creditAccountId` are locked and cannot be modified.
   - `name` remains editable.
   - **Two-tier `startDate` rule**:
     - If `startDate` is today or in the past (already active), it cannot be modified (`validation.msg.tax.component.start.date.cannot.be.modified.after.activation`).
     - If `startDate` is in the future, it can be updated to another future date (> today), even if the component is in use.
3. **Field Updates When Not In Use**:
   - All fields are editable, including updating GL accounts (`debitAccountType`, `debitAccountId`, `creditAccountType`, `creditAccountId`) or percentage.
4. **API and Swagger Documentation**:
   - Added `accountsEditable` boolean property to `TaxComponentData` and OpenAPI annotations.
   - Updated GET `/v1/taxes/component/{id}` template behavior so that GL account dropdown options are omitted when accounts are locked.
5. **Testing**:
   - Comprehensive unit tests added in `fineract-tax` and `fineract-provider` testing validation rules, domain state updates, service layer permissions, and response payloads.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).
- [x] If merging this PR resolves a JIRA issue, I will mark that issue as resolved and set "Fix Version/s" appropriately.
- [x] I followed the [AI Policy](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#ai-policy).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
